### PR TITLE
[Issue #78] TurnResult expansion — add RiskTier enum and 7 new fields

### DIFF
--- a/src/Pinder.Core/Conversation/TurnResult.cs
+++ b/src/Pinder.Core/Conversation/TurnResult.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Pinder.Core.Rolls;
 
 namespace Pinder.Core.Conversation
@@ -31,6 +33,27 @@ namespace Pinder.Core.Conversation
         /// <summary>The outcome if the game ended, null otherwise.</summary>
         public GameOutcome? Outcome { get; }
 
+        /// <summary>Human-readable descriptions of shadow stat growth that occurred this turn. Empty if none.</summary>
+        public IReadOnlyList<string> ShadowGrowthEvents { get; }
+
+        /// <summary>Name/identifier of the combo triggered this turn, or null if no combo fired.</summary>
+        public string? ComboTriggered { get; }
+
+        /// <summary>Callback bonus modifier applied to the roll or interest delta this turn. 0 if none.</summary>
+        public int CallbackBonusApplied { get; }
+
+        /// <summary>Tell-read bonus modifier applied this turn. 0 if no tell-read occurred.</summary>
+        public int TellReadBonus { get; }
+
+        /// <summary>Descriptive message about the tell that was read, or null if none.</summary>
+        public string? TellReadMessage { get; }
+
+        /// <summary>Risk tier of the action chosen by the player this turn.</summary>
+        public RiskTier RiskTier { get; }
+
+        /// <summary>Amount of XP earned from this turn's outcome. 0 if none.</summary>
+        public int XpEarned { get; }
+
         public TurnResult(
             RollResult roll,
             string deliveredMessage,
@@ -39,16 +62,30 @@ namespace Pinder.Core.Conversation
             int interestDelta,
             GameStateSnapshot stateAfter,
             bool isGameOver,
-            GameOutcome? outcome)
+            GameOutcome? outcome,
+            IReadOnlyList<string>? shadowGrowthEvents = null,
+            string? comboTriggered = null,
+            int callbackBonusApplied = 0,
+            int tellReadBonus = 0,
+            string? tellReadMessage = null,
+            RiskTier riskTier = RiskTier.Safe,
+            int xpEarned = 0)
         {
-            Roll = roll ?? throw new System.ArgumentNullException(nameof(roll));
-            DeliveredMessage = deliveredMessage ?? throw new System.ArgumentNullException(nameof(deliveredMessage));
-            OpponentMessage = opponentMessage ?? throw new System.ArgumentNullException(nameof(opponentMessage));
+            Roll = roll ?? throw new ArgumentNullException(nameof(roll));
+            DeliveredMessage = deliveredMessage ?? throw new ArgumentNullException(nameof(deliveredMessage));
+            OpponentMessage = opponentMessage ?? throw new ArgumentNullException(nameof(opponentMessage));
             NarrativeBeat = narrativeBeat;
             InterestDelta = interestDelta;
-            StateAfter = stateAfter ?? throw new System.ArgumentNullException(nameof(stateAfter));
+            StateAfter = stateAfter ?? throw new ArgumentNullException(nameof(stateAfter));
             IsGameOver = isGameOver;
             Outcome = outcome;
+            ShadowGrowthEvents = shadowGrowthEvents ?? Array.Empty<string>();
+            ComboTriggered = comboTriggered;
+            CallbackBonusApplied = callbackBonusApplied;
+            TellReadBonus = tellReadBonus;
+            TellReadMessage = tellReadMessage;
+            RiskTier = riskTier;
+            XpEarned = xpEarned;
         }
     }
 }

--- a/src/Pinder.Core/Rolls/RiskTier.cs
+++ b/src/Pinder.Core/Rolls/RiskTier.cs
@@ -1,0 +1,13 @@
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Risk tier of the action chosen by the player. Ascending risk order.
+    /// </summary>
+    public enum RiskTier
+    {
+        Safe,
+        Medium,
+        Hard,
+        Bold
+    }
+}

--- a/tests/Pinder.Core.Tests/TurnResultExpansionTests.cs
+++ b/tests/Pinder.Core.Tests/TurnResultExpansionTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for TurnResult expansion (Issue #78) and RiskTier enum.
+    /// </summary>
+    public class TurnResultExpansionTests
+    {
+        // Helper to create a minimal valid RollResult
+        private static RollResult MakeRoll() =>
+            new RollResult(10, null, 10, StatType.Charm, 2, 0, 13, FailureTier.None);
+
+        // Helper to create a minimal valid GameStateSnapshot
+        private static GameStateSnapshot MakeSnapshot() =>
+            new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1);
+
+        #region RiskTier Enum
+
+        [Fact]
+        public void RiskTier_HasFourMembers()
+        {
+            var values = Enum.GetValues(typeof(RiskTier));
+            Assert.Equal(4, values.Length);
+        }
+
+        [Theory]
+        [InlineData(RiskTier.Safe, 0)]
+        [InlineData(RiskTier.Medium, 1)]
+        [InlineData(RiskTier.Hard, 2)]
+        [InlineData(RiskTier.Bold, 3)]
+        public void RiskTier_MembersHaveExpectedValues(RiskTier tier, int expected)
+        {
+            Assert.Equal(expected, (int)tier);
+        }
+
+        #endregion
+
+        #region TurnResult Defaults
+
+        [Fact]
+        public void TurnResult_NewFieldsDefaultCorrectly_WhenNotSpecified()
+        {
+            var result = new TurnResult(
+                MakeRoll(), "hello", "hi back", null, 1, MakeSnapshot(), false, null);
+
+            Assert.NotNull(result.ShadowGrowthEvents);
+            Assert.Empty(result.ShadowGrowthEvents);
+            Assert.Null(result.ComboTriggered);
+            Assert.Equal(0, result.CallbackBonusApplied);
+            Assert.Equal(0, result.TellReadBonus);
+            Assert.Null(result.TellReadMessage);
+            Assert.Equal(RiskTier.Safe, result.RiskTier);
+            Assert.Equal(0, result.XpEarned);
+        }
+
+        [Fact]
+        public void TurnResult_ExistingFieldsUnchanged()
+        {
+            var roll = MakeRoll();
+            var snap = MakeSnapshot();
+            var result = new TurnResult(roll, "msg", "reply", "beat", -2, snap, true, GameOutcome.Ghosted);
+
+            Assert.Same(roll, result.Roll);
+            Assert.Equal("msg", result.DeliveredMessage);
+            Assert.Equal("reply", result.OpponentMessage);
+            Assert.Equal("beat", result.NarrativeBeat);
+            Assert.Equal(-2, result.InterestDelta);
+            Assert.Same(snap, result.StateAfter);
+            Assert.True(result.IsGameOver);
+            Assert.Equal(GameOutcome.Ghosted, result.Outcome);
+        }
+
+        #endregion
+
+        #region ShadowGrowthEvents null-coalescing
+
+        [Fact]
+        public void TurnResult_ShadowGrowthEvents_NullBecomesEmptyList()
+        {
+            var result = new TurnResult(
+                MakeRoll(), "a", "b", null, 0, MakeSnapshot(), false, null,
+                shadowGrowthEvents: null);
+
+            Assert.NotNull(result.ShadowGrowthEvents);
+            Assert.Empty(result.ShadowGrowthEvents);
+        }
+
+        [Fact]
+        public void TurnResult_ShadowGrowthEvents_PreservesList()
+        {
+            var events = new List<string> { "Horniness +1 (Rizz overuse)", "Dread +1" };
+            var result = new TurnResult(
+                MakeRoll(), "a", "b", null, 0, MakeSnapshot(), false, null,
+                shadowGrowthEvents: events);
+
+            Assert.Equal(2, result.ShadowGrowthEvents.Count);
+            Assert.Equal("Horniness +1 (Rizz overuse)", result.ShadowGrowthEvents[0]);
+            Assert.Equal("Dread +1", result.ShadowGrowthEvents[1]);
+        }
+
+        #endregion
+
+        #region All new fields populated
+
+        [Fact]
+        public void TurnResult_AllNewFieldsPopulated()
+        {
+            var events = new[] { "Shadow event" };
+            var result = new TurnResult(
+                MakeRoll(), "a", "b", null, 3, MakeSnapshot(), false, null,
+                shadowGrowthEvents: events,
+                comboTriggered: "SmoothOperator",
+                callbackBonusApplied: 1,
+                tellReadBonus: 2,
+                tellReadMessage: "Cats tell",
+                riskTier: RiskTier.Bold,
+                xpEarned: 15);
+
+            Assert.Single(result.ShadowGrowthEvents);
+            Assert.Equal("SmoothOperator", result.ComboTriggered);
+            Assert.Equal(1, result.CallbackBonusApplied);
+            Assert.Equal(2, result.TellReadBonus);
+            Assert.Equal("Cats tell", result.TellReadMessage);
+            Assert.Equal(RiskTier.Bold, result.RiskTier);
+            Assert.Equal(15, result.XpEarned);
+        }
+
+        #endregion
+
+        #region Null validation on required fields still works
+
+        [Fact]
+        public void TurnResult_ThrowsOnNullRoll()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TurnResult(null!, "a", "b", null, 0, MakeSnapshot(), false, null));
+        }
+
+        [Fact]
+        public void TurnResult_ThrowsOnNullDeliveredMessage()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TurnResult(MakeRoll(), null!, "b", null, 0, MakeSnapshot(), false, null));
+        }
+
+        [Fact]
+        public void TurnResult_ThrowsOnNullOpponentMessage()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TurnResult(MakeRoll(), "a", null!, null, 0, MakeSnapshot(), false, null));
+        }
+
+        [Fact]
+        public void TurnResult_ThrowsOnNullStateAfter()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TurnResult(MakeRoll(), "a", "b", null, 0, null!, false, null));
+        }
+
+        #endregion
+
+        #region Edge cases: negative values stored as-is
+
+        [Fact]
+        public void TurnResult_NegativeNumericValues_StoredAsIs()
+        {
+            var result = new TurnResult(
+                MakeRoll(), "a", "b", null, 0, MakeSnapshot(), false, null,
+                callbackBonusApplied: -1,
+                tellReadBonus: -3,
+                xpEarned: -5);
+
+            Assert.Equal(-1, result.CallbackBonusApplied);
+            Assert.Equal(-3, result.TellReadBonus);
+            Assert.Equal(-5, result.XpEarned);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #78

## What was done
Added `RiskTier` enum (Safe/Medium/Hard/Bold) to `Pinder.Core.Rolls` and expanded `TurnResult` with 7 new optional fields: `ShadowGrowthEvents`, `ComboTriggered`, `CallbackBonusApplied`, `TellReadBonus`, `TellReadMessage`, `RiskTier`, `XpEarned`. All new constructor parameters are optional with safe defaults, preserving backward compatibility.

## Files changed
- `src/Pinder.Core/Rolls/RiskTier.cs` — **New**: RiskTier enum
- `src/Pinder.Core/Conversation/TurnResult.cs` — Expanded with 7 new properties + optional constructor params
- `tests/Pinder.Core.Tests/TurnResultExpansionTests.cs` — **New**: 15 tests covering defaults, population, null-coalescing, edge cases

## How to test
```bash
dotnet test
```
All 130 tests pass (115 existing + 15 new). Zero warnings.

## Deviations from contract
None — implementation matches the spec in `docs/specs/issue-78-spec.md` exactly.

## DoD Evidence
**Branch:** issue-78-turnresult-expansion-add-fields-for-new-
**Commit:** b86e970
**Tests:** Passed! - Failed: 0, Passed: 130, Skipped: 0, Total: 130
