### PR TITLE
[Issue #63] ILlmAdapter expansion — add OpponentResponse type and new context fields

### DIFF
--- a/src/Pinder.Core/Conversation/CallbackOpportunity.cs
+++ b/src/Pinder.Core/Conversation/CallbackOpportunity.cs
@@ -1,0 +1,21 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// A callback opportunity — a conversation topic that can be referenced later for a bonus.
+    /// Stub type — feature PRs will flesh out usage.
+    /// </summary>
+    public sealed class CallbackOpportunity
+    {
+        /// <summary>Key identifying the topic (e.g. "pizza_story", "childhood_fear").</summary>
+        public string TopicKey { get; }
+
+        /// <summary>The turn number when this topic was introduced.</summary>
+        public int TurnIntroduced { get; }
+
+        public CallbackOpportunity(string topicKey, int turnIntroduced)
+        {
+            TopicKey = topicKey ?? throw new System.ArgumentNullException(nameof(topicKey));
+            TurnIntroduced = turnIntroduced;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/DeliveryContext.cs
+++ b/src/Pinder.Core/Conversation/DeliveryContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
 {
@@ -36,6 +37,12 @@ namespace Pinder.Core.Conversation
         /// <summary>Active trap LLM instructions (full taint text, not just names).</summary>
         public IReadOnlyList<string> ActiveTraps { get; }
 
+        /// <summary>Shadow stat thresholds for the player, or null if not applicable.</summary>
+        public Dictionary<ShadowStatType, int>? ShadowThresholds { get; }
+
+        /// <summary>Full trap taint instructions for active traps, or null if none.</summary>
+        public string[]? ActiveTrapInstructions { get; }
+
         public DeliveryContext(
             string playerPrompt,
             string opponentPrompt,
@@ -44,7 +51,9 @@ namespace Pinder.Core.Conversation
             DialogueOption chosenOption,
             FailureTier outcome,
             int beatDcBy,
-            IReadOnlyList<string> activeTraps)
+            IReadOnlyList<string> activeTraps,
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -54,6 +63,8 @@ namespace Pinder.Core.Conversation
             Outcome = outcome;
             BeatDcBy = beatDcBy;
             ActiveTraps = activeTraps ?? throw new System.ArgumentNullException(nameof(activeTraps));
+            ShadowThresholds = shadowThresholds;
+            ActiveTrapInstructions = activeTrapInstructions;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/DialogueContext.cs
+++ b/src/Pinder.Core/Conversation/DialogueContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
 {
@@ -26,13 +27,33 @@ namespace Pinder.Core.Conversation
         /// <summary>Current interest meter value.</summary>
         public int CurrentInterest { get; }
 
+        /// <summary>Shadow stat thresholds for the player, or null if not applicable.</summary>
+        public Dictionary<ShadowStatType, int>? ShadowThresholds { get; }
+
+        /// <summary>Available callback opportunities from prior turns, or null if none.</summary>
+        public List<CallbackOpportunity>? CallbackOpportunities { get; }
+
+        /// <summary>Current horniness shadow stat level (0 if not applicable).</summary>
+        public int HorninessLevel { get; }
+
+        /// <summary>Whether a Rizz option must be included due to Horniness mechanic.</summary>
+        public bool RequiresRizzOption { get; }
+
+        /// <summary>Full trap taint instructions for active traps, or null if none.</summary>
+        public string[]? ActiveTrapInstructions { get; }
+
         public DialogueContext(
             string playerPrompt,
             string opponentPrompt,
             IReadOnlyList<(string Sender, string Text)> conversationHistory,
             string opponentLastMessage,
             IReadOnlyList<string> activeTraps,
-            int currentInterest)
+            int currentInterest,
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            List<CallbackOpportunity>? callbackOpportunities = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false,
+            string[]? activeTrapInstructions = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -40,6 +61,11 @@ namespace Pinder.Core.Conversation
             OpponentLastMessage = opponentLastMessage ?? throw new System.ArgumentNullException(nameof(opponentLastMessage));
             ActiveTraps = activeTraps ?? throw new System.ArgumentNullException(nameof(activeTraps));
             CurrentInterest = currentInterest;
+            ShadowThresholds = shadowThresholds;
+            CallbackOpportunities = callbackOpportunities;
+            HorninessLevel = horninessLevel;
+            RequiresRizzOption = requiresRizzOption;
+            ActiveTrapInstructions = activeTrapInstructions;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -244,7 +244,8 @@ namespace Pinder.Core.Conversation
                 interestAfter: interestAfter,
                 responseDelayMinutes: responseDelayMinutes);
 
-            string opponentMessage = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
+            var opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
+            string opponentMessage = opponentResponse.MessageText;
 
             // 12. Append opponent message to history
             _history.Add((_opponent.DisplayName, opponentMessage));

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -40,11 +40,11 @@ namespace Pinder.Core.Conversation
         }
 
         /// <summary>
-        /// Returns a minimal placeholder response: "...".
+        /// Returns a minimal placeholder OpponentResponse with "..." text and no signals.
         /// </summary>
-        public Task<string> GetOpponentResponseAsync(OpponentContext context)
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
         {
-            return Task.FromResult("...");
+            return Task.FromResult(new OpponentResponse("..."));
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/OpponentContext.cs
+++ b/src/Pinder.Core/Conversation/OpponentContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
 {
@@ -37,6 +38,12 @@ namespace Pinder.Core.Conversation
         /// <summary>Opponent's simulated response delay in minutes (from timing profile).</summary>
         public double ResponseDelayMinutes { get; }
 
+        /// <summary>Shadow stat thresholds for the player, or null if not applicable.</summary>
+        public Dictionary<ShadowStatType, int>? ShadowThresholds { get; }
+
+        /// <summary>Full trap taint instructions for active traps, or null if none.</summary>
+        public string[]? ActiveTrapInstructions { get; }
+
         public OpponentContext(
             string playerPrompt,
             string opponentPrompt,
@@ -47,7 +54,9 @@ namespace Pinder.Core.Conversation
             string playerDeliveredMessage,
             int interestBefore,
             int interestAfter,
-            double responseDelayMinutes)
+            double responseDelayMinutes,
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -59,6 +68,8 @@ namespace Pinder.Core.Conversation
             InterestBefore = interestBefore;
             InterestAfter = interestAfter;
             ResponseDelayMinutes = responseDelayMinutes;
+            ShadowThresholds = shadowThresholds;
+            ActiveTrapInstructions = activeTrapInstructions;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/OpponentResponse.cs
+++ b/src/Pinder.Core/Conversation/OpponentResponse.cs
@@ -1,0 +1,29 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Structured response from the opponent, replacing a plain string return.
+    /// Carries the message text plus optional gameplay-relevant signals
+    /// (tells, weakness windows) detected by the LLM.
+    /// </summary>
+    public sealed class OpponentResponse
+    {
+        /// <summary>The opponent's message text.</summary>
+        public string MessageText { get; }
+
+        /// <summary>A tell detected in the opponent's response, or null if none.</summary>
+        public Tell? DetectedTell { get; }
+
+        /// <summary>A weakness window opened by the opponent's response, or null if none.</summary>
+        public WeaknessWindow? WeaknessWindow { get; }
+
+        public OpponentResponse(
+            string messageText,
+            Tell? detectedTell = null,
+            WeaknessWindow? weaknessWindow = null)
+        {
+            MessageText = messageText ?? throw new System.ArgumentNullException(nameof(messageText));
+            DetectedTell = detectedTell;
+            WeaknessWindow = weaknessWindow;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/Tell.cs
+++ b/src/Pinder.Core/Conversation/Tell.cs
@@ -1,0 +1,24 @@
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// A behavioural tell detected in an opponent's response.
+    /// Indicates which stat the opponent revealed vulnerability in.
+    /// Stub type — feature PRs will flesh out usage.
+    /// </summary>
+    public sealed class Tell
+    {
+        /// <summary>The stat the tell relates to.</summary>
+        public StatType Stat { get; }
+
+        /// <summary>Human-readable description of the tell.</summary>
+        public string Description { get; }
+
+        public Tell(StatType stat, string description)
+        {
+            Stat = stat;
+            Description = description ?? throw new System.ArgumentNullException(nameof(description));
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/WeaknessWindow.cs
+++ b/src/Pinder.Core/Conversation/WeaknessWindow.cs
@@ -1,0 +1,24 @@
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// A temporary weakness window opened by the opponent's response.
+    /// Reduces the DC for a specific defending stat.
+    /// Stub type — feature PRs will flesh out usage.
+    /// </summary>
+    public sealed class WeaknessWindow
+    {
+        /// <summary>The defending stat whose DC is reduced.</summary>
+        public StatType DefendingStat { get; }
+
+        /// <summary>How much the DC is reduced by.</summary>
+        public int DcReduction { get; }
+
+        public WeaknessWindow(StatType defendingStat, int dcReduction)
+        {
+            DefendingStat = defendingStat;
+            DcReduction = dcReduction;
+        }
+    }
+}

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -22,8 +22,9 @@ namespace Pinder.Core.Interfaces
 
         /// <summary>
         /// Generate the opponent's response to the player's delivered message.
+        /// Returns an OpponentResponse containing the message text and optional gameplay signals.
         /// </summary>
-        Task<string> GetOpponentResponseAsync(OpponentContext context);
+        Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context);
 
         /// <summary>
         /// Generate a narrative beat when interest crosses a threshold.

--- a/tests/Pinder.Core.Tests/LlmAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/LlmAdapterTests.cs
@@ -143,7 +143,9 @@ namespace Pinder.Core.Tests
             var result = await _adapter.GetOpponentResponseAsync(ctx);
 
             Assert.NotNull(result);
-            Assert.Equal("...", result);
+            Assert.Equal("...", result.MessageText);
+            Assert.Null(result.DetectedTell);
+            Assert.Null(result.WeaknessWindow);
         }
 
         // --- GetInterestChangeBeatAsync ---

--- a/tests/Pinder.Core.Tests/OpponentResponseTests.cs
+++ b/tests/Pinder.Core.Tests/OpponentResponseTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for OpponentResponse, Tell, WeaknessWindow, and CallbackOpportunity types.
+    /// Prototype maturity: happy-path construction and property tests.
+    /// </summary>
+    public class OpponentResponseTests
+    {
+        // --- OpponentResponse ---
+
+        [Fact]
+        public void OpponentResponse_Stores_MessageText()
+        {
+            var response = new OpponentResponse("Hello back!");
+            Assert.Equal("Hello back!", response.MessageText);
+        }
+
+        [Fact]
+        public void OpponentResponse_Defaults_Optional_Fields_To_Null()
+        {
+            var response = new OpponentResponse("Hi");
+            Assert.Null(response.DetectedTell);
+            Assert.Null(response.WeaknessWindow);
+        }
+
+        [Fact]
+        public void OpponentResponse_Stores_DetectedTell()
+        {
+            var tell = new Tell(StatType.Charm, "They blushed");
+            var response = new OpponentResponse("Hi", detectedTell: tell);
+
+            Assert.NotNull(response.DetectedTell);
+            Assert.Equal(StatType.Charm, response.DetectedTell!.Stat);
+            Assert.Equal("They blushed", response.DetectedTell.Description);
+        }
+
+        [Fact]
+        public void OpponentResponse_Stores_WeaknessWindow()
+        {
+            var window = new WeaknessWindow(StatType.Wit, 3);
+            var response = new OpponentResponse("Hmm", weaknessWindow: window);
+
+            Assert.NotNull(response.WeaknessWindow);
+            Assert.Equal(StatType.Wit, response.WeaknessWindow!.DefendingStat);
+            Assert.Equal(3, response.WeaknessWindow.DcReduction);
+        }
+
+        [Fact]
+        public void OpponentResponse_Stores_Both_Tell_And_WeaknessWindow()
+        {
+            var tell = new Tell(StatType.Honesty, "Nervous laugh");
+            var window = new WeaknessWindow(StatType.Honesty, 2);
+            var response = new OpponentResponse("Uh...", tell, window);
+
+            Assert.NotNull(response.DetectedTell);
+            Assert.NotNull(response.WeaknessWindow);
+        }
+
+        [Fact]
+        public void OpponentResponse_Throws_On_Null_MessageText()
+        {
+            Assert.Throws<ArgumentNullException>(() => new OpponentResponse(null!));
+        }
+
+        // --- Tell ---
+
+        [Fact]
+        public void Tell_Stores_Properties()
+        {
+            var tell = new Tell(StatType.Rizz, "Fidgeting");
+            Assert.Equal(StatType.Rizz, tell.Stat);
+            Assert.Equal("Fidgeting", tell.Description);
+        }
+
+        [Fact]
+        public void Tell_Throws_On_Null_Description()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Tell(StatType.Charm, null!));
+        }
+
+        // --- WeaknessWindow ---
+
+        [Fact]
+        public void WeaknessWindow_Stores_Properties()
+        {
+            var window = new WeaknessWindow(StatType.Chaos, 5);
+            Assert.Equal(StatType.Chaos, window.DefendingStat);
+            Assert.Equal(5, window.DcReduction);
+        }
+
+        // --- CallbackOpportunity ---
+
+        [Fact]
+        public void CallbackOpportunity_Stores_Properties()
+        {
+            var cb = new CallbackOpportunity("pizza_story", 3);
+            Assert.Equal("pizza_story", cb.TopicKey);
+            Assert.Equal(3, cb.TurnIntroduced);
+        }
+
+        [Fact]
+        public void CallbackOpportunity_Throws_On_Null_TopicKey()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CallbackOpportunity(null!, 1));
+        }
+
+        // --- Context type new optional fields ---
+
+        [Fact]
+        public void DialogueContext_New_Fields_Default_To_Null_Or_Zero()
+        {
+            var ctx = new DialogueContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: new List<string>(),
+                currentInterest: 10);
+
+            Assert.Null(ctx.ShadowThresholds);
+            Assert.Null(ctx.CallbackOpportunities);
+            Assert.Equal(0, ctx.HorninessLevel);
+            Assert.False(ctx.RequiresRizzOption);
+            Assert.Null(ctx.ActiveTrapInstructions);
+        }
+
+        [Fact]
+        public void DialogueContext_Accepts_New_Optional_Fields()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Horniness, 7 }
+            };
+            var callbacks = new List<CallbackOpportunity>
+            {
+                new CallbackOpportunity("topic1", 2)
+            };
+
+            var ctx = new DialogueContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: new List<string>(),
+                currentInterest: 10,
+                shadowThresholds: shadows,
+                callbackOpportunities: callbacks,
+                horninessLevel: 7,
+                requiresRizzOption: true,
+                activeTrapInstructions: new[] { "Taint: say something weird" });
+
+            Assert.NotNull(ctx.ShadowThresholds);
+            Assert.Single(ctx.ShadowThresholds!);
+            Assert.NotNull(ctx.CallbackOpportunities);
+            Assert.Single(ctx.CallbackOpportunities!);
+            Assert.Equal(7, ctx.HorninessLevel);
+            Assert.True(ctx.RequiresRizzOption);
+            Assert.NotNull(ctx.ActiveTrapInstructions);
+            Assert.Single(ctx.ActiveTrapInstructions!);
+        }
+
+        [Fact]
+        public void DeliveryContext_New_Fields_Default_To_Null()
+        {
+            var option = new DialogueOption(StatType.Charm, "Hi");
+            var ctx = new DeliveryContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                chosenOption: option,
+                outcome: Rolls.FailureTier.None,
+                beatDcBy: 3,
+                activeTraps: new List<string>());
+
+            Assert.Null(ctx.ShadowThresholds);
+            Assert.Null(ctx.ActiveTrapInstructions);
+        }
+
+        [Fact]
+        public void DeliveryContext_Accepts_New_Optional_Fields()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 4 }
+            };
+            var option = new DialogueOption(StatType.Charm, "Hi");
+            var ctx = new DeliveryContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                chosenOption: option,
+                outcome: Rolls.FailureTier.None,
+                beatDcBy: 3,
+                activeTraps: new List<string>(),
+                shadowThresholds: shadows,
+                activeTrapInstructions: new[] { "Be creepy" });
+
+            Assert.NotNull(ctx.ShadowThresholds);
+            Assert.NotNull(ctx.ActiveTrapInstructions);
+        }
+
+        [Fact]
+        public void OpponentContext_New_Fields_Default_To_Null()
+        {
+            var ctx = new OpponentContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: new List<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hello!",
+                interestBefore: 10,
+                interestAfter: 11,
+                responseDelayMinutes: 1.5);
+
+            Assert.Null(ctx.ShadowThresholds);
+            Assert.Null(ctx.ActiveTrapInstructions);
+        }
+
+        [Fact]
+        public void OpponentContext_Accepts_New_Optional_Fields()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Dread, 6 }
+            };
+            var ctx = new OpponentContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: new List<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hello!",
+                interestBefore: 10,
+                interestAfter: 11,
+                responseDelayMinutes: 1.5,
+                shadowThresholds: shadows,
+                activeTrapInstructions: new[] { "Add dread" });
+
+            Assert.NotNull(ctx.ShadowThresholds);
+            Assert.NotNull(ctx.ActiveTrapInstructions);
+            Assert.Single(ctx.ActiveTrapInstructions!);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63

## What was implemented

- **OpponentResponse** class: replaces plain `string` return from `GetOpponentResponseAsync`, carries `MessageText`, optional `DetectedTell`, optional `WeaknessWindow`
- **Tell** stub type: `StatType Stat` + `string Description`
- **WeaknessWindow** stub type: `StatType DefendingStat` + `int DcReduction`
- **CallbackOpportunity** stub type: `string TopicKey` + `int TurnIntroduced`
- **ILlmAdapter** signature change: `GetOpponentResponseAsync` now returns `Task<OpponentResponse>`
- **DialogueContext** new optional fields: `ShadowThresholds`, `CallbackOpportunities`, `HorninessLevel`, `RequiresRizzOption`, `ActiveTrapInstructions`
- **DeliveryContext** new optional fields: `ShadowThresholds`, `ActiveTrapInstructions`
- **OpponentContext** new optional fields: `ShadowThresholds`, `ActiveTrapInstructions`
- **NullLlmAdapter** updated to return `OpponentResponse`
- **GameSession** updated to use `.MessageText` from `OpponentResponse`

## How to test

```bash
dotnet test
```

All 115 tests pass (98 existing + 17 new).

## Deviations from contract
None — all acceptance criteria met.

## DoD Evidence
**Branch:** issue-63-illmadapter-expansion-add-opponentrespon
**Commit:** f140dc9
**Tests:** 115 passed, 0 failed
