### PR TITLE
[Issue #55] PlayerResponseDelay — penalize player for slow replies

### DIFF
--- a/src/Pinder.Core/Conversation/DelayPenalty.cs
+++ b/src/Pinder.Core/Conversation/DelayPenalty.cs
@@ -1,0 +1,33 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Result of evaluating a player's response delay.
+    /// Contains the interest penalty and an optional conversational test trigger.
+    /// </summary>
+    public sealed class DelayPenalty
+    {
+        /// <summary>
+        /// The interest change to apply. Always ≤ 0 (penalty) or 0 (no penalty).
+        /// </summary>
+        public int InterestDelta { get; }
+
+        /// <summary>
+        /// True when the delay is long enough to trigger a conversational test
+        /// (e.g. opponent sends "thought you ghosted me").
+        /// </summary>
+        public bool TriggerTest { get; }
+
+        /// <summary>
+        /// Optional prompt hint for the LLM when TriggerTest is true.
+        /// Null when TriggerTest is false.
+        /// </summary>
+        public string? TestPrompt { get; }
+
+        public DelayPenalty(int interestDelta, bool triggerTest, string? testPrompt = null)
+        {
+            InterestDelta = interestDelta;
+            TriggerTest = triggerTest;
+            TestPrompt = testPrompt;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/PlayerResponseDelayEvaluator.cs
+++ b/src/Pinder.Core/Conversation/PlayerResponseDelayEvaluator.cs
@@ -1,0 +1,95 @@
+using System;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Pure function: evaluates the interest penalty for the player taking too long
+    /// to respond. Penalty is modified by the opponent's personality stats.
+    /// </summary>
+    public static class PlayerResponseDelayEvaluator
+    {
+        private const string DefaultTestPrompt = "Opponent noticed the long gap between replies";
+
+        /// <summary>
+        /// Evaluates the interest penalty for the player taking <paramref name="delay"/>
+        /// to respond. The penalty is modified by the opponent's personality stats.
+        /// </summary>
+        /// <param name="delay">Time elapsed since the opponent's last message.
+        ///     Provided by GameClock (issue #54). Must be non-negative.</param>
+        /// <param name="opponentStats">The opponent's full StatBlock, used to check
+        ///     Chaos base stat and shadow stat values (Fixation, Overthinking).</param>
+        /// <param name="currentInterest">The current InterestState of the conversation,
+        ///     used to gate the 15–60 min penalty bucket.</param>
+        /// <returns>A DelayPenalty describing the interest delta and optional test trigger.</returns>
+        public static DelayPenalty Evaluate(
+            TimeSpan delay,
+            StatBlock opponentStats,
+            InterestState currentInterest)
+        {
+            if (opponentStats == null)
+                throw new ArgumentNullException(nameof(opponentStats));
+
+            // Negative delay = no time has passed
+            if (delay.Ticks < 0)
+                return new DelayPenalty(0, false, null);
+
+            // Step 1-2: Determine delay bucket and base penalty
+            int basePenalty = GetBasePenalty(delay, currentInterest);
+            bool isOneToSixHourBucket = IsOneToSixHourBucket(delay);
+
+            // If base penalty is 0, short-circuit — no modifiers needed
+            if (basePenalty == 0)
+                return new DelayPenalty(0, false, null);
+
+            // Step 3: Chaos override — base stat >= 4 zeroes everything
+            if (opponentStats.GetBase(StatType.Chaos) >= 4)
+                return new DelayPenalty(0, false, null);
+
+            // Step 4: Fixation doubling
+            int penalty = basePenalty;
+            if (opponentStats.GetShadow(ShadowStatType.Fixation) >= 6)
+                penalty *= 2;
+
+            // Step 5: Overthinking +1 additional penalty
+            if (opponentStats.GetShadow(ShadowStatType.Overthinking) >= 6)
+                penalty -= 1;
+
+            // Step 6: Trigger test only in 1-6h bucket with non-zero penalty
+            bool triggerTest = isOneToSixHourBucket && penalty != 0;
+            string? testPrompt = triggerTest ? DefaultTestPrompt : null;
+
+            return new DelayPenalty(penalty, triggerTest, testPrompt);
+        }
+
+        private static int GetBasePenalty(TimeSpan delay, InterestState currentInterest)
+        {
+            double totalMinutes = delay.TotalMinutes;
+
+            if (totalMinutes < 1.0)
+                return 0;
+            if (totalMinutes < 15.0)
+                return 0;
+            if (totalMinutes < 60.0)
+            {
+                // 15-60 min bucket: only applies if interest >= 16
+                if (currentInterest == InterestState.VeryIntoIt ||
+                    currentInterest == InterestState.AlmostThere ||
+                    currentInterest == InterestState.DateSecured)
+                    return -1;
+                return 0;
+            }
+            if (totalMinutes < 360.0) // < 6 hours
+                return -2;
+            if (totalMinutes < 1440.0) // < 24 hours
+                return -3;
+            return -5; // 24+ hours
+        }
+
+        private static bool IsOneToSixHourBucket(TimeSpan delay)
+        {
+            double totalMinutes = delay.TotalMinutes;
+            return totalMinutes >= 60.0 && totalMinutes < 360.0;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/PlayerResponseDelayEvaluatorTests.cs
+++ b/tests/Pinder.Core.Tests/PlayerResponseDelayEvaluatorTests.cs
@@ -1,0 +1,451 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class PlayerResponseDelayEvaluatorTests
+    {
+        #region Helpers
+
+        private static StatBlock MakeStats(int chaos = 2, int fixation = 0, int overthinking = 0)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 },
+                    { StatType.Rizz, 2 },
+                    { StatType.Honesty, 2 },
+                    { StatType.Chaos, chaos },
+                    { StatType.Wit, 2 },
+                    { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 },
+                    { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 },
+                    { ShadowStatType.Fixation, fixation },
+                    { ShadowStatType.Dread, 0 },
+                    { ShadowStatType.Overthinking, overthinking }
+                });
+        }
+
+        #endregion
+
+        #region Delay Bucket — Base Penalties
+
+        [Theory]
+        [InlineData(0)]       // zero
+        [InlineData(30)]      // 30 seconds
+        [InlineData(59)]      // 59 seconds
+        public void LessThanOneMinute_NoPenalty(int seconds)
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromSeconds(seconds), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(14)]
+        public void OneToFifteenMinutes_NoPenalty(double minutes)
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(minutes), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+        }
+
+        [Theory]
+        [InlineData(InterestState.Unmatched)]
+        [InlineData(InterestState.Bored)]
+        [InlineData(InterestState.Interested)]
+        public void FifteenToSixtyMinutes_LowInterest_NoPenalty(InterestState state)
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(30), MakeStats(), state);
+
+            Assert.Equal(0, result.InterestDelta);
+        }
+
+        [Theory]
+        [InlineData(InterestState.VeryIntoIt)]
+        [InlineData(InterestState.AlmostThere)]
+        [InlineData(InterestState.DateSecured)]
+        public void FifteenToSixtyMinutes_HighInterest_MinusOne(InterestState state)
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(30), MakeStats(), state);
+
+            Assert.Equal(-1, result.InterestDelta);
+            Assert.False(result.TriggerTest);  // not in 1-6h bucket
+        }
+
+        [Fact]
+        public void OneToSixHours_MinusTwo()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-2, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+            Assert.NotNull(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SixToTwentyFourHours_MinusThree()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(12), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-3, result.InterestDelta);
+            Assert.False(result.TriggerTest);  // not 1-6h bucket
+        }
+
+        [Fact]
+        public void TwentyFourPlusHours_MinusFive()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(48), MakeStats(), InterestState.Bored);
+
+            Assert.Equal(-5, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+        }
+
+        #endregion
+
+        #region Boundary Precision
+
+        [Fact]
+        public void ExactlyOneMinute_InOneToFifteenBucket_NoPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(1), MakeStats(), InterestState.VeryIntoIt);
+
+            Assert.Equal(0, result.InterestDelta);
+        }
+
+        [Fact]
+        public void ExactlyFifteenMinutes_InFifteenToSixtyBucket()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(15), MakeStats(), InterestState.VeryIntoIt);
+
+            Assert.Equal(-1, result.InterestDelta);
+        }
+
+        [Fact]
+        public void ExactlySixtyMinutes_InOneToSixHourBucket()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(60), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-2, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+        }
+
+        [Fact]
+        public void ExactlySixHours_InSixToTwentyFourBucket()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(6), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-3, result.InterestDelta);
+        }
+
+        [Fact]
+        public void ExactlyTwentyFourHours_InTwentyFourPlusBucket()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(24), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-5, result.InterestDelta);
+        }
+
+        [Fact]
+        public void VeryLargeDelay_ThirtyDays_MinusFive()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromDays(30), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-5, result.InterestDelta);
+        }
+
+        #endregion
+
+        #region Chaos Override
+
+        [Fact]
+        public void ChaosBaseFour_ZeroesPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 4), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Fact]
+        public void ChaosBaseFive_ZeroesPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 5), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+        }
+
+        [Fact]
+        public void ChaosBaseThree_PenaltyApplies()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 3), InterestState.Interested);
+
+            Assert.Equal(-2, result.InterestDelta);
+        }
+
+        [Fact]
+        public void ChaosOverridesFixationAndOverthinking()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 4, fixation: 10, overthinking: 10), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+        }
+
+        #endregion
+
+        #region Fixation Doubling
+
+        [Fact]
+        public void FixationSix_DoublesPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(12), MakeStats(fixation: 6), InterestState.Interested);
+
+            // base -3, doubled to -6
+            Assert.Equal(-6, result.InterestDelta);
+        }
+
+        [Fact]
+        public void FixationFive_NoDoubling()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(12), MakeStats(fixation: 5), InterestState.Interested);
+
+            Assert.Equal(-3, result.InterestDelta);
+        }
+
+        #endregion
+
+        #region Overthinking Addition
+
+        [Fact]
+        public void OverthinkingSix_AddsOne()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(2), MakeStats(overthinking: 6), InterestState.Interested);
+
+            // base -2, overthinking -1 = -3
+            Assert.Equal(-3, result.InterestDelta);
+        }
+
+        [Fact]
+        public void OverthinkingFive_NoAddition()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(2), MakeStats(overthinking: 5), InterestState.Interested);
+
+            Assert.Equal(-2, result.InterestDelta);
+        }
+
+        #endregion
+
+        #region Combined Modifiers
+
+        [Fact]
+        public void FixationAndOverthinking_DoubleFirst_ThenAddOne()
+        {
+            // Example 8 from spec: base -2, fixation doubles -> -4, overthinking +1 -> -5
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(2), MakeStats(fixation: 7, overthinking: 8), InterestState.Interested);
+
+            Assert.Equal(-5, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+        }
+
+        #endregion
+
+        #region Test Trigger
+
+        [Fact]
+        public void OneToSixHourBucket_TriggerTest_True()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(), InterestState.Interested);
+
+            Assert.True(result.TriggerTest);
+            Assert.NotNull(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SixToTwentyFourBucket_TriggerTest_False()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(12), MakeStats(), InterestState.Interested);
+
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Fact]
+        public void OneToSixHourBucket_ChaosZeroesPenalty_TriggerTest_False()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 4), InterestState.Interested);
+
+            Assert.False(result.TriggerTest);
+        }
+
+        #endregion
+
+        #region Error Conditions
+
+        [Fact]
+        public void NegativeDelay_NoPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(-10), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Fact]
+        public void NullOpponentStats_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                PlayerResponseDelayEvaluator.Evaluate(
+                    TimeSpan.FromHours(1), null!, InterestState.Interested));
+        }
+
+        [Fact]
+        public void UndefinedEnumValue_TreatedAsLowInterest()
+        {
+            // Cast an invalid value — should not throw, treated as "not >= 16"
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(30), MakeStats(), (InterestState)99);
+
+            Assert.Equal(0, result.InterestDelta);
+        }
+
+        #endregion
+
+        #region Spec Examples
+
+        [Fact]
+        public void SpecExample1_ShortDelay_NoPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(5), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SpecExample2_ThirtyMin_InterestBelowThreshold()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(30), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+        }
+
+        [Fact]
+        public void SpecExample3_ThirtyMin_VeryIntoIt()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromMinutes(30), MakeStats(), InterestState.VeryIntoIt);
+
+            Assert.Equal(-1, result.InterestDelta);
+        }
+
+        [Fact]
+        public void SpecExample4_ThreeHours_TriggersTest()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(), InterestState.Interested);
+
+            Assert.Equal(-2, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+            Assert.NotNull(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SpecExample5_ThreeHours_HighChaos_NoPenalty()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(3), MakeStats(chaos: 4), InterestState.Interested);
+
+            Assert.Equal(0, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+            Assert.Null(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SpecExample6_TwelveHours_FixationDoubling()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(12), MakeStats(fixation: 6), InterestState.Interested);
+
+            Assert.Equal(-6, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+        }
+
+        [Fact]
+        public void SpecExample7_TwoHours_OverthinkingAddsOne()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(2), MakeStats(overthinking: 6), InterestState.Interested);
+
+            Assert.Equal(-3, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+            Assert.NotNull(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SpecExample8_TwoHours_FixationAndOverthinking()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(2), MakeStats(fixation: 7, overthinking: 8), InterestState.Interested);
+
+            Assert.Equal(-5, result.InterestDelta);
+            Assert.True(result.TriggerTest);
+            Assert.NotNull(result.TestPrompt);
+        }
+
+        [Fact]
+        public void SpecExample9_FortyEightHours()
+        {
+            var result = PlayerResponseDelayEvaluator.Evaluate(
+                TimeSpan.FromHours(48), MakeStats(), InterestState.Bored);
+
+            Assert.Equal(-5, result.InterestDelta);
+            Assert.False(result.TriggerTest);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #55

## What was implemented

- **`DelayPenalty`** sealed class in `Pinder.Core.Conversation` — holds InterestDelta, TriggerTest, and TestPrompt
- **`PlayerResponseDelayEvaluator.Evaluate()`** static method — pure function that evaluates player response delay penalties

### Penalty Table (from spec)
| Delay Range | Base Interest Δ | Condition |
|---|---|---|
| < 1 minute | 0 | — |
| 1–15 minutes | 0 | — |
| 15–60 minutes | −1 | Only if interest ≥ 16 (VeryIntoIt/AlmostThere/DateSecured) |
| 1–6 hours | −2 | TriggerTest fires |
| 6–24 hours | −3 | — |
| 24+ hours | −5 | — |

### Personality Modifiers
1. **Chaos base ≥ 4** → zeroes all penalties (priority override)
2. **Fixation shadow ≥ 6** → doubles base penalty
3. **Overthinking shadow ≥ 6** → adds −1 after doubling

## How to test
```bash
dotnet test --filter PlayerResponseDelayEvaluator
```
45 tests covering all delay buckets, boundary values, personality modifiers, combined modifiers, error conditions, and all 9 spec examples.

## DoD Evidence
**Branch:** issue-55-playerresponsedelay-penalize-player-for-
**Commit:** 026a625
**Tests:** 45 passed, 0 failed

## Deviations from contract
None — implemented exactly per docs/specs/issue-55-spec.md
