### PR TITLE
[Issue #139] Architecture Review: RPG Rules Complete — Sprint 8

### DIFF
--- a/contracts/sprint-8-callback-bonus.md
+++ b/contracts/sprint-8-callback-bonus.md
@@ -1,0 +1,44 @@
+# Contract: Issue #47 — Callback Bonus (§15)
+
+## Component
+Callback distance detection + bonus computation in `GameSession`
+
+## Depends on
+- #139 Wave 0: `RollEngine.Resolve(externalBonus)` for flowing bonus into roll
+
+## Maturity: Prototype
+
+---
+
+## Callback Bonus Table
+
+| When topic introduced | Distance | Hidden roll bonus |
+|---|---|---|
+| 2 turns ago | 2 | +1 |
+| 4+ turns ago | 4+ | +2 |
+| Opener (turn 0) | any (first message) | +3 |
+
+---
+
+## Data Flow
+
+1. `DialogueOption.CallbackTurnNumber` set by LLM when option references a prior topic
+2. In `ResolveTurnAsync`: if `chosenOption.CallbackTurnNumber != null`:
+   - `callbackTurnNumber == 0` → bonus = +3 (opener)
+   - `distance >= 4` → bonus = +2
+   - `distance >= 2` → bonus = +1
+   - else → bonus = 0
+3. Bonus summed with tell + triple combo into single `externalBonus` param to `RollEngine.Resolve()`
+4. `TurnResult.CallbackBonusApplied` = computed bonus value
+
+## Behavioral Invariants
+- Callback bonus is **hidden** — displayed success % does NOT include it
+- Bonus = 0 if `CallbackTurnNumber` is null
+- Multiple bonuses (callback + tell + triple) summed into single `externalBonus`
+
+## Dependencies
+- `RollEngine.Resolve(externalBonus)` (#139)
+- `DialogueOption.CallbackTurnNumber` (already exists)
+
+## Consumers
+- `TurnResult.CallbackBonusApplied` (already exists on TurnResult)

--- a/contracts/sprint-8-combo-system.md
+++ b/contracts/sprint-8-combo-system.md
@@ -1,0 +1,78 @@
+# Contract: Issue #46 — Combo System (§15)
+
+## Component
+`Pinder.Core.Conversation.ComboTracker` (new class)
+
+## Depends on
+- #139 Wave 0: `RollEngine.Resolve(externalBonus)` for The Triple's +1 roll bonus
+
+## Maturity: Prototype
+
+---
+
+## ComboTracker
+
+**File:** `src/Pinder.Core/Conversation/ComboTracker.cs`
+
+```csharp
+namespace Pinder.Core.Conversation
+{
+    public sealed class ComboTracker
+    {
+        /// <summary>Record the stat used this turn and whether the roll succeeded.</summary>
+        public void RecordTurn(StatType stat, bool succeeded);
+
+        /// <summary>
+        /// After RecordTurn, check if a combo completed this turn.
+        /// Returns combo name and bonus, or null if no combo fired.
+        /// Only returns a value when the completing roll succeeded.
+        /// </summary>
+        public ComboResult? CheckCombo();
+
+        /// <summary>
+        /// True if The Triple was completed last turn → +1 to all rolls this turn.
+        /// Resets to false after being read (one-turn only).
+        /// </summary>
+        public bool HasTripleBonus { get; }
+
+        /// <summary>
+        /// Returns which combo(s) would be completed if the given stat were played and succeeded.
+        /// Used by StartTurnAsync to preview combos on dialogue options.
+        /// </summary>
+        public string? PeekCombo(StatType stat);
+    }
+
+    public sealed class ComboResult
+    {
+        public string Name { get; }
+        public int InterestBonus { get; }    // 0 for The Triple (roll bonus instead)
+        public bool IsTriple { get; }        // true = +1 roll bonus next turn
+    }
+}
+```
+
+## Combo Definitions
+
+| Name | Sequence | Interest Bonus |
+|---|---|---|
+| The Setup | Wit → Charm (success) | +1 |
+| The Reveal | Charm → Honesty (success) | +1 |
+| The Read | SA → Honesty (success) | +1 |
+| The Pivot | Honesty → Chaos (success) | +1 |
+| The Recovery | Any fail → SA (success) | +2 |
+| The Escalation | Chaos → Rizz (success) | +1 |
+| The Disarm | Wit → Honesty (success) | +1 |
+| The Triple | 3 different stats in 3 turns (success on 3rd) | +1 roll bonus next turn |
+
+## Behavioral Invariants
+- Only fires when completing roll succeeds
+- The Recovery: first element = any stat that failed (not a specific stat)
+- The Triple: 3 distinct StatType values in last 3 turns; only 3rd must succeed
+- ComboTracker is pure data — GameSession applies interest/roll bonus
+- Multiple combos can match but only the highest-bonus one fires (or first if tied)
+
+## Dependencies
+- `StatType`
+
+## Consumers
+- `GameSession.ResolveTurnAsync()` and `GameSession.StartTurnAsync()` (peek)

--- a/contracts/sprint-8-conversation-registry.md
+++ b/contracts/sprint-8-conversation-registry.md
@@ -1,0 +1,118 @@
+# Contract: Issue #56 — ConversationRegistry
+
+## Component
+`Pinder.Core.Conversation.ConversationRegistry` (new class) + supporting types
+
+## Depends on
+- #54: GameClock (IGameClock for time management)
+- #44: Shadow growth (SessionShadowTracker for cross-chat bleed)
+- #139: IGameClock, SessionShadowTracker, GameSessionConfig
+
+## Maturity: Prototype
+
+---
+
+## New Types
+
+### ConversationLifecycle
+
+```csharp
+public enum ConversationLifecycle
+{
+    Active,
+    Paused,
+    Ghosted,
+    Fizzled,
+    DateSecured,
+    Unmatched
+}
+```
+
+### ConversationEntry
+
+```csharp
+public sealed class ConversationEntry
+{
+    public string ConversationId { get; }
+    public GameSession Session { get; }
+    public ConversationLifecycle Lifecycle { get; }
+    public DateTimeOffset? NextOpponentReplyAt { get; }
+    public DateTimeOffset LastActivity { get; }
+}
+```
+
+### CrossChatEvent
+
+```csharp
+public sealed class CrossChatEvent
+{
+    public string SourceConversationId { get; }
+    public string TargetConversationId { get; }
+    public ShadowStatType Shadow { get; }
+    public int Amount { get; }
+    public string Reason { get; }
+}
+```
+
+### ConversationRegistry
+
+```csharp
+public sealed class ConversationRegistry
+{
+    public ConversationRegistry(IGameClock clock);
+
+    /// <summary>Register a new conversation.</summary>
+    public void Add(string conversationId, GameSession session);
+
+    /// <summary>Get a conversation by ID.</summary>
+    public ConversationEntry? Get(string conversationId);
+
+    /// <summary>All active conversations.</summary>
+    public IReadOnlyList<ConversationEntry> Active { get; }
+
+    /// <summary>Schedule when the opponent will reply in a conversation.</summary>
+    public void ScheduleOpponentReply(string conversationId, TimeSpan delay);
+
+    /// <summary>
+    /// Advance clock to the next scheduled event. Returns conversations with ready replies.
+    /// Does NOT execute turns — host is responsible for calling GameSession methods.
+    /// </summary>
+    public IReadOnlyList<string> FastForward();
+
+    /// <summary>
+    /// Check ghost/fizzle conditions across all active conversations.
+    /// Returns list of conversations whose lifecycle changed.
+    /// </summary>
+    public IReadOnlyList<string> CheckLifecycleEvents();
+
+    /// <summary>
+    /// Apply cross-chat shadow bleed: shadow growth in one conversation bleeds into others.
+    /// Returns list of cross-chat events that were applied.
+    /// </summary>
+    public IReadOnlyList<CrossChatEvent> ApplyShadowBleed();
+}
+```
+
+## Behavioral Invariants
+- Registry does NOT make LLM calls
+- Registry does NOT execute turns on GameSession
+- Registry owns scheduling and lifecycle, host owns turn execution
+- Ghost: conversation idle > 24h with interest < 10 → Ghosted
+- Fizzle: conversation idle > 48h regardless of interest → Fizzled
+- Shadow bleed: when shadow growth occurs in one conversation, 50% (rounded down) bleeds to other active conversations' SessionShadowTrackers
+
+## GameSession Public Interest Accessor (#160)
+ConversationRegistry needs to read current interest from GameSession. Add:
+
+```csharp
+// On GameSession:
+public int CurrentInterest => _interest.Current;
+```
+
+## Dependencies
+- `IGameClock` (#54/#139)
+- `SessionShadowTracker` (#139)
+- `GameSession` (existing + #160 accessor)
+
+## Consumers
+- Host (Unity game loop or test harness)

--- a/contracts/sprint-8-game-clock.md
+++ b/contracts/sprint-8-game-clock.md
@@ -1,0 +1,58 @@
+# Contract: Issue #54 — GameClock Implementation
+
+## Component
+`Pinder.Core.Conversation.GameClock` — concrete implementation of `IGameClock`
+
+## Maturity: Prototype
+## NFR: all methods < 1ms
+
+---
+
+## GameClock
+
+**File:** `src/Pinder.Core/Conversation/GameClock.cs`
+
+```csharp
+namespace Pinder.Core.Conversation
+{
+    public sealed class GameClock : IGameClock
+    {
+        /// <param name="startTime">Initial simulated time.</param>
+        /// <param name="dailyEnergy">Energy budget per day. Default: 10.</param>
+        public GameClock(DateTimeOffset startTime, int dailyEnergy = 10);
+
+        public DateTimeOffset Now { get; }
+        public void Advance(TimeSpan amount);               // amount must be positive
+        public void AdvanceTo(DateTimeOffset target);        // target > Now, else ArgumentException
+        public TimeOfDay GetTimeOfDay();                     // based on Now.Hour
+        public int GetHorninessModifier();                   // Morning=-2, Afternoon=0, Evening=+1, LateNight=+3, AfterTwoAm=+5
+        public int RemainingEnergy { get; }
+        public bool ConsumeEnergy(int amount);               // false if insufficient
+    }
+}
+```
+
+**Time-of-Day mapping (Now.Hour):**
+- 6–11 → Morning
+- 12–17 → Afternoon
+- 18–21 → Evening
+- 22–23, 0–1 → LateNight
+- 2–5 → AfterTwoAm
+
+**Energy:** resets when day changes (crossing midnight). `ConsumeEnergy` returns false and does NOT deduct when insufficient.
+
+**Testing helper (same file or separate):**
+
+```csharp
+/// <summary>Fixed clock for deterministic testing.</summary>
+public sealed class FixedGameClock : IGameClock
+{
+    // Constructor takes all values as params for full control
+}
+```
+
+## Dependencies
+- `IGameClock`, `TimeOfDay` (from #139 Wave 0)
+
+## Consumers
+- #51 (Horniness), #55 (PlayerResponseDelay), #56 (ConversationRegistry)

--- a/contracts/sprint-8-horniness-forced-rizz.md
+++ b/contracts/sprint-8-horniness-forced-rizz.md
@@ -1,0 +1,53 @@
+# Contract: Issue #51 — Horniness-Forced Rizz (§15 🔥 Mechanic)
+
+## Component
+`Pinder.Core.Conversation.GameSession` (extend)
+
+## Depends on
+- #45: Shadow thresholds (Horniness T2/T3 effects)
+- #54: GameClock (time-of-day Horniness modifier)
+- #139: `SessionShadowTracker`, `IGameClock`, `GameSessionConfig`
+
+## Maturity: Prototype
+
+---
+
+## Horniness Calculation (at session start)
+
+```
+horninessBase   = dice.Roll(10)                                // 1d10 → 1–10
+timeModifier    = gameClock?.GetHorninessModifier() ?? 0       // -2/0/+1/+3/+5
+shadowHorniness = playerShadows?.GetEffectiveShadow(Horniness) ?? player.Stats.GetShadow(Horniness)
+horniness       = Math.Max(0, horninessBase + timeModifier + shadowHorniness)
+```
+
+Computed once in GameSession constructor. Stored as `private readonly int _horniness`. Does NOT change during conversation.
+
+## Forced Rizz Rules
+
+| Horniness Level | Effect |
+|---|---|
+| < 6 | No effect |
+| 6–11 | At least 1 of 4 options must be Rizz. If LLM returned none, replace the last option. Marked with 🔥. |
+| 12–17 | Exactly 1 option is always Rizz (forced). Others can be anything. |
+| ≥ 18 | ALL options become Rizz. |
+
+Applied in `StartTurnAsync()` after receiving LLM options and before returning `TurnStart`.
+
+## Option Replacement Logic
+
+When forcing Rizz options:
+1. Count existing Rizz options in the LLM response
+2. If count < required: replace non-Rizz options from the end of the array
+3. Replacement option: keep original `IntendedText` but change `Stat` to `StatType.Rizz`
+4. Mark replaced options with `IsForced = true` (or similar — for UI 🔥 display)
+
+**Note:** `DialogueOption` may need an `IsForced` bool property added. If not feasible without breaking changes, the 🔥 indicator can be inferred from `Stat == Rizz` when `_horniness >= 6`.
+
+## Dependencies
+- `IGameClock.GetHorninessModifier()` (#54)
+- `SessionShadowTracker.GetEffectiveShadow(Horniness)` (#139)
+- `IDiceRoller.Roll(10)` (already exists)
+
+## Consumers
+- `TurnStart.Options` (modified options returned to host)

--- a/contracts/sprint-8-player-response-delay.md
+++ b/contracts/sprint-8-player-response-delay.md
@@ -1,0 +1,65 @@
+# Contract: Issue #55 — PlayerResponseDelay
+
+## Component
+`Pinder.Core.Conversation.PlayerResponseDelayEvaluator` (new static class)
+
+## Depends on
+- #54: GameClock (provides delay duration)
+
+## Maturity: Prototype
+
+---
+
+## PlayerResponseDelayEvaluator
+
+**File:** `src/Pinder.Core/Conversation/PlayerResponseDelayEvaluator.cs`
+
+```csharp
+namespace Pinder.Core.Conversation
+{
+    public static class PlayerResponseDelayEvaluator
+    {
+        /// <summary>
+        /// Pure function: evaluates interest penalty for player response delay.
+        /// </summary>
+        /// <param name="delay">Time since opponent's last message.</param>
+        /// <param name="opponentStats">Opponent's stat block (Chaos modifies tolerance).</param>
+        /// <param name="currentInterest">Current interest state.</param>
+        /// <returns>Penalty result with interest delta and optional test trigger.</returns>
+        public static DelayPenalty Evaluate(TimeSpan delay, StatBlock opponentStats, InterestState currentInterest);
+    }
+
+    public sealed class DelayPenalty
+    {
+        /// <summary>Interest delta to apply (0 or negative).</summary>
+        public int InterestDelta { get; }
+
+        /// <summary>Human-readable description of the penalty reason, or null if no penalty.</summary>
+        public string? Reason { get; }
+
+        /// <summary>True if the delay should trigger a "conversation test" event.</summary>
+        public bool TriggersTest { get; }
+    }
+}
+```
+
+## Delay Penalty Table
+
+| Delay | Base Penalty | Notes |
+|---|---|---|
+| < 1 minute | 0 | No penalty |
+| 1–15 minutes | 0 | Normal reply speed |
+| 15–60 minutes | −1 | Only if interest ≥ 16 (VeryIntoIt+) |
+| 1–6 hours | −2 | Always applies |
+| 6–24 hours | −3 | Always applies |
+| 24+ hours | −5 | Always applies; triggers conversation test |
+
+**Chaos modifier:** If opponent's Chaos stat ≥ 3, the penalty thresholds shift one tier more lenient (e.g., 15–60min becomes 0 regardless of interest). Implementation detail for #55 implementer.
+
+## Dependencies
+- `StatBlock` (from Stats/)
+- `InterestState` (from Conversation/)
+
+## Consumers
+- `ConversationRegistry` (#56)
+- `GameSession` (when host provides delay via clock)

--- a/contracts/sprint-8-qa-review.md
+++ b/contracts/sprint-8-qa-review.md
@@ -1,0 +1,29 @@
+# Contract: Issue #38 — QA Review
+
+## Component
+`tests/Pinder.Core.Tests/` (all test files)
+
+## Maturity: Prototype
+
+---
+
+## Scope
+
+Audit and improve test quality across all test files. This is a parallel QA task with no code dependencies.
+
+## Deliverables
+
+1. **Coverage gaps**: Identify untested public methods/properties
+2. **Edge case tests**: Add tests for boundary conditions identified in specs
+3. **Test quality**: Ensure tests assert behavior, not implementation details
+4. **Naming**: Consistent test naming convention
+5. **SuccessScale tests**: Address #39 (zero coverage for SuccessScale)
+6. **DateSecured test**: Address #40 (missing DateSecured end condition test)
+
+## Constraints
+- Do NOT modify production code
+- Do NOT break existing tests
+- New tests must pass with current production code
+
+## Dependencies
+- None (parallel with all other work)

--- a/contracts/sprint-8-read-recover-wait.md
+++ b/contracts/sprint-8-read-recover-wait.md
@@ -1,0 +1,87 @@
+# Contract: Issue #43 — Read, Recover, Wait Turn Actions
+
+## Component
+`Pinder.Core.Conversation.GameSession` (extend) + new `ReadResult`, `RecoverResult` types
+
+## Depends on
+- #139 Wave 0: `RollEngine.ResolveFixedDC`, `TrapState.HasActive`, `SessionShadowTracker`
+
+## Maturity: Prototype
+
+---
+
+## New Methods on GameSession
+
+```csharp
+/// <summary>
+/// Read action: SA vs DC 12. Success reveals interest. Failure: −1 interest + Overthinking +1.
+/// Self-contained turn action — does NOT require StartTurnAsync() first.
+/// Clears _currentOptions if set. Checks end conditions independently.
+/// </summary>
+public Task<ReadResult> ReadAsync();
+
+/// <summary>
+/// Recover action: SA vs DC 12. Success clears one active trap. Failure: −1 interest.
+/// Throws InvalidOperationException if no traps active (TrapState.HasActive == false).
+/// </summary>
+public Task<RecoverResult> RecoverAsync();
+
+/// <summary>
+/// Wait action: −1 interest, advance trap timers. No roll.
+/// Synchronous — no LLM calls.
+/// </summary>
+public void Wait();
+```
+
+## New Types
+
+### ReadResult
+**File:** `src/Pinder.Core/Conversation/ReadResult.cs`
+
+```csharp
+public sealed class ReadResult
+{
+    public bool Success { get; }
+    public int? InterestValue { get; }      // non-null only on success
+    public RollResult Roll { get; }
+    public GameStateSnapshot StateAfter { get; }
+    public int XpEarned { get; }            // 5 on success, 2 on failure (wired by #48)
+    public IReadOnlyList<string> ShadowGrowthEvents { get; }  // "Overthinking +1 (Read failed)" on failure
+}
+```
+
+### RecoverResult
+**File:** `src/Pinder.Core/Conversation/RecoverResult.cs`
+
+```csharp
+public sealed class RecoverResult
+{
+    public bool Success { get; }
+    public string? ClearedTrapName { get; }  // non-null only on success
+    public RollResult Roll { get; }
+    public GameStateSnapshot StateAfter { get; }
+    public int XpEarned { get; }             // 15 on success, 2 on failure (wired by #48)
+}
+```
+
+## Behavioral Invariants
+
+1. All three actions increment `_turnNumber` by 1.
+2. All three actions check end conditions (interest 0/25) and ghost trigger (Bored → 25%) at start.
+3. `ReadAsync`/`RecoverAsync` use `RollEngine.ResolveFixedDC(StatType.SelfAwareness, player.Stats, 12, ...)`.
+4. On Read failure: `SessionShadowTracker.ApplyGrowth(Overthinking, 1, "Read failed")` → event in result.
+5. On Recover failure: −1 interest only (no shadow growth).
+6. Wait: −1 interest + `TrapState.AdvanceTurn()`. No roll.
+7. `RecoverAsync` throws `InvalidOperationException` if `!_traps.HasActive`.
+8. If called after `StartTurnAsync()`, `_currentOptions` is cleared.
+9. Read/Recover/Wait do NOT call any `ILlmAdapter` methods.
+
+## Dependencies
+- `RollEngine.ResolveFixedDC` (#139)
+- `SessionShadowTracker` (#139)
+- `TrapState.HasActive` (#139)
+- `XpLedger` (#48 — XP values are wired when #48 is implemented)
+
+## Consumers
+- #44 (shadow growth — Overthinking from Read failure)
+- #48 (XP from Read/Recover success/failure)

--- a/contracts/sprint-8-shadow-growth.md
+++ b/contracts/sprint-8-shadow-growth.md
@@ -1,0 +1,76 @@
+# Contract: Issue #44 — Shadow Growth Events (§7 Growth Table)
+
+## Component
+`Pinder.Core.Conversation.GameSession` (extend) — shadow growth trigger detection
+
+## Depends on
+- #139 Wave 0: `SessionShadowTracker` (with `DrainGrowthEvents()`)
+- #43: Read/Recover (Overthinking growth on Read failure)
+
+## Maturity: Prototype
+
+---
+
+## Architectural Decision: No CharacterState class
+
+Per #161 resolution, all shadow mutation goes through `SessionShadowTracker` (from #139).
+The `CharacterState` class specified in the original #44 spec is **not implemented**.
+`GameSession` uses `GameSessionConfig.PlayerShadows` (a `SessionShadowTracker`) for all shadow growth.
+
+## previousOpener
+
+Per #162 resolution, `previousOpener` is read from `GameSessionConfig.PreviousOpener`, not a constructor param.
+
+## TurnResult.ShadowGrowthEvents
+
+Per #163, this field already exists on `TurnResult`. Implementation **populates** it; does not add it.
+
+---
+
+## Shadow Growth Trigger Table
+
+GameSession detects these conditions and calls `SessionShadowTracker.ApplyGrowth()`:
+
+| Shadow Stat | Trigger | Amount | When Checked |
+|---|---|---|---|
+| Madness | Nat 1 on Charm roll | +2 | ResolveTurnAsync |
+| Madness | 3+ TropeTrap failures in session | +1 (once, on 3rd) | ResolveTurnAsync |
+| Horniness | (rolled at session start — not grown during session) | — | — |
+| Denial | 3+ successful Honesty checks in session | +1 (once, on 3rd) | ResolveTurnAsync |
+| Fixation | Same stat 3 turns in a row | +1 | ResolveTurnAsync |
+| Fixation | Picked highest-% option 3 turns in a row | +1 | ResolveTurnAsync |
+| Dread | Nat 1 on any stat | +1 | ResolveTurnAsync |
+| Dread | Interest drops to Bored from higher state | +1 | ResolveTurnAsync |
+| Overthinking | Read action failure | +1 | ReadAsync (#43) |
+| Overthinking | Interest ≥ 21 (AlmostThere) and player uses SA | +1 | ResolveTurnAsync |
+
+## Internal Tracking Fields
+
+GameSession needs these new private fields:
+
+```csharp
+private readonly List<StatType> _statsUsedPerTurn;     // stat chosen each turn
+private int _honestySuccessCount;                       // for Denial trigger
+private int _tropeTrapCount;                            // for Madness trigger
+private readonly List<bool> _highestPctOptionPicked;    // for Fixation trigger
+private bool _madnessTropeTrapTriggered;                // one-shot flag
+private bool _denialTriggered;                          // one-shot flag
+```
+
+## Data Flow
+
+1. After `RollEngine.Resolve()` in `ResolveTurnAsync`:
+   - Check each trigger condition
+   - Call `_playerShadows.ApplyGrowth(shadow, amount, reason)` for each matched trigger
+   - After all growth: `var events = _playerShadows.DrainGrowthEvents()`
+   - Pass `events` to `TurnResult` constructor as `shadowGrowthEvents`
+
+2. "Highest-%" detection: the chosen option index is compared against the option that would have the highest success probability (lowest DC or highest stat modifier). GameSession can approximate this by comparing effective stat values across options.
+
+## Dependencies
+- `SessionShadowTracker` with `DrainGrowthEvents()` (#139)
+- `GameSessionConfig.PreviousOpener` (#139)
+
+## Consumers
+- #45 (threshold effects read effective shadow values)
+- #48 (XP ledger records events)

--- a/contracts/sprint-8-shadow-thresholds.md
+++ b/contracts/sprint-8-shadow-thresholds.md
@@ -1,0 +1,53 @@
+# Contract: Issue #45 — Shadow Thresholds (§7 Effects)
+
+## Component
+- `Pinder.Core.Stats.ShadowThresholdEvaluator` (new static class)
+- `Pinder.Core.Conversation.GameSession` (extend)
+
+## Depends on
+- #44: Shadow growth events (threshold effects require grown shadow values)
+- #139: `SessionShadowTracker`, `GameSessionConfig`
+
+## Maturity: Prototype
+
+---
+
+## ShadowThresholdEvaluator
+
+**File:** `src/Pinder.Core/Stats/ShadowThresholdEvaluator.cs`
+
+```csharp
+namespace Pinder.Core.Stats
+{
+    public static class ShadowThresholdEvaluator
+    {
+        /// <summary>
+        /// Returns threshold tier: 0 (0–5), 1 (6–11), 2 (12–17), 3 (18+).
+        /// </summary>
+        public static int GetThresholdLevel(int shadowValue);
+    }
+}
+```
+
+## Threshold Effects (applied in GameSession)
+
+| Tier | Shadow Value | Effect |
+|------|-------------|--------|
+| T0 | 0–5 | None |
+| T1 | 6–11 | Flavor text injected into LLM prompt (DialogueContext gains shadow flavor field) |
+| T2 | 12–17 | Disadvantage on rolls using the paired stat |
+| T3 | 18+ | **Dread ≥18**: Starting interest drops to 8 (via GameSessionConfig.StartingInterest). **Horniness ≥18**: All options forced to Rizz (handled by #51). **Others**: Stat suppressed — options using that stat are removed. |
+
+## GameSession Integration
+
+1. In `StartTurnAsync()`: evaluate all 6 shadow thresholds via `_playerShadows.GetEffectiveShadow(shadow)`
+2. T2 effects: set `hasDisadvantage = true` for the paired stat's rolls
+3. T3 Dread: handled at construction time via `GameSessionConfig.StartingInterest = 8`
+4. T3 suppression: filter LLM-returned options to exclude suppressed stats (if all suppressed, keep one Chaos option as fallback)
+
+## Dependencies
+- `SessionShadowTracker.GetEffectiveShadow()` (#139)
+
+## Consumers
+- #51 (Horniness T3 check)
+- GameSession (all threshold effects)

--- a/contracts/sprint-8-tells.md
+++ b/contracts/sprint-8-tells.md
@@ -1,0 +1,46 @@
+# Contract: Issue #50 — Tells (§15 Hidden Roll Bonus)
+
+## Component
+`Pinder.Core.Conversation.GameSession` (extend)
+
+## Depends on
+- #139 Wave 0: `RollEngine.Resolve(externalBonus)`
+
+## Maturity: Prototype
+
+---
+
+## Mechanism
+
+1. `ILlmAdapter.GetOpponentResponseAsync()` returns `OpponentResponse` with optional `Tell? DetectedTell`
+2. GameSession stores `_activeTell` (the Tell from the most recent opponent response)
+3. On next `ResolveTurnAsync()`: if `chosenOption.HasTellBonus` or `chosenOption.Stat == _activeTell.Stat`:
+   - Tell bonus = +2
+   - Summed into `externalBonus` with callback + triple combo
+4. After use (or after one turn passes without use), `_activeTell` is cleared
+
+## Tell Types (from Tell.cs — already exists)
+
+```csharp
+public sealed class Tell
+{
+    public StatType Stat { get; }
+    public string Description { get; }
+}
+```
+
+## TurnResult Fields (already exist)
+- `TellReadBonus` (int) — 0 or +2
+- `TellReadMessage` (string?) — description of the tell that was read
+
+## Behavioral Invariants
+- Tell bonus is **hidden** — not shown in success % preview
+- Tell is one-shot: consumed on the turn it's used, or expires if not used
+- +2 is a constant (not variable per tell type)
+
+## Dependencies
+- `OpponentResponse.DetectedTell` (already exists)
+- `RollEngine.Resolve(externalBonus)` (#139)
+
+## Consumers
+- `TurnResult.TellReadBonus`, `TurnResult.TellReadMessage`

--- a/contracts/sprint-8-wave0-infrastructure.md
+++ b/contracts/sprint-8-wave0-infrastructure.md
@@ -1,0 +1,221 @@
+# Contract: Issue #139 — Wave 0 Infrastructure Prerequisites (Sprint 8)
+
+## Components
+- `SessionShadowTracker` (Stats/) — with `DrainGrowthEvents()` addition per #161 resolution
+- `IGameClock` + `TimeOfDay` (Interfaces/)
+- `RollEngine` extensions (Rolls/)
+- `RollResult` changes (Rolls/)
+- `GameSessionConfig` (Conversation/) — with `PreviousOpener` per #162 resolution
+- `InterestMeter` overload (Conversation/)
+- `TrapState.HasActive` (Traps/)
+
+## Maturity: Prototype
+## NFR: latency target — all methods < 1ms (pure computation, no I/O)
+
+---
+
+## 1. SessionShadowTracker
+
+**File:** `src/Pinder.Core/Stats/SessionShadowTracker.cs`
+
+```csharp
+namespace Pinder.Core.Stats
+{
+    public sealed class SessionShadowTracker
+    {
+        /// <param name="baseStats">Immutable StatBlock to wrap. Throws ArgumentNullException if null.</param>
+        public SessionShadowTracker(StatBlock baseStats);
+
+        /// <summary>Returns base shadow + in-session delta.</summary>
+        public int GetEffectiveShadow(ShadowStatType shadow);
+
+        /// <summary>
+        /// Apply shadow growth. Returns "{ShadowName} +{amount} ({reason})".
+        /// Also stores the description internally for DrainGrowthEvents().
+        /// Throws ArgumentOutOfRangeException if amount <= 0.
+        /// </summary>
+        public string ApplyGrowth(ShadowStatType shadow, int amount, string reason);
+
+        /// <summary>
+        /// Effective stat modifier with session shadow growth.
+        /// Formula: baseStats.GetBase(stat) - floor((baseStats.GetShadow(paired) + delta[paired]) / 3)
+        /// </summary>
+        public int GetEffectiveStat(StatType stat);
+
+        /// <summary>In-session delta only (0 if no growth).</summary>
+        public int GetDelta(ShadowStatType shadow);
+
+        /// <summary>
+        /// Returns all growth event description strings accumulated since last drain.
+        /// Clears internal log after copying. Returns empty list if none.
+        /// Added per #161 resolution — replaces CharacterState.DrainGrowthEvents().
+        /// </summary>
+        public IReadOnlyList<string> DrainGrowthEvents();
+    }
+}
+```
+
+**Dependencies:** `StatBlock`, `StatType`, `ShadowStatType`, `StatBlock.ShadowPairs`
+**Consumers:** #43, #44, #45, #48, #51, #56
+
+---
+
+## 2. IGameClock + TimeOfDay
+
+**File:** `src/Pinder.Core/Interfaces/IGameClock.cs`
+
+```csharp
+namespace Pinder.Core.Interfaces
+{
+    public enum TimeOfDay
+    {
+        Morning,      // 06:00–11:59
+        Afternoon,    // 12:00–17:59
+        Evening,      // 18:00–21:59
+        LateNight,    // 22:00–01:59
+        AfterTwoAm    // 02:00–05:59
+    }
+
+    public interface IGameClock
+    {
+        DateTimeOffset Now { get; }
+        void Advance(TimeSpan amount);
+        void AdvanceTo(DateTimeOffset target);  // throws ArgumentException if target <= Now
+        TimeOfDay GetTimeOfDay();
+        int GetHorninessModifier();             // Morning=-2, Afternoon=0, Evening=+1, LateNight=+3, AfterTwoAm=+5
+        int RemainingEnergy { get; }
+        bool ConsumeEnergy(int amount);         // false if insufficient (no deduction on failure)
+    }
+}
+```
+
+**Dependencies:** System.DateTimeOffset, System.TimeSpan (BCL only)
+**Consumers:** #51, #54, #55, #56
+
+---
+
+## 3. RollEngine Extensions
+
+**File:** `src/Pinder.Core/Rolls/RollEngine.cs` (modify existing)
+
+```csharp
+// MODIFIED — two new optional params (backward-compatible)
+public static RollResult Resolve(
+    StatType stat, StatBlock attacker, StatBlock defender,
+    TrapState attackerTraps, int level, ITrapRegistry trapRegistry, IDiceRoller dice,
+    bool hasAdvantage = false, bool hasDisadvantage = false,
+    int externalBonus = 0,    // added to total before success check
+    int dcAdjustment = 0);    // subtracted from DC (positive = easier)
+
+// NEW overload — fixed DC instead of computing from defender
+public static RollResult ResolveFixedDC(
+    StatType stat, StatBlock attacker, int fixedDc,
+    TrapState attackerTraps, int level, ITrapRegistry trapRegistry, IDiceRoller dice,
+    bool hasAdvantage = false, bool hasDisadvantage = false,
+    int externalBonus = 0);
+```
+
+**Behavioral notes:**
+- `externalBonus` flows into `RollResult` constructor → affects `FinalTotal` and `IsSuccess`
+- `dcAdjustment` subtracted from DC before the check. Adjusted DC used in `RollResult`.
+- Nat 1 = auto-fail regardless of bonuses. Nat 20 = auto-success regardless of penalties.
+- `ResolveFixedDC` has identical trap/advantage logic to `Resolve`, just no defender param.
+
+---
+
+## 4. RollResult Changes
+
+**File:** `src/Pinder.Core/Rolls/RollResult.cs` (modify existing)
+
+```csharp
+// Constructor gains optional externalBonus
+public RollResult(..., int externalBonus = 0);
+
+// IsSuccess changes from: Total >= dc
+// to:                      FinalTotal >= dc
+// where FinalTotal = Total + ExternalBonus
+// When externalBonus=0: identical behavior (backward-compatible)
+
+// AddExternalBonus() remains but is DEPRECATED
+```
+
+**MissMargin:** stays as `DC - Total` (not FinalTotal) for backward compat.
+
+---
+
+## 5. GameSessionConfig
+
+**File:** `src/Pinder.Core/Conversation/GameSessionConfig.cs`
+
+```csharp
+namespace Pinder.Core.Conversation
+{
+    public sealed class GameSessionConfig
+    {
+        public IGameClock? Clock { get; }
+        public SessionShadowTracker? PlayerShadows { get; }
+        public SessionShadowTracker? OpponentShadows { get; }
+        public int? StartingInterest { get; }
+        public string? PreviousOpener { get; }  // per #162 resolution
+
+        public GameSessionConfig(
+            IGameClock? clock = null,
+            SessionShadowTracker? playerShadows = null,
+            SessionShadowTracker? opponentShadows = null,
+            int? startingInterest = null,
+            string? previousOpener = null);
+    }
+}
+```
+
+**Dependencies:** `IGameClock`, `SessionShadowTracker`
+**Consumers:** GameSession, #44, #48, #51, #56
+
+---
+
+## 6. InterestMeter Overload
+
+**File:** `src/Pinder.Core/Conversation/InterestMeter.cs` (modify existing)
+
+```csharp
+// NEW — custom starting value, clamped to [Min, Max]
+public InterestMeter(int startingValue);
+// Current = Math.Max(Min, Math.Min(Max, startingValue))
+```
+
+---
+
+## 7. TrapState.HasActive
+
+**File:** `src/Pinder.Core/Traps/TrapState.cs` (modify existing)
+
+```csharp
+/// <summary>True if any trap is currently active.</summary>
+public bool HasActive => _active.Count > 0;
+```
+
+---
+
+## 8. GameSession Constructor Overload
+
+**File:** `src/Pinder.Core/Conversation/GameSession.cs` (modify existing)
+
+```csharp
+// Existing constructor unchanged
+public GameSession(CharacterProfile player, CharacterProfile opponent,
+    ILlmAdapter llm, IDiceRoller dice, ITrapRegistry trapRegistry);
+
+// NEW overload — stores config fields for use by feature issues
+public GameSession(CharacterProfile player, CharacterProfile opponent,
+    ILlmAdapter llm, IDiceRoller dice, ITrapRegistry trapRegistry,
+    GameSessionConfig? config);
+```
+
+When `config?.StartingInterest` is set → `new InterestMeter(value)`.
+Stores `config.PlayerShadows`, `config.OpponentShadows`, `config.Clock`, `config.PreviousOpener` as private fields.
+
+---
+
+## Backward Compatibility
+
+All changes are additive or use default parameter values. Existing 254 tests must pass without modification.

--- a/contracts/sprint-8-weakness-windows.md
+++ b/contracts/sprint-8-weakness-windows.md
@@ -1,0 +1,51 @@
+# Contract: Issue #49 — Weakness Windows (§15 DC Reduction)
+
+## Component
+`Pinder.Core.Conversation.GameSession` (extend)
+
+## Depends on
+- #139 Wave 0: `RollEngine.Resolve(dcAdjustment)`
+
+## Maturity: Prototype
+
+---
+
+## Mechanism
+
+1. `ILlmAdapter.GetOpponentResponseAsync()` returns `OpponentResponse` with optional `WeaknessWindow? WeaknessWindow`
+2. GameSession stores `_activeWeakness` (from most recent opponent response)
+3. On next `ResolveTurnAsync()`: if chosen option's stat's defence pairing matches `_activeWeakness.DefendingStat`:
+   - `dcAdjustment = _activeWeakness.DcReduction` (positive value = DC lowered)
+4. Passed to `RollEngine.Resolve(dcAdjustment:)`
+5. After one turn, `_activeWeakness` is cleared (used or not)
+
+## WeaknessWindow (already exists)
+
+```csharp
+public sealed class WeaknessWindow
+{
+    public StatType DefendingStat { get; }    // the stat whose DC is reduced
+    public int DcReduction { get; }           // 2 or 3
+}
+```
+
+## Crack Trigger Table
+
+| Opponent Behaviour | Defending Stat | DC Reduction |
+|---|---|---|
+| Contradicts themselves | Honesty | −2 |
+| Laughs genuinely | Charm | −2 |
+| Shares something personal | SelfAwareness | −3 |
+| Gets flustered | Wit | −2 |
+| Asks personal question | Honesty | −2 |
+| Makes risky joke | Chaos | −2 |
+
+## Behavioral Invariants
+- Weakness window is one-turn-only: expires after one turn whether used or not
+- DC reduction is applied by checking if the chosen stat attacks via the weakened defence stat
+- The match logic: `StatBlock.DefenceTable[chosenOption.Stat] == _activeWeakness.DefendingStat`
+
+## Dependencies
+- `OpponentResponse.WeaknessWindow` (already exists)
+- `RollEngine.Resolve(dcAdjustment)` (#139)
+- `StatBlock.DefenceTable` (already exists)

--- a/contracts/sprint-8-xp-tracking.md
+++ b/contracts/sprint-8-xp-tracking.md
@@ -1,0 +1,65 @@
+# Contract: Issue #48 — XP Tracking (§10)
+
+## Component
+- `Pinder.Core.Progression.XpLedger` (new class)
+- `Pinder.Core.Conversation.GameSession` (extend)
+
+## Depends on
+- #43: Read/Recover actions (XP from those)
+- #44: Shadow growth (potential XP from recovery events)
+
+## Maturity: Prototype
+
+---
+
+## XpLedger
+
+**File:** `src/Pinder.Core/Progression/XpLedger.cs`
+
+```csharp
+namespace Pinder.Core.Progression
+{
+    public sealed class XpLedger
+    {
+        /// <summary>Record an XP event with label and amount.</summary>
+        public void Record(string label, int amount);
+
+        /// <summary>Total XP accumulated this session.</summary>
+        public int Total { get; }
+
+        /// <summary>All recorded events for audit/display.</summary>
+        public IReadOnlyList<(string Label, int Amount)> Events { get; }
+    }
+}
+```
+
+## XP Source Table
+
+| Action | XP | Label | When |
+|---|---|---|---|
+| Success (DC ≤ 13) | 5 | "success-easy" | ResolveTurnAsync |
+| Success (DC 14–17) | 10 | "success-medium" | ResolveTurnAsync |
+| Success (DC ≥ 18) | 15 | "success-hard" | ResolveTurnAsync |
+| Failed check | 2 | "failure" | ResolveTurnAsync |
+| Nat 20 | 25 | "nat20" | ResolveTurnAsync (replaces success XP) |
+| Nat 1 | 10 | "nat1" | ResolveTurnAsync (replaces failure XP) |
+| Date secured | 50 | "date-secured" | Game end |
+| Trap recovery | 15 | "recovery" | RecoverAsync success |
+| Conversation complete (no date) | 5 | "conversation-complete" | Game end (Unmatched/Ghosted) |
+
+**Nat 20/Nat 1 override**: They REPLACE the normal success/failure XP, not stack.
+
+## GameSession Integration
+
+1. GameSession creates `XpLedger` on construction
+2. After each roll resolution, compute XP and call `_xpLedger.Record(label, amount)`
+3. Pass `_xpLedger.Total - previousTotal` as `xpEarned` on `TurnResult`
+4. On game end: record date-secured (50) or conversation-complete (5)
+5. Expose `public int TotalXpEarned => _xpLedger.Total` on GameSession for host
+
+## Dependencies
+- `LevelTable.GetLevel()` (already exists)
+
+## Consumers
+- `TurnResult.XpEarned` (already exists)
+- Host reads `GameSession.TotalXpEarned` at session end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,19 +10,20 @@ The engine is **stateless at the roll level** — all state is passed in via par
 
 ```
 Pinder.Core/
-├── Stats/          — StatType, ShadowStatType, StatBlock, SessionShadowTracker
+├── Stats/          — StatType, ShadowStatType, StatBlock, SessionShadowTracker, ShadowThresholdEvaluator
 ├── Rolls/          — RollEngine (stateless), RollResult, FailureTier, SuccessScale, FailureScale, RiskTier, RiskTierBonus
 ├── Traps/          — TrapDefinition, TrapState, ActiveTrap (trap lifecycle)
 ├── Progression/    — LevelTable, XpLedger (XP accumulation)
 ├── Conversation/   — InterestMeter, InterestState, TimingProfile, GameSession, GameSessionConfig,
-│                     ComboTracker, PlayerResponseDelayEvaluator, ConversationRegistry
+│                     ComboTracker, PlayerResponseDelayEvaluator, ConversationRegistry,
+│                     ReadResult, RecoverResult, DelayPenalty, ConversationEntry, ConversationLifecycle, CrossChatEvent, GameClock
 ├── Characters/     — CharacterAssembler, FragmentCollection, CharacterProfile, ItemDefinition, AnatomyTierDefinition, TimingModifier
 ├── Prompts/        — PromptBuilder (assembles LLM system prompt from fragments + traps)
-├── Interfaces/     — IDiceRoller, IFailurePool, ITrapRegistry, IItemRepository, IAnatomyRepository, ILlmAdapter, IGameClock
+├── Interfaces/     — IDiceRoller, IFailurePool, ITrapRegistry, IItemRepository, IAnatomyRepository, ILlmAdapter, IGameClock, TimeOfDay
 └── Data/           — JsonItemRepository, JsonAnatomyRepository, JsonParser (hand-rolled JSON parser)
 ```
 
-### Data Flow (full turn — updated Sprint 7)
+### Data Flow (full turn — Sprint 8)
 
 ```
 Host creates GameSession(player, opponent, llm, dice, trapRegistry, config?)
@@ -45,15 +46,15 @@ Per turn (Speak action):
      → RollEngine.Resolve() with adv/disadv + externalBonus + dcAdjustment
      → SuccessScale or FailureScale → interest delta
      → add RiskTierBonus, momentum, combo interest bonus
-     → shadow growth events (#44)
-     → XP recording (#48)
+     → shadow growth events
+     → XP recording
      → InterestMeter.Apply(total delta)
      → ILlmAdapter.DeliverMessageAsync()
      → ILlmAdapter.GetOpponentResponseAsync() → store Tell/WeaknessWindow for next turn
      → ILlmAdapter.GetInterestChangeBeatAsync() if threshold crossed
      → return TurnResult (with shadow events, combo, XP, etc.)
 
-Per turn (Read/Recover/Wait — #43):
+Per turn (Read/Recover/Wait):
   3a. ReadAsync()
      → RollEngine.ResolveFixedDC(SA, 12) → reveal interest on success, −1 + Overthinking on fail
   3b. RecoverAsync()
@@ -61,7 +62,7 @@ Per turn (Read/Recover/Wait — #43):
   3c. Wait()
      → −1 interest, advance trap timers
 
-Multi-session (ConversationRegistry — #56):
+Multi-session (ConversationRegistry):
   ConversationRegistry owns N ConversationEntry instances
     → ScheduleOpponentReply, FastForward (advance IGameClock), ghost/fizzle checks
     → Cross-chat shadow bleed via SessionShadowTracker
@@ -77,62 +78,86 @@ Multi-session (ConversationRegistry — #56):
 
 ---
 
-## Sprint 7: RPG Rules Complete — Architecture Briefing
+## Sprint 8: RPG Rules Complete — Architecture Briefing
 
 ### What's changing
 
-**Previous architecture (Sprint 6)**: GameSession orchestrates Speak turns only. Shadow stats are read-only via StatBlock. No XP tracking. No time system. No multi-session management. External bonuses (tell, callback, combo) are typed as fields on TurnResult/DialogueOption but never populated.
+**Previous architecture (Sprint 7)**: GameSession orchestrates Speak turns only. Shadow stats are read-only via StatBlock. No XP tracking. No time system. No multi-session management. External bonuses (tell, callback, combo) are typed as fields on TurnResult/DialogueOption but never populated.
 
-**Sprint 7 additions** — 6 new components, significant GameSession expansion:
+**Sprint 8 additions** — 6 new components, significant GameSession expansion:
 
 #### New Components
 
-1. **`SessionShadowTracker`** (Stats/) — Mutable shadow tracking layer wrapping immutable `StatBlock`. Tracks in-session delta per shadow stat. Provides `GetEffectiveStat()` that accounts for session-grown shadows. This is the **key architectural addition** — it solves the StatBlock immutability problem without breaking the snapshot contract.
+1. **`SessionShadowTracker`** (Stats/) — Mutable shadow tracking layer wrapping immutable `StatBlock`. Tracks in-session delta per shadow stat. Provides `GetEffectiveStat()` that accounts for session-grown shadows. Includes `DrainGrowthEvents()` for collecting growth event descriptions. This is the **canonical shadow-tracking wrapper** — replaces the `CharacterState` concept from the #44 spec (see ADR: #161 resolution below).
 
-2. **`IGameClock` + `GameClock`** (Interfaces/ + Conversation/) — Simulated in-game time. Owns `TimeOfDay`, Horniness modifier, energy system. Injectable for testing via `FixedGameClock`.
+2. **`ShadowThresholdEvaluator`** (Stats/) — Pure static utility: given a shadow value, returns tier (0/1/2/3). Thresholds: 6=T1, 12=T2, 18+=T3.
 
-3. **`ComboTracker`** (Conversation/) — Tracks last N stat plays and detects 8 named combo sequences. Pure data tracker — returns combo name/bonus, GameSession applies the effect.
+3. **`IGameClock` + `GameClock`** (Interfaces/ + Conversation/) — Simulated in-game time. Owns `TimeOfDay`, Horniness modifier, energy system. Injectable for testing via `FixedGameClock`.
 
-4. **`XpLedger`** (Progression/) — Accumulates XP events per session. GameSession records events; host reads total at session end.
+4. **`ComboTracker`** (Conversation/) — Tracks last N stat plays and detects 8 named combo sequences. Pure data tracker — returns combo name/bonus, GameSession applies the effect.
 
-5. **`PlayerResponseDelayEvaluator`** (Conversation/) — Pure function: `(TimeSpan, StatBlock, InterestState) → DelayPenalty`. No state, no clock dependency.
+5. **`XpLedger`** (Progression/) — Accumulates XP events per session. GameSession records events; host reads total at session end.
 
-6. **`ConversationRegistry`** (Conversation/) — Multi-session scheduler. Owns a collection of `ConversationEntry`. Delegates to `IGameClock` for time. Orchestrates fast-forward, ghost/fizzle triggers, cross-chat shadow bleed. Does NOT make LLM calls.
+6. **`PlayerResponseDelayEvaluator`** (Conversation/) — Pure function: `(TimeSpan, StatBlock, InterestState) → DelayPenalty`. No state, no clock dependency.
+
+7. **`ConversationRegistry`** (Conversation/) — Multi-session scheduler. Owns a collection of `ConversationEntry`. Delegates to `IGameClock` for time. Orchestrates fast-forward, ghost/fizzle triggers, cross-chat shadow bleed. Does NOT make LLM calls.
 
 #### Extended Components
 
-7. **`RollEngine`** — Gains `ResolveFixedDC()` overload (for DC 12 rolls). Existing `Resolve()` gains `externalBonus` and `dcAdjustment` optional params (backward-compatible defaults of 0).
+8. **`RollEngine`** — Gains `ResolveFixedDC()` overload (for DC 12 rolls). Existing `Resolve()` gains `externalBonus` and `dcAdjustment` optional params (backward-compatible defaults of 0).
 
-8. **`RollResult`** — `IsSuccess` becomes computed from `FinalTotal` (= Total + ExternalBonus) instead of `Total`. Backward-compatible when ExternalBonus=0 (default).
+9. **`RollResult`** — `IsSuccess` becomes computed from `FinalTotal` (= Total + ExternalBonus) instead of `Total`. Backward-compatible when ExternalBonus=0 (default).
 
-9. **`GameSession`** — Major expansion:
-   - New constructor overload accepting `GameSessionConfig` (optional clock, shadow trackers, starting interest)
-   - Three new action methods: `ReadAsync()`, `RecoverAsync()`, `Wait()`
-   - Shadow growth event detection and recording (#44)
-   - Shadow threshold effects on options/rolls (#45)
-   - Combo detection via ComboTracker (#46)
-   - Callback bonus computation (#47)
-   - Tell/WeaknessWindow application (#49, #50)
-   - XP recording via XpLedger (#48)
-   - Horniness-forced Rizz option logic (#51)
+10. **`GameSession`** — Major expansion:
+    - New constructor overload accepting `GameSessionConfig` (optional clock, shadow trackers, starting interest)
+    - Three new action methods: `ReadAsync()`, `RecoverAsync()`, `Wait()`
+    - Shadow growth event detection and recording (#44)
+    - Shadow threshold effects on options/rolls (#45)
+    - Combo detection via ComboTracker (#46)
+    - Callback bonus computation (#47)
+    - Tell/WeaknessWindow application (#49, #50)
+    - XP recording via XpLedger (#48)
+    - Horniness-forced Rizz option logic (#51)
 
-10. **`GameSessionConfig`** (Conversation/) — Optional configuration carrier: IGameClock, SessionShadowTracker (player/opponent), starting interest override.
+11. **`GameSessionConfig`** (Conversation/) — Optional configuration carrier: IGameClock, SessionShadowTracker (player/opponent), starting interest override, previousOpener.
 
-11. **`InterestMeter`** — Gains `InterestMeter(int startingValue)` constructor overload for Dread≥18 effect.
+12. **`InterestMeter`** — Gains `InterestMeter(int startingValue)` constructor overload for Dread≥18 effect.
 
-12. **`TrapState`** — Gains `HasActive` boolean property.
+13. **`TrapState`** — Gains `HasActive` boolean property.
 
 ### What is NOT changing
 - Stats/StatBlock (remains immutable — SessionShadowTracker wraps it)
 - Characters/, Prompts/, Data/ modules remain untouched
-- Existing context types (DialogueContext, DeliveryContext, etc.) — already have the fields needed (ShadowThresholds, HorninessLevel, etc. added in previous PRs)
-- Existing TurnResult — already has ShadowGrowthEvents, ComboTriggered, XpEarned etc. fields (added by PR #117)
+- Existing context types (DialogueContext, DeliveryContext, etc.) — already have the fields needed
+- Existing TurnResult — already has ShadowGrowthEvents, ComboTriggered, XpEarned etc. fields
 
-### Vision Concern Resolutions
+### Key Architectural Decisions
 
-**#146 (Dual ExternalBonus paths)**: The `externalBonus` parameter on `RollEngine.Resolve()` is the **canonical path** for all external bonuses (callback, tell, triple combo). `AddExternalBonus()` on RollResult is deprecated — implementers MUST NOT use it for new code. After Sprint 7, we should remove `AddExternalBonus()` in a cleanup issue.
+#### ADR: Resolve #161 — SessionShadowTracker is canonical, CharacterState is dropped
 
-**#147 (Read/Recover/Wait routing)**: These actions can be called **instead of** `ResolveTurnAsync()` after `StartTurnAsync()`, OR directly without calling `StartTurnAsync()` first. If called after `StartTurnAsync()`, `_currentOptions` is cleared. Ghost triggers and end-condition checks run at the start of each action method independently. The `StartTurnAsync → ResolveTurnAsync` alternation invariant is relaxed to: "StartTurnAsync is required before ResolveTurnAsync, but Read/Recover/Wait are self-contained turn actions that handle their own pre-checks."
+**Context:** #44 spec introduces `CharacterState(CharacterProfile)` while #139 introduces `SessionShadowTracker(StatBlock)`. Both wrap immutable data with mutable shadow deltas. 5 issues reference `SessionShadowTracker`, only #44 references `CharacterState`.
+
+**Decision:** Keep `SessionShadowTracker` as the sole shadow-tracking wrapper. Add `DrainGrowthEvents()` method to it (from `CharacterState` design). Update #44 implementation to use `SessionShadowTracker` instead of creating `CharacterState`.
+
+**Consequences:**
+- `SessionShadowTracker` gains: `DrainGrowthEvents() → IReadOnlyList<string>` (returns accumulated growth event descriptions, clears internal log)
+- `SessionShadowTracker.ApplyGrowth()` already returns a description string — `DrainGrowthEvents()` collects these
+- #44 implementer uses `GameSessionConfig.PlayerShadows` (a `SessionShadowTracker`) for all shadow mutation
+- No `CharacterState` class is created
+
+#### ADR: Resolve #162 — previousOpener goes into GameSessionConfig
+
+**Context:** #44 spec adds `previousOpener` as a GameSession constructor parameter. #139 establishes `GameSessionConfig` as the extension point for optional configuration.
+
+**Decision:** Add `string? PreviousOpener` to `GameSessionConfig`. GameSession reads it from config, not from a dedicated constructor parameter.
+
+#### ADR: Resolve #147 — Read/Recover/Wait action routing
+
+**Decision:** `ReadAsync()`, `RecoverAsync()`, and `Wait()` are self-contained turn actions. They do NOT require `StartTurnAsync()` first. If called after `StartTurnAsync()`, they clear `_currentOptions`. Each method independently checks end conditions and ghost triggers. The `StartTurnAsync → ResolveTurnAsync` invariant only applies to the Speak action path.
+
+#### ADR: Resolve #146 — AddExternalBonus() deprecated
+
+**Decision:** `AddExternalBonus()` remains for backward compatibility but is DEPRECATED. All new external bonuses flow through `RollEngine.Resolve(externalBonus)` parameter. Removal deferred to a cleanup sprint post-Sprint 8.
 
 ### Implicit assumptions for implementers
 
@@ -140,9 +165,10 @@ Multi-session (ConversationRegistry — #56):
 2. **Zero NuGet dependencies**: Do not add any packages.
 3. **Nullable reference types enabled**: Use `?` annotations.
 4. **`RollEngine.Resolve` mutates `TrapState`**: On TropeTrap, `attackerTraps.Activate()` is called.
-5. **`SessionShadowTracker` does NOT replace `StatBlock` in `RollEngine.Resolve()`**: The roll engine continues to receive `StatBlock` for the attacker/defender. `SessionShadowTracker.GetEffectiveStat()` is used by `GameSession` when it needs to check shadow-adjusted values for non-roll purposes (threshold checks, Horniness level). For rolls, the session should pass the tracker's effective stat values via the existing `StatBlock` pattern or use the new `externalBonus`/`dcAdjustment` params.
+5. **`SessionShadowTracker` does NOT replace `StatBlock` in `RollEngine.Resolve()`**: Roll engine receives `StatBlock`. `SessionShadowTracker.GetEffectiveStat()` is used by `GameSession` for threshold/horniness checks.
 6. **Existing 254 tests must continue to pass**: All changes must be backward-compatible.
 7. **`AddExternalBonus()` is DEPRECATED**: All new external bonuses flow through `RollEngine.Resolve(externalBonus)`.
+8. **`TurnResult.ShadowGrowthEvents` already exists** (from PR #117): Implementers populate the existing field, not add a new one.
 
 ---
 
@@ -158,14 +184,11 @@ Multi-session (ConversationRegistry — #56):
 
 ### Constant Sync Table
 
-Every numeric constant or structural table in the engine traces back to a rules section. When a rule changes, this table tells you exactly which C# code to update.
-
 | Rules Section | Rule Value | C# Location | C# Constant/Expression |
 |---|---|---|---|
 | §3 Defence pairings | Charm→SA, Rizz→Wit, Honesty→Chaos, Chaos→Charm, Wit→Rizz, SA→Honesty | `Stats/StatBlock.cs` | `StatBlock.DefenceTable` |
 | §3 Base DC | 13 | `Stats/StatBlock.cs` | `StatBlock.GetDefenceDC()` — hardcoded `13 +` |
 | §5 Fail tiers | Nat1→Legendary, miss 1–2→Fumble, 3–5→Misfire, 6–9→TropeTrap, 10+→Catastrophe | `Rolls/RollEngine.cs` | Boundary checks in `Resolve()` |
-| §5 Fail tier enum | None, Fumble, Misfire, TropeTrap, Catastrophe, Legendary | `Rolls/FailureTier.cs` | `FailureTier` enum |
 | §5 Success scale | Beat DC by 1–4→+1, 5–9→+2, 10+→+3, Nat20→+4 | `Rolls/SuccessScale.cs` | `SuccessScale.GetInterestDelta()` |
 | §5 Failure scale | Fumble→-1, Misfire→-2, TropeTrap→-3, Catastrophe→-4, Legendary→-5 | `Rolls/FailureScale.cs` | `FailureScale.GetInterestDelta()` |
 | §5 Risk tier | Need ≤5→Safe, 6–10→Medium, 11–15→Hard, ≥16→Bold | `Rolls/RollResult.cs` | `ComputeRiskTier()` |
@@ -174,46 +197,20 @@ Every numeric constant or structural table in the engine traces back to a rules 
 | §6 Starting interest | 10 | `Conversation/InterestMeter.cs` | `StartingValue = 10` |
 | §6 Interest states | Unmatched(0), Bored(1–4), Interested(5–15), VeryIntoIt(16–20), AlmostThere(21–24), DateSecured(25) | `Conversation/InterestMeter.cs` | `GetState()`, `InterestState` enum |
 | §6 Advantage from interest | VeryIntoIt/AlmostThere → advantage; Bored → disadvantage | `Conversation/InterestMeter.cs` | `GrantsAdvantage`/`GrantsDisadvantage` |
-| §7 Shadow growth table | 20+ trigger conditions | `Conversation/GameSession.cs` | Shadow growth logic — **NEW Sprint 7** |
-| §7 Shadow thresholds | 6=T1, 12=T2, 18+=T3 | `Stats/ShadowThresholdEvaluator.cs` | `GetThresholdLevel()` — **NEW Sprint 7** |
-| §8 Read/Recover/Wait | DC 12, SA stat, −1 interest on fail | `Conversation/GameSession.cs` | `ReadAsync`/`RecoverAsync`/`Wait` — **NEW Sprint 7** |
+| §7 Shadow growth table | 20+ trigger conditions | `Conversation/GameSession.cs` | Shadow growth logic |
+| §7 Shadow thresholds | 6=T1, 12=T2, 18+=T3 | `Stats/ShadowThresholdEvaluator.cs` | `GetThresholdLevel()` |
+| §8 Read/Recover/Wait | DC 12, SA stat, −1 interest on fail | `Conversation/GameSession.cs` | `ReadAsync`/`RecoverAsync`/`Wait` |
 | §10 XP thresholds | L1=0...L11=3500 | `Progression/LevelTable.cs` | `XpThresholds` array |
-| §10 Level bonuses | L1–2=+0...L11=+5 | `Progression/LevelTable.cs` | `LevelBonuses` array |
-| §10 XP sources | Success 5/10/15, Fail 2, Nat20 25, Nat1 10, Date 50, Recovery 15, Complete 5 | `Progression/XpLedger.cs` | XP award methods — **NEW Sprint 7** |
-| §10 Build points | L1=0(12 creation)...L11=0(prestige) | `Progression/LevelTable.cs` | `BuildPointsGranted` array |
-| §10 Item slots | L1–2=2...L9–11=6 | `Progression/LevelTable.cs` | `ItemSlots` array |
-| §10 Stat caps | Creation=4, Base=6 | `Progression/LevelTable.cs` | `CreationStatCap`, `BaseStatCap` |
-| §8 Shadow pairs | Charm↔Madness, etc. | `Stats/StatBlock.cs` | `ShadowPairs` |
-| §8 Shadow penalty | -1 per 3 shadow points | `Stats/StatBlock.cs` | `GetEffective()` |
-| §7 Trap effects | Disadvantage, StatPenalty, OpponentDCIncrease | `Traps/TrapDefinition.cs` | `TrapEffect` enum |
-| §15 Combos | 8 named combos with sequences and bonuses | `Conversation/ComboTracker.cs` | Combo definitions — **NEW Sprint 7** |
-| §15 Callback bonus | 2 turns→+1, 4+→+2, opener→+3 | `Conversation/GameSession.cs` | Callback logic — **NEW Sprint 7** |
-| §15 Tell bonus | +2 hidden roll bonus | `Conversation/GameSession.cs` | Tell logic — **NEW Sprint 7** |
-| §15 Weakness DC | −2 or −3 per crack type | `Conversation/GameSession.cs` | Weakness window logic — **NEW Sprint 7** |
-| §15 Horniness forced Rizz | ≥6→1 option, ≥12→always 1, ≥18→all Rizz | `Conversation/GameSession.cs` | Horniness logic — **NEW Sprint 7** |
-| §async-time Horniness mod | Morning −2, Afternoon +0, Evening +1, LateNight +3, After2AM +5 | `Conversation/GameClock.cs` | `GetHorninessModifier()` — **NEW Sprint 7** |
-| §async-time Delay penalty | <1m→0, 1–15m→0, 15–60m→-1(if≥16), 1–6h→-2, 6–24h→-3, 24h+→-5 | `Conversation/PlayerResponseDelayEvaluator.cs` | Penalty table — **NEW Sprint 7** |
+| §10 XP sources | Success 5/10/15, Fail 2, Nat20 25, Nat1 10, Date 50, Recovery 15, Complete 5 | `Progression/XpLedger.cs` | XP award methods |
+| §15 Combos | 8 named combos with sequences and bonuses | `Conversation/ComboTracker.cs` | Combo definitions |
+| §15 Callback bonus | 2 turns→+1, 4+→+2, opener→+3 | `Conversation/GameSession.cs` | Callback logic |
+| §15 Tell bonus | +2 hidden roll bonus | `Conversation/GameSession.cs` | Tell logic |
+| §15 Weakness DC | −2 or −3 per crack type | `Conversation/GameSession.cs` | Weakness window logic |
+| §15 Horniness forced Rizz | ≥6→1 option, ≥12→always 1, ≥18→all Rizz | `Conversation/GameSession.cs` | Horniness logic |
+| §async-time Horniness mod | Morning −2, Afternoon +0, Evening +1, LateNight +3, After2AM +5 | `Conversation/GameClock.cs` | `GetHorninessModifier()` |
+| §async-time Delay penalty | <1m→0, 1–15m→0, 15–60m→-1(if≥16), 1–6h→-2, 6–24h→-3, 24h+→-5 | `Conversation/PlayerResponseDelayEvaluator.cs` | Penalty table |
 | Momentum | 3-streak→+2, 4-streak→+2, 5+→+3, reset on fail | `Conversation/GameSession.cs` | `GetMomentumBonus()` |
 | Ghost trigger | Bored state → 25% chance per turn (dice.Roll(4)==1) | `Conversation/GameSession.cs` | `StartTurnAsync()` |
-
-### Drift Detection
-
-1. **Automated**: `tests/Pinder.Core.Tests/RulesConstantsTests.cs` asserts every value in the sync table above.
-2. **Quick grep patterns** to find hardcoded rule values in C#:
-   - Base DC: `grep -rn "13 +" src/Pinder.Core/Stats/`
-   - Interest bounds: `grep -rn "Max\|Min\|StartingValue" src/Pinder.Core/Conversation/`
-   - XP thresholds: `grep -rn "XpThresholds" src/Pinder.Core/Progression/`
-   - Shadow penalty divisor: `grep -rn "/ 3" src/Pinder.Core/Stats/`
-   - Failure tier boundaries: `grep -rn "miss\|<= 2\|<= 5\|<= 9" src/Pinder.Core/Rolls/`
-3. **Manual checklist** when `rules-v3.md` changes:
-   - Open this sync table → find C# location → update → update test → `dotnet test`
-
-### Known Gaps (as of Sprint 7)
-
-| Gap | Rules Section | Status |
-|-----|--------------|--------|
-| Shadow persistence across sessions | §8 | Not addressed — shadows are per-session via SessionShadowTracker. Host must persist deltas. |
-| `AddExternalBonus()` deprecated but not removed | — | Cleanup issue needed post-Sprint 7 |
 
 ---
 
@@ -263,3 +260,14 @@ Every numeric constant or structural table in the engine traces back to a rules 
 - **Owns**: Abstraction contracts for injection points
 - **Public API**: `IDiceRoller`, `IFailurePool`, `ITrapRegistry`, `IItemRepository`, `IAnatomyRepository`, `ILlmAdapter`, `IGameClock`, `TimeOfDay`
 - **Does NOT own**: Any implementation (implementations live in their owning modules)
+
+---
+
+## Known Gaps (as of Sprint 8)
+
+| Gap | Rules Section | Status |
+|-----|--------------|--------|
+| Shadow persistence across sessions | §8 | Not addressed — shadows are per-session via SessionShadowTracker. Host must persist deltas. |
+| `AddExternalBonus()` deprecated but not removed | — | Cleanup issue needed post-Sprint 8 |
+| Energy system consumers | #144 | IGameClock.ConsumeEnergy() exists but nothing calls it this sprint |
+| GameSession god object trajectory | #87 | Acknowledged — extraction planned for next maturity level |


### PR DESCRIPTION
Fixes #139

## Summary

Architecture review and interface definitions for Sprint 8 (RPG Rules Complete).

### Architecture Decisions
- **#161 resolved**: `SessionShadowTracker` is canonical shadow-tracking wrapper. `CharacterState` from #44 spec is dropped. `DrainGrowthEvents()` added to `SessionShadowTracker`.
- **#162 resolved**: `previousOpener` goes into `GameSessionConfig`, not a constructor parameter.
- **#147 resolved**: Read/Recover/Wait are self-contained turn actions (no `StartTurnAsync()` required).
- **#146 resolved**: `AddExternalBonus()` deprecated but retained. Removal deferred post-Sprint 8.
- **#163 noted**: `TurnResult.ShadowGrowthEvents` already exists — populate, don't add.

### Wave Plan
- **Wave 0**: #139 (infra), #38 (QA) — no dependencies
- **Wave 1**: #54, #43, #46, #47, #49, #50 — depend only on #139
- **Wave 2**: #44, #55 — depend on Wave 1
- **Wave 3**: #45, #48 — depend on Wave 2
- **Wave 4**: #51 — depends on #45, #54
- **Wave 5**: #56 — depends on #54, #44 (most complex, most dependencies)

### Files Changed
- `docs/architecture.md` — full Sprint 8 briefing with ADRs
- 14 contract files in `contracts/sprint-8-*.md` covering all sprint issues

### Verdict: PROCEED WITH CHANGES
Sprint plan is solid. #161 must be resolved as specified (keep SessionShadowTracker). Minor additions needed (#160 public interest accessor on GameSession).

## DoD Evidence
**Branch:** issue-139-architecture-review-rpg-rules-complete-s
**Commit:** 9b89363
