### PR TITLE
[Issue #1] Architecture Review: Rules v3.4 Sync

### DIFF
--- a/contracts/interest-meter.md
+++ b/contracts/interest-meter.md
@@ -1,0 +1,102 @@
+# Contract: InterestMeter (Issues #2, #6)
+
+## Component
+`Pinder.Core.Conversation.InterestMeter`
+
+## File
+`src/Pinder.Core/Conversation/InterestMeter.cs`
+
+## Changes Required
+
+### Issue #2 — Max 20 → 25
+
+```csharp
+// BEFORE:
+public const int Max = 20;
+
+// AFTER:
+public const int Max = 25;
+```
+
+`StartingValue` remains 10. `Min` remains 0. `IsMaxed` and `IsZero` logic unchanged.
+
+### Issue #6 — Add InterestState enum and GetState() method
+
+Per rules v3.4 §6, there are exactly **6** interest states (NOT 7 — no "Lukewarm"):
+
+```csharp
+public enum InterestState
+{
+    Unmatched,    // 0
+    Bored,        // 1–4
+    Interested,   // 5–15
+    VeryIntoIt,   // 16–20
+    AlmostThere,  // 21–24
+    DateSecured   // 25
+}
+```
+
+Add to `InterestMeter`:
+
+```csharp
+/// <summary>Returns the current interest state based on rules v3.4 §6 boundaries.</summary>
+public InterestState GetState()
+{
+    if (Current <= 0)  return InterestState.Unmatched;
+    if (Current <= 4)  return InterestState.Bored;
+    if (Current <= 15) return InterestState.Interested;
+    if (Current <= 20) return InterestState.VeryIntoIt;
+    if (Current <= 24) return InterestState.AlmostThere;
+    return InterestState.DateSecured;
+}
+
+/// <summary>True if the current state grants the player advantage.</summary>
+public bool HasAdvantage => GetState() == InterestState.VeryIntoIt || GetState() == InterestState.AlmostThere;
+
+/// <summary>True if the current state imposes disadvantage.</summary>
+public bool HasDisadvantage => GetState() == InterestState.Bored;
+```
+
+## Public Interface (post-change)
+
+```csharp
+public sealed class InterestMeter
+{
+    public const int Max = 25;           // CHANGED from 20
+    public const int Min = 0;            // unchanged
+    public const int StartingValue = 10; // unchanged
+
+    public int Current { get; }
+    public void Apply(int delta);
+    public bool IsMaxed { get; }
+    public bool IsZero { get; }
+
+    // NEW:
+    public InterestState GetState();
+    public bool HasAdvantage { get; }
+    public bool HasDisadvantage { get; }
+}
+
+public enum InterestState
+{
+    Unmatched, Bored, Interested, VeryIntoIt, AlmostThere, DateSecured
+}
+```
+
+## Invariants
+- Exactly 6 states. No gaps, no overlaps in ranges.
+- `DateSecured` is only reachable at exactly `Max` (25).
+- `Unmatched` is only reachable at exactly 0.
+- State boundaries are inclusive on the lower bound per the ranges above.
+
+## Side-effect on TimingProfile
+`TimingProfile.ComputeDelay()` currently hardcodes `Math.Min(20, interestLevel)`. This must change to `Math.Min(InterestMeter.Max, interestLevel)` or `Math.Min(25, ...)`. File: `src/Pinder.Core/Conversation/TimingProfile.cs`, line with `Math.Min(20, interestLevel)`.
+
+## Dependencies
+- None
+
+## Consumers
+- `RollEngine` (indirectly — caller checks `HasAdvantage`/`HasDisadvantage` and passes to Resolve)
+- `TimingProfile.ComputeDelay()` — clamps interest to [0, Max]
+- `CharacterSystemTests` — assertions on Max
+- Future: `RulesConstantsTests` (issue #7)

--- a/contracts/readme-update.md
+++ b/contracts/readme-update.md
@@ -1,0 +1,24 @@
+# Contract: README Update (Issue #5 concern)
+
+## Purpose
+After v3.4 sync, the README will contain stale information. This should be updated as part of the sprint.
+
+## File
+`README.md`
+
+## Changes Required
+
+### 1. Roll formula section
+```
+BEFORE: DC = 10 + opponent's defending stat modifier
+AFTER:  DC = 13 + opponent's defending stat modifier
+```
+
+### 2. Defence pairings (implicit in description)
+The README doesn't list all pairings explicitly, but the roll formula section implies base DC = 10. Just update the number.
+
+### 3. Interest range
+If the README mentions interest max (it currently doesn't explicitly), update to 25.
+
+## Owner
+This can be done by any issue's implementer as a drive-by fix, or as a separate commit in the architecture PR (#3).

--- a/contracts/rules-constants-tests.md
+++ b/contracts/rules-constants-tests.md
@@ -1,0 +1,73 @@
+# Contract: Rules Constants Test File (Issue #7)
+
+## Purpose
+A dedicated test file that asserts every numeric constant from rules v3.4. If a rule value changes and code is updated but this file is not (or vice versa), tests fail — making drift impossible to miss.
+
+## File
+`tests/Pinder.Core.Tests/RulesConstantsTests.cs`
+
+## Test Structure
+
+One test (or test class section) per rules section:
+
+### §3 Defence Pairings
+```csharp
+[Fact] void DefenceTable_CharmDefendedBySelfAwareness()
+[Fact] void DefenceTable_RizzDefendedByWit()
+[Fact] void DefenceTable_HonestyDefendedByChaos()       // v3.4 change
+[Fact] void DefenceTable_ChaosDefendedByCharm()
+[Fact] void DefenceTable_WitDefendedByRizz()             // v3.4 change
+[Fact] void DefenceTable_SelfAwarenessDefendedByHonesty()
+```
+
+### §3 Base DC
+```csharp
+[Fact] void BaseDC_Is13()
+// Assert StatBlock.BaseDC == 13
+```
+
+### §4 Interest Meter
+```csharp
+[Fact] void InterestMax_Is25()
+[Fact] void InterestMin_Is0()
+[Fact] void InterestStart_Is10()
+```
+
+### §5 Success Scale
+```csharp
+[Fact] void SuccessMargin1to4_InterestDelta1()
+[Fact] void SuccessMargin5to9_InterestDelta2()
+[Fact] void SuccessMargin10Plus_InterestDelta3()
+[Fact] void Nat20_InterestDelta4()
+```
+
+### §6 Interest State Boundaries
+```csharp
+[Fact] void Interest0_IsUnmatched()
+[Fact] void Interest1to4_IsBored()
+[Fact] void Interest5to15_IsInterested()
+[Fact] void Interest16to20_IsVeryIntoIt()
+[Fact] void Interest21to24_IsAlmostThere()
+[Fact] void Interest25_IsDateSecured()
+[Fact] void Bored_HasDisadvantage()
+[Fact] void VeryIntoIt_HasAdvantage()
+[Fact] void AlmostThere_HasAdvantage()
+```
+
+### §7 Failure Tiers (already tested but repeated here for completeness)
+```csharp
+[Fact] void MissBy1to2_IsFumble()
+[Fact] void MissBy3to5_IsMisfire()
+[Fact] void MissBy6to9_IsTropeTrap()
+[Fact] void MissBy10Plus_IsCatastrophe()
+[Fact] void Nat1_IsLegendary()
+```
+
+## Dependencies
+- `StatBlock.BaseDC` constant (from issue #1)
+- `InterestMeter.Max/Min/StartingValue` (from issue #2)
+- `InterestState` enum and `GetState()` (from issue #6)
+- `RollResult.SuccessMargin` and `InterestDelta` (from issue #8 / success scale)
+
+## Note
+Issue #7 depends on #1, #2, #6, and the success scale code existing. Per issue #10 (dependency concern), #7 should be implemented **last** in the sprint.

--- a/contracts/statblock-defence-dc.md
+++ b/contracts/statblock-defence-dc.md
@@ -1,0 +1,74 @@
+# Contract: StatBlock Defence Table & Base DC (Issues #1, #2 tests)
+
+## Component
+`Pinder.Core.Stats.StatBlock`
+
+## File
+`src/Pinder.Core/Stats/StatBlock.cs`
+
+## Changes Required (v3.4 sync)
+
+### 1. DefenceTable — update two pairings
+
+```csharp
+// BEFORE (current):
+{ StatType.Honesty, StatType.SelfAwareness }
+{ StatType.Wit,     StatType.Wit           }
+
+// AFTER (v3.4):
+{ StatType.Honesty, StatType.Chaos  }
+{ StatType.Wit,     StatType.Rizz   }
+```
+
+All other pairings remain unchanged:
+- `Charm → SelfAwareness` ✓
+- `Rizz → Wit` ✓
+- `Chaos → Charm` ✓
+- `SelfAwareness → Honesty` ✓
+
+### 2. GetDefenceDC — base DC 10 → 13
+
+```csharp
+// BEFORE:
+return 10 + GetEffective(defenceStat);
+
+// AFTER:
+public const int BaseDC = 13;
+return BaseDC + GetEffective(defenceStat);
+```
+
+Extract `BaseDC` as a named constant for testability (issue #7 will assert against it).
+
+## Public Interface (post-change)
+
+```csharp
+public sealed class StatBlock
+{
+    public const int BaseDC = 13;  // NEW — extracted constant
+
+    public static readonly Dictionary<StatType, StatType> DefenceTable;
+    public static readonly Dictionary<StatType, ShadowStatType> ShadowPairs;  // unchanged
+
+    public int GetBase(StatType stat);           // unchanged
+    public int GetShadow(ShadowStatType shadow); // unchanged
+    public int GetEffective(StatType stat);      // unchanged
+    public int GetDefenceDC(StatType attackingStat);  // formula changes: 13 + effective
+}
+```
+
+## Invariants
+- `DefenceTable` must contain exactly 6 entries (one per `StatType`)
+- `GetDefenceDC` must use `BaseDC` constant, not a magic number
+- No stat defends against itself after v3.4 (Wit→Wit is gone)
+
+## Test Impact
+- All tests asserting `DC == 10` must change to `DC == 13` (issue #2)
+- Tests asserting old defence pairings must update (issue #2)
+
+## Dependencies
+- None (StatBlock has no dependencies on other components)
+
+## Consumers
+- `RollEngine.Resolve()` — calls `defender.GetDefenceDC(stat)`
+- `RollEngineTests` — hardcoded DC assertions
+- Future: `RulesConstantsTests` (issue #7)

--- a/contracts/success-scale.md
+++ b/contracts/success-scale.md
@@ -1,0 +1,59 @@
+# Contract: Success Scale (Issue #8 concern, needed by #7)
+
+## Context
+Rules v3.4 §5 defines interest deltas on success. The current codebase has **no implementation** — `RollResult` only tracks `MissMargin` (0 on success). This contract defines the new properties.
+
+## Component
+`Pinder.Core.Rolls.RollResult`
+
+## File
+`src/Pinder.Core/Rolls/RollResult.cs`
+
+## New Properties
+
+```csharp
+/// <summary>By how much the roll beat the DC. 0 on failure.</summary>
+public int SuccessMargin => IsSuccess ? Total - DC : 0;
+
+/// <summary>
+/// Interest delta to apply on success, per rules v3.4 §5.
+/// 0 on failure. Nat 20 always returns 4.
+/// </summary>
+public int InterestDelta
+{
+    get
+    {
+        if (!IsSuccess) return 0;
+        if (IsNatTwenty) return 4;
+        int margin = SuccessMargin;
+        if (margin >= 10) return 3;  // Crit
+        if (margin >= 5)  return 2;
+        if (margin >= 1)  return 1;
+        return 1;  // Beat DC by 0 (exact tie) still counts as +1
+    }
+}
+```
+
+## Success Scale Table (rules v3.4 §5)
+
+| Condition | Interest Delta |
+|---|---|
+| Beat DC by 1–4 | +1 |
+| Beat DC by 5–9 | +2 |
+| Beat DC by 10+ | +3 (Crit) |
+| Nat 20 | +4 |
+
+## Edge Cases
+- **Nat 20 with high margin**: `InterestDelta` is 4 (Nat 20 overrides margin-based calculation)
+- **Exact tie (Total == DC)**: This is a success (`Total >= DC`), `SuccessMargin == 0`, returns +1
+- **Nat 1**: Always failure regardless of modifiers, `InterestDelta == 0`
+
+## Dependencies
+- None (computed properties on existing fields)
+
+## Consumers
+- Caller code that applies `result.InterestDelta` to `InterestMeter.Apply()`
+- `RulesConstantsTests` (issue #7) — asserts scale values
+
+## Implementation Note
+These are **read-only computed properties** — no constructor changes needed. They derive from existing `Total`, `DC`, `IsSuccess`, `IsNatTwenty` fields.

--- a/contracts/test-value-updates.md
+++ b/contracts/test-value-updates.md
@@ -1,0 +1,41 @@
+# Contract: Test Value Updates (Issue #2)
+
+## Purpose
+After issue #1 changes `StatBlock.DefenceTable` and base DC, all existing tests with hardcoded DC values and defence pairing assumptions must be updated.
+
+## Files to Modify
+- `tests/Pinder.Core.Tests/RollEngineTests.cs`
+- `tests/Pinder.Core.Tests/CharacterSystemTests.cs`
+
+## Specific Changes in RollEngineTests.cs
+
+### DC assertions: 10 → 13
+Every test that asserts `result.DC == 10` (with zero-stat defenders) must change to `result.DC == 13`.
+
+Affected tests:
+- `MissByOne_IsFumble`: `Assert.Equal(10, result.DC)` → `Assert.Equal(13, result.DC)`
+  - Roll 8 + 0 + 0 = 8. New DC = 13. Miss by 5 → **Misfire** (not Fumble). Test logic must be reworked.
+- `MissByFive_IsMisfire`: Roll 5, DC was 10, miss 5. Now DC 13, miss 8 → **TropeTrap**. Must rework.
+- `MissBySeven_IsTropeTrap`: Roll 3, DC was 10, miss 7. Now DC 13, miss 10 → **Catastrophe**. Must rework.
+- `LevelBonus_AppliesToRoll`: Roll 9 + 0 + 2 = 11 vs DC 10 → success. Now DC 13 → fail. Must rework.
+
+### Defender stat adjustments for Charm tests
+`Charm → SelfAwareness` defence pairing is **unchanged**. The `MakeStats` helper only sets `charm` and `selfAwareness`, so defence pairing changes (Honesty, Wit) don't affect existing tests.
+
+### Strategy
+The implementer should recalculate every test's expected values against DC=13 and adjust die roll inputs or stat values to preserve the intended failure tier being tested.
+
+## Specific Changes in CharacterSystemTests.cs
+
+### InterestMeter tests
+- `InterestMeter_ClampsAtMax`: asserts `meter.Current == InterestMeter.Max` — no hardcoded 20, so this auto-updates when Max changes. **No change needed.**
+- No explicit `== 20` assertions found.
+
+### TimingProfile tests
+- `TimingProfile_HighInterest_FasterThanLow`: passes `interestLevel: 20` — should pass `InterestMeter.Max` (25) to test full range. Minor update.
+
+## Invariant
+After all updates, `dotnet test` must pass with zero failures.
+
+## Dependencies
+- Issue #1 must be implemented first (or simultaneously in the same PR per issue #4 recommendation)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# Pinder.Core — Architecture
+
+## Overview
+
+Pinder.Core is a **pure C# rules engine** (netstandard2.0, zero dependencies) for a comedy dating RPG. It is consumed by a Unity client and potentially standalone .NET hosts. The library is **stateless at the class level** — all mutable state (traps, interest, shadow stats) is owned by the caller and passed in.
+
+### Module Boundaries
+
+| Namespace | Responsibility | Key Types |
+|---|---|---|
+| `Stats` | Stat definitions, shadow penalties, defence DC calculation | `StatType`, `ShadowStatType`, `StatBlock` |
+| `Rolls` | d20 resolution, failure tier classification | `RollEngine` (static), `RollResult`, `FailureTier` |
+| `Traps` | Trap data model and active-trap tracking | `TrapDefinition`, `TrapState`, `ActiveTrap`, `TrapEffect` |
+| `Progression` | XP/level tables, build points, item slots | `LevelTable` (static), `FailurePoolTier` |
+| `Conversation` | Interest tracking, reply timing | `InterestMeter`, `TimingProfile` |
+| `Characters` | Item/anatomy data models, character assembly pipeline | `CharacterAssembler`, `FragmentCollection`, `ItemDefinition`, `AnatomyParameterDefinition` |
+| `Prompts` | LLM system prompt construction | `PromptBuilder` (static) |
+| `Data` | JSON parsing, repository implementations | `JsonItemRepository`, `JsonAnatomyRepository`, `JsonParser` |
+| `Interfaces` | Abstractions for external dependencies | `IDiceRoller`, `IFailurePool`, `ITrapRegistry`, `IItemRepository`, `IAnatomyRepository` |
+
+### Data Flow
+
+```
+Player input → RollEngine.Resolve(stat, attacker, defender, traps, level, ...) → RollResult
+                                                                                    ↓
+                                                            InterestMeter.Apply(delta)  ← (success scale — NOT YET IMPLEMENTED)
+                                                                                    ↓
+                                                            PromptBuilder.BuildSystemPrompt(fragments, traps) → LLM prompt string
+```
+
+### Key Patterns
+- **Immutable data models**: `StatBlock`, `RollResult`, `ItemDefinition`, `TrapDefinition` are read-only after construction
+- **Mutable state containers**: `InterestMeter`, `TrapState` — caller owns lifecycle
+- **Interface-based extensibility**: Unity swaps in ScriptableObject implementations of `IDiceRoller`, `ITrapRegistry`, `IFailurePool`
+- **No external dependencies**: Custom `JsonParser` instead of Newtonsoft/System.Text.Json
+
+### Constants That Are Rules-Derived
+
+The following constants in code correspond to values in the design rules document. When rules change, these must be updated in lockstep:
+
+| Rules Section | Code Location | Current Value | v3.4 Value |
+|---|---|---|---|
+| §3 Defence pairings | `StatBlock.DefenceTable` | Honesty→SA, Wit→Wit | Honesty→Chaos, Wit→Rizz |
+| §3 Base DC | `StatBlock.GetDefenceDC()` | 10 | **13** |
+| §4 Interest max | `InterestMeter.Max` | 20 | **25** |
+| §5 Success scale | *(not implemented)* | — | +1/+2/+3/+4 per margin |
+| §6 Interest states | *(not implemented)* | — | 6 states with adv/disadv |
+| §6 Interest states (note) | *(not implemented)* | — | NO "Lukewarm" state — only 6 states per rules |
+
+---
+
+## Rules-to-Code Sync Process
+
+### Source of Truth
+- **Authoritative**: `design/systems/rules-v3.md` (in the parent pinder repo)
+- **Content data**: `design/settings/` (items, anatomy, traps — JSON)
+- **Implementation**: this repo (`pinder-core`)
+
+### Sync Table
+
+Every rules-derived constant MUST appear in the table above. When the rules change:
+
+1. Update the sync table in this file
+2. Update the C# constants
+3. Update/add tests in `RulesConstantsTests.cs` that assert every value
+4. Update README.md if affected (DC formula, defence pairings, interest range)
+
+### Which Files Map to Which Rules Sections
+
+| Rules Section | C# File(s) |
+|---|---|
+| §3 Stats & DC | `Stats/StatBlock.cs`, `Stats/StatType.cs` |
+| §4 Interest meter | `Conversation/InterestMeter.cs` |
+| §5 Success scale | `Rolls/RollResult.cs` (to be added: `SuccessMargin`, `InterestDelta`) |
+| §6 Interest states | `Conversation/InterestMeter.cs` (to be added: `InterestState` enum, `GetState()`) |
+| §7 Failure tiers | `Rolls/FailureTier.cs`, `Rolls/RollEngine.cs` |
+| §8 Traps | `Traps/TrapDefinition.cs`, `Traps/TrapState.cs` |
+| §10 Progression | `Progression/LevelTable.cs` |
+
+---
+
+## Component Dependency Graph
+
+```
+Interfaces ← (no deps)
+Stats      ← (no deps)
+Progression ← Rolls (FailureTier enum only, via FailurePoolTier)
+Rolls      ← Stats, Progression, Traps, Interfaces
+Traps      ← Stats
+Conversation ← Interfaces
+Characters ← Stats, Conversation, Interfaces
+Prompts    ← Characters, Stats, Traps
+Data       ← Characters, Interfaces, Stats
+```
+
+No circular dependencies. Each namespace can be understood in isolation given its dependency list.


### PR DESCRIPTION
Fixes #1

## Summary

Architecture overview and interface definitions for the Rules v3.4 Sync sprint.

### Architecture Overview
- Created `docs/architecture.md` with full module boundaries, data flow, dependency graph, and rules-to-code sync process documentation

### Interface Definitions (contracts/)
- **statblock-defence-dc.md** — Defence table pairing changes + base DC 10→13 (#1)
- **interest-meter.md** — Max 20→25, new InterestState enum with 6 states (#2, #6)
- **success-scale.md** — New SuccessMargin/InterestDelta properties on RollResult (#8)
- **test-value-updates.md** — Which tests break and how to fix them (#2)
- **rules-constants-tests.md** — Test file structure for #7
- **readme-update.md** — README corrections needed (#5)

### Implementation Strategy
1. **#1 + #2 merged together** (per #4 concern) — keeps main green
2. **#3 done in this PR** — architecture.md with sync process
3. **#6 after #2** — InterestState enum + boundaries
4. **Success scale code alongside #6** (per #8 concern) — so #7 has something to assert
5. **#7 last** — rules constants test file depends on all above

### Sprint Plan Changes
- **#3 is partially delivered by this PR** (architecture.md created; implementer adds remaining sync-process details)
- **#1 and #2 should be one PR** to avoid broken main (per #4)
- **Success scale implementation must happen before #7** (per #8)
- **No Lukewarm state** — only 6 InterestState values per rules (per #9)
- **#3 can start immediately** — it documents process, doesn't depend on code changes (per #10)

## DoD Evidence
**Branch:** issue-1-architecture-review-rules-v3-4-sync
**Commit:** cf6f812
