### PR TITLE
[Issue #51] Horniness-forced Rizz option — implement §15 🔥 mechanic

### DIFF
--- a/src/Pinder.Core/Conversation/DialogueOption.cs
+++ b/src/Pinder.Core/Conversation/DialogueOption.cs
@@ -28,13 +28,20 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public bool HasWeaknessWindow { get; }
 
+        /// <summary>
+        /// True if this option was injected or replaced by the Horniness mechanic (§15).
+        /// Informational for the UI — no mechanical difference in the roll.
+        /// </summary>
+        public bool IsHorninessForced { get; }
+
         public DialogueOption(
             StatType stat,
             string intendedText,
             int? callbackTurnNumber = null,
             string? comboName = null,
             bool hasTellBonus = false,
-            bool hasWeaknessWindow = false)
+            bool hasWeaknessWindow = false,
+            bool isHorninessForced = false)
         {
             Stat = stat;
             IntendedText = intendedText ?? throw new System.ArgumentNullException(nameof(intendedText));
@@ -42,6 +49,7 @@ namespace Pinder.Core.Conversation
             ComboName = comboName;
             HasTellBonus = hasTellBonus;
             HasWeaknessWindow = hasWeaknessWindow;
+            IsHorninessForced = isHorninessForced;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -64,6 +64,9 @@ namespace Pinder.Core.Conversation
         // Tell from opponent's last response (#50)
         private Tell? _activeTell;
 
+        // Horniness-forced Rizz option tracking (#51)
+        private readonly int _horniness;
+
         // Shadow threshold tracking (#45)
         private StatType? _lastStatUsed;
         private HashSet<StatType>? _shadowDisadvantagedStats;
@@ -128,6 +131,24 @@ namespace Pinder.Core.Conversation
             _playerShadows = config?.PlayerShadows;
             _opponentShadows = config?.OpponentShadows;
             _previousOpener = config?.PreviousOpener;
+
+            // Horniness-forced Rizz option (#51): compute once at session start
+            // Formula: dice.Roll(10) + timeModifier + shadowHorniness, clamped to min 0
+            // Only computed when a clock is available (time-of-day modifier is a required component).
+            // Without a clock, horniness defaults to 0 (no forced Rizz).
+            if (_clock != null)
+            {
+                int horninessBase = _dice.Roll(10);
+                int timeModifier = _clock.GetHorninessModifier();
+                int shadowHorniness = _playerShadows != null
+                    ? _playerShadows.GetEffectiveShadow(ShadowStatType.Horniness)
+                    : player.Stats.GetShadow(ShadowStatType.Horniness);
+                _horniness = Math.Max(0, horninessBase + timeModifier + shadowHorniness);
+            }
+            else
+            {
+                _horniness = 0;
+            }
 
             // XP tracking (#48)
             _xpLedger = new XpLedger();
@@ -258,7 +279,7 @@ namespace Pinder.Core.Conversation
             var activeTrapNames = GetActiveTrapNames();
             var activeTrapInstructions = GetActiveTrapInstructions();
 
-            // Build dialogue context — pass callback topics (#47) and shadow thresholds (#45)
+            // Build dialogue context — pass callback topics (#47), shadow thresholds (#45), horniness (#51)
             var context = new DialogueContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -268,7 +289,9 @@ namespace Pinder.Core.Conversation
                 currentInterest: _interest.Current,
                 shadowThresholds: shadowThresholds,
                 activeTrapInstructions: activeTrapInstructions,
-                callbackOpportunities: _topics.Count > 0 ? new List<CallbackOpportunity>(_topics) : null);
+                callbackOpportunities: _topics.Count > 0 ? new List<CallbackOpportunity>(_topics) : null,
+                horninessLevel: _horniness,
+                requiresRizzOption: _horniness >= 6);
 
             // Get dialogue options from LLM
             var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
@@ -321,6 +344,9 @@ namespace Pinder.Core.Conversation
                     options = filtered;
                 }
             }
+
+            // Horniness-forced Rizz option overrides (#51) — applied after all other T3 filters
+            options = ApplyHorninessOverrides(options);
 
             _currentOptions = options;
 
@@ -809,6 +835,68 @@ namespace Pinder.Core.Conversation
         }
 
         /// <summary>
+        /// Applies Horniness-forced Rizz option rules to the LLM-returned options (§15).
+        /// - Horniness &lt; 6: no change.
+        /// - Horniness 6–17: ensures at least one Rizz option; replaces last if none present.
+        /// - Horniness ≥ 18: all options become forced Rizz.
+        /// Returns a new array with replacements applied.
+        /// </summary>
+        private DialogueOption[] ApplyHorninessOverrides(DialogueOption[] options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (options.Length == 0 || _horniness < 6)
+                return options;
+
+            if (_horniness >= 18)
+            {
+                // Threshold 3 (Overwhelming): ALL options become forced Rizz
+                var result = new DialogueOption[options.Length];
+                for (int i = 0; i < options.Length; i++)
+                {
+                    result[i] = new DialogueOption(
+                        StatType.Rizz,
+                        options[i].IntendedText,
+                        callbackTurnNumber: null,
+                        comboName: null,
+                        hasTellBonus: false,
+                        hasWeaknessWindow: false,
+                        isHorninessForced: true);
+                }
+                return result;
+            }
+
+            // Threshold 1 or 2 (6–17): ensure at least one Rizz option
+            bool hasRizz = false;
+            for (int i = 0; i < options.Length; i++)
+            {
+                if (options[i].Stat == StatType.Rizz)
+                {
+                    hasRizz = true;
+                    break;
+                }
+            }
+
+            if (hasRizz)
+                return options;
+
+            // Replace last option with forced Rizz
+            var overridden = new DialogueOption[options.Length];
+            Array.Copy(options, overridden, options.Length);
+            var last = options[options.Length - 1];
+            overridden[options.Length - 1] = new DialogueOption(
+                StatType.Rizz,
+                last.IntendedText,
+                callbackTurnNumber: null,
+                comboName: null,
+                hasTellBonus: false,
+                hasWeaknessWindow: false,
+                isHorninessForced: true);
+            return overridden;
+        }
+
+        /// <summary>
         /// Get momentum bonus for the current streak length.
         /// 3-streak → +2, 4-streak → +2, 5+ → +3.
         /// </summary>
@@ -831,7 +919,8 @@ namespace Pinder.Core.Conversation
                 momentumStreak: _momentumStreak,
                 activeTrapNames: trapNames,
                 turnNumber: _turnNumber,
-                tripleBonusActive: _comboTracker.HasTripleBonus);
+                tripleBonusActive: _comboTracker.HasTripleBonus,
+                horniness: _horniness);
         }
 
         private string GetLastOpponentMessage()

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -23,13 +23,17 @@ namespace Pinder.Core.Conversation
         /// <summary>True if The Triple bonus is active for the current turn (+1 to all rolls).</summary>
         public bool TripleBonusActive { get; }
 
+        /// <summary>Session Horniness level computed at session start (§15). 0 when not computed.</summary>
+        public int Horniness { get; }
+
         public GameStateSnapshot(
             int interest,
             InterestState state,
             int momentumStreak,
             string[] activeTrapNames,
             int turnNumber,
-            bool tripleBonusActive = false)
+            bool tripleBonusActive = false,
+            int horniness = 0)
         {
             Interest = interest;
             State = state;
@@ -37,6 +41,7 @@ namespace Pinder.Core.Conversation
             ActiveTrapNames = activeTrapNames ?? System.Array.Empty<string>();
             TurnNumber = turnNumber;
             TripleBonusActive = tripleBonusActive;
+            Horniness = horniness;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/HorninessForceRizzTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessForceRizzTests.cs
@@ -1,0 +1,482 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for the Horniness-forced Rizz option mechanic (§15, issue #51).
+    /// Covers AC1–AC5 from the spec.
+    /// </summary>
+    public class HorninessForceRizzTests
+    {
+        private static StatBlock MakeStatBlock(int allStats = 2, int allShadow = 0)
+        {
+            return TestHelpers.MakeStatBlock(allStats, allShadow);
+        }
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2, int allShadow = 0)
+        {
+            return new CharacterProfile(
+                stats: MakeStatBlock(allStats, allShadow),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// Creates a GameSession with a clock and controlled dice for horniness computation.
+        /// The first dice value is consumed by the horniness roll (1d10).
+        /// </summary>
+        private static GameSession CreateSessionWithClock(
+            FixedDice dice,
+            IGameClock clock,
+            CharacterProfile? player = null,
+            SessionShadowTracker? playerShadows = null)
+        {
+            var p = player ?? MakeProfile("Player");
+            var opponent = MakeProfile("Opponent");
+            var config = new GameSessionConfig(
+                clock: clock,
+                playerShadows: playerShadows);
+            return new GameSession(p, opponent, new NullLlmAdapter(), dice, new NullTrapRegistry(), config);
+        }
+
+        // ========== AC1: Horniness Rolled at Session Start ==========
+
+        [Fact]
+        public void AC1_HorninessComputedAtConstruction_StoredInSnapshot()
+        {
+            // dice.Roll(10)=5, clock=Morning(-2), shadow=0 → horniness=3
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(5); // horniness roll
+            var session = CreateSessionWithClock(dice, clock);
+            // Can't directly access _horniness, but it's exposed via GameStateSnapshot
+            // We need to call StartTurnAsync to get a snapshot — but that needs more dice
+            // Instead, verify through the snapshot exposed at turnstart
+        }
+
+        [Fact]
+        public async Task AC1_HorninessVisibleInSnapshot()
+        {
+            // dice.Roll(10)=5, clock=Morning(-2), shadow=0 → horniness=3
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            // First value: horniness roll=5. Then d20=15, d100=50 for turn resolution
+            var dice = new FixedDice(5);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(3, turnStart.State.Horniness); // 5 + (-2) + 0 = 3
+        }
+
+        [Fact]
+        public async Task AC1_HorninessClampedToZero()
+        {
+            // dice.Roll(10)=1, clock=Morning(-2), shadow=0 → max(0, 1-2+0)=0
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(1);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(0, turnStart.State.Horniness);
+        }
+
+        [Fact]
+        public async Task AC1_HorninessIncludesShadowStat()
+        {
+            // dice.Roll(10)=3, clock=Afternoon(0), shadowHorniness=5 → horniness=8
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 14, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 5); // allShadow=5 → Horniness=5
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(3);
+            var player = MakeProfile("Player", allShadow: 5);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(8, turnStart.State.Horniness); // 3 + 0 + 5 = 8
+        }
+
+        [Fact]
+        public async Task AC1_HorninessWithLateNightModifier()
+        {
+            // dice.Roll(10)=7, clock=LateNight(+3), shadow=0 → 10
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(7);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(10, turnStart.State.Horniness);
+        }
+
+        [Fact]
+        public async Task AC1_HorninessWithAfterTwoAmModifier()
+        {
+            // dice.Roll(10)=10, clock=AfterTwoAm(+5), shadow=0 → 15
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(10);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(15, turnStart.State.Horniness);
+        }
+
+        [Fact]
+        public async Task AC1_NoClock_HorninessIsZero()
+        {
+            // Without a clock, horniness defaults to 0 — no dice consumed
+            var dice = new FixedDice();
+            var player = MakeProfile("Player");
+            var opponent = MakeProfile("Opponent");
+            var session = new GameSession(player, opponent, new NullLlmAdapter(), dice, new NullTrapRegistry());
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(0, turnStart.State.Horniness);
+        }
+
+        // ========== AC2: DialogueContext carries correct values ==========
+
+        [Fact]
+        public async Task AC2_HorninessBelow6_RequiresRizzOptionFalse()
+        {
+            // horniness=3 → RequiresRizzOption=false
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(5); // 5 + (-2) = 3
+            var captureLlm = new CaptureLlmAdapter();
+            var player = MakeProfile("Player");
+            var opponent = MakeProfile("Opponent");
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(player, opponent, captureLlm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            Assert.NotNull(captureLlm.LastDialogueContext);
+            Assert.Equal(3, captureLlm.LastDialogueContext!.HorninessLevel);
+            Assert.False(captureLlm.LastDialogueContext.RequiresRizzOption);
+        }
+
+        [Fact]
+        public async Task AC2_HorninessAt6_RequiresRizzOptionTrue()
+        {
+            // dice.Roll(10)=8, clock=Morning(-2), shadow=0 → 6
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(8);
+            var captureLlm = new CaptureLlmAdapter();
+            var player = MakeProfile("Player");
+            var opponent = MakeProfile("Opponent");
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(player, opponent, captureLlm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            Assert.Equal(6, captureLlm.LastDialogueContext!.HorninessLevel);
+            Assert.True(captureLlm.LastDialogueContext.RequiresRizzOption);
+        }
+
+        // ========== AC3: Threshold 1/2 (Horniness 6–17) ==========
+
+        [Fact]
+        public async Task AC3_Horniness6_NoRizzInLlm_LastOptionReplaced()
+        {
+            // horniness=6, LLM returns no Rizz → last option replaced
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(8); // 8 + (-2) + 0 = 6
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            // NullLlmAdapter returns: Charm, Honesty, Wit, Chaos
+            // Last option (Chaos) should be replaced with Rizz
+            var options = turnStart.Options;
+            Assert.Equal(4, options.Length);
+            Assert.Equal(StatType.Charm, options[0].Stat);
+            Assert.Equal(StatType.Honesty, options[1].Stat);
+            Assert.Equal(StatType.Wit, options[2].Stat);
+            Assert.Equal(StatType.Rizz, options[3].Stat);
+            Assert.True(options[3].IsHorninessForced);
+            // Original text preserved
+            Assert.Equal("I once ate a whole pizza in a bouncy castle.", options[3].IntendedText);
+        }
+
+        [Fact]
+        public async Task AC3_Horniness6_LlmAlreadyHasRizz_NoReplacement()
+        {
+            // horniness=6, LLM returns a Rizz option → no replacement needed
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(8);
+            var rizzLlm = new RizzLlmAdapter();
+            var player = MakeProfile("Player");
+            var opponent = MakeProfile("Opponent");
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(player, opponent, rizzLlm, dice, new NullTrapRegistry(), config);
+
+            var turnStart = await session.StartTurnAsync();
+            var options = turnStart.Options;
+            // RizzLlmAdapter returns Charm, Rizz, Wit, Chaos
+            Assert.Equal(StatType.Rizz, options[1].Stat);
+            Assert.False(options[1].IsHorninessForced); // Organic Rizz, not forced
+            // No other option should be IsHorninessForced
+            Assert.All(options, o => Assert.False(o.IsHorninessForced));
+        }
+
+        [Fact]
+        public async Task AC3_Horniness12_NoRizzInLlm_LastOptionReplaced()
+        {
+            // dice.Roll(10)=9, clock=LateNight(+3), shadow=0 → 12
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(9);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            var options = turnStart.Options;
+            Assert.Equal(StatType.Rizz, options[3].Stat);
+            Assert.True(options[3].IsHorninessForced);
+        }
+
+        [Fact]
+        public async Task AC3_ForcedOption_ClearsCallbackComboTell()
+        {
+            // Forced Rizz options should have null callback/combo and false tell
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(8); // horniness=6
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            var forced = turnStart.Options[3]; // last option, forced
+            Assert.True(forced.IsHorninessForced);
+            Assert.Null(forced.CallbackTurnNumber);
+            Assert.Null(forced.ComboName);
+            Assert.False(forced.HasTellBonus);
+            Assert.False(forced.HasWeaknessWindow);
+        }
+
+        // ========== AC4: Threshold 3 (Horniness ≥ 18) ==========
+
+        [Fact]
+        public async Task AC4_Horniness18_AllOptionsBecomeForcedRizz()
+        {
+            // dice.Roll(10)=10, clock=AfterTwoAm(+5), shadow=3 → 18
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 3);
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(10);
+            var player = new CharacterProfile(
+                playerStats,
+                "You are Player.",
+                "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                1);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            var options = turnStart.Options;
+            Assert.Equal(4, options.Length);
+            Assert.All(options, o =>
+            {
+                Assert.Equal(StatType.Rizz, o.Stat);
+                Assert.True(o.IsHorninessForced);
+            });
+        }
+
+        [Fact]
+        public async Task AC4_Horniness20_AllRizz_TextPreserved()
+        {
+            // dice.Roll(10)=8, clock=AfterTwoAm(+5), shadow=7 → 20
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 7);
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(8);
+            var player = new CharacterProfile(
+                playerStats,
+                "You are Player.",
+                "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                1);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            var options = turnStart.Options;
+            // NullLlmAdapter texts preserved
+            Assert.Equal("Hey, you come here often?", options[0].IntendedText);
+            Assert.Equal("I have to be real with you...", options[1].IntendedText);
+            Assert.Equal("Did you know that penguins propose with pebbles?", options[2].IntendedText);
+            Assert.Equal("I once ate a whole pizza in a bouncy castle.", options[3].IntendedText);
+        }
+
+        [Fact]
+        public async Task AC4_Horniness18_ForcedOptions_ClearBonuses()
+        {
+            // All forced options should have cleared bonuses
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 3, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 3);
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(10); // 10+5+3=18
+            var player = new CharacterProfile(
+                playerStats, "You are Player.", "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.All(turnStart.Options, o =>
+            {
+                Assert.Null(o.CallbackTurnNumber);
+                Assert.Null(o.ComboName);
+                Assert.False(o.HasTellBonus);
+                Assert.False(o.HasWeaknessWindow);
+            });
+        }
+
+        // ========== AC5: Edge cases ==========
+
+        [Fact]
+        public async Task AC5_HorninessBelow6_NoChanges()
+        {
+            // horniness=3 → no forced options
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(5); // 5+(-2)+0=3
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.All(turnStart.Options, o => Assert.False(o.IsHorninessForced));
+            Assert.Equal(StatType.Charm, turnStart.Options[0].Stat);
+            Assert.Equal(StatType.Honesty, turnStart.Options[1].Stat);
+            Assert.Equal(StatType.Wit, turnStart.Options[2].Stat);
+            Assert.Equal(StatType.Chaos, turnStart.Options[3].Stat);
+        }
+
+        [Fact]
+        public async Task AC5_HorninessExactly0_Clamped_NoEffect()
+        {
+            // dice.Roll(10)=1, clock=Morning(-2), shadow=0 → max(0,-1)=0
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            var dice = new FixedDice(1);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(0, turnStart.State.Horniness);
+            Assert.All(turnStart.Options, o => Assert.False(o.IsHorninessForced));
+        }
+
+        [Fact]
+        public async Task AC5_HorninessDoesNotChangeBetweenTurns()
+        {
+            // Verify horniness is constant across turns
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero));
+            // horniness roll=8 → 8+(-2)+0=6. Then: d20=15, d100=50 for turn
+            var dice = new FixedDice(8, 15, 50);
+            var session = CreateSessionWithClock(dice, clock);
+
+            var start1 = await session.StartTurnAsync();
+            Assert.Equal(6, start1.State.Horniness);
+
+            var result = await session.ResolveTurnAsync(0);
+            Assert.Equal(6, result.StateAfter.Horniness);
+
+            var start2 = await session.StartTurnAsync();
+            Assert.Equal(6, start2.State.Horniness);
+        }
+
+        [Fact]
+        public async Task AC5_HighShadowHorniness_Reaches18()
+        {
+            // dice.Roll(10)=7, clock=LateNight(+3), shadowHorniness=8 → 7+3+8=18
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 8);
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(7);
+            var player = new CharacterProfile(
+                playerStats, "You are Player.", "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(18, turnStart.State.Horniness);
+            Assert.All(turnStart.Options, o =>
+            {
+                Assert.Equal(StatType.Rizz, o.Stat);
+                Assert.True(o.IsHorninessForced);
+            });
+        }
+
+        [Fact]
+        public async Task AC5_Threshold2Boundary_Horniness12()
+        {
+            // dice.Roll(10)=5, clock=Evening(+1), shadow=6 → 5+1+6=12
+            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 19, 0, 0, TimeSpan.Zero));
+            var playerStats = MakeStatBlock(2, 6);
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var dice = new FixedDice(5);
+            var player = new CharacterProfile(
+                playerStats, "You are Player.", "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+            var session = CreateSessionWithClock(dice, clock, player, playerShadows);
+
+            var turnStart = await session.StartTurnAsync();
+            Assert.Equal(12, turnStart.State.Horniness);
+            // Should have at least one Rizz (last option replaced since NullLlmAdapter has none)
+            Assert.Equal(StatType.Rizz, turnStart.Options[3].Stat);
+            Assert.True(turnStart.Options[3].IsHorninessForced);
+        }
+    }
+
+    /// <summary>
+    /// LLM adapter that captures the DialogueContext for inspection.
+    /// </summary>
+    internal sealed class CaptureLlmAdapter : ILlmAdapter
+    {
+        public DialogueContext? LastDialogueContext { get; private set; }
+
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        {
+            LastDialogueContext = context;
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hey"),
+                new DialogueOption(StatType.Honesty, "Truth"),
+                new DialogueOption(StatType.Wit, "Clever"),
+                new DialogueOption(StatType.Chaos, "Wild")
+            };
+            return Task.FromResult(options);
+        }
+
+        public Task<string> DeliverMessageAsync(DeliveryContext context)
+            => Task.FromResult(context.ChosenOption.IntendedText);
+
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            => Task.FromResult(new OpponentResponse("..."));
+
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            => Task.FromResult<string?>(null);
+    }
+
+    /// <summary>
+    /// LLM adapter that returns options including a Rizz option.
+    /// </summary>
+    internal sealed class RizzLlmAdapter : ILlmAdapter
+    {
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        {
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hey"),
+                new DialogueOption(StatType.Rizz, "You look incredible"),
+                new DialogueOption(StatType.Wit, "Clever"),
+                new DialogueOption(StatType.Chaos, "Wild")
+            };
+            return Task.FromResult(options);
+        }
+
+        public Task<string> DeliverMessageAsync(DeliveryContext context)
+            => Task.FromResult(context.ChosenOption.IntendedText);
+
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            => Task.FromResult(new OpponentResponse("..."));
+
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            => Task.FromResult<string?>(null);
+    }
+}


### PR DESCRIPTION
Fixes #51

## What was implemented

Implemented the Horniness-forced Rizz option mechanic per §15 spec:

1. **Horniness calculation at session start**: `dice.Roll(10) + gameClock.GetHorninessModifier() + shadowHorniness`, clamped to min 0. Only computed when IGameClock is provided via GameSessionConfig (backward-compatible: no clock = horniness 0).

2. **DialogueOption.IsHorninessForced**: New boolean property (default false) marking engine-injected Rizz options.

3. **ApplyHorninessOverrides** in GameSession:
   - Horniness < 6: no change
   - Horniness 6–17: ensures at least one Rizz option; replaces last option if none present
   - Horniness ≥ 18: ALL options become forced Rizz

4. **DialogueContext**: HorninessLevel and RequiresRizzOption populated each turn.

5. **GameStateSnapshot.Horniness**: Exposes session horniness for UI/test observability.

## How to test

```bash
dotnet test --filter "FullyQualifiedName~HorninessForceRizz"
```

21 tests covering:
- AC1: Horniness computed at construction with clock, shadow, clamping
- AC2: DialogueContext carries correct HorninessLevel and RequiresRizzOption
- AC3: Threshold 1/2 replacement logic (with/without organic Rizz)
- AC4: Threshold 3 (≥18) all-Rizz override with text preservation
- AC5: Edge cases (no clock, boundary values, cross-turn consistency)

## Files changed
- `src/Pinder.Core/Conversation/DialogueOption.cs` — added IsHorninessForced
- `src/Pinder.Core/Conversation/GameSession.cs` — horniness field, ApplyHorninessOverrides, StartTurnAsync integration
- `src/Pinder.Core/Conversation/GameStateSnapshot.cs` — added Horniness property
- `tests/Pinder.Core.Tests/HorninessForceRizzTests.cs` — 21 new tests

## DoD Evidence
**Branch:** issue-51-horniness-forced-rizz-option-implement-1
**Commit:** 03c7b0f
**Tests:** 1139 passed, 1 pre-existing failure, 0 new failures
**Deviations from contract:** Horniness roll is only performed when IGameClock is provided via config (not on the 5-param constructor path). This preserves backward compatibility with all 1118 existing tests. The spec's alternative path ('Accept int horninessModifier as constructor parameter') was not needed.
