### PR TITLE
[Issue #38] Write spec document: QA review: audit and improve test quality across all test files

### DIFF
--- a/docs/specs/issue-38-spec.md
+++ b/docs/specs/issue-38-spec.md
@@ -2,321 +2,423 @@
 
 ## Overview
 
-This issue is a dedicated QA pass across the entire Pinder.Core test suite (currently 98 tests in 7 files). The goal is to audit existing tests for quality, coverage gaps relative to interface contracts, and naming conventions — then fix straightforward gaps directly and file GitHub issues for complex ones. The output is a measurably improved test suite plus a contract-to-test coverage gap report.
+This issue is a dedicated QA pass across the entire Pinder.Core test suite (currently 254 tests in 14 files). The goal is to audit existing tests for quality, coverage gaps relative to interface contracts, and naming conventions — then fix straightforward gaps directly and file GitHub issues for complex ones. The output is a measurably improved test suite plus a contract-to-test coverage gap report. This is an implementation issue: the QA engineer must write actual C# test code, not just a report.
 
 ---
 
 ## 1. Scope and Inputs
 
-### Test Files Under Audit
+### 1.1 Test Files Under Audit
 
-| File | Approx. Tests | Covers |
-|------|---------------|--------|
-| `tests/Pinder.Core.Tests/RollEngineTests.cs` | 10 | d20 resolution, nat1/nat20, fail tiers, advantage/disadvantage, shadow penalty, level bonus |
-| `tests/Pinder.Core.Tests/StatBlockTests.cs` | 9 | Defence pairings, base DC, shadow penalty |
-| `tests/Pinder.Core.Tests/CharacterSystemTests.cs` | 17 | Item/anatomy loading, character assembly, prompt builder, InterestMeter basics, TimingProfile |
-| `tests/Pinder.Core.Tests/InterestMeterTests.cs` | 12 | Interest states, clamping, advantage/disadvantage, boundary transitions |
-| `tests/Pinder.Core.Tests/LlmAdapterTests.cs` | 10 | NullLlmAdapter output shapes, context type construction |
-| `tests/Pinder.Core.Tests/GameSessionTests.cs` | 11 | Turn sequencing, game outcomes, momentum, ghost trigger, FailureScale, CharacterProfile |
-| `tests/Pinder.Core.Tests/RulesConstantsTests.cs` | (inline in StatBlockTests or separate) | Numeric constants from rules-v3.4 |
+| File | Tests | Covers |
+|------|-------|--------|
+| `RollEngineTests.cs` | 10 | d20 resolution, nat1/nat20, fail tiers, advantage/disadvantage, shadow penalty, level bonus |
+| `StatBlockTests.cs` | 9 | Defence pairings, base DC |
+| `CharacterSystemTests.cs` | 17 | Item/anatomy loading, character assembly, prompt builder, InterestMeter basics, TimingProfile |
+| `InterestMeterTests.cs` | 12 | Interest states, clamping, advantage/disadvantage, boundary transitions |
+| `LlmAdapterTests.cs` | 10 | NullLlmAdapter output shapes, context type construction |
+| `GameSessionTests.cs` | 11 | Turn sequencing, game outcomes, momentum, ghost trigger, FailureScale, CharacterProfile |
+| `RiskTierTests.cs` | 19 | RiskTier computation, RiskTierBonus, boundary values |
+| `TrapTaintInjectionTests.cs` | 19 | JsonTrapRepository parsing, trap registration, error handling |
+| `TurnResultExpansionTests.cs` | 12 | TurnResult expanded fields (shadow, combo, XP, tell, weakness) |
+| `TurnResultExpansionSpecTests.cs` | 33 | TurnResult spec compliance, DialogueOption expanded fields |
+| `OpponentTimingCalculatorTests.cs` | 29 | Opponent reply delay calculation |
+| `OpponentResponseTests.cs` | 17 | OpponentResponse type, Tell, WeaknessWindow, CallbackOpportunity |
+| `JsonTimingRepositoryTests.cs` | 6 | TimingProfile JSON loading |
 
-### Contracts to Audit Against
+**Total**: 254 tests.
+
+### 1.2 Contracts to Audit Against
 
 | Contract File | Key Clauses to Check |
 |---------------|---------------------|
 | `contracts/issue-26-llm-adapter.md` | `ILlmAdapter` 4 methods; `NullLlmAdapter` behavioural contract (4 options, distinct stats, non-null text, failure prefix, null narrative beat); context type immutability |
-| `contracts/issue-27-game-session.md` | `GameSession` constructor, `StartTurnAsync` sequence (end checks, ghost trigger, advantage/disadvantage, pending options), `ResolveTurnAsync` sequence (validation, roll, interest delta, momentum, trap advance, deliver, opponent, history, turn increment); `FailureScale` deltas; `CharacterProfile` construction; `GameEndedException`; alternating call contract |
+| `contracts/issue-27-game-session.md` | `GameSession` constructor, `StartTurnAsync` sequence (end checks, ghost trigger, adv/disadv, pending options), `ResolveTurnAsync` sequence (validation, roll, interest delta, momentum, trap advance, deliver, opponent, history, turn increment); `FailureScale` deltas; `CharacterProfile` construction; `GameEndedException`; alternating call contract |
 | `contracts/issue-6-interest-state.md` | `InterestState` enum (6 values), `GetState()` boundaries, `GrantsAdvantage`/`GrantsDisadvantage` logic, exhaustive non-overlapping ranges |
 | `contracts/issue-7-rules-constants-tests.md` | Every rules-v3.4 numeric constant has a corresponding assertion |
+| `contracts/sprint-7-qa-review.md` | Meta-contract defining QA scope and deliverables |
+
+### 1.3 Source Files Referenced
+
+| Source File | What It Contains |
+|-------------|------------------|
+| `src/Pinder.Core/Rolls/RollEngine.cs` | `Resolve()` — d20 resolution with stat mod, level bonus, advantage/disadvantage, trap activation |
+| `src/Pinder.Core/Rolls/SuccessScale.cs` | `GetInterestDelta(RollResult)` — maps beat-DC-by margin to +1/+2/+3/+4 |
+| `src/Pinder.Core/Rolls/FailureScale.cs` | `GetInterestDelta(RollResult)` — maps failure tier to -1/-2/-3/-4/-5 |
+| `src/Pinder.Core/Rolls/RollResult.cs` | Roll outcome data: `IsSuccess`, `Tier`, `Total`, `DieRoll`, `DC`, `IsNatTwenty`, `IsNatOne`, `ComputeRiskTier()` |
+| `src/Pinder.Core/Rolls/RiskTierBonus.cs` | `GetInterestBonus(RollResult)` — Hard→+1, Bold→+2 |
+| `src/Pinder.Core/Stats/StatBlock.cs` | Immutable stat container, `GetDefenceDC()`, `GetEffective()`, `DefenceTable`, shadow pairs |
+| `src/Pinder.Core/Conversation/InterestMeter.cs` | Interest tracking, `GetState()`, `Apply()`, `GrantsAdvantage`, `GrantsDisadvantage`, constants `Max=25`, `Min=0`, `StartingValue=10` |
+| `src/Pinder.Core/Conversation/GameSession.cs` | Session orchestrator: `StartTurnAsync()`, `ResolveTurnAsync()`, momentum, ghost trigger |
+| `src/Pinder.Core/Conversation/NullLlmAdapter.cs` | Test-only `ILlmAdapter` implementation |
+| `src/Pinder.Core/Conversation/TurnResult.cs` | Extended with shadow events, combo, XP, tell, weakness fields |
+| `src/Pinder.Core/Conversation/OpponentTimingCalculator.cs` | Static `ComputeDelayMinutes()` |
+| `src/Pinder.Core/Interfaces/IRollDataProvider.cs` | `IDiceRoller`, `IFailurePool`, `ITrapRegistry` interfaces |
+| `src/Pinder.Core/Interfaces/ILlmAdapter.cs` | LLM adapter interface (4 async methods) |
 
 ---
 
-## 2. Audit Procedure (Function-Level)
+## 2. Audit Procedure
 
-There are no new public functions introduced by this issue. The work is analytical (audit) and corrective (new/improved tests). The QA engineer must perform the following steps as discrete tasks:
+There are no new public production functions introduced by this issue. The work is analytical (audit) and corrective (new/improved tests in `tests/Pinder.Core.Tests/`). The QA engineer must perform the following tasks:
 
 ### 2.1 Contract-First Review
 
-**Procedure**: For each contract file listed in Section 1, enumerate every behavioural clause. For each clause, search the test files for a test that exercises it. Produce a coverage matrix.
+**Procedure**: For each contract file in Section 1.2, enumerate every behavioural clause. For each clause, search test files for a test that exercises it.
 
-**Output**: A Markdown table (in the PR description) with columns:
-- `Contract` (file name)
-- `Clause` (short description)
-- `Test(s)` (test method name, or "MISSING")
-- `Action` (fixed in this PR / filed as issue #N / already covered)
+**Output**: A Markdown table in the PR description with columns:
+- `Contract` — file name
+- `Clause` — short description of the behavioural clause
+- `Test(s)` — test method name(s), or `MISSING`
+- `Action` — "already covered" / "fixed in this PR" / "filed as issue #N"
 
-### 2.2 Happy Path Coverage Audit
-
-The following happy-path scenarios must each have at least one test. If missing, add it.
+### 2.2 Happy Path Coverage
 
 #### 2.2.1 GameSession: Full 3-Turn Successful Conversation
 
-- **What to verify**: A `GameSession` initialized with `NullLlmAdapter` and a `FixedDice` that produces successes runs 3 turns. After 3 turns: interest has risen from `InterestMeter.StartingValue` (10), `TurnNumber` is 3, history contains 6 entries (3 player messages + 3 opponent messages).
-- **Existing coverage**: `GameSessionTests.ThreeTurnSession_HighRolls_SuccessfulTurns` — covers this. Audit should verify it asserts all three conditions (interest change, turn number, history length). Currently it does NOT assert history length — that is a gap.
+**What to verify**: A `GameSession` with `NullLlmAdapter` and a `FixedDice` producing high rolls runs 3 turns. After 3 turns: interest has risen above `InterestMeter.StartingValue` (10), `TurnNumber` is 3, `DeliveredMessage` and `OpponentMessage` are populated each turn.
+
+**Existing coverage**: `GameSessionTests.ThreeTurnSession_HighRolls_SuccessfulTurns` — verify it asserts interest change AND turn count. If history length is accessible via `GameStateSnapshot`, assert that too.
 
 #### 2.2.2 RollEngine: Success Margin to Interest Delta Mapping
 
-- **What to verify**: Rolls that beat the DC by 1–4, 5–9, and 10+ map to `SuccessScale` deltas of +1, +2, +3 respectively. Nat 20 maps to +4.
-- **Existing coverage**: `RollEngineTests` tests nat20 and fail tiers but does NOT directly test `SuccessScale.GetInterestDelta()` output for specific margins. This is a gap.
+**What to verify**: `SuccessScale.GetInterestDelta()` returns the correct delta for each margin range:
+- Beat DC by 1–4 → +1
+- Beat DC by 5–9 → +2
+- Beat DC by 10+ → +3
+- Nat 20 → +4
+
+**Gap**: Current `RollEngineTests` tests nat20 and fail tiers but does NOT directly test `SuccessScale.GetInterestDelta()` for specific margins. This requires new tests.
+
+**New tests to add** (at minimum):
+
+| Test Name | Input | Expected Output |
+|-----------|-------|-----------------|
+| `SuccessScale_BeatBy1_ReturnsPlus1` | `RollResult` where `BeatDcBy=1`, `IsNatTwenty=false` | `+1` |
+| `SuccessScale_BeatBy4_ReturnsPlus1` | `RollResult` where `BeatDcBy=4`, `IsNatTwenty=false` | `+1` |
+| `SuccessScale_BeatBy5_ReturnsPlus2` | `RollResult` where `BeatDcBy=5`, `IsNatTwenty=false` | `+2` |
+| `SuccessScale_BeatBy9_ReturnsPlus2` | `RollResult` where `BeatDcBy=9`, `IsNatTwenty=false` | `+2` |
+| `SuccessScale_BeatBy10_ReturnsPlus3` | `RollResult` where `BeatDcBy=10`, `IsNatTwenty=false` | `+3` |
+| `SuccessScale_Nat20_ReturnsPlus4` | `RollResult` where `IsNatTwenty=true` | `+4` |
+
+These may be implemented as a `[Theory]` with `[InlineData]`.
 
 #### 2.2.3 InterestMeter: Full State Machine Traversal
 
-- **What to verify**: A single `InterestMeter` instance transitions through all 6 states in sequence: `Interested` (start) → `VeryIntoIt` → `AlmostThere` → `DateSecured` (going up) and `Interested` → `Bored` → `Unmatched` (going down).
-- **Existing coverage**: `InterestMeterTests` covers individual boundary transitions (4→5, 15→16, 20→21, 24→25) but not a single-instance full traversal. Partial gap — boundary tests are sufficient for prototype maturity, but a full traversal test is recommended.
+**What to verify**: A single `InterestMeter` instance transitions through all 6 `InterestState` values: `Interested` (start at 10) → `VeryIntoIt` → `AlmostThere` → `DateSecured` (going up) and separately `Interested` → `Bored` → `Unmatched` (going down).
 
-### 2.3 Error/Edge Path Coverage Audit
+**Existing coverage**: `InterestMeterTests` covers individual boundary transitions at 4→5, 15→16, 20→21, 24→25. This is adequate for prototype maturity. A single full-traversal test is recommended but optional.
+
+### 2.3 Error/Edge Path Coverage
 
 #### 2.3.1 RollEngine: All 5 Failure Tiers with Correct Miss Ranges
 
-- **What to verify**: Each failure tier is triggered at the correct miss margin:
-  - Nat 1 → `Legendary` (regardless of margin)
-  - Miss by 1–2 → `Fumble`
-  - Miss by 3–5 → `Misfire`
-  - Miss by 6–9 → `TropeTrap`
-  - Miss by 10+ → `Catastrophe`
-- **Existing coverage**: `RollEngineTests` has `Nat1_IsLegendaryFail`, `MissByOne_IsFumble` (actually miss by 2), `MissByFive_IsMisfire`, `MissBySeven_IsTropeTrap`, `MissByTen_IsCatastrophe`. All 5 tiers are covered. Audit should verify boundary values (e.g., miss by exactly 2 for Fumble upper bound, miss by exactly 3 for Misfire lower bound, miss by exactly 9 for TropeTrap upper bound, miss by exactly 10 for Catastrophe lower bound).
+Per rules §5:
+- Nat 1 → `FailureTier.Legendary` (regardless of margin)
+- Miss by 1–2 → `FailureTier.Fumble`
+- Miss by 3–5 → `FailureTier.Misfire`
+- Miss by 6–9 → `FailureTier.TropeTrap`
+- Miss by 10+ → `FailureTier.Catastrophe`
 
-**Gap**: Missing boundary-exact tests. The current test names are misleading (e.g., `MissByOne_IsFumble` actually tests miss-by-2). The QA engineer should add or rename tests to cover exact boundaries.
+**Existing coverage**: Tests exist for all 5 tiers. However, boundary values need verification:
 
-#### 2.3.2 InterestMeter: Clamping at 0 and 25 with Large Deltas
+| Boundary | Expected Tier | Existing Test? |
+|----------|--------------|----------------|
+| Miss by exactly 1 | Fumble | Named `MissByOne_IsFumble` but implementation may test miss-by-2 — **audit** |
+| Miss by exactly 2 | Fumble (upper bound) | **Check** |
+| Miss by exactly 3 | Misfire (lower bound) | **Check** |
+| Miss by exactly 5 | Misfire (upper bound) | `MissByFive_IsMisfire` — verify |
+| Miss by exactly 6 | TropeTrap (lower bound) | **Check** |
+| Miss by exactly 9 | TropeTrap (upper bound) | `MissBySeven_IsTropeTrap` — off by 2, missing boundary |
+| Miss by exactly 10 | Catastrophe (lower bound) | `MissByTen_IsCatastrophe` — verify |
 
-- **What to verify**: `Apply(-100)` when at 10 clamps to 0. `Apply(+100)` when at 10 clamps to 25.
-- **Existing coverage**: `CharacterSystemTests.InterestMeter_ClampsAtMin` (applies -20 from 10) and `InterestMeter_ClampsAtMax` (applies +20 from 10). These are adequate.
+**Action**: Add missing boundary tests. Rename misleading test names.
+
+#### 2.3.2 InterestMeter: Clamping at 0 and 25
+
+**What to verify**: `Apply(-100)` from 10 clamps to 0. `Apply(+100)` from 10 clamps to 25.
+
+**Existing coverage**: `CharacterSystemTests.InterestMeter_ClampsAtMin` (applies -20) and `InterestMeter_ClampsAtMax` (applies +20). Adequate. Verify assertions use `InterestMeter.Min`/`InterestMeter.Max` constants.
 
 #### 2.3.3 GameSession: Ghost Trigger
 
-- **What to verify**: When interest is in `Bored` state (1–4), `StartTurnAsync` calls `dice.Roll(4)`. If result is 1, game ends with `GameOutcome.Ghosted`. If result is 2/3/4, turn proceeds normally.
-- **Existing coverage**: `GameSessionTests.GhostTrigger_WhenBored_25PercentChance` covers the trigger case. **Gap**: No test for the non-trigger case (dice returns 2/3/4 and turn proceeds).
+**What to verify**: When interest is in `Bored` state (1–4), `StartTurnAsync` calls `dice.Roll(4)`. If result is 1, game ends with `GameOutcome.Ghosted`. If result is 2/3/4, turn proceeds.
+
+**Existing coverage**: `GhostTrigger_WhenBored_25PercentChance` covers the trigger case.
+**Gap**: No test for the non-trigger case (dice returns 2/3/4, turn proceeds normally). Add one.
 
 #### 2.3.4 GameSession: Game Over on Interest = 0
 
-- **What to verify**: When interest reaches 0, the game ends with `GameOutcome.Unmatched` and subsequent `StartTurnAsync` throws `GameEndedException`.
-- **Existing coverage**: `GameSessionTests.EndCondition_InterestHitsZero_ThrowsOnNextStart` covers this.
+**Existing coverage**: `EndCondition_InterestHitsZero_ThrowsOnNextStart`. Adequate.
 
 #### 2.3.5 StatBlock: Shadow Penalty
 
-- **What to verify**: `GetEffective(stat)` returns `baseStat - floor(shadowStat / 3)` using the correct shadow pairing (Charm↔Madness, Rizz↔Horniness, etc.).
-- **Existing coverage**: `RollEngineTests.ShadowPenalty_ReducesModifier` tests Charm with Madness=9 → penalty 3. **Gap**: Only one shadow pair is tested. Ideally test at least 2-3 pairs, and test floor behavior (e.g., shadow=4 → penalty 1, shadow=5 → penalty 1, shadow=6 → penalty 2).
+**What to verify**: `GetEffective(stat)` returns `baseStat - floor(shadowStat / 3)`.
 
-### 2.4 Test Quality Audit
+**Existing coverage**: `RollEngineTests.ShadowPenalty_ReducesModifier` tests Charm with Madness=9 → penalty 3.
+**Gap**: Only one shadow pair tested. Should test additional pairs and floor behavior (shadow=1→0, shadow=2→0, shadow=3→1, shadow=5→1, shadow=6→2).
+
+### 2.4 Test Quality
 
 #### 2.4.1 Test Naming Convention
 
-**Required pattern**: Descriptive method names that express the scenario and expected outcome. Acceptable patterns:
-- `MethodUnderTest_Scenario_ExpectedResult` (e.g., `GetDefenceDC_BaseDCIs13`)
-- `Given_When_Then` style
+**Required pattern**: `MethodUnderTest_Scenario_ExpectedResult` or descriptive `Given_When_Then`.
 
-**Violations to flag and fix**:
-- `Nat20_IsAlwaysSuccess` — missing the method under test prefix. Should be `Resolve_Nat20_IsAlwaysSuccess` or similar.
-- `Nat1_IsLegendaryFail` — same issue.
-- `MissByOne_IsFumble` — misleading name (tests miss-by-2, not miss-by-1). Rename to `Resolve_MissByTwo_IsFumble` or fix to actually test miss-by-1.
+**Known violations to fix**:
+- `Nat20_IsAlwaysSuccess` → `Resolve_Nat20_IsAlwaysSuccess`
+- `Nat1_IsLegendaryFail` → `Resolve_Nat1_IsLegendaryFailure`
+- `MissByOne_IsFumble` → rename to match actual miss margin tested
+- `Disadvantage_UsesMinium` → `Resolve_Disadvantage_UsesMinimum` (also fix typo "Minium")
 
 #### 2.4.2 Assert-Only-No-Throw Anti-Pattern
 
-**Rule**: Every test must assert at least one specific output value, not merely that execution completes without throwing.
+**Rule**: Every test must assert at least one specific output value via `Assert.*`. No test should only verify a method runs without throwing.
 
-**Review each test**: Verify no test body is just a method call with no `Assert.*`. Current tests appear to all have assertions — confirm during audit.
+**Action**: Audit all 254 tests. Flag any that lack `Assert.*` calls checking return values.
 
 #### 2.4.3 Magic Number Elimination
 
-**Rule**: Where a constant exists in the production code, tests should reference it rather than hardcoding the value.
+**Rule**: Where a named constant exists in production code, tests should reference it.
 
-**Known violations to check**:
-- Tests that use literal `10` for starting interest should use `InterestMeter.StartingValue`.
-- Tests that use literal `25` for max interest should use `InterestMeter.Max`.
-- Tests that use literal `0` for min interest should use `InterestMeter.Min`.
-- Tests that use literal `13` for base DC should reference `StatBlock` if it exposes a constant (if not, the literal is acceptable with a comment).
+| Magic Number | Replacement Constant |
+|-------------|---------------------|
+| `10` (starting interest) | `InterestMeter.StartingValue` |
+| `25` (max interest) | `InterestMeter.Max` |
+| `0` (min interest) | `InterestMeter.Min` |
+| `13` (base DC) | Comment referencing §3 if no public constant exists |
 
-**Note**: Some existing tests in `CharacterSystemTests` already reference `InterestMeter.Max` and `InterestMeter.StartingValue`. Others in `GameSessionTests` use literal `10`. These should be made consistent.
+**Note**: Literal values used as test *inputs* (dice rolls, stat values) are acceptable — they represent test scenarios, not system constants.
 
 #### 2.4.4 NullLlmAdapter Structural Verification
 
-**Rule**: `NullLlmAdapter` tests must verify structural correctness, not just non-null.
-
 **What to verify**:
-- `GetDialogueOptionsAsync`: returns exactly 4 options, each with a distinct `StatType` from {Charm, Honesty, Wit, Chaos}, each with non-null non-empty `IntendedText`.
-- `DeliverMessageAsync` success: returns the `IntendedText` verbatim.
-- `DeliverMessageAsync` failure: returns string prefixed with `[{FailureTier}] `.
-- `GetOpponentResponseAsync`: returns non-null, non-empty string.
-- `GetInterestChangeBeatAsync`: returns null.
+- `GetDialogueOptionsAsync`: returns exactly 4 options, each with a distinct `StatType` from {Charm, Honesty, Wit, Chaos}, each with non-null non-empty `IntendedText`
+- `DeliverMessageAsync` success: returns `IntendedText` verbatim
+- `DeliverMessageAsync` failure: returns string prefixed with `[{FailureTier}] `
+- `GetOpponentResponseAsync`: returns non-null, non-empty string
+- `GetInterestChangeBeatAsync`: returns null
 
-**Existing coverage**: `LlmAdapterTests` already covers all of these. This criterion is already met.
+**Existing coverage**: `LlmAdapterTests` covers all of the above. Already adequate.
 
 ### 2.5 Mock/Interface Drift Check
 
 #### 2.5.1 NullLlmAdapter vs ILlmAdapter
 
-**What to verify**: `NullLlmAdapter` implements `ILlmAdapter` (compiler enforces this). Method signatures match: same async `Task<T>` return types, same parameter types. This is enforced by the C# compiler — if `NullLlmAdapter : ILlmAdapter`, it compiles only if signatures match.
-
-**Action**: Confirm `NullLlmAdapter` declaration includes `: ILlmAdapter`. Already true if the code compiles.
+`NullLlmAdapter` implements `ILlmAdapter` — compiler enforces signature compliance. Verify the declaration includes `: ILlmAdapter`. If it compiles, signatures match.
 
 #### 2.5.2 FixedDice vs IDiceRoller
 
-**What to verify**: `FixedDice` in `GameSessionTests.cs` implements `IDiceRoller`. Confirm `public int Roll(int sides)` signature matches.
+**Known issue**: Multiple `FixedDice` implementations exist across test files:
+1. `RollEngineTests.cs` — private class
+2. `GameSessionTests.cs` — public class with `Enqueue` method
+3. `CharacterSystemTests.cs` — private class
 
-**Known issue**: There are TWO `FixedDice` implementations — one in `RollEngineTests.cs` (private class) and one in `GameSessionTests.cs` (public class). Additionally, `CharacterSystemTests.cs` has a third private `FixedDice`. These should be consolidated into a single shared test helper.
+**Action**: Consolidate into a single shared `FixedDice` class in a common location (e.g., `tests/Pinder.Core.Tests/TestHelpers/FixedDice.cs` or a `TestHelpers.cs` file). All must implement `IDiceRoller` with signature `int Roll(int sides)`. Update all references. Verify compilation passes.
 
 ---
 
-## 3. Acceptance Criteria (mapped from issue)
+## 3. Function Signatures
+
+This issue introduces no new production code. All changes are in `tests/Pinder.Core.Tests/`.
+
+### Test Helper (consolidation target)
+
+```csharp
+// tests/Pinder.Core.Tests/TestHelpers/FixedDice.cs (or similar)
+namespace Pinder.Core.Tests.TestHelpers
+{
+    public sealed class FixedDice : IDiceRoller
+    {
+        // Constructor accepting predetermined roll sequence
+        public FixedDice(params int[] rolls);
+
+        // Optional: enqueue additional rolls
+        public void Enqueue(params int[] values);
+
+        // IDiceRoller implementation — returns next value from sequence
+        // Falls back to `sides` (max value) when sequence is exhausted
+        public int Roll(int sides);
+    }
+}
+```
+
+### New Test Methods (minimum 5 required)
+
+The QA engineer must add at least 5 new or improved tests. Recommended additions:
+
+1. **`SuccessScale_BeatByMargin_ReturnsCorrectDelta`** — `[Theory]` covering margins 1, 4, 5, 9, 10, and nat20
+2. **`Resolve_MissByExactly1_IsFumble`** — boundary test for Fumble lower bound
+3. **`Resolve_MissByExactly3_IsMisfire`** — boundary test for Misfire lower bound
+4. **`Resolve_MissByExactly9_IsTropeTrap`** — boundary test for TropeTrap upper bound
+5. **`GhostTrigger_WhenBored_DiceReturns2_TurnProceeds`** — non-trigger ghost case
+6. **`ShadowPenalty_MultipleStatPairs_CorrectFloor`** — additional shadow pair tests
+7. **`GetEffective_ShadowFloorBehavior`** — shadow=4→penalty 1, shadow=6→penalty 2
+
+---
+
+## 4. Input/Output Examples
+
+### 4.1 SuccessScale Margin Mapping
+
+| BeatDcBy | IsNatTwenty | Expected Delta |
+|----------|-------------|----------------|
+| 1 | false | +1 |
+| 4 | false | +1 |
+| 5 | false | +2 |
+| 9 | false | +2 |
+| 10 | false | +3 |
+| 15 | false | +3 |
+| any | true | +4 |
+
+### 4.2 FailureTier Boundary Values
+
+To produce a specific miss margin, set up `StatBlock` and `FixedDice` such that:
+`miss_margin = DC - (DieRoll + StatMod + LevelBonus)`
+
+Example: To test miss-by-exactly-3 (Misfire lower bound):
+- Attacker Charm=0, Level=1 (LevelBonus=0)
+- Defender SA=0 → DC=13
+- DieRoll=10 → Total=10, miss by 3
+- Expected: `FailureTier.Misfire`
+
+### 4.3 Shadow Penalty Floor Behavior
+
+| Shadow Value | Expected Penalty (floor(shadow/3)) |
+|-------------|-----------------------------------|
+| 0 | 0 |
+| 1 | 0 |
+| 2 | 0 |
+| 3 | 1 |
+| 4 | 1 |
+| 5 | 1 |
+| 6 | 2 |
+| 9 | 3 |
+
+---
+
+## 5. Acceptance Criteria
 
 ### AC-1: Contract-First Review
 
-**Criterion**: Read contracts in `contracts/` (especially `issue-27-game-session.md`, `issue-26-llm-adapter.md`) and verify every contract clause has at least one test. Flag any clause with NO test.
-
-**Specification**: The QA engineer must produce a contract-to-test matrix as described in Section 2.1. Every row with "MISSING" in the Test(s) column constitutes a gap. Gaps that are straightforward to fix (e.g., adding a simple assertion) must be fixed in this PR. Gaps requiring complex business logic must be filed as separate GitHub issues with the `test-gap` label.
+Read contracts in `contracts/` and verify every contract clause has at least one test. The PR description must contain a contract-to-test coverage matrix. Every row marked "MISSING" is a gap. Straightforward gaps (simple assertion additions) must be fixed in this PR. Complex gaps must be filed as GitHub issues with label `test-gap`.
 
 ### AC-2: Happy Path — GameSession 3-Turn Conversation
 
-**Criterion**: A full 3-turn successful conversation test where interest rises from 10 toward the date-secured range.
-
-**Specification**: `GameSessionTests.ThreeTurnSession_HighRolls_SuccessfulTurns` exists but should additionally assert that `result.StateAfter` contains the expected history length (6 entries after 3 turns, if exposed via snapshot) or that `DeliveredMessage` and `OpponentMessage` are populated each turn. If `GameStateSnapshot` does not expose history length, assert turn number and interest values instead (already done).
+Verify `GameSessionTests.ThreeTurnSession_HighRolls_SuccessfulTurns` asserts: (a) interest rose above starting value, (b) turn number is 3, (c) `DeliveredMessage` and `OpponentMessage` are non-null each turn. Add missing assertions if needed.
 
 ### AC-3: Happy Path — RollEngine Success Margins
 
-**Criterion**: Success with exact margin mapping to +1/+2/+3 interest (beat by 1–4, 5–9, 10+).
-
-**Specification**: Add tests (or verify existing) that call `SuccessScale.GetInterestDelta()` with `RollResult` objects where:
-- `BeatDcBy` = 1 → returns +1
-- `BeatDcBy` = 4 → returns +1
-- `BeatDcBy` = 5 → returns +2
-- `BeatDcBy` = 9 → returns +2
-- `BeatDcBy` = 10 → returns +3
-- Nat 20 (`IsNatTwenty = true`) → returns +4
-
-Each assertion must check the exact return value. If `SuccessScale` tests don't exist in a dedicated file, they may be added to `RollEngineTests.cs` or a new `SuccessScaleTests.cs`.
+Add tests verifying `SuccessScale.GetInterestDelta()` returns +1 for beat-by 1–4, +2 for beat-by 5–9, +3 for beat-by 10+, +4 for nat20. At minimum test all boundary values (1, 4, 5, 9, 10).
 
 ### AC-4: Happy Path — InterestMeter Full State Machine
 
-**Criterion**: Transition through all 6 InterestState values.
-
-**Specification**: Already covered by boundary transition tests in `InterestMeterTests.cs`. A single full-traversal test (up from 10→25, down from 10→0) would improve confidence but is optional at prototype maturity.
+Verify all 6 `InterestState` values are covered by existing boundary tests. Optionally add a full-traversal test.
 
 ### AC-5: Error Path — All 5 Failure Tiers
 
-**Criterion**: All 5 fail tiers triggered with correct miss ranges (Fumble 1–2, Misfire 3–5, TropeTrap 6–9, Catastrophe 10+, Legendary Nat1).
-
-**Specification**: Existing tests cover all 5 tiers. The QA pass should verify boundary correctness:
-- Miss by exactly 1 → Fumble
-- Miss by exactly 2 → Fumble (upper bound)
-- Miss by exactly 3 → Misfire (lower bound)
-- Miss by exactly 5 → Misfire (upper bound)
-- Miss by exactly 6 → TropeTrap (lower bound)
-- Miss by exactly 9 → TropeTrap (upper bound)
-- Miss by exactly 10 → Catastrophe (lower bound)
-
-Add any missing boundary tests. Fix misleading test names.
+Verify all 5 failure tiers are tested. Add boundary-exact tests where missing (miss by exactly 1, 2, 3, 5, 6, 9, 10). Fix misleading test names.
 
 ### AC-6: Error Path — InterestMeter Clamping
 
-**Criterion**: Clamping at 0 and 25 with large deltas.
+Verify clamping tests exist and use named constants (`InterestMeter.Min`, `InterestMeter.Max`) rather than magic numbers.
 
-**Specification**: Already covered. Verify assertions reference `InterestMeter.Min` and `InterestMeter.Max` constants rather than magic numbers.
+### AC-7: Error Path — Ghost Trigger (Non-Trigger Case)
 
-### AC-7: Error Path — Ghost Trigger
-
-**Criterion**: GameSession ghost trigger (interest in Bored state, 25% per turn).
-
-**Specification**: Existing test covers trigger case. Add a test for the non-trigger case: interest in Bored range, `dice.Roll(4)` returns 2, `StartTurnAsync` returns a `TurnStart` (does NOT throw).
+Add a test: interest in Bored range, `dice.Roll(4)` returns 2 (or 3 or 4), `StartTurnAsync` returns `TurnStart` without throwing.
 
 ### AC-8: Error Path — Game Over on Interest = 0
 
-**Criterion**: Already covered by `EndCondition_InterestHitsZero_ThrowsOnNextStart`.
+Already covered. Verify test name is descriptive.
 
 ### AC-9: Error Path — Shadow Penalty
 
-**Criterion**: Shadow penalty correctly reduces effective stat (`floor(shadow/3)`).
+Add tests for additional shadow pairs beyond Charm↔Madness. Add floor-behavior tests (shadow=1→0, shadow=3→1, shadow=6→2).
 
-**Specification**: Add tests for at least one additional shadow pair beyond Charm↔Madness. Test floor behavior: shadow=1 → penalty 0, shadow=2 → penalty 0, shadow=3 → penalty 1, shadow=5 → penalty 1, shadow=6 → penalty 2.
+### AC-10: Test Naming Convention
 
-### AC-10: Test Quality — Naming Convention
+Rename tests with ambiguous or misleading names. At minimum fix: `Nat20_IsAlwaysSuccess`, `Nat1_IsLegendaryFail`, `MissByOne_IsFumble` (if it tests a different margin), `Disadvantage_UsesMinium` (typo).
 
-**Criterion**: Test method names follow descriptive pattern.
+### AC-11: No Assert-Only-No-Throw
 
-**Specification**: Rename tests with ambiguous or misleading names. At minimum:
-- `Nat20_IsAlwaysSuccess` → `Resolve_Nat20_IsAlwaysSuccess`
-- `Nat1_IsLegendaryFail` → `Resolve_Nat1_IsLegendaryFailure`
-- `MissByOne_IsFumble` → rename to match actual miss margin tested
+Confirm all tests have at least one `Assert.*` call checking a return value, property, or exception type. Flag and fix any violations.
 
-### AC-11: Test Quality — No Assert-Only-No-Throw
+### AC-12: No Magic Numbers
 
-**Criterion**: No tests assert only that a method doesn't throw.
+Replace hardcoded `10`/`25`/`0` with `InterestMeter.StartingValue`/`InterestMeter.Max`/`InterestMeter.Min` in test assertions where those constants exist and the value represents the same concept.
 
-**Specification**: Confirm all tests have at least one `Assert.*` call checking a return value, property, or exception type.
+### AC-13: NullLlmAdapter Structural Verification
 
-### AC-12: Test Quality — No Magic Numbers
+Verify `LlmAdapterTests` covers all structural assertions (4 options, distinct stats, non-null text, failure prefix, null narrative beat). Already adequate — confirm only.
 
-**Criterion**: Constants reference `InterestMeter.Max`, `InterestMeter.StartingValue`, etc.
+### AC-14: Mock/Interface Drift — FixedDice Consolidation
 
-**Specification**: Replace hardcoded `10` with `InterestMeter.StartingValue`, `25` with `InterestMeter.Max`, `0` with `InterestMeter.Min` in test assertions where applicable. Literal values in test setup (e.g., dice roll values, stat values) are acceptable since they represent test inputs, not system constants.
-
-### AC-13: Test Quality — NullLlmAdapter Structural Verification
-
-**Criterion**: Verify output is structurally correct (4 options, correct stat types, non-null texts).
-
-**Specification**: Already covered by `LlmAdapterTests`. No action needed.
-
-### AC-14: Mock/Interface Drift Check
-
-**Criterion**: `NullLlmAdapter` matches `ILlmAdapter`; `FixedDice` matches `IDiceRoller`.
-
-**Specification**: Compiler enforces interface compliance. The QA engineer should additionally verify there is no parameter name drift (parameter names match between interface and implementation). Consolidate duplicate `FixedDice` implementations into a single shared test helper class.
+Consolidate duplicate `FixedDice` implementations into a single shared test helper. Verify it implements `IDiceRoller` with correct signature. Update all test files to use the shared implementation. All tests must still compile and pass.
 
 ### AC-15: Report Findings
 
-**Criterion**: Open a GitHub issue for each gap found (label `test-gap`). Fix straightforward gaps in this PR. Leave complex gaps as issues.
-
-**Specification**: The PR description must contain:
-1. Contract-to-test coverage matrix
+PR description must contain:
+1. Contract-to-test coverage matrix (per AC-1)
 2. List of tests added/renamed/improved
-3. List of issues filed for deferred gaps
-4. Confirmation that `dotnet test` passes with no regressions
+3. List of issues filed for deferred gaps (with issue numbers)
+4. Confirmation that `dotnet test` passes with zero regressions
 
 ---
 
-## 4. Edge Cases
+## 6. Edge Cases
 
-- **Duplicate FixedDice classes**: Three separate `FixedDice` implementations exist across test files. Consolidation must not break existing tests. The shared helper should live in a common location (e.g., a `TestHelpers` class or file in the test project root).
-- **RulesConstantsTests location**: The issue mentions `RulesConstantsTests.cs` as a standalone file, but it may be embedded in `StatBlockTests.cs`. The audit should locate and verify its existence.
-- **Test count regression**: The issue states 98 existing tests. After the QA pass, the count must be ≥ 98 (tests may be added or renamed, but none removed unless they are genuinely wrong). Run `dotnet test` and compare counts.
-- **CharacterSystemTests file-loading**: Some tests in `CharacterSystemTests.cs` load JSON from the filesystem (`/root/.openclaw/agents-extra/pinder/data/...`). These tests are environment-dependent. The QA engineer should note this as a known limitation but not attempt to fix it in this sprint (it requires a test data embedding strategy).
+| Edge Case | Handling |
+|-----------|---------|
+| Duplicate FixedDice classes across 3 files | Consolidate into one shared helper. Must not break any existing test. Run `dotnet test` after consolidation. |
+| RulesConstantsTests location ambiguous | May be embedded in `StatBlockTests.cs` or exist as a separate file. Audit must locate it and verify coverage. |
+| Test count must not decrease | After QA pass, `dotnet test` must report ≥ 254 passed. Tests may be renamed but not removed unless genuinely incorrect (document any removal with justification). |
+| `CharacterSystemTests` depends on filesystem JSON | Tests loading from external paths are environment-dependent. Note as known limitation — do not attempt to fix in this sprint. |
+| `RollResult` construction for SuccessScale tests | `RollResult` may have a private constructor or require specific factory patterns. Check actual constructor signature before writing tests. If `RollResult` cannot be easily constructed in tests, document this as a testability gap. |
+| Renaming tests may break CI references | If any CI config references test names by string, renaming could break. Check for `.runsettings` or CI filter expressions. |
+| `SuccessScale`/`FailureScale` may take `RollResult` not raw values | Tests must construct valid `RollResult` objects, not call with raw ints. Check method signatures. |
 
 ---
 
-## 5. Error Conditions
+## 7. Error Conditions
 
 | Condition | Expected Behavior |
 |-----------|-------------------|
-| Contract clause has no corresponding test | Flag as gap in coverage matrix; fix if straightforward, file issue if complex |
-| Test name is misleading | Rename the test method; ensure old and new names don't conflict |
-| Magic number found in assertion | Replace with named constant from production code |
-| `dotnet test` fails after changes | All changes must be reverted or fixed before PR is opened |
-| `dotnet test` count drops below 98 | Investigate — no tests should be deleted without replacement |
-| Duplicate test helper classes | Consolidate; update all references; verify compilation |
+| Contract clause has no corresponding test | Flag as gap in coverage matrix; fix if straightforward, file issue with `test-gap` label if complex |
+| Test name is misleading (e.g., says miss-by-1 but tests miss-by-2) | Rename the test method to accurately describe what it tests |
+| Magic number in test assertion for a value that has a named constant | Replace with the named constant reference |
+| `dotnet test` fails after changes | Revert or fix before opening PR. Never merge failing tests. |
+| Test count drops below 254 | Investigate — no tests should be deleted without a replacement and documented justification |
+| Duplicate test helper consolidation breaks compilation | Fix all `using` statements and namespaces. Verify with `dotnet build` before `dotnet test`. |
+| `RollResult` not constructible from tests | Document as testability gap issue. May need to add a test-friendly constructor or factory. |
 
 ---
 
-## 6. Dependencies
+## 8. Dependencies
 
 | Dependency | Type | Status |
 |------------|------|--------|
-| All existing test files compile and pass | Prerequisite | Assumed — run `dotnet test` before starting audit |
+| All 254 existing tests compile and pass | Prerequisite | Verified — `dotnet test` returns 254 passed |
 | `contracts/issue-26-llm-adapter.md` | Input (audit reference) | Exists on main |
 | `contracts/issue-27-game-session.md` | Input (audit reference) | Exists on main |
 | `contracts/issue-6-interest-state.md` | Input (audit reference) | Exists on main |
 | `contracts/issue-7-rules-constants-tests.md` | Input (audit reference) | Exists on main |
+| `contracts/sprint-7-qa-review.md` | Input (meta-contract) | Exists on main |
 | xUnit test framework | External library | Already in test project |
 | .NET SDK (netstandard2.0 target, net8.0 test runner) | Tooling | Already configured |
-| `NullLlmAdapter` | Production code | Exists at `src/Pinder.Core/Conversation/NullLlmAdapter.cs` |
-| `FixedDice` (test helper) | Test code | Exists in `GameSessionTests.cs` (public), `RollEngineTests.cs` (private), `CharacterSystemTests.cs` (private) |
+| `NullLlmAdapter` | Production code (under audit) | `src/Pinder.Core/Conversation/NullLlmAdapter.cs` |
+| `FixedDice` (test helper) | Test code (consolidation target) | Multiple copies in `GameSessionTests.cs`, `RollEngineTests.cs`, `CharacterSystemTests.cs` |
+| No production source code changes | Constraint | This issue modifies ONLY files under `tests/` |
 
 ---
 
-## 7. Definition of Done
+## 9. Definition of Done
 
 - [ ] QA report (contract-to-test coverage matrix) written and posted as PR description
 - [ ] At minimum 5 new or improved tests added
-- [ ] All new tests pass (`dotnet test`)
-- [ ] No test regressions — all pre-existing tests still pass (count ≥ 98)
+- [ ] All tests pass (`dotnet test`) — zero failures
+- [ ] No test regressions — test count ≥ 254
 - [ ] Contract-to-test coverage gap report in PR description
 - [ ] Any complex gaps filed as GitHub issues with `test-gap` label
+- [ ] Test naming violations fixed (at minimum the 4 listed in AC-10)
+- [ ] Magic numbers replaced with named constants where applicable
+- [ ] FixedDice consolidation completed (or documented as deferred if complex)
+- [ ] No production source code modified (`src/` unchanged)


### PR DESCRIPTION
Fixes #38

## DoD Evidence
**Branch:** issue-38-write-spec-document-qa-review-audit-and-
**Commit:** 61c7cf3

## Summary
Updated spec document `docs/specs/issue-38-spec.md` for the QA review audit issue. The previous version was written against 98 tests; this revision reflects the current 254-test baseline and includes:

- Complete inventory of all 14 test files (254 tests)
- Contract-to-test audit procedure against 5 contract files
- Specific new tests to add (SuccessScale margins, failure tier boundaries, ghost non-trigger, shadow pair coverage)
- Test quality standards (naming, magic numbers, assert patterns)
- FixedDice consolidation specification
- Input/output examples with concrete values
- Edge cases and error conditions
- Clear acceptance criteria mapped from issue requirements
