### PR TITLE
[Issue #50] Write spec document: Tells — implement §15 opponent tell detection and hidden roll bonus

### DIFF
--- a/docs/specs/issue-50-spec.md
+++ b/docs/specs/issue-50-spec.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Tells are a hidden bonus mechanic from rules v3.4 §15. The opponent's messages contain subtle behavioural cues ("tells") that hint at which stat will work best on the next turn. When the LLM detects a tell in the opponent's response, it returns a `Tell` object indicating the stat. If the player then picks a dialogue option using that stat, they receive a hidden +2 bonus to their roll total. The bonus is invisible in the displayed success percentage but is revealed post-roll via a message on `TurnResult`.
+Tells are a hidden bonus mechanic from rules v3.4 §15. When an opponent's response contains a behavioural cue (e.g. "flirts", "makes a joke"), the LLM detects a `Tell` indicating which stat will work best next turn. If the player then picks a dialogue option using that stat, they receive a hidden +2 bonus to their roll total. The bonus is invisible in the displayed success percentage but is revealed post-roll via `TurnResult.TellReadBonus` and `TellReadMessage`.
+
+This issue implements the **GameSession integration** — the `Tell` and `OpponentResponse` types already exist (merged via #63/PR #114). The `TurnResult` fields (`TellReadBonus`, `TellReadMessage`) and `DialogueOption.HasTellBonus` also already exist (merged via #78/PR #117). What remains is wiring these together inside `GameSession` and routing the +2 bonus through `RollEngine.Resolve`.
 
 ---
 
@@ -25,172 +27,50 @@ Note: Some behaviours map to two possible stats. The LLM chooses one per respons
 
 ---
 
-## New Type: `Tell`
+## Existing Types (No Changes Needed)
 
-### Namespace
-`Pinder.Core.Conversation`
+These types already exist in the codebase and require NO modification:
 
-### Signature
+### `Tell` (`Pinder.Core.Conversation`)
 ```csharp
-namespace Pinder.Core.Conversation
+public sealed class Tell
 {
-    /// <summary>
-    /// Represents a detected tell from the opponent's behaviour.
-    /// Matching the tell stat on the next turn grants a hidden +2 roll bonus.
-    /// </summary>
-    public sealed class Tell
-    {
-        /// <summary>The stat that the tell hints at.</summary>
-        public StatType Stat { get; }
-
-        /// <summary>Human-readable description of the tell behaviour (e.g. "Flirts").</summary>
-        public string Description { get; }
-
-        public Tell(StatType stat, string description);
-    }
+    public StatType Stat { get; }
+    public string Description { get; }
+    public Tell(StatType stat, string description);  // throws ArgumentNullException if description is null
 }
 ```
 
-### Constraints
-- Must be a `sealed class`, NOT a `record` (netstandard2.0 / C# 8.0).
-- `Description` must not be null; constructor throws `ArgumentNullException` if null.
-- `Stat` is a `StatType` enum value — no null check needed (value type).
-
----
-
-## New Type: `OpponentResponse`
-
-### Namespace
-`Pinder.Core.Conversation`
-
-### Rationale
-`ILlmAdapter.GetOpponentResponseAsync` currently returns `Task<string>`. To carry the optional tell, a new return type is needed that wraps both the response text and the detected tell.
-
-### Signature
+### `OpponentResponse` (`Pinder.Core.Conversation`)
 ```csharp
-namespace Pinder.Core.Conversation
+public sealed class OpponentResponse
 {
-    /// <summary>
-    /// The opponent's response message plus any detected tell for the next turn.
-    /// </summary>
-    public sealed class OpponentResponse
-    {
-        /// <summary>The opponent's message text.</summary>
-        public string Text { get; }
-
-        /// <summary>The tell detected in this response, or null if no tell was detected.</summary>
-        public Tell? DetectedTell { get; }
-
-        public OpponentResponse(string text, Tell? detectedTell = null);
-    }
+    public string MessageText { get; }
+    public Tell? DetectedTell { get; }
+    public WeaknessWindow? WeaknessWindow { get; }
+    public OpponentResponse(string messageText, Tell? detectedTell = null, WeaknessWindow? weaknessWindow = null);
 }
 ```
 
-### Constraints
-- `Text` must not be null; constructor throws `ArgumentNullException` if null.
-- `DetectedTell` may be null (no tell detected this turn).
+### `DialogueOption.HasTellBonus` — already exists as a `bool` property (default `false`)
+
+### `TurnResult.TellReadBonus` — already exists as `int` (default `0`)
+
+### `TurnResult.TellReadMessage` — already exists as `string?` (default `null`)
+
+### `ILlmAdapter.GetOpponentResponseAsync` — already returns `Task<OpponentResponse>`
 
 ---
 
-## Interface Change: `ILlmAdapter.GetOpponentResponseAsync`
+## Changes Required
 
-### Current Signature
-```csharp
-Task<string> GetOpponentResponseAsync(OpponentContext context);
-```
+### 1. `RollEngine.Resolve` — Add `externalBonus` and `dcAdjustment` Parameters
 
-### New Signature
-```csharp
-Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context);
-```
+**File:** `src/Pinder.Core/Rolls/RollEngine.cs`
 
-### Impact
-- **`ILlmAdapter`**: return type changes from `Task<string>` to `Task<OpponentResponse>`.
-- **`NullLlmAdapter`**: must be updated to return `new OpponentResponse("...", detectedTell: null)`.
-- **`GameSession`**: must unwrap `OpponentResponse.Text` for the history entry and store `OpponentResponse.DetectedTell` for the next turn.
+**Note:** This is a Wave 0 dependency (#139). If `externalBonus` has already been added by another issue, skip this section.
 
----
-
-## Changes to `GameSession`
-
-### New Internal State
-
-| Field | Type | Initial Value | Purpose |
-|-------|------|---------------|---------|
-| `_activeTell` | `Tell?` | `null` | The tell detected from the opponent's last response. Consumed on the next `ResolveTurnAsync`. |
-
-### `ResolveTurnAsync` Changes
-
-After step 1 (dice roll via `RollEngine.Resolve`), before computing interest delta:
-
-1. **Check tell match**: If `_activeTell` is not null AND `chosenOption.Stat == _activeTell.Stat`:
-   - Add +2 to `rollResult.Total` for the purpose of success/failure determination. **Important**: the +2 is applied to the roll total, NOT to the interest delta. It can turn a miss into a hit.
-   - Record `tellReadBonus = 2` and `tellReadMessage = "📖 You read the moment. +2 bonus."`.
-2. **Clear the active tell**: Set `_activeTell = null` regardless of whether it matched. A tell is consumed after one turn.
-3. The `DialogueOption.HasTellBonus` flag is set during `StartTurnAsync` (see below) and is purely informational for the UI — it does NOT affect the roll computation in `ResolveTurnAsync`.
-
-**Clarification on "hidden"**: The +2 bonus is NOT reflected in any success percentage shown to the player before they choose. After the roll resolves, the `TurnResult` reveals whether the tell was read correctly.
-
-### `StartTurnAsync` Changes
-
-When building `DialogueContext` or processing options returned from the LLM:
-
-1. After receiving `DialogueOption[]` from `_llm.GetDialogueOptionsAsync(context)`:
-   - For each option, if `_activeTell` is not null and `option.Stat == _activeTell.Stat`, reconstruct the option with `hasTellBonus = true`.
-   - (Since `DialogueOption` properties are readonly, this means creating a new `DialogueOption` with the same values but `hasTellBonus = true`.)
-2. Store the modified options as `_currentOptions`.
-
-This allows the host/UI to show a hint (e.g. a 📖 icon) without revealing the actual bonus.
-
-### Opponent Response Handling
-
-In `ResolveTurnAsync`, after calling `_llm.GetOpponentResponseAsync(opponentContext)`:
-
-1. Unwrap the `OpponentResponse`: extract `.Text` for the history entry.
-2. Store `.DetectedTell` as `_activeTell` for the next turn.
-
----
-
-## Changes to `TurnResult`
-
-### New Properties
-
-```csharp
-/// <summary>
-/// The tell bonus applied this turn: 0 if no tell matched, 2 if the player read the tell correctly.
-/// </summary>
-public int TellReadBonus { get; }
-
-/// <summary>
-/// Post-roll message if the tell was read correctly, e.g. "📖 You read the moment. +2 bonus."
-/// Null if no tell bonus was applied.
-/// </summary>
-public string? TellReadMessage { get; }
-```
-
-### Constructor Change
-The constructor must accept two additional parameters: `int tellReadBonus` and `string? tellReadMessage`.
-
----
-
-## Roll Bonus Mechanics
-
-The +2 tell bonus is applied to the **d20 roll total** (i.e. `d20 + statMod + levelBonus + tellBonus`), which means:
-- It affects whether the roll succeeds or fails (can push a miss over the DC).
-- It affects the "beat DC by" margin, which in turn affects `SuccessScale` / `FailureScale` outputs.
-- It is NOT a separate interest delta addition — it modifies the roll itself.
-
-### Integration with `RollEngine`
-
-`RollEngine.Resolve` currently computes `total = d20Roll + modifier + levelBonus`. The tell bonus needs to be added. There are two approaches:
-
-**Option A (preferred)**: Add an optional `int rollBonus = 0` parameter to `RollEngine.Resolve`. `GameSession` passes `2` when the tell matches, `0` otherwise. This keeps the bonus visible in `RollResult.Total`.
-
-**Option B**: `GameSession` applies the +2 after the roll by constructing a modified `RollResult`. This is less clean because `RollResult` is immutable.
-
-The implementer should use **Option A** — adding a `rollBonus` parameter to `RollEngine.Resolve` — since it is the simplest change and keeps all roll math in one place.
-
-### Updated `RollEngine.Resolve` Signature
+#### Updated Signature
 ```csharp
 public static RollResult Resolve(
     StatType stat,
@@ -200,17 +80,126 @@ public static RollResult Resolve(
     int level,
     ITrapRegistry trapRegistry,
     IDiceRoller dice,
-    bool hasAdvantage,
-    bool hasDisadvantage,
-    int rollBonus = 0)  // NEW — hidden bonus from tells (or future mechanics)
+    bool hasAdvantage = false,
+    bool hasDisadvantage = false,
+    int externalBonus = 0,    // NEW — added to total before success check
+    int dcAdjustment = 0)     // NEW — subtracted from DC (positive = easier roll)
 ```
 
-The `rollBonus` is added to `total` before comparing against DC:
-```
-total = d20Roll + modifier + levelBonus + rollBonus
+#### Behaviour
+- `externalBonus` is added to `total` before the success/failure comparison: `total = usedDieRoll + statModifier + levelBonus + externalBonus`
+- `dcAdjustment` is subtracted from the computed DC: `effectiveDC = dc - dcAdjustment`
+- Both default to `0`, making this backward-compatible with all existing callers
+- The `RollResult` constructor must receive the adjusted values so `Total`, `IsSuccess`, and `MissMargin` all reflect external bonuses
+- Nat 1 remains auto-fail regardless of `externalBonus`
+- Nat 20 remains auto-success regardless of DC
+
+#### RollResult Impact
+`RollResult.Total` must include `externalBonus`. Two approaches:
+
+**Option A (preferred, per architecture §#146):** Pass `externalBonus` into `RollEngine.Resolve`, compute `total = usedDieRoll + statModifier + levelBonus + externalBonus` inside the engine, and construct `RollResult` with the full total. `RollResult.ExternalBonus` property and `AddExternalBonus()` method become unused for new code (deprecated per architecture doc).
+
+**Option B (backward compat):** Keep `RollResult.Total` as `usedDieRoll + statModifier + levelBonus` and have the engine call `AddExternalBonus()` before returning. This preserves `Total` semantics but `FinalTotal` becomes the canonical success check.
+
+The implementer should follow the architecture decision in §#146: external bonuses flow through `RollEngine.Resolve(externalBonus)` as the canonical path. The existing `AddExternalBonus()` is deprecated.
+
+---
+
+### 2. `GameSession` — Add Tell State and Tell Bonus Logic
+
+**File:** `src/Pinder.Core/Conversation/GameSession.cs`
+
+#### New Field
+```csharp
+private Tell? _activeTell;  // initialized to null
 ```
 
-All existing callers pass 0 (default), so this is backward-compatible.
+#### `StartTurnAsync()` Changes
+
+After receiving `DialogueOption[]` from `_llm.GetDialogueOptionsAsync(context)`, before storing as `_currentOptions`:
+
+1. For each option, check if `_activeTell != null && option.Stat == _activeTell.Stat`
+2. If matching, reconstruct the option with `hasTellBonus: true`:
+   ```csharp
+   new DialogueOption(
+       stat: option.Stat,
+       intendedText: option.IntendedText,
+       callbackTurnNumber: option.CallbackTurnNumber,
+       comboName: option.ComboName,
+       hasTellBonus: true)
+   ```
+3. Store the (possibly modified) options as `_currentOptions`
+
+This allows the host/UI to display a 📖 icon on matching options without revealing the bonus amount.
+
+#### `ResolveTurnAsync(int optionIndex)` Changes
+
+**Before the roll** (between selecting `chosenOption` and calling `RollEngine.Resolve`):
+
+1. Compute tell bonus:
+   ```
+   int tellBonus = 0;
+   if (_activeTell != null && chosenOption.Stat == _activeTell.Stat)
+       tellBonus = 2;
+   ```
+
+2. Pass `tellBonus` as part of `externalBonus` to `RollEngine.Resolve`:
+   ```csharp
+   var rollResult = RollEngine.Resolve(
+       stat: chosenOption.Stat,
+       attacker: _player.Stats,
+       defender: _opponent.Stats,
+       attackerTraps: _traps,
+       level: _player.Level,
+       trapRegistry: _trapRegistry,
+       dice: _dice,
+       hasAdvantage: _currentHasAdvantage,
+       hasDisadvantage: _currentHasDisadvantage,
+       externalBonus: tellBonus);  // +2 when tell matches, 0 otherwise
+   ```
+
+   Note: When other external bonuses (callback #47, triple combo #46) are also implemented, they should be summed: `externalBonus: tellBonus + callbackBonus + tripleComboBonus`.
+
+3. Clear the active tell regardless of match:
+   ```
+   _activeTell = null;
+   ```
+
+**After the opponent response** (after calling `_llm.GetOpponentResponseAsync`):
+
+4. Store the new tell for next turn:
+   ```
+   _activeTell = opponentResponse.DetectedTell;
+   ```
+
+**When constructing `TurnResult`:**
+
+5. Pass tell fields:
+   ```csharp
+   tellReadBonus: tellBonus,
+   tellReadMessage: tellBonus > 0 ? "📖 You read the moment. +2 bonus." : null
+   ```
+
+#### Tell Bonus Value
+The tell bonus is always exactly `+2` when matched, `0` when not matched. There is no variable tell bonus amount.
+
+#### Tell Message
+The exact string is: `"📖 You read the moment. +2 bonus."` — this is the canonical post-roll reveal message.
+
+---
+
+## Function Signatures Summary
+
+### Modified Functions
+
+| Function | Change |
+|----------|--------|
+| `RollEngine.Resolve(...)` | Add `int externalBonus = 0, int dcAdjustment = 0` params |
+| `GameSession.StartTurnAsync()` | Set `HasTellBonus` on matching dialogue options |
+| `GameSession.ResolveTurnAsync(int)` | Compute tell bonus, pass to `externalBonus`, populate `TurnResult` tell fields, store new tell from opponent response |
+
+### No New Public Functions
+All tell logic is internal to `GameSession`. No new public API surfaces are needed.
 
 ---
 
@@ -218,18 +207,17 @@ All existing callers pass 0 (default), so this is backward-compatible.
 
 ### Example 1: Tell Matched — Bonus Applied
 ```
-Turn 2 opponent response: OpponentResponse("Ha, that's actually funny", new Tell(StatType.Wit, "Makes a joke"))
-  → _activeTell = Tell(Wit, "Makes a joke")
+State: _activeTell = Tell(StatType.Wit, "Makes a joke")
 
-Turn 3 StartTurnAsync:
-  → LLM returns options: [Charm, Honesty, Wit, Chaos]
-  → Wit option gets HasTellBonus = true
-  → Player sees 📖 indicator on Wit option
+StartTurnAsync():
+  → LLM returns options: [DialogueOption(Charm, "..."), DialogueOption(Wit, "..."), DialogueOption(SA, "...")]
+  → Wit option reconstructed with HasTellBonus = true
+  → Returns TurnStart with modified options
 
-Turn 3 ResolveTurnAsync(optionIndex = 2):  // Player picks Wit
-  → chosenOption.Stat == Wit == _activeTell.Stat → match!
-  → RollEngine.Resolve(..., rollBonus: 2)
-  → Total = d20(12) + witMod(3) + levelBonus(1) + tellBonus(2) = 18 vs DC 16 → success
+ResolveTurnAsync(1):  // Player picks Wit (index 1)
+  → chosenOption.Stat == Wit == _activeTell.Stat → tellBonus = 2
+  → RollEngine.Resolve(..., externalBonus: 2)
+  → d20(12) + witMod(3) + levelBonus(1) + externalBonus(2) = 18 vs DC 16 → success
   → _activeTell = null (consumed)
   → TurnResult.TellReadBonus = 2
   → TurnResult.TellReadMessage = "📖 You read the moment. +2 bonus."
@@ -237,12 +225,11 @@ Turn 3 ResolveTurnAsync(optionIndex = 2):  // Player picks Wit
 
 ### Example 2: Tell Not Matched — No Bonus
 ```
-Turn 2 opponent response: OpponentResponse("...", new Tell(StatType.SelfAwareness, "Goes silent"))
-  → _activeTell = Tell(SelfAwareness, "Goes silent")
+State: _activeTell = Tell(StatType.SelfAwareness, "Goes silent")
 
-Turn 3 ResolveTurnAsync(optionIndex = 0):  // Player picks Charm
-  → chosenOption.Stat == Charm != SelfAwareness → no match
-  → RollEngine.Resolve(..., rollBonus: 0)
+ResolveTurnAsync(0):  // Player picks Charm
+  → chosenOption.Stat == Charm ≠ SelfAwareness → tellBonus = 0
+  → RollEngine.Resolve(..., externalBonus: 0)
   → _activeTell = null (consumed regardless)
   → TurnResult.TellReadBonus = 0
   → TurnResult.TellReadMessage = null
@@ -250,86 +237,96 @@ Turn 3 ResolveTurnAsync(optionIndex = 0):  // Player picks Charm
 
 ### Example 3: No Tell Active
 ```
-Turn 2 opponent response: OpponentResponse("Ok.", null)
-  → _activeTell = null
+State: _activeTell = null
 
-Turn 3 ResolveTurnAsync:
-  → _activeTell is null → no tell check
-  → RollEngine.Resolve(..., rollBonus: 0)
+ResolveTurnAsync(2):
+  → _activeTell is null → tellBonus = 0
+  → RollEngine.Resolve(..., externalBonus: 0)
   → TurnResult.TellReadBonus = 0
   → TurnResult.TellReadMessage = null
 ```
 
 ### Example 4: Tell Bonus Turns Miss Into Hit
 ```
-_activeTell = Tell(StatType.Honesty, "Shares something vulnerable")
+State: _activeTell = Tell(StatType.Honesty, "Shares something vulnerable")
 Player picks Honesty option.
 
 Without bonus: d20(11) + honestyMod(2) + levelBonus(0) = 13 vs DC 15 → miss by 2
-With bonus:    d20(11) + honestyMod(2) + levelBonus(0) + tellBonus(2) = 15 vs DC 15 → success (beat by 0 → SuccessScale +1)
+With bonus:    d20(11) + honestyMod(2) + levelBonus(0) + externalBonus(2) = 15 vs DC 15 → success (beat by 0 → +1 interest)
 
 TurnResult.TellReadBonus = 2
 TurnResult.TellReadMessage = "📖 You read the moment. +2 bonus."
+```
+
+### Example 5: Tell Stored from Opponent Response
+```
+ResolveTurnAsync completes:
+  → _llm.GetOpponentResponseAsync() returns OpponentResponse("Haha nice one", Tell(StatType.Charm, "Flirts"))
+  → opponentMessage = "Haha nice one"
+  → _activeTell = Tell(StatType.Charm, "Flirts")  // stored for next turn
 ```
 
 ---
 
 ## Acceptance Criteria
 
-### AC1: `Tell` type defined
-- `Tell` is a `sealed class` in `Pinder.Core.Conversation`.
-- Has `StatType Stat` and `string Description` readonly properties.
-- Constructor throws `ArgumentNullException` if `description` is null.
+### AC1: GameSession stores active tell from previous turn's OpponentResponse.DetectedTell
+- After `ResolveTurnAsync` calls `_llm.GetOpponentResponseAsync()`, the returned `OpponentResponse.DetectedTell` is stored as `_activeTell`
+- `_activeTell` persists until the next `ResolveTurnAsync` call
+- On the first turn, `_activeTell` is `null` (no prior opponent response)
 
-### AC2: `OpponentResponse` carries optional `Tell`
-- `OpponentResponse` is a `sealed class` in `Pinder.Core.Conversation`.
-- Has `string Text` and `Tell? DetectedTell` properties.
-- `ILlmAdapter.GetOpponentResponseAsync` return type changes from `Task<string>` to `Task<OpponentResponse>`.
-- `NullLlmAdapter` updated to return `new OpponentResponse("...", null)`.
+### AC2: On matching stat — +2 added via externalBonus on RollEngine.Resolve
+- When `_activeTell != null` and `chosenOption.Stat == _activeTell.Stat`, `externalBonus` of `2` is passed to `RollEngine.Resolve`
+- The bonus affects `RollResult.Total` (or `FinalTotal`), `IsSuccess`, and `MissMargin`
+- When the stat does not match, `externalBonus` is `0` (for the tell component)
+- `_activeTell` is set to `null` after consumption regardless of match
 
-### AC3: `GameSession` applies +2 on roll for matching stat
-- `GameSession` stores `_activeTell` from the previous turn's `OpponentResponse.DetectedTell`.
-- In `ResolveTurnAsync`, if `_activeTell?.Stat == chosenOption.Stat`, passes `rollBonus: 2` to `RollEngine.Resolve`.
-- The +2 is added to the roll total (affects success/failure determination).
-- `_activeTell` is set to null after consumption (whether matched or not).
+### AC3: Displayed percentage excludes bonus
+- The `HasTellBonus` flag on `DialogueOption` is set during `StartTurnAsync` for UI purposes only
+- No success probability calculation should include the +2 — it is hidden until post-roll reveal
+- The engine does not compute success percentages; this is a constraint on host/UI implementations
 
-### AC4: Displayed percentage excludes bonus
-- The `HasTellBonus` flag on `DialogueOption` is set during `StartTurnAsync` for UI display purposes only.
-- No success percentage computation includes the +2 bonus. The bonus is hidden until post-roll reveal.
-- (Note: the engine does not compute success percentages — this is a constraint on any future UI/host implementation.)
+### AC4: TurnResult.TellReadBonus and TellReadMessage populated correctly
+- When tell matches: `TellReadBonus = 2`, `TellReadMessage = "📖 You read the moment. +2 bonus."`
+- When tell does not match: `TellReadBonus = 0`, `TellReadMessage = null`
+- When no tell was active: `TellReadBonus = 0`, `TellReadMessage = null`
 
-### AC5: `TurnResult.TellReadBonus` and `TellReadMessage` populated correctly
-- `TurnResult` has new properties: `int TellReadBonus` (0 or 2) and `string? TellReadMessage`.
-- When tell matches: `TellReadBonus = 2`, `TellReadMessage = "📖 You read the moment. +2 bonus."`.
-- When tell does not match or no tell active: `TellReadBonus = 0`, `TellReadMessage = null`.
+### AC5: DialogueOption.HasTellBonus set when option stat matches active tell
+- During `StartTurnAsync`, each `DialogueOption` whose `Stat` matches `_activeTell.Stat` must be reconstructed with `hasTellBonus: true`
+- Options with non-matching stats retain `hasTellBonus: false`
+- If `_activeTell` is null, all options have `hasTellBonus: false`
 
 ### AC6: Tests cover tell bonus application
-- Test: tell bonus applied when chosen stat matches active tell — verify `TurnResult.TellReadBonus == 2` and `TellReadMessage` is non-null.
-- Test: tell bonus NOT applied when chosen stat differs from active tell — verify `TurnResult.TellReadBonus == 0`.
-- Test: no tell active — verify `TurnResult.TellReadBonus == 0`.
-- Test: tell consumed after one turn (second turn after tell set has no bonus).
-- Test: tell bonus can turn a miss into a hit (integration with `RollEngine`).
+- Tell bonus applied when chosen stat matches → `TellReadBonus == 2`, `TellReadMessage` is non-null
+- Tell bonus NOT applied when chosen stat differs → `TellReadBonus == 0`
+- No tell active → `TellReadBonus == 0`
+- Tell consumed after one turn (second turn has no bonus unless new tell detected)
+- Tell bonus can turn a miss into a hit (verified via `RollResult.IsSuccess`)
+- `HasTellBonus` set correctly on options during `StartTurnAsync`
 
 ### AC7: Build clean
-- `dotnet build` succeeds with zero warnings/errors.
-- All existing tests pass (`dotnet test`).
+- `dotnet build` succeeds with zero errors
+- All existing tests pass (`dotnet test`)
 
 ---
 
 ## Edge Cases
 
-| Case | Expected Behaviour |
-|------|-------------------|
-| No tell active (`_activeTell == null`) | `rollBonus = 0`, `TellReadBonus = 0`, `TellReadMessage = null` |
-| Tell active but player picks different stat | `rollBonus = 0`, tell consumed (set to null), `TellReadBonus = 0` |
-| Tell active and player picks matching stat | `rollBonus = 2`, tell consumed, `TellReadBonus = 2` |
-| Tell from turn N, player doesn't act until turn N+2 | Tells persist until consumed. One `StartTurnAsync`/`ResolveTurnAsync` cycle consumes the tell regardless of match. (Tell set in turn N's resolve is active for turn N+1's resolve.) |
-| Multiple tells in sequence (opponent sends tell every turn) | Each new tell overwrites the previous one. Only the most recent tell is active. |
-| First turn (no prior opponent response) | `_activeTell` is null; no tell bonus possible. |
-| Nat 20 with tell bonus | `rollBonus: 2` is added to total. Nat 20 is already auto-success; the +2 increases the "beat DC by" margin, potentially yielding a higher `SuccessScale` tier. |
-| Nat 1 with tell bonus | Nat 1 is auto-failure (Legendary tier). The tell bonus does not override natural 1 auto-fail. Tell is still consumed. `TellReadBonus = 2` because the player correctly read the tell (picked the matching stat); the `rollBonus: 2` was passed to `RollEngine.Resolve` but Nat 1 auto-fail takes precedence. `TellReadMessage` is set. This is consistent with the "tell matches but roll still fails" case — the tell was read, the bonus was applied, the outcome was just too bad. |
-| Tell stat matches but roll still fails after +2 | `TellReadBonus = 2`, `TellReadMessage` is set. The bonus was applied but wasn't enough. (The tell was "read" even if the roll failed — the player picked the right stat.) |
-| `DialogueOption.HasTellBonus` is true but player picks a different option | The non-selected option's `HasTellBonus` flag is irrelevant. Only the chosen option's stat is compared to the tell. |
+| # | Case | Expected Behaviour |
+|---|------|-------------------|
+| 1 | No tell active (`_activeTell == null`) | `externalBonus = 0` (tell portion), `TellReadBonus = 0`, `TellReadMessage = null` |
+| 2 | Tell active, player picks different stat | `externalBonus = 0`, tell consumed (set to null), `TellReadBonus = 0` |
+| 3 | Tell active, player picks matching stat | `externalBonus = 2`, tell consumed, `TellReadBonus = 2` |
+| 4 | Tell from turn N not consumed until turn N+1 | Tell persists in `_activeTell` across `StartTurnAsync`/`ResolveTurnAsync` boundary. It is only consumed when `ResolveTurnAsync` runs. |
+| 5 | Multiple tells in sequence | Each new `OpponentResponse.DetectedTell` overwrites `_activeTell`. Only the most recent tell is active. |
+| 6 | First turn (no prior opponent response) | `_activeTell` is null; no tell bonus possible. |
+| 7 | Nat 20 with tell bonus | `externalBonus: 2` is passed. Nat 20 is already auto-success; the +2 increases the "beat DC by" margin, potentially yielding a higher `SuccessScale` tier. `TellReadBonus = 2`. |
+| 8 | Nat 1 with tell bonus | Nat 1 is auto-failure (Legendary tier). The `externalBonus: 2` is passed to `RollEngine.Resolve` but Nat 1 auto-fail takes precedence. `TellReadBonus = 2` because the player correctly identified the matching stat — the tell was "read" even though the roll auto-failed. `TellReadMessage` is set. |
+| 9 | Tell matches but roll still fails after +2 | `TellReadBonus = 2`, `TellReadMessage` is set. The bonus was applied but wasn't enough to beat DC. The tell was correctly read; the outcome was just insufficient. |
+| 10 | `HasTellBonus` is true on option but player picks different option | The non-selected option's `HasTellBonus` flag is irrelevant. Only the chosen option's stat is compared to `_activeTell.Stat`. |
+| 11 | Opponent response has no tell (`DetectedTell = null`) | `_activeTell = null` after this turn. Next turn has no tell bonus available. |
+| 12 | Two options share the same stat that matches tell | Both get `HasTellBonus = true`. Whichever is chosen triggers the +2. |
+| 13 | Read/Recover/Wait actions with active tell | These actions do NOT consume the tell. The tell persists for the next Speak turn. Only `ResolveTurnAsync` consumes the tell. |
 
 ---
 
@@ -337,67 +334,74 @@ TurnResult.TellReadMessage = "📖 You read the moment. +2 bonus."
 
 | Condition | Error Type | Message |
 |-----------|-----------|---------|
-| `Tell` constructed with null `description` | `ArgumentNullException` | `"description"` |
-| `OpponentResponse` constructed with null `text` | `ArgumentNullException` | `"text"` |
-
-No other new error conditions. The tell mechanic is additive — it introduces new fields and a bonus but does not create new failure modes in the game session flow.
+| No new error conditions | — | The tell mechanic is purely additive. It does not introduce new failure modes. Existing `ResolveTurnAsync` errors (game ended, no options, index out of range) are unchanged. |
 
 ---
 
 ## Dependencies
 
-| Dependency | Type | Status |
-|-----------|------|--------|
-| **#27 — GameSession** | Hard (modifies `GameSession`) | Merged |
-| **#63 — Architecture review** | Hard (per issue) | Merged |
-| `ILlmAdapter` | Interface (return type change) | Existing — modified |
-| `NullLlmAdapter` | Test adapter | Existing — modified |
-| `RollEngine.Resolve` | Static method (new `rollBonus` param) | Existing — modified |
-| `DialogueOption.HasTellBonus` | Existing property | Already present in codebase |
-| `TurnResult` | Existing class (new properties) | Existing — modified |
-| `StatType` | Existing enum | Unchanged |
+| Dependency | Type | Status | Notes |
+|-----------|------|--------|-------|
+| #27 — GameSession | Hard | ✅ Merged | Base GameSession implementation |
+| #63 — Tell/OpponentResponse types | Hard | ✅ Merged (PR #114) | `Tell`, `OpponentResponse`, `ILlmAdapter` return type |
+| #78 — TurnResult expansion | Hard | ✅ Merged (PR #117) | `TellReadBonus`, `TellReadMessage` fields on `TurnResult`; `HasTellBonus` on `DialogueOption` |
+| #139 — Wave 0 (externalBonus param) | Hard | ⚠️ Not yet merged | `RollEngine.Resolve(externalBonus)` — must be implemented before or alongside this issue |
 
 ---
-
-## Files to Create
-
-| File | Content |
-|------|---------|
-| `src/Pinder.Core/Conversation/Tell.cs` | `Tell` sealed class |
-| `src/Pinder.Core/Conversation/OpponentResponse.cs` | `OpponentResponse` sealed class |
 
 ## Files to Modify
 
 | File | Change |
 |------|--------|
-| `src/Pinder.Core/Interfaces/ILlmAdapter.cs` | `GetOpponentResponseAsync` returns `Task<OpponentResponse>` |
-| `src/Pinder.Core/Conversation/NullLlmAdapter.cs` | Return `OpponentResponse` instead of `string` |
-| `src/Pinder.Core/Conversation/GameSession.cs` | Add `_activeTell` field; tell matching + bonus in `ResolveTurnAsync`; flag options in `StartTurnAsync`; extract tell from `OpponentResponse` |
-| `src/Pinder.Core/Conversation/TurnResult.cs` | Add `TellReadBonus` and `TellReadMessage` properties |
-| `src/Pinder.Core/Rolls/RollEngine.cs` | Add `int rollBonus = 0` parameter to `Resolve` |
+| `src/Pinder.Core/Rolls/RollEngine.cs` | Add `int externalBonus = 0, int dcAdjustment = 0` params to `Resolve()`; incorporate into total and DC computation. **Skip if Wave 0 already did this.** |
+| `src/Pinder.Core/Conversation/GameSession.cs` | Add `_activeTell` field; tell matching + `externalBonus` in `ResolveTurnAsync`; flag options in `StartTurnAsync`; store tell from `OpponentResponse` |
 
-## Test Files
+## Files NOT Modified (already exist with needed shape)
 
-| File | Tests |
-|------|-------|
-| `tests/Pinder.Core.Tests/TellTests.cs` | Constructor validation, null description throws |
-| `tests/Pinder.Core.Tests/OpponentResponseTests.cs` | Constructor validation, null text throws, null tell allowed |
-| `tests/Pinder.Core.Tests/GameSessionTellTests.cs` | Tell bonus applied on match; not applied on mismatch; no tell active; tell consumed after one turn; tell bonus turns miss into hit; Nat 1 with tell; HasTellBonus flag set on matching options |
+| File | Reason |
+|------|--------|
+| `src/Pinder.Core/Conversation/Tell.cs` | Already exists with correct shape |
+| `src/Pinder.Core/Conversation/OpponentResponse.cs` | Already exists, returns `DetectedTell` |
+| `src/Pinder.Core/Conversation/TurnResult.cs` | Already has `TellReadBonus`, `TellReadMessage` with correct defaults |
+| `src/Pinder.Core/Conversation/DialogueOption.cs` | Already has `HasTellBonus` with correct default |
+| `src/Pinder.Core/Interfaces/ILlmAdapter.cs` | Already returns `Task<OpponentResponse>` |
 
 ---
 
-## Stacking Order in `ResolveTurnAsync` (Updated)
+## Stacking Order in `ResolveTurnAsync`
 
-After this issue is implemented, the full interest delta computation in `ResolveTurnAsync` follows this order:
+After this issue is implemented, the full interest delta computation follows this order:
 
 ```
-0. Tell bonus    = +2 to ROLL TOTAL if tell stat matches chosen stat (applied via rollBonus param)
-1. Base delta    = SuccessScale.GetInterestDelta(roll) or FailureScale.GetInterestDelta(roll)
-2. Risk bonus    = (from #42, if implemented) +1 for Hard, +2 for Bold — success only
-3. Callback bonus = (from #47, if implemented) CallbackBonus.Compute() — success only
-4. Momentum bonus = GetMomentumBonus(streak) — success only
-───────────────────
+0. Tell bonus      → +2 to ROLL TOTAL if tell stat matches chosen stat
+                     (applied via externalBonus param on RollEngine.Resolve)
+                     This can turn a failure into success.
+
+1. Base delta      = SuccessScale.GetInterestDelta(roll)
+                     or FailureScale.GetInterestDelta(roll)
+
+2. Risk bonus      = RiskTierBonus.GetInterestBonus(roll) — success only
+
+3. Callback bonus  = (from #47, if implemented) — success only
+
+4. Momentum bonus  = GetMomentumBonus(streak) — success only
+───────────────────────────
    Total interestDelta = sum of 1–4 → InterestMeter.Apply(total)
 ```
 
-The tell bonus (step 0) is fundamentally different from the other bonuses: it modifies the **roll total**, not the interest delta. This means it can change the roll from failure to success, which then unlocks the other success-only bonuses.
+The tell bonus (step 0) modifies the **roll total**, not the interest delta. It can change the roll from failure to success, which then unlocks the success-only bonuses (steps 2–4).
+
+---
+
+## Test Guidance
+
+Tests should use a mock `ILlmAdapter` that returns controlled `OpponentResponse` objects with specific `Tell` values, and a fixed `IDiceRoller` to control roll outcomes. Key test scenarios:
+
+1. **Tell match → bonus applied**: Set up `OpponentResponse` with `Tell(Wit, "joke")`, next turn pick Wit option → verify `TellReadBonus == 2`
+2. **Tell mismatch → no bonus**: Same tell, pick Charm → verify `TellReadBonus == 0`
+3. **No tell → no bonus**: `OpponentResponse` with `null` tell → verify `TellReadBonus == 0`
+4. **Tell consumed**: After one `ResolveTurnAsync`, tell is cleared. Next turn (without new tell) → `TellReadBonus == 0`
+5. **Miss → hit conversion**: Set dice to roll value that misses DC by 1-2, add tell match → verify `IsSuccess == true`
+6. **Nat 1 with tell**: Tell matches but Nat 1 → `IsSuccess == false`, `TellReadBonus == 2`
+7. **HasTellBonus flag**: Call `StartTurnAsync` with active tell → verify matching options have `HasTellBonus == true`, non-matching have `false`
+8. **Tell overwrite**: Two consecutive opponent responses with different tells → only latest is active


### PR DESCRIPTION
Fixes #50

## DoD Evidence
**Branch:** issue-50-write-spec-document-tells-implement-15-o
**Commit:** cee81e5

Updated spec document reflecting current codebase state. Tell/OpponentResponse types, TurnResult fields, and DialogueOption.HasTellBonus already exist. Spec focuses on GameSession integration and RollEngine externalBonus wiring.