### PR TITLE
[Issue #47] Write tests: Callback bonus — implement §15 callback distance detection

### DIFF
--- a/src/Pinder.Core/Conversation/CallbackBonus.cs
+++ b/src/Pinder.Core/Conversation/CallbackBonus.cs
@@ -1,0 +1,38 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Pure static utility: computes the hidden callback bonus from turn distance.
+    /// §15 callback distance detection: referencing earlier conversation topics
+    /// gives a hidden roll bonus based on how far back the topic was introduced.
+    /// </summary>
+    public static class CallbackBonus
+    {
+        /// <summary>
+        /// Compute the hidden callback bonus given the current turn number
+        /// and the turn the referenced topic was introduced.
+        /// Returns 0 if no bonus applies (distance &lt; 2).
+        /// </summary>
+        /// <param name="currentTurn">The current turn number (0-based).</param>
+        /// <param name="callbackTurnNumber">The turn when the topic was introduced (0-based).</param>
+        /// <returns>0, 1, 2, or 3.</returns>
+        public static int Compute(int currentTurn, int callbackTurnNumber)
+        {
+            int distance = currentTurn - callbackTurnNumber;
+
+            // Too recent or same turn — no bonus
+            if (distance < 2)
+                return 0;
+
+            // Opener reference always wins when distance >= 2
+            if (callbackTurnNumber == 0)
+                return 3;
+
+            // Long-distance callback
+            if (distance >= 4)
+                return 2;
+
+            // Mid-distance callback (distance 2 or 3, non-opener)
+            return 1;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -36,6 +36,9 @@ namespace Pinder.Core.Conversation
         // Combo tracking (#46)
         private readonly ComboTracker _comboTracker;
 
+        // Callback tracking (#47)
+        private readonly List<CallbackOpportunity> _topics;
+
         // Shadow growth tracking fields (#44)
         private readonly List<StatType> _statsUsedPerTurn;
         private readonly List<bool> _highestPctOptionPicked;
@@ -103,6 +106,9 @@ namespace Pinder.Core.Conversation
             // Combo tracking (#46)
             _comboTracker = new ComboTracker();
 
+            // Callback tracking (#47)
+            _topics = new List<CallbackOpportunity>();
+
             // Shadow growth tracking (#44)
             _statsUsedPerTurn = new List<StatType>();
             _highestPctOptionPicked = new List<bool>();
@@ -112,6 +118,19 @@ namespace Pinder.Core.Conversation
             _saUsageCount = 0;
             _saOverthinkingTriggered = false;
             _sessionOpener = null;
+        }
+
+        /// <summary>
+        /// Register a conversation topic for future callback opportunities.
+        /// Called by the host or LLM adapter after each turn to seed topics.
+        /// </summary>
+        /// <param name="topic">The topic to register. Must not be null.</param>
+        /// <exception cref="ArgumentNullException">If topic is null.</exception>
+        public void AddTopic(CallbackOpportunity topic)
+        {
+            if (topic == null)
+                throw new ArgumentNullException(nameof(topic));
+            _topics.Add(topic);
         }
 
         /// <summary>
@@ -173,7 +192,7 @@ namespace Pinder.Core.Conversation
             var activeTrapNames = GetActiveTrapNames();
             var activeTrapInstructions = GetActiveTrapInstructions();
 
-            // Build dialogue context
+            // Build dialogue context — pass callback topics (#47)
             var context = new DialogueContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -181,7 +200,8 @@ namespace Pinder.Core.Conversation
                 opponentLastMessage: GetLastOpponentMessage(),
                 activeTraps: activeTrapNames,
                 currentInterest: _interest.Current,
-                activeTrapInstructions: activeTrapInstructions);
+                activeTrapInstructions: activeTrapInstructions,
+                callbackOpportunities: _topics.Count > 0 ? new List<CallbackOpportunity>(_topics) : null);
 
             // Get dialogue options from LLM
             var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
@@ -226,8 +246,15 @@ namespace Pinder.Core.Conversation
 
             var chosenOption = _currentOptions[optionIndex];
 
-            // Compute external bonus from Triple combo (#46)
-            int externalBonus = 0;
+            // Compute callback bonus (#47)
+            int callbackBonus = 0;
+            if (chosenOption.CallbackTurnNumber.HasValue)
+            {
+                callbackBonus = CallbackBonus.Compute(_turnNumber, chosenOption.CallbackTurnNumber.Value);
+            }
+
+            // Compute external bonus: callback + Triple combo (#46, #47)
+            int externalBonus = callbackBonus;
             if (_comboTracker.HasTripleBonus)
             {
                 externalBonus += 1;
@@ -404,7 +431,8 @@ namespace Pinder.Core.Conversation
                 isGameOver: isGameOver,
                 outcome: outcome,
                 shadowGrowthEvents: shadowGrowthEvents,
-                comboTriggered: comboTriggered);
+                comboTriggered: comboTriggered,
+                callbackBonusApplied: callbackBonus);
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Spec-driven tests for Issue #47: Callback Bonus (§15 callback distance detection).
+    /// Tests verify behavior described in docs/specs/issue-47-spec.md.
+    /// </summary>
+    public class CallbackBonusSpecTests
+    {
+        // =================================================================
+        // AC4: Distance-to-bonus mapping: 2→+1, 4+→+2, opener→+3
+        // =================================================================
+
+        // Mutation: would catch if Compute returned a non-zero value for distance < 2
+        [Theory]
+        [InlineData(0, 0)]  // distance 0 — same turn
+        [InlineData(5, 5)]  // distance 0 — same turn (higher turns)
+        [InlineData(5, 4)]  // distance 1
+        [InlineData(1, 0)]  // opener at distance 1 — opener rule must NOT override distance < 2
+        public void AC4_DistanceLessThan2_ReturnsZero(int currentTurn, int callbackTurn)
+        {
+            Assert.Equal(0, CallbackBonus.Compute(currentTurn, callbackTurn));
+        }
+
+        // Mutation: would catch if distance >= 2 non-opener returned 0 or 2 instead of 1
+        [Theory]
+        [InlineData(5, 3)]  // distance 2 — lower boundary
+        [InlineData(5, 2)]  // distance 3 — upper boundary before long-distance
+        [InlineData(3, 1)]  // distance 2, non-opener, small turn numbers
+        public void AC4_MidDistance_NonOpener_ReturnsOne(int currentTurn, int callbackTurn)
+        {
+            Assert.Equal(1, CallbackBonus.Compute(currentTurn, callbackTurn));
+        }
+
+        // Mutation: would catch if distance >= 4 returned 1 or 3 instead of 2
+        [Theory]
+        [InlineData(5, 1)]   // distance 4 — exact boundary
+        [InlineData(6, 1)]   // distance 5
+        [InlineData(100, 1)] // distance 99 — very long
+        [InlineData(10, 3)]  // distance 7
+        public void AC4_LongDistance_NonOpener_ReturnsTwo(int currentTurn, int callbackTurn)
+        {
+            Assert.Equal(2, CallbackBonus.Compute(currentTurn, callbackTurn));
+        }
+
+        // Mutation: would catch if opener check was missing or returned +2 instead of +3
+        [Theory]
+        [InlineData(2, 0)]   // opener at distance 2 — minimum
+        [InlineData(3, 0)]   // opener at distance 3
+        [InlineData(5, 0)]   // opener at distance 5
+        [InlineData(6, 0)]   // opener at distance 6 — opener wins over 4+ rule
+        [InlineData(100, 0)] // opener at distance 100
+        public void AC4_OpenerReference_AlwaysReturnsThree(int currentTurn, int callbackTurn)
+        {
+            Assert.Equal(3, CallbackBonus.Compute(currentTurn, callbackTurn));
+        }
+
+        // =================================================================
+        // Evaluation Order: opener priority over long-distance
+        // =================================================================
+
+        // Mutation: would catch if distance >= 4 check ran before callbackTurnNumber == 0 check
+        [Fact]
+        public void OpenerPriority_OpenerAtDistance4Plus_ReturnsThreeNotTwo()
+        {
+            // distance = 4 - 0 = 4. Both opener and 4+ rules match.
+            // Opener must take priority → +3, not +2.
+            Assert.Equal(3, CallbackBonus.Compute(4, 0));
+        }
+
+        // Mutation: would catch if opener at huge distance fell through to the +2 branch
+        [Fact]
+        public void OpenerPriority_OpenerAtDistance100_ReturnsThree()
+        {
+            Assert.Equal(3, CallbackBonus.Compute(100, 0));
+        }
+
+        // =================================================================
+        // Boundary values
+        // =================================================================
+
+        // Mutation: would catch if boundary for mid-distance was > 2 instead of >= 2
+        [Fact]
+        public void Boundary_ExactlyDistance2_NonOpener_ReturnsOne()
+        {
+            Assert.Equal(1, CallbackBonus.Compute(4, 2));
+        }
+
+        // Mutation: would catch if boundary for long-distance was > 4 instead of >= 4
+        [Fact]
+        public void Boundary_ExactlyDistance4_NonOpener_ReturnsTwo()
+        {
+            Assert.Equal(2, CallbackBonus.Compute(5, 1));
+        }
+
+        // Mutation: would catch if opener at min distance returned 0
+        [Fact]
+        public void Boundary_OpenerAtMinDistance2_ReturnsThree()
+        {
+            Assert.Equal(3, CallbackBonus.Compute(2, 0));
+        }
+
+        // Mutation: would catch if currentTurn=0 somehow produced a non-zero bonus
+        [Fact]
+        public void Boundary_CurrentTurn0_AlwaysZero()
+        {
+            Assert.Equal(0, CallbackBonus.Compute(0, 0));
+        }
+
+        // Mutation: would catch if currentTurn=1 with callback=0 was >= 2 distance
+        [Fact]
+        public void Boundary_CurrentTurn1_MaxDistance1_ReturnsZero()
+        {
+            Assert.Equal(0, CallbackBonus.Compute(1, 0));
+        }
+
+        // =================================================================
+        // Edge case: distance exactly at transition points
+        // =================================================================
+
+        // Mutation: would catch if distance 3 was treated as long-distance (+2)
+        [Fact]
+        public void EdgeCase_Distance3_NonOpener_ReturnsOne()
+        {
+            Assert.Equal(1, CallbackBonus.Compute(6, 3));
+        }
+
+        // Mutation: would catch if distance 1 was treated as mid-distance (+1)
+        [Fact]
+        public void EdgeCase_Distance1_ReturnsZero()
+        {
+            Assert.Equal(0, CallbackBonus.Compute(3, 2));
+        }
+
+        // =================================================================
+        // AC6 + AC3: GameSession integration tests
+        // =================================================================
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// Stub LLM adapter that dequeues pre-configured option sets.
+        /// </summary>
+        private sealed class StubLlmAdapter : ILlmAdapter
+        {
+            private readonly Queue<DialogueOption[]> _optionSets = new Queue<DialogueOption[]>();
+
+            public void EnqueueOptions(params DialogueOption[] options)
+            {
+                _optionSets.Enqueue(options);
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                if (_optionSets.Count > 0)
+                    return Task.FromResult(_optionSets.Dequeue());
+                return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(context.ChosenOption.IntendedText);
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse("..."));
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+
+        // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0
+        [Fact]
+        public async Task AC3_ResolveTurn_OpenerCallback_RecordsBonusThree()
+        {
+            // Turn 2 with callback to turn 0 (opener) → distance 2 → +3
+            var dice = new FixedDice(
+                15, 50,  // Turn 0
+                15, 50,  // Turn 1
+                15, 50,  // Turn 2
+                50, 50, 50, 50  // buffer
+            );
+
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Hello"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Middle"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Remember opener?", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(3, result.CallbackBonusApplied);
+        }
+
+        // Mutation: would catch if no-callback options still somehow produced a bonus
+        [Fact]
+        public async Task AC3_ResolveTurn_NoCallbackOption_ZeroBonus()
+        {
+            var dice = new FixedDice(15, 50, 50, 50);
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Plain text"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(0, result.CallbackBonusApplied);
+        }
+
+        // Mutation: would catch if mid-distance callback returned +2 or +3 instead of +1
+        [Fact]
+        public async Task AC3_ResolveTurn_MidDistanceCallback_RecordsBonusOne()
+        {
+            // Turn 3, callback to turn 1 → distance 2 → +1 (non-opener)
+            var dice = new FixedDice(
+                15, 50,  // Turn 0
+                15, 50,  // Turn 1
+                15, 50,  // Turn 2
+                15, 50,  // Turn 3
+                50, 50, 50, 50, 50, 50  // buffer
+            );
+
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T0"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T1"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T2"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback to T1", callbackTurnNumber: 1));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            for (int i = 0; i < 3; i++)
+            {
+                await session.StartTurnAsync();
+                await session.ResolveTurnAsync(0);
+            }
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+            Assert.Equal(1, result.CallbackBonusApplied);
+        }
+
+        // =================================================================
+        // AC5: Bonus flows through RollEngine.Resolve(externalBonus) — NOT post-hoc
+        // =================================================================
+
+        // Mutation: would catch if callback bonus was added to interest delta instead of externalBonus
+        [Fact]
+        public async Task AC5_CallbackBonus_TurnsMissIntoSuccess()
+        {
+            // DC = 13 + 2 = 15. Roll d20=12, mod=2, levelBonus=0 → Total=14.
+            // Without bonus: 14 < 15 → fail.
+            // With opener callback bonus +3: FinalTotal = 14 + 3 = 17 >= 15 → success.
+            var dice = new FixedDice(
+                15, 50,  // Turn 0: auto-success to keep interest up
+                15, 50,  // Turn 1: auto-success
+                12, 50,  // Turn 2: would-fail roll (12 + 2 = 14 < 15)
+                50, 50, 50, 50  // buffer
+            );
+
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Opener"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Middle"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback!", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess, "Callback bonus should turn near-miss into success via externalBonus");
+            Assert.Equal(3, result.CallbackBonusApplied);
+        }
+
+        // =================================================================
+        // Error Conditions
+        // =================================================================
+
+        // Mutation: would catch if AddTopic accepted null without throwing
+        [Fact]
+        public void ErrorCondition_AddTopic_NullThrowsArgumentNullException()
+        {
+            var dice = new FixedDice(15);
+            var llm = new StubLlmAdapter();
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            Assert.Throws<ArgumentNullException>(() => session.AddTopic(null!));
+        }
+
+        // Mutation: would catch if AddTopic threw on valid input
+        [Fact]
+        public void ErrorCondition_AddTopic_ValidTopic_Succeeds()
+        {
+            var dice = new FixedDice(15);
+            var llm = new StubLlmAdapter();
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            var exception = Record.Exception(() => session.AddTopic(new CallbackOpportunity("pizza", 0)));
+            Assert.Null(exception);
+        }
+
+        // =================================================================
+        // Edge Cases from spec
+        // =================================================================
+
+        // Mutation: would catch if CallbackTurnNumber == currentTurn gave a bonus
+        [Fact]
+        public void EdgeCase_SameTurn_Distance0_ReturnsZero()
+        {
+            Assert.Equal(0, CallbackBonus.Compute(5, 5));
+        }
+
+        // Mutation: would catch if very large non-opener distance returned 3 instead of 2
+        [Fact]
+        public void EdgeCase_Distance100_NonOpener_ReturnsTwo()
+        {
+            Assert.Equal(2, CallbackBonus.Compute(101, 1));
+        }
+
+        // Mutation: would catch if opener at very large distance didn't take priority
+        [Fact]
+        public void EdgeCase_OpenerAtDistance100_ReturnsThree()
+        {
+            Assert.Equal(3, CallbackBonus.Compute(100, 0));
+        }
+
+        // =================================================================
+        // AC1: CallbackOpportunity is a sealed class (not record)
+        // =================================================================
+
+        // Mutation: would catch if CallbackOpportunity was changed to a struct or removed
+        [Fact]
+        public void AC1_CallbackOpportunity_IsSealed_WithExpectedProperties()
+        {
+            var topic = new CallbackOpportunity("test-topic", 5);
+            Assert.Equal("test-topic", topic.TopicKey);
+            Assert.Equal(5, topic.TurnIntroduced);
+        }
+
+        // Mutation: would catch if CallbackOpportunity accepted null topicKey
+        [Fact]
+        public void AC1_CallbackOpportunity_NullTopicKey_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CallbackOpportunity(null!, 0));
+        }
+
+        // =================================================================
+        // Edge case: Nat1 with callback bonus — auto-fail override
+        // =================================================================
+
+        // Mutation: would catch if nat1 auto-fail was removed when externalBonus present
+        [Fact]
+        public async Task EdgeCase_Nat1_WithCallback_StillFails()
+        {
+            // Nat1 = auto-fail regardless of bonus
+            var dice = new FixedDice(
+                15, 50,  // Turn 0
+                15, 50,  // Turn 1
+                1, 50,   // Turn 2: nat 1
+                50, 50, 50, 50  // buffer
+            );
+
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Opener"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Middle"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback!", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess, "Nat 1 should always fail even with callback bonus");
+            // Callback bonus is still computed and recorded
+            Assert.Equal(3, result.CallbackBonusApplied);
+        }
+
+        // =================================================================
+        // Edge case: Nat20 with callback — auto-success, bonus still recorded
+        // =================================================================
+
+        // Mutation: would catch if nat20 handling suppressed callback bonus recording
+        [Fact]
+        public async Task EdgeCase_Nat20_WithCallback_SucceedsAndRecordsBonus()
+        {
+            var dice = new FixedDice(
+                15, 50,  // Turn 0
+                15, 50,  // Turn 1
+                20, 50,  // Turn 2: nat 20
+                50, 50, 50, 50  // buffer
+            );
+
+            var llm = new StubLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Opener"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Middle"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback!", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess, "Nat 20 should always succeed");
+            Assert.Equal(3, result.CallbackBonusApplied);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/CallbackBonusTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusTests.cs
@@ -1,0 +1,89 @@
+using Pinder.Core.Conversation;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Unit tests for CallbackBonus.Compute — §15 callback distance detection.
+    /// Covers all tiers (0, +1, +2, +3) including boundary values and opener priority.
+    /// </summary>
+    public class CallbackBonusTests
+    {
+        // --- Distance < 2: no bonus ---
+
+        [Theory]
+        [InlineData(5, 5, 0)]  // distance 0 — same turn
+        [InlineData(5, 4, 0)]  // distance 1 — too recent
+        [InlineData(1, 0, 0)]  // opener at distance 1 — still too recent
+        [InlineData(0, 0, 0)]  // turn 0, callback turn 0 — distance 0
+        public void Compute_DistanceLessThan2_ReturnsZero(int current, int callback, int expected)
+        {
+            Assert.Equal(expected, CallbackBonus.Compute(current, callback));
+        }
+
+        // --- Mid-distance (distance 2-3, non-opener): +1 ---
+
+        [Theory]
+        [InlineData(5, 3, 1)]  // distance 2
+        [InlineData(5, 2, 1)]  // distance 3
+        [InlineData(3, 1, 1)]  // distance 2, non-opener
+        public void Compute_MidDistance_NonOpener_ReturnsOne(int current, int callback, int expected)
+        {
+            Assert.Equal(expected, CallbackBonus.Compute(current, callback));
+        }
+
+        // --- Long-distance (distance >= 4, non-opener): +2 ---
+
+        [Theory]
+        [InlineData(5, 1, 2)]   // distance 4
+        [InlineData(6, 1, 2)]   // distance 5
+        [InlineData(100, 1, 2)] // distance 99
+        [InlineData(10, 3, 2)]  // distance 7
+        public void Compute_LongDistance_NonOpener_ReturnsTwo(int current, int callback, int expected)
+        {
+            Assert.Equal(expected, CallbackBonus.Compute(current, callback));
+        }
+
+        // --- Opener reference (callbackTurnNumber == 0, distance >= 2): +3 ---
+
+        [Theory]
+        [InlineData(2, 0, 3)]   // opener at distance 2 — minimum for bonus
+        [InlineData(3, 0, 3)]   // opener at distance 3
+        [InlineData(5, 0, 3)]   // opener at distance 5
+        [InlineData(6, 0, 3)]   // opener at distance 6 — opener wins over 4+ rule
+        [InlineData(100, 0, 3)] // opener at distance 100
+        public void Compute_OpenerReference_ReturnsThree(int current, int callback, int expected)
+        {
+            Assert.Equal(expected, CallbackBonus.Compute(current, callback));
+        }
+
+        // --- Boundary: exactly distance 2 ---
+
+        [Fact]
+        public void Compute_ExactlyDistance2_NonOpener_ReturnsOne()
+        {
+            Assert.Equal(1, CallbackBonus.Compute(4, 2));
+        }
+
+        [Fact]
+        public void Compute_ExactlyDistance2_Opener_ReturnsThree()
+        {
+            Assert.Equal(3, CallbackBonus.Compute(2, 0));
+        }
+
+        // --- Boundary: exactly distance 4 ---
+
+        [Fact]
+        public void Compute_ExactlyDistance4_NonOpener_ReturnsTwo()
+        {
+            Assert.Equal(2, CallbackBonus.Compute(5, 1));
+        }
+
+        [Fact]
+        public void Compute_ExactlyDistance4_Opener_ReturnsThree()
+        {
+            // Opener always beats the 4+ rule
+            Assert.Equal(3, CallbackBonus.Compute(4, 0));
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Integration tests for callback bonus flowing through GameSession.ResolveTurnAsync.
+    /// Verifies that CallbackBonus is computed and passed as externalBonus to RollEngine.Resolve,
+    /// and that TurnResult.CallbackBonusApplied reflects the bonus.
+    /// </summary>
+    public class CallbackGameSessionTests
+    {
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// LLM adapter that returns options with configurable CallbackTurnNumber.
+        /// </summary>
+        private sealed class CallbackTestLlmAdapter : ILlmAdapter
+        {
+            private readonly Queue<DialogueOption[]> _optionSets = new Queue<DialogueOption[]>();
+
+            public void EnqueueOptions(params DialogueOption[] options)
+            {
+                _optionSets.Enqueue(options);
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                if (_optionSets.Count > 0)
+                    return Task.FromResult(_optionSets.Dequeue());
+                return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(context.ChosenOption.IntendedText);
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse("..."));
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+
+        [Fact]
+        public async Task ResolveTurn_WithCallbackOption_AppliesCallbackBonus()
+        {
+            // Setup: roll = 13, stat mod = 2, level bonus = 0 → total = 15
+            // DC = 13 + 2 = 15. Without bonus: 15 >= 15 → success.
+            // With callback bonus: FinalTotal = 15 + bonus.
+            // We want to verify the bonus is recorded.
+            var dice = new FixedDice(
+                // Turn 0: d20=15, d100=50 (timing)
+                15, 50,
+                // Turn 1: d20=15, d100=50 (timing)
+                15, 50,
+                // Turn 2: d20=15, d100=50 (timing)
+                15, 50,
+                // Extra buffer
+                50, 50, 50, 50
+            );
+
+            var llm = new CallbackTestLlmAdapter();
+            // Turn 0: no callback
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Hello there"));
+            // Turn 1: no callback
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Nice day"));
+            // Turn 2: callback referencing turn 0 (opener) → distance 2 → +3
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Remember hello?", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turn 0
+            await session.StartTurnAsync();
+            var r0 = await session.ResolveTurnAsync(0);
+            Assert.Equal(0, r0.CallbackBonusApplied);
+
+            // Turn 1
+            await session.StartTurnAsync();
+            var r1 = await session.ResolveTurnAsync(0);
+            Assert.Equal(0, r1.CallbackBonusApplied);
+
+            // Turn 2: callback to opener
+            await session.StartTurnAsync();
+            var r2 = await session.ResolveTurnAsync(0);
+            Assert.Equal(3, r2.CallbackBonusApplied);
+        }
+
+        [Fact]
+        public async Task ResolveTurn_CallbackBonusTurnsMissIntoSuccess()
+        {
+            // DC = 13 + 2 = 15. Roll = 12. Total = 12 + 2 + 0 = 14.
+            // Without bonus: 14 < 15 → fail.
+            // With callback bonus +3 (opener at distance 2): FinalTotal = 14 + 3 = 17 >= 15 → success.
+            var dice = new FixedDice(
+                // Turn 0: d20=15, d100=50 (timing) — success to keep interest up
+                15, 50,
+                // Turn 1: d20=15, d100=50 (timing) — success
+                15, 50,
+                // Turn 2: d20=12, d100=50 (timing) — would fail without bonus
+                12, 50,
+                // Extra buffer
+                50, 50, 50, 50
+            );
+
+            var llm = new CallbackTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Opener"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Middle"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback!", callbackTurnNumber: 0));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            // Turn 0 & 1
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2: callback should turn miss into success
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess, "Callback bonus should turn near-miss into success");
+            Assert.Equal(3, result.CallbackBonusApplied);
+        }
+
+        [Fact]
+        public async Task ResolveTurn_NoCallbackOption_ZeroBonus()
+        {
+            var dice = new FixedDice(15, 50);
+            var llm = new CallbackTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Just chatting"));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(0, result.CallbackBonusApplied);
+        }
+
+        [Fact]
+        public async Task ResolveTurn_MidDistanceCallback_ReturnsOne()
+        {
+            // Turn 3, callback to turn 1 → distance 2 → +1 (non-opener)
+            // Each turn needs d20 (roll) + d100 (timing delay)
+            var dice = new FixedDice(
+                15, 50,  // Turn 0: d20, d100
+                15, 50,  // Turn 1: d20, d100
+                15, 50,  // Turn 2: d20, d100
+                15, 50,  // Turn 3: d20, d100
+                50, 50, 50, 50, 50, 50, 50, 50  // extra buffer for any additional rolls
+            );
+
+            var llm = new CallbackTestLlmAdapter();
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T0"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T1"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "T2"));
+            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Callback to T1", callbackTurnNumber: 1));
+
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            for (int i = 0; i < 3; i++)
+            {
+                await session.StartTurnAsync();
+                await session.ResolveTurnAsync(0);
+            }
+
+            // Turn 3
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+            Assert.Equal(1, result.CallbackBonusApplied);
+        }
+
+        [Fact]
+        public void AddTopic_NullThrows()
+        {
+            var dice = new FixedDice(15);
+            var llm = new CallbackTestLlmAdapter();
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            Assert.Throws<ArgumentNullException>(() => session.AddTopic(null!));
+        }
+
+        [Fact]
+        public void AddTopic_ValidTopic_DoesNotThrow()
+        {
+            var dice = new FixedDice(15);
+            var llm = new CallbackTestLlmAdapter();
+            var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
+
+            session.AddTopic(new CallbackOpportunity("pizza", 0));
+            // No exception means success
+        }
+    }
+}


### PR DESCRIPTION
Fixes #47

## DoD Evidence
**Branch:** issue-47-write-tests-callback-bonus-implement-15-
**Commit:** a47919d

## Test Summary
38 spec-driven tests covering:
- **AC4**: Distance-to-bonus mapping (0, +1, +2, +3) with boundary values
- **AC3**: GameSession integration — callback bonus recorded in TurnResult
- **AC5**: Callback bonus flows through RollEngine.Resolve(externalBonus), turning near-misses into successes
- **AC1**: CallbackOpportunity sealed class with expected properties
- **Error conditions**: AddTopic(null) throws ArgumentNullException
- **Edge cases**: Nat1/Nat20 with callback, opener priority over long-distance, same-turn distance 0, very large distances

Each test includes mutation comment describing what specific code change it would catch.
