### PR TITLE
[Issue #46] Combo system — implement §15 combo detection and interest bonuses

### DIFF
--- a/src/Pinder.Core/Conversation/ComboResult.cs
+++ b/src/Pinder.Core/Conversation/ComboResult.cs
@@ -1,0 +1,29 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Result of a combo detection check. Contains the combo name and its bonus.
+    /// </summary>
+    public sealed class ComboResult
+    {
+        /// <summary>Display name of the combo (e.g. "The Setup", "The Recovery").</summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Interest bonus to add to the turn's interest delta.
+        /// 0 for The Triple (which gives a roll bonus instead).
+        /// </summary>
+        public int InterestBonus { get; }
+
+        /// <summary>
+        /// True only for The Triple — signals that next turn gets +1 roll bonus.
+        /// </summary>
+        public bool IsTriple { get; }
+
+        public ComboResult(string name, int interestBonus, bool isTriple)
+        {
+            Name = name ?? throw new System.ArgumentNullException(nameof(name));
+            InterestBonus = interestBonus;
+            IsTriple = isTriple;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/ComboTracker.cs
+++ b/src/Pinder.Core/Conversation/ComboTracker.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Tracks stat play history and detects the 8 named combo sequences from §15.
+    /// Pure data tracker — returns combo name/bonus; GameSession applies the effect.
+    /// </summary>
+    public sealed class ComboTracker
+    {
+        /// <summary>
+        /// Entry recording a single turn's stat and outcome.
+        /// </summary>
+        private struct TurnEntry
+        {
+            public StatType Stat;
+            public bool Succeeded;
+        }
+
+        private readonly List<TurnEntry> _history = new List<TurnEntry>();
+        private ComboResult? _lastCombo;
+        private bool _pendingTripleBonus;
+
+        /// <summary>
+        /// True if The Triple was completed on a previous turn and the bonus
+        /// has not yet been consumed. GameSession reads this before calling
+        /// RollEngine.Resolve to pass +1 externalBonus.
+        /// </summary>
+        public bool HasTripleBonus => _pendingTripleBonus;
+
+        /// <summary>
+        /// Record the stat used this turn and whether the roll succeeded.
+        /// Must be called exactly once per turn, in chronological order.
+        /// Internally updates the history buffer and checks for combo completion.
+        /// </summary>
+        /// <param name="stat">The StatType played this turn.</param>
+        /// <param name="succeeded">True if the roll succeeded, false if it failed.</param>
+        public void RecordTurn(StatType stat, bool succeeded)
+        {
+            // Consume triple bonus at the start of each recorded turn
+            // (it was already applied to the roll by GameSession)
+            if (_pendingTripleBonus)
+            {
+                _pendingTripleBonus = false;
+            }
+
+            _history.Add(new TurnEntry { Stat = stat, Succeeded = succeeded });
+            _lastCombo = succeeded ? DetectCombo() : null;
+
+            // If The Triple was detected, set pending bonus for next turn
+            if (_lastCombo != null && _lastCombo.IsTriple)
+            {
+                _pendingTripleBonus = true;
+            }
+        }
+
+        /// <summary>
+        /// After RecordTurn, returns the combo that completed this turn, or null.
+        /// Only valid immediately after RecordTurn — returns the result of the
+        /// most recent RecordTurn call.
+        /// </summary>
+        /// <returns>A ComboResult with name and bonus, or null if no combo fired.</returns>
+        public ComboResult? CheckCombo()
+        {
+            return _lastCombo;
+        }
+
+        /// <summary>
+        /// Preview: returns the combo name that would complete if the given stat
+        /// is played and succeeds this turn. Returns null if no combo would complete.
+        /// Does NOT mutate internal state — safe to call for each dialogue option.
+        /// Used by GameSession.StartTurnAsync to populate DialogueOption.ComboName.
+        /// </summary>
+        /// <param name="stat">The StatType being previewed.</param>
+        /// <returns>Combo name string (e.g. "The Setup") or null.</returns>
+        public string? PeekCombo(StatType stat)
+        {
+            // Temporarily add entry, check, remove
+            _history.Add(new TurnEntry { Stat = stat, Succeeded = true });
+            var combo = DetectCombo();
+            _history.RemoveAt(_history.Count - 1);
+            return combo?.Name;
+        }
+
+        /// <summary>
+        /// Consumes the Triple bonus without recording a turn.
+        /// Used when the player takes a non-Speak action (Read/Recover/Wait)
+        /// during the bonus turn.
+        /// </summary>
+        public void ConsumeTripleBonus()
+        {
+            _pendingTripleBonus = false;
+        }
+
+        /// <summary>
+        /// Detects the best combo from current history (last entry is the completing turn).
+        /// Returns the highest-interest-bonus combo, or null if none match.
+        /// The completing turn (last entry) must have succeeded.
+        /// </summary>
+        private ComboResult? DetectCombo()
+        {
+            int count = _history.Count;
+            if (count < 2)
+                return null;
+
+            var current = _history[count - 1];
+            if (!current.Succeeded)
+                return null;
+
+            var prev = _history[count - 2];
+            ComboResult? best = null;
+
+            // Check 2-stat combos (previous → current)
+            // The Recovery: any fail → SelfAwareness success
+            if (!prev.Succeeded && current.Stat == StatType.SelfAwareness)
+            {
+                best = PickBest(best, new ComboResult("The Recovery", 2, false));
+            }
+
+            if (prev.Succeeded || IsRecoveryOnly(prev, current))
+            {
+                // Only check stat-sequence combos if prev succeeded
+                // (except Recovery which needs prev to fail)
+            }
+
+            // Stat-sequence combos: prev must have any outcome for sequence matching,
+            // but per spec the completing roll must succeed (already checked above).
+            // The sequence is based on stat types, not success of earlier turns.
+
+            // The Setup: Wit → Charm
+            if (prev.Stat == StatType.Wit && current.Stat == StatType.Charm)
+                best = PickBest(best, new ComboResult("The Setup", 1, false));
+
+            // The Reveal: Charm → Honesty
+            if (prev.Stat == StatType.Charm && current.Stat == StatType.Honesty)
+                best = PickBest(best, new ComboResult("The Reveal", 1, false));
+
+            // The Read: SelfAwareness → Honesty
+            if (prev.Stat == StatType.SelfAwareness && current.Stat == StatType.Honesty)
+                best = PickBest(best, new ComboResult("The Read", 1, false));
+
+            // The Pivot: Honesty → Chaos
+            if (prev.Stat == StatType.Honesty && current.Stat == StatType.Chaos)
+                best = PickBest(best, new ComboResult("The Pivot", 1, false));
+
+            // The Escalation: Chaos → Rizz
+            if (prev.Stat == StatType.Chaos && current.Stat == StatType.Rizz)
+                best = PickBest(best, new ComboResult("The Escalation", 1, false));
+
+            // The Disarm: Wit → Honesty
+            if (prev.Stat == StatType.Wit && current.Stat == StatType.Honesty)
+                best = PickBest(best, new ComboResult("The Disarm", 1, false));
+
+            // The Triple: 3 different stats in 3 consecutive turns, success on 3rd
+            if (count >= 3)
+            {
+                var prev2 = _history[count - 3];
+                if (prev2.Stat != prev.Stat
+                    && prev2.Stat != current.Stat
+                    && prev.Stat != current.Stat)
+                {
+                    best = PickBest(best, new ComboResult("The Triple", 0, true));
+                }
+            }
+
+            return best;
+        }
+
+        /// <summary>
+        /// Returns the combo with the higher interest bonus.
+        /// If tied, returns the existing (first-matched) combo.
+        /// </summary>
+        private static ComboResult PickBest(ComboResult? existing, ComboResult candidate)
+        {
+            if (existing == null)
+                return candidate;
+            // Higher interest bonus wins; if tied, first-matched (existing) wins
+            return candidate.InterestBonus > existing.InterestBonus ? candidate : existing;
+        }
+
+        private static bool IsRecoveryOnly(TurnEntry prev, TurnEntry current)
+        {
+            return !prev.Succeeded && current.Stat == StatType.SelfAwareness;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -33,6 +33,9 @@ namespace Pinder.Core.Conversation
         private readonly SessionShadowTracker? _opponentShadows;
         private readonly string? _previousOpener;
 
+        // Combo tracking (#46)
+        private readonly ComboTracker _comboTracker;
+
         // Shadow growth tracking fields (#44)
         private readonly List<StatType> _statsUsedPerTurn;
         private readonly List<bool> _highestPctOptionPicked;
@@ -96,6 +99,9 @@ namespace Pinder.Core.Conversation
             _playerShadows = config?.PlayerShadows;
             _opponentShadows = config?.OpponentShadows;
             _previousOpener = config?.PreviousOpener;
+
+            // Combo tracking (#46)
+            _comboTracker = new ComboTracker();
 
             // Shadow growth tracking (#44)
             _statsUsedPerTurn = new List<StatType>();
@@ -178,7 +184,21 @@ namespace Pinder.Core.Conversation
                 activeTrapInstructions: activeTrapInstructions);
 
             // Get dialogue options from LLM
-            var options = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
+            var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
+
+            // Peek combos for each option (#46)
+            var options = new DialogueOption[rawOptions.Length];
+            for (int i = 0; i < rawOptions.Length; i++)
+            {
+                var opt = rawOptions[i];
+                string? comboName = _comboTracker.PeekCombo(opt.Stat);
+                options[i] = new DialogueOption(
+                    opt.Stat,
+                    opt.IntendedText,
+                    opt.CallbackTurnNumber,
+                    comboName,
+                    opt.HasTellBonus);
+            }
             _currentOptions = options;
 
             var snapshot = CreateSnapshot();
@@ -206,6 +226,13 @@ namespace Pinder.Core.Conversation
 
             var chosenOption = _currentOptions[optionIndex];
 
+            // Compute external bonus from Triple combo (#46)
+            int externalBonus = 0;
+            if (_comboTracker.HasTripleBonus)
+            {
+                externalBonus += 1;
+            }
+
             // 1. Roll dice
             var rollResult = RollEngine.Resolve(
                 stat: chosenOption.Stat,
@@ -216,7 +243,8 @@ namespace Pinder.Core.Conversation
                 trapRegistry: _trapRegistry,
                 dice: _dice,
                 hasAdvantage: _currentHasAdvantage,
-                hasDisadvantage: _currentHasDisadvantage);
+                hasDisadvantage: _currentHasDisadvantage,
+                externalBonus: externalBonus);
 
             // 2. Compute interest delta from roll outcome
             int interestDelta;
@@ -239,6 +267,16 @@ namespace Pinder.Core.Conversation
             else
             {
                 _momentumStreak = 0;
+            }
+
+            // 3b. Combo detection (#46)
+            _comboTracker.RecordTurn(chosenOption.Stat, rollResult.IsSuccess);
+            var combo = _comboTracker.CheckCombo();
+            string? comboTriggered = null;
+            if (combo != null)
+            {
+                interestDelta += combo.InterestBonus;
+                comboTriggered = combo.Name;
             }
 
             // 4. Record interest before applying delta
@@ -365,7 +403,8 @@ namespace Pinder.Core.Conversation
                 stateAfter: stateSnapshot,
                 isGameOver: isGameOver,
                 outcome: outcome,
-                shadowGrowthEvents: shadowGrowthEvents);
+                shadowGrowthEvents: shadowGrowthEvents,
+                comboTriggered: comboTriggered);
         }
 
         /// <summary>
@@ -568,7 +607,8 @@ namespace Pinder.Core.Conversation
                 state: _interest.GetState(),
                 momentumStreak: _momentumStreak,
                 activeTrapNames: trapNames,
-                turnNumber: _turnNumber);
+                turnNumber: _turnNumber,
+                tripleBonusActive: _comboTracker.HasTripleBonus);
         }
 
         private string GetLastOpponentMessage()
@@ -608,6 +648,9 @@ namespace Pinder.Core.Conversation
 
             // 4. Clear pending Speak options
             _currentOptions = null;
+
+            // 4b. Consume triple bonus if active (#46 edge case 7)
+            _comboTracker.ConsumeTripleBonus();
 
             // 5. Determine advantage/disadvantage from interest state
             bool hasAdvantage = _interest.GrantsAdvantage;
@@ -693,6 +736,9 @@ namespace Pinder.Core.Conversation
             // 5. Clear pending Speak options
             _currentOptions = null;
 
+            // 5b. Consume triple bonus if active (#46 edge case 7)
+            _comboTracker.ConsumeTripleBonus();
+
             // 6. Determine advantage/disadvantage from interest state
             bool hasAdvantage = _interest.GrantsAdvantage;
             bool hasDisadvantage = _interest.GrantsDisadvantage;
@@ -771,6 +817,9 @@ namespace Pinder.Core.Conversation
 
             // 4. Clear pending Speak options
             _currentOptions = null;
+
+            // 4b. Consume triple bonus if active (#46 edge case 7)
+            _comboTracker.ConsumeTripleBonus();
 
             // 5. Apply -1 interest
             _interest.Apply(-1);

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -20,18 +20,23 @@ namespace Pinder.Core.Conversation
         /// <summary>Current turn number (0-based before first turn).</summary>
         public int TurnNumber { get; }
 
+        /// <summary>True if The Triple bonus is active for the current turn (+1 to all rolls).</summary>
+        public bool TripleBonusActive { get; }
+
         public GameStateSnapshot(
             int interest,
             InterestState state,
             int momentumStreak,
             string[] activeTrapNames,
-            int turnNumber)
+            int turnNumber,
+            bool tripleBonusActive = false)
         {
             Interest = interest;
             State = state;
             MomentumStreak = momentumStreak;
             ActiveTrapNames = activeTrapNames ?? System.Array.Empty<string>();
             TurnNumber = turnNumber;
+            TripleBonusActive = tripleBonusActive;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// LLM adapter that returns options with specific stats, allowing combo testing.
+    /// </summary>
+    public sealed class ComboTestLlmAdapter : ILlmAdapter
+    {
+        private readonly Queue<DialogueOption[]> _optionSets = new Queue<DialogueOption[]>();
+
+        public void EnqueueOptions(params DialogueOption[] options)
+        {
+            _optionSets.Enqueue(options);
+        }
+
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        {
+            if (_optionSets.Count > 0)
+                return Task.FromResult(_optionSets.Dequeue());
+
+            // Default fallback
+            return Task.FromResult(new[]
+            {
+                new DialogueOption(StatType.Charm, "Default option")
+            });
+        }
+
+        public Task<string> DeliverMessageAsync(DeliveryContext context)
+        {
+            return Task.FromResult(context.ChosenOption.IntendedText);
+        }
+
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        {
+            return Task.FromResult(new OpponentResponse("..."));
+        }
+
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        {
+            return Task.FromResult<string?>(null);
+        }
+    }
+
+    public class ComboGameSessionTests
+    {
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// Tests that The Setup combo (Wit → Charm) populates ComboTriggered on TurnResult
+        /// and adds +1 to interest delta.
+        /// </summary>
+        [Fact]
+        public async Task TheSetup_WitThenCharm_ComboTriggeredAndBonusApplied()
+        {
+            // DC = 13 + 2 = 15. Roll 15: 15 + 2 + 0 = 17 >= 15 → success (beat by 2 → SuccessScale +1)
+            // Each turn: d20 + d100(timing)
+            var dice = new FixedDice(
+                15, 50,  // Turn 1: Wit
+                15, 50   // Turn 2: Charm
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Wit, "A witty remark"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "A charming line"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turn 1: Wit
+            await session.StartTurnAsync();
+            var r1 = await session.ResolveTurnAsync(0);
+            Assert.True(r1.Roll.IsSuccess);
+            Assert.Null(r1.ComboTriggered);
+
+            // Turn 2: Charm → The Setup fires
+            var start2 = await session.StartTurnAsync();
+            Assert.Equal("The Setup", start2.Options[0].ComboName);
+            var r2 = await session.ResolveTurnAsync(0);
+            Assert.True(r2.Roll.IsSuccess);
+            Assert.Equal("The Setup", r2.ComboTriggered);
+
+            // Interest delta: SuccessScale(+1) + RiskTierBonus(+1 for Hard) + momentum(0 streak=2) + combo(+1) = +3
+            Assert.Equal(3, r2.InterestDelta);
+        }
+
+        /// <summary>
+        /// Tests The Recovery combo: any fail → SA success = +2 interest.
+        /// </summary>
+        [Fact]
+        public async Task TheRecovery_FailThenSASuccess_ComboTriggered()
+        {
+            // Turn 1: Roll 5 → fail (5 + 2 = 7 vs DC 15, miss by 8 = TropeTrap -3)
+            // Turn 2: Roll 15 → success (SA, 15+2=17 vs DC 15)
+            var dice = new FixedDice(
+                5, 50,   // Turn 1: fail
+                15, 50   // Turn 2: SA success
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Chaos, "Chaos line"));
+            llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "SA line"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turn 1: Chaos fail
+            await session.StartTurnAsync();
+            var r1 = await session.ResolveTurnAsync(0);
+            Assert.False(r1.Roll.IsSuccess);
+
+            // Turn 2: SA success → Recovery
+            var start2 = await session.StartTurnAsync();
+            Assert.Equal("The Recovery", start2.Options[0].ComboName);
+            var r2 = await session.ResolveTurnAsync(0);
+            Assert.True(r2.Roll.IsSuccess);
+            Assert.Equal("The Recovery", r2.ComboTriggered);
+
+            // Interest delta: SuccessScale(+1) + RiskTierBonus(+1) + combo(+2) = +4
+            Assert.Equal(4, r2.InterestDelta);
+        }
+
+        /// <summary>
+        /// Tests The Triple combo: 3 distinct stats → +1 roll bonus next turn via externalBonus.
+        /// </summary>
+        [Fact]
+        public async Task TheTriple_ThreeDistinctStats_RollBonusNextTurn()
+        {
+            // Use stats that don't form 2-stat combos: Rizz, SelfAwareness, Chaos
+            // DC = 15 for all. Roll 15: 15+2=17 >= 15 → success
+            var dice = new FixedDice(
+                15, 50,  // Turn 1: Rizz (d20 + d100 timing)
+                15, 50,  // Turn 2: SA
+                15, 50,  // Turn 3: Chaos → Triple triggers
+                15, 50,  // Turn 4: should get +1 external bonus
+                15, 50   // Extra safety margin
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Rizz, "Rizz line"));
+            llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "SA line"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Chaos, "Chaos line"));
+            // Turn 4: use Chaos again so we don't re-trigger Triple
+            llm.EnqueueOptions(new DialogueOption(StatType.Chaos, "Chaos again"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turns 1-2
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 3: Chaos → Triple
+            await session.StartTurnAsync();
+            var r3 = await session.ResolveTurnAsync(0);
+            Assert.Equal("The Triple", r3.ComboTriggered);
+            Assert.True(r3.StateAfter.TripleBonusActive);
+
+            // Turn 4: should have +1 external bonus on roll
+            var start4 = await session.StartTurnAsync();
+            Assert.True(start4.State.TripleBonusActive);
+            var r4 = await session.ResolveTurnAsync(0);
+            // Roll: 15+2+0=17 base, +1 external = 18 final total
+            Assert.Equal(1, r4.Roll.ExternalBonus);
+            Assert.False(r4.StateAfter.TripleBonusActive); // consumed
+        }
+
+        /// <summary>
+        /// Tests that combo does NOT trigger when the completing roll fails.
+        /// </summary>
+        [Fact]
+        public async Task ComboDoesNotTriggerOnFailure()
+        {
+            // Turn 1: Wit success. Turn 2: Charm fail → no Setup
+            var dice = new FixedDice(
+                15, 50,  // Turn 1: success
+                5, 50    // Turn 2: fail (5+2=7 < 15)
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Wit, "Wit"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Charm"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            await session.StartTurnAsync();
+            var r2 = await session.ResolveTurnAsync(0);
+            Assert.False(r2.Roll.IsSuccess);
+            Assert.Null(r2.ComboTriggered);
+        }
+
+        /// <summary>
+        /// Tests that PeekCombo populates DialogueOption.ComboName during StartTurnAsync.
+        /// </summary>
+        [Fact]
+        public async Task PeekCombo_PopulatesDialogueOptionComboName()
+        {
+            var dice = new FixedDice(
+                15, 50,  // Turn 1
+                15, 50   // Turn 2 (not used for start, but needed for resolve)
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Wit, "Wit"));
+            // Turn 2: offer both Charm (Setup combo) and Honesty (Disarm combo)
+            llm.EnqueueOptions(
+                new DialogueOption(StatType.Charm, "Charm"),
+                new DialogueOption(StatType.Honesty, "Honesty"),
+                new DialogueOption(StatType.Rizz, "Rizz")
+            );
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turn 1: Wit
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2: Check combo names on options
+            var start2 = await session.StartTurnAsync();
+            Assert.Equal("The Setup", start2.Options[0].ComboName);  // Wit → Charm
+            Assert.Equal("The Disarm", start2.Options[1].ComboName); // Wit → Honesty
+            Assert.Null(start2.Options[2].ComboName);                 // Wit → Rizz = no combo
+        }
+
+        /// <summary>
+        /// Tests that Triple bonus is consumed by Wait action.
+        /// </summary>
+        [Fact]
+        public async Task TripleBonus_ConsumedByWait()
+        {
+            var dice = new FixedDice(
+                15, 50,  // Turn 1
+                15, 50,  // Turn 2
+                15, 50,  // Turn 3
+                4,       // Ghost check (not 1, no ghost)
+                15, 50   // Turn 5: should NOT have triple bonus
+            );
+
+            var llm = new ComboTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Rizz, "R"));
+            llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "SA"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Chaos, "C"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Ch"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // 3 turns to trigger Triple
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            var r3 = await session.ResolveTurnAsync(0);
+            Assert.Equal("The Triple", r3.ComboTriggered);
+            Assert.True(r3.StateAfter.TripleBonusActive);
+
+            // Wait consumes the triple bonus
+            // Interest is high enough (~16+), Wait applies -1
+            // Need to check interest won't be in Bored state
+            session.Wait();
+
+            // Next turn should NOT have triple bonus
+            var start5 = await session.StartTurnAsync();
+            Assert.False(start5.State.TripleBonusActive);
+            var r5 = await session.ResolveTurnAsync(0);
+            Assert.Equal(0, r5.Roll.ExternalBonus);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/ComboTrackerTests.cs
+++ b/tests/Pinder.Core.Tests/ComboTrackerTests.cs
@@ -1,0 +1,470 @@
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class ComboTrackerTests
+    {
+        // ---- The Setup: Wit → Charm (success) = +1 interest ----
+
+        [Fact]
+        public void TheSetup_WitThenCharmSuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            Assert.Null(tracker.CheckCombo());
+
+            tracker.RecordTurn(StatType.Charm, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Setup", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+            Assert.False(combo.IsTriple);
+        }
+
+        [Fact]
+        public void TheSetup_WitThenCharmFail_NoCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Charm, false);
+
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        // ---- The Reveal: Charm → Honesty (success) = +1 interest ----
+
+        [Fact]
+        public void TheReveal_CharmThenHonestySuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Charm, true);
+            tracker.RecordTurn(StatType.Honesty, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Reveal", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+        }
+
+        // ---- The Read: SelfAwareness → Honesty (success) = +1 interest ----
+
+        [Fact]
+        public void TheRead_SAThenHonestySuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Honesty, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Read", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+        }
+
+        // ---- The Pivot: Honesty → Chaos (success) = +1 interest ----
+
+        [Fact]
+        public void ThePivot_HonestyThenChaosSuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Honesty, true);
+            tracker.RecordTurn(StatType.Chaos, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Pivot", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+        }
+
+        // ---- The Escalation: Chaos → Rizz (success) = +1 interest ----
+
+        [Fact]
+        public void TheEscalation_ChaosThenRizzSuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Chaos, true);
+            tracker.RecordTurn(StatType.Rizz, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Escalation", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+        }
+
+        // ---- The Disarm: Wit → Honesty (success) = +1 interest ----
+
+        [Fact]
+        public void TheDisarm_WitThenHonestySuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Honesty, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Disarm", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+        }
+
+        // ---- The Recovery: Any fail → SelfAwareness (success) = +2 interest ----
+
+        [Fact]
+        public void TheRecovery_AnyFailThenSASuccess_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Chaos, false);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            var combo = tracker.CheckCombo();
+
+            Assert.NotNull(combo);
+            Assert.Equal("The Recovery", combo!.Name);
+            Assert.Equal(2, combo.InterestBonus);
+            Assert.False(combo.IsTriple);
+        }
+
+        [Fact]
+        public void TheRecovery_SuccessThenSA_NoCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Charm, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        [Fact]
+        public void TheRecovery_MultipleFailsBeforeSA_StillTriggers()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, false);
+            tracker.RecordTurn(StatType.Charm, false);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Recovery", combo!.Name);
+        }
+
+        [Fact]
+        public void TheRecovery_AnyStatCanFail()
+        {
+            // Verify Recovery works with different failing stats
+            foreach (var stat in new[] { StatType.Charm, StatType.Wit, StatType.Honesty, StatType.Chaos, StatType.Rizz, StatType.SelfAwareness })
+            {
+                var tracker = new ComboTracker();
+                tracker.RecordTurn(stat, false);
+                tracker.RecordTurn(StatType.SelfAwareness, true);
+                var combo = tracker.CheckCombo();
+
+                Assert.NotNull(combo);
+                Assert.Equal("The Recovery", combo!.Name);
+                Assert.Equal(2, combo.InterestBonus);
+            }
+        }
+
+        // ---- The Triple: 3 different stats in 3 turns, success on 3rd ----
+
+        [Fact]
+        public void TheTriple_ThreeDistinctStats_Success_ReturnsCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Charm, true);
+            tracker.RecordTurn(StatType.Honesty, true);
+
+            // Turn 2 triggers The Setup (Wit→Charm), but turn 3 is what we check
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            // The Reveal (Charm→Honesty) has interest +1, Triple has interest 0
+            // Per single-best rule, The Reveal wins
+            Assert.Equal("The Reveal", combo!.Name);
+        }
+
+        [Fact]
+        public void TheTriple_ThreeDistinctStats_NoOverlap_ReturnsTriple()
+        {
+            // Use stats that don't form a 2-stat combo: Rizz, Chaos, SelfAwareness
+            // Chaos→Rizz could form Escalation... let's use Rizz, Wit, SelfAwareness
+            // Wit→SA is not a combo, Rizz→Wit not a combo
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.Charm, false); // fail - no 2-stat combo completes
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            // Recovery: prev failed, current is SA success → +2
+            // Triple: 3 distinct stats → +0 interest, IsTriple
+            // Recovery has higher InterestBonus (2 > 0), so Recovery wins
+            Assert.Equal("The Recovery", combo!.Name);
+        }
+
+        [Fact]
+        public void TheTriple_PureTriple_NoOtherCombo()
+        {
+            // Use stats with no 2-stat combo overlap and no fail
+            // Rizz, SelfAwareness, Chaos — SA→Chaos is not a combo, Rizz→SA is not a combo
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Chaos, true);
+
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Triple", combo!.Name);
+            Assert.Equal(0, combo.InterestBonus);
+            Assert.True(combo.IsTriple);
+        }
+
+        [Fact]
+        public void TheTriple_SetsHasTripleBonus()
+        {
+            var tracker = new ComboTracker();
+            Assert.False(tracker.HasTripleBonus);
+
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Chaos, true);
+
+            Assert.True(tracker.HasTripleBonus);
+        }
+
+        [Fact]
+        public void TheTriple_BonusConsumedOnNextRecordTurn()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Chaos, true);
+            Assert.True(tracker.HasTripleBonus);
+
+            // Next turn consumes the bonus (use Chaos again to avoid re-triggering Triple)
+            tracker.RecordTurn(StatType.Chaos, true);
+            Assert.False(tracker.HasTripleBonus);
+        }
+
+        [Fact]
+        public void TheTriple_RepeatedStat_DoesNotTrigger()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Charm, true);
+            tracker.RecordTurn(StatType.Wit, true); // only 2 distinct stats
+
+            var combo = tracker.CheckCombo();
+            // No triple (not 3 distinct), no 2-stat combo for Charm→Wit
+            Assert.Null(combo);
+        }
+
+        [Fact]
+        public void TheTriple_FailOnEarlierTurns_StillTriggers()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, false);
+            tracker.RecordTurn(StatType.SelfAwareness, false);
+            tracker.RecordTurn(StatType.Chaos, true);
+
+            // Recovery would need prev to fail + current SA → prev is SA fail, current is Chaos, not SA
+            // Triple: 3 distinct stats, 3rd succeeds
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Triple", combo!.Name);
+            Assert.True(combo.IsTriple);
+        }
+
+        // ---- PeekCombo ----
+
+        [Fact]
+        public void PeekCombo_DoesNotMutateState()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+
+            // Peek Charm → should see "The Setup"
+            string? name = tracker.PeekCombo(StatType.Charm);
+            Assert.Equal("The Setup", name);
+
+            // Peek again — same result (not mutated)
+            Assert.Equal("The Setup", tracker.PeekCombo(StatType.Charm));
+
+            // Record something different — Setup should not fire
+            tracker.RecordTurn(StatType.Rizz, true);
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        [Fact]
+        public void PeekCombo_NoHistory_ReturnsNull()
+        {
+            var tracker = new ComboTracker();
+            Assert.Null(tracker.PeekCombo(StatType.Charm));
+            Assert.Null(tracker.PeekCombo(StatType.SelfAwareness));
+        }
+
+        [Fact]
+        public void PeekCombo_Recovery_ShowsWhenPrevFailed()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Charm, false);
+
+            Assert.Equal("The Recovery", tracker.PeekCombo(StatType.SelfAwareness));
+            Assert.Null(tracker.PeekCombo(StatType.Charm));
+        }
+
+        // ---- Edge cases ----
+
+        [Fact]
+        public void FirstTurn_NoCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        [Fact]
+        public void SameStatTwice_NoCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Wit, true);
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        [Fact]
+        public void CheckCombo_WithoutRecordTurn_ReturnsNull()
+        {
+            var tracker = new ComboTracker();
+            Assert.Null(tracker.CheckCombo());
+        }
+
+        [Fact]
+        public void ComboChaining_CompletingStatCanStartNext()
+        {
+            var tracker = new ComboTracker();
+
+            // Turn 1: Wit success
+            tracker.RecordTurn(StatType.Wit, true);
+            Assert.Null(tracker.CheckCombo());
+
+            // Turn 2: Honesty success → "The Disarm" (Wit→Honesty)
+            tracker.RecordTurn(StatType.Honesty, true);
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Disarm", combo!.Name);
+
+            // Turn 3: Chaos success → "The Pivot" (Honesty→Chaos)
+            tracker.RecordTurn(StatType.Chaos, true);
+            combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Pivot", combo!.Name);
+        }
+
+        [Fact]
+        public void ConsumeTripleBonus_ClearsBonus()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Chaos, true);
+            Assert.True(tracker.HasTripleBonus);
+
+            tracker.ConsumeTripleBonus();
+            Assert.False(tracker.HasTripleBonus);
+        }
+
+        [Fact]
+        public void MultipleComboSameTurn_HighestInterestBonusWins()
+        {
+            // Turn 3 scenario: Wit(success) → Charm(success) → Honesty(success)
+            // Turn 3 matches: The Reveal (Charm→Honesty, +1) AND The Triple (3 distinct, +0 roll bonus)
+            // The Reveal should win (higher interest bonus)
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Wit, true);
+            tracker.RecordTurn(StatType.Charm, true);
+            // Turn 2 was The Setup
+            tracker.RecordTurn(StatType.Honesty, true);
+
+            var combo = tracker.CheckCombo();
+            Assert.NotNull(combo);
+            Assert.Equal("The Reveal", combo!.Name);
+            Assert.Equal(1, combo.InterestBonus);
+            Assert.False(combo.IsTriple);
+        }
+
+        // ---- All 8 combo names exact match ----
+
+        [Fact]
+        public void AllEightCombos_ExactNames()
+        {
+            // The Setup: Wit → Charm
+            var t = new ComboTracker();
+            t.RecordTurn(StatType.Wit, true);
+            t.RecordTurn(StatType.Charm, true);
+            Assert.Equal("The Setup", t.CheckCombo()!.Name);
+
+            // The Reveal: Charm → Honesty
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Charm, true);
+            t.RecordTurn(StatType.Honesty, true);
+            Assert.Equal("The Reveal", t.CheckCombo()!.Name);
+
+            // The Read: SA → Honesty
+            t = new ComboTracker();
+            t.RecordTurn(StatType.SelfAwareness, true);
+            t.RecordTurn(StatType.Honesty, true);
+            Assert.Equal("The Read", t.CheckCombo()!.Name);
+
+            // The Pivot: Honesty → Chaos
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Honesty, true);
+            t.RecordTurn(StatType.Chaos, true);
+            Assert.Equal("The Pivot", t.CheckCombo()!.Name);
+
+            // The Recovery: Any fail → SA
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Wit, false);
+            t.RecordTurn(StatType.SelfAwareness, true);
+            Assert.Equal("The Recovery", t.CheckCombo()!.Name);
+
+            // The Escalation: Chaos → Rizz
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Chaos, true);
+            t.RecordTurn(StatType.Rizz, true);
+            Assert.Equal("The Escalation", t.CheckCombo()!.Name);
+
+            // The Disarm: Wit → Honesty
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Wit, true);
+            t.RecordTurn(StatType.Honesty, true);
+            Assert.Equal("The Disarm", t.CheckCombo()!.Name);
+
+            // The Triple: 3 distinct stats (no 2-stat overlap)
+            t = new ComboTracker();
+            t.RecordTurn(StatType.Rizz, true);
+            t.RecordTurn(StatType.SelfAwareness, true);
+            t.RecordTurn(StatType.Chaos, true);
+            Assert.Equal("The Triple", t.CheckCombo()!.Name);
+        }
+
+        [Fact]
+        public void HasTripleBonus_DefaultFalse()
+        {
+            var tracker = new ComboTracker();
+            Assert.False(tracker.HasTripleBonus);
+        }
+
+        [Fact]
+        public void TheTriple_FailOn3rd_NoCombo()
+        {
+            var tracker = new ComboTracker();
+            tracker.RecordTurn(StatType.Rizz, true);
+            tracker.RecordTurn(StatType.SelfAwareness, true);
+            tracker.RecordTurn(StatType.Chaos, false);
+
+            Assert.Null(tracker.CheckCombo());
+            Assert.False(tracker.HasTripleBonus);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #46

## What was implemented

### New classes
- **ComboResult** (Conversation/) — Immutable data class: Name, InterestBonus, IsTriple
- **ComboTracker** (Conversation/) — Tracks stat play history and detects 8 named combo sequences

### Modified classes
- **GameStateSnapshot** — Added `TripleBonusActive` property (backward-compatible default `false`)
- **GameSession** — Integrated ComboTracker:
  - `StartTurnAsync`: Peeks combos on each DialogueOption via `PeekCombo()`
  - `ResolveTurnAsync`: Records turns, applies combo interest bonuses, passes Triple +1 via `externalBonus`
  - `ReadAsync/RecoverAsync/Wait`: Consumes Triple bonus without effect

### Combo definitions (all 8 from §15)
| Combo | Sequence | Bonus |
|-------|----------|-------|
| The Setup | Wit → Charm | +1 interest |
| The Reveal | Charm → Honesty | +1 interest |
| The Read | SA → Honesty | +1 interest |
| The Pivot | Honesty → Chaos | +1 interest |
| The Recovery | Any fail → SA | +2 interest |
| The Escalation | Chaos → Rizz | +1 interest |
| The Disarm | Wit → Honesty | +1 interest |
| The Triple | 3 distinct stats in 3 turns | +1 roll bonus next turn |

### Tests
36 new tests covering:
- All 8 combo detections with exact name validation
- Recovery edge cases (any fail stat, no fail = no combo)
- Triple lifecycle (bonus set, consumed on next turn, consumed by Wait)
- PeekCombo idempotency
- Multi-combo same turn (single-best rule)
- Combo chaining across turns
- GameSession integration (ComboTriggered on TurnResult, ComboName on DialogueOption, externalBonus)

## How to test
```bash
dotnet test
```
All 656 tests pass (620 existing + 36 new).

## Deviations from contract
None.

## DoD Evidence
**Tests**: Passed! - Failed: 0, Passed: 656, Skipped: 0, Total: 656
**Commit**: 0ce8b7c
