### PR TITLE
[Issue #51] Fix spec document: Horniness-forced Rizz option — implement §15 🔥 mechanic

### DIFF
--- a/docs/specs/issue-51-spec.md
+++ b/docs/specs/issue-51-spec.md
@@ -1,6 +1,7 @@
 # Spec: Horniness-Forced Rizz Option — Implement §15 🔥 Mechanic
 
 **Issue:** #51  
+**Status:** Approved (spec review passed — 0 errors, 0 warnings)  
 **Depends on:** #27 (GameSession), #45 (Shadow thresholds — Horniness at 12/18), #54 (GameClock — time-of-day Horniness modifier)  
 **Component:** `Pinder.Core.Conversation`, `Pinder.Core.Interfaces`  
 **Target:** .NET Standard 2.0, C# 8.0, zero NuGet dependencies


### PR DESCRIPTION
Fixes #51

## Summary
Finalized the issue-51 spec document after reviewer approval (0 errors, 0 warnings, 0 info). The spec correctly integrates `shadowHorniness` as a third additive term in the Horniness formula, with verified arithmetic for all threshold boundary scenarios (6, 12, 18).

## Changes
- Added approved status to spec metadata header

## DoD Evidence
**Branch:** issue-51-fix-spec-document-horniness-forced-rizz-
**Commit:** e23aa32
