### PR TITLE
[Issue #205] Create Pinder.LlmAdapters project — csproj, Newtonsoft.Json, DTOs

### DIFF
--- a/Pinder.Core.sln
+++ b/Pinder.Core.sln
@@ -11,6 +11,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{045D9318
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinder.Core.Tests", "tests\Pinder.Core.Tests\Pinder.Core.Tests.csproj", "{0623E521-B4A6-44AE-9CFD-786B56610D84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinder.LlmAdapters", "src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinder.LlmAdapters.Tests", "tests\Pinder.LlmAdapters.Tests\Pinder.LlmAdapters.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,9 +32,19 @@ Global
 		{0623E521-B4A6-44AE-9CFD-786B56610D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0623E521-B4A6-44AE-9CFD-786B56610D84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0623E521-B4A6-44AE-9CFD-786B56610D84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{34017A49-6A92-41CF-854F-EC31687D3471} = {66983487-A9C3-46BF-98B2-B829E99C211B}
 		{0623E521-B4A6-44AE-9CFD-786B56610D84} = {045D9318-B32E-4259-8AB6-9A02DE6E0C31}
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {66983487-A9C3-46BF-98B2-B829E99C211B}
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {045D9318-B32E-4259-8AB6-9A02DE6E0C31}
 	EndGlobalSection
 EndGlobal

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicApiException.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicApiException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Pinder.LlmAdapters.Anthropic
+{
+    /// <summary>
+    /// Exception thrown when the Anthropic Messages API returns a non-success HTTP status code.
+    /// </summary>
+    public class AnthropicApiException : Exception
+    {
+        /// <summary>
+        /// The HTTP status code returned by the Anthropic API.
+        /// </summary>
+        public int StatusCode { get; }
+
+        /// <summary>
+        /// The raw response body returned by the Anthropic API.
+        /// </summary>
+        public string ResponseBody { get; }
+
+        public AnthropicApiException(int statusCode, string responseBody)
+            : base($"Anthropic API error {statusCode}: {responseBody}")
+        {
+            StatusCode = statusCode;
+            ResponseBody = responseBody;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicOptions.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicOptions.cs
@@ -1,0 +1,18 @@
+namespace Pinder.LlmAdapters.Anthropic
+{
+    /// <summary>
+    /// Configuration carrier for the Anthropic LLM adapter.
+    /// Per-method temperature overrides fall back to <see cref="Temperature"/> when null.
+    /// </summary>
+    public sealed class AnthropicOptions
+    {
+        public string ApiKey { get; set; } = "";
+        public string Model { get; set; } = "claude-sonnet-4-20250514";
+        public int MaxTokens { get; set; } = 1024;
+        public double Temperature { get; set; } = 0.9;
+        public double? DialogueOptionsTemperature { get; set; }
+        public double? DeliveryTemperature { get; set; }
+        public double? OpponentResponseTemperature { get; set; }
+        public double? InterestChangeBeatTemperature { get; set; }
+    }
+}

--- a/src/Pinder.LlmAdapters/Anthropic/Dto/ContentBlock.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/Dto/ContentBlock.cs
@@ -1,0 +1,41 @@
+using Newtonsoft.Json;
+
+namespace Pinder.LlmAdapters.Anthropic.Dto
+{
+    /// <summary>
+    /// Represents a content block in the Anthropic Messages API system prompt.
+    /// Supports both plain text and cached text blocks.
+    /// </summary>
+    public sealed class ContentBlock
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; } = "text";
+
+        [JsonProperty("text")]
+        public string Text { get; set; } = "";
+
+        [JsonProperty("cache_control", NullValueHandling = NullValueHandling.Ignore)]
+        public CacheControl? CacheControl { get; set; }
+    }
+
+    /// <summary>
+    /// Cache control directive for Anthropic prompt caching.
+    /// </summary>
+    public sealed class CacheControl
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; } = "ephemeral";
+    }
+
+    /// <summary>
+    /// A message in the Anthropic Messages API conversation.
+    /// </summary>
+    public sealed class Message
+    {
+        [JsonProperty("role")]
+        public string Role { get; set; } = "";
+
+        [JsonProperty("content")]
+        public string Content { get; set; } = "";
+    }
+}

--- a/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesRequest.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesRequest.cs
@@ -1,0 +1,26 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pinder.LlmAdapters.Anthropic.Dto
+{
+    /// <summary>
+    /// Serializes to the Anthropic Messages API request body.
+    /// </summary>
+    public sealed class MessagesRequest
+    {
+        [JsonProperty("model")]
+        public string Model { get; set; } = "";
+
+        [JsonProperty("max_tokens")]
+        public int MaxTokens { get; set; } = 1024;
+
+        [JsonProperty("temperature")]
+        public double Temperature { get; set; } = 0.9;
+
+        [JsonProperty("system")]
+        public ContentBlock[] System { get; set; } = Array.Empty<ContentBlock>();
+
+        [JsonProperty("messages")]
+        public Message[] Messages { get; set; } = Array.Empty<Message>();
+    }
+}

--- a/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesResponse.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesResponse.cs
@@ -1,0 +1,52 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Pinder.LlmAdapters.Anthropic.Dto
+{
+    /// <summary>
+    /// Deserializes an Anthropic Messages API response.
+    /// </summary>
+    public sealed class MessagesResponse
+    {
+        [JsonProperty("content")]
+        public ResponseContent[] Content { get; set; } = Array.Empty<ResponseContent>();
+
+        [JsonProperty("usage")]
+        public UsageStats? Usage { get; set; }
+
+        /// <summary>
+        /// Returns the text of the first content block, or empty string if no content blocks exist.
+        /// </summary>
+        public string GetText() => Content.Length > 0 ? Content[0].Text : "";
+    }
+
+    /// <summary>
+    /// A single content block in an Anthropic response.
+    /// </summary>
+    public sealed class ResponseContent
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; } = "";
+
+        [JsonProperty("text")]
+        public string Text { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Token usage statistics from the Anthropic API, including prompt caching metrics.
+    /// </summary>
+    public sealed class UsageStats
+    {
+        [JsonProperty("input_tokens")]
+        public int InputTokens { get; set; }
+
+        [JsonProperty("output_tokens")]
+        public int OutputTokens { get; set; }
+
+        [JsonProperty("cache_creation_input_tokens")]
+        public int CacheCreationInputTokens { get; set; }
+
+        [JsonProperty("cache_read_input_tokens")]
+        public int CacheReadInputTokens { get; set; }
+    }
+}

--- a/src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj
+++ b/src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Pinder.LlmAdapters</RootNamespace>
+    <AssemblyName>Pinder.LlmAdapters</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pinder.Core\Pinder.Core.csproj" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicApiExceptionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicApiExceptionTests.cs
@@ -1,0 +1,36 @@
+using Pinder.LlmAdapters.Anthropic;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    public class AnthropicApiExceptionTests
+    {
+        [Fact]
+        public void Constructor_SetsPropertiesAndMessage()
+        {
+            var body = "{\"error\":{\"type\":\"rate_limit_error\"}}";
+            var ex = new AnthropicApiException(429, body);
+
+            Assert.Equal(429, ex.StatusCode);
+            Assert.Equal(body, ex.ResponseBody);
+            Assert.Equal($"Anthropic API error 429: {body}", ex.Message);
+        }
+
+        [Fact]
+        public void Constructor_HandlesEmptyResponseBody()
+        {
+            var ex = new AnthropicApiException(500, "");
+
+            Assert.Equal(500, ex.StatusCode);
+            Assert.Equal("", ex.ResponseBody);
+            Assert.Equal("Anthropic API error 500: ", ex.Message);
+        }
+
+        [Fact]
+        public void IsException()
+        {
+            var ex = new AnthropicApiException(400, "bad request");
+            Assert.IsAssignableFrom<System.Exception>(ex);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicOptionsTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicOptionsTests.cs
@@ -1,0 +1,48 @@
+using Pinder.LlmAdapters.Anthropic;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    public class AnthropicOptionsTests
+    {
+        [Fact]
+        public void Defaults_AreCorrect()
+        {
+            var options = new AnthropicOptions();
+
+            Assert.Equal("", options.ApiKey);
+            Assert.Equal("claude-sonnet-4-20250514", options.Model);
+            Assert.Equal(1024, options.MaxTokens);
+            Assert.Equal(0.9, options.Temperature);
+            Assert.Null(options.DialogueOptionsTemperature);
+            Assert.Null(options.DeliveryTemperature);
+            Assert.Null(options.OpponentResponseTemperature);
+            Assert.Null(options.InterestChangeBeatTemperature);
+        }
+
+        [Fact]
+        public void Properties_AreSettable()
+        {
+            var options = new AnthropicOptions
+            {
+                ApiKey = "sk-test",
+                Model = "claude-opus-4-20250514",
+                MaxTokens = 2048,
+                Temperature = 0.7,
+                DialogueOptionsTemperature = 1.0,
+                DeliveryTemperature = 0.5,
+                OpponentResponseTemperature = 0.8,
+                InterestChangeBeatTemperature = 0.6
+            };
+
+            Assert.Equal("sk-test", options.ApiKey);
+            Assert.Equal("claude-opus-4-20250514", options.Model);
+            Assert.Equal(2048, options.MaxTokens);
+            Assert.Equal(0.7, options.Temperature);
+            Assert.Equal(1.0, options.DialogueOptionsTemperature);
+            Assert.Equal(0.5, options.DeliveryTemperature);
+            Assert.Equal(0.8, options.OpponentResponseTemperature);
+            Assert.Equal(0.6, options.InterestChangeBeatTemperature);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/ContentBlockTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/ContentBlockTests.cs
@@ -1,0 +1,52 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
+{
+    public class ContentBlockTests
+    {
+        [Fact]
+        public void CacheControl_OmittedFromJson_WhenNull()
+        {
+            var block = new ContentBlock { Type = "text", Text = "Hello" };
+            var json = JObject.Parse(JsonConvert.SerializeObject(block));
+
+            Assert.Equal("text", json["type"]!.Value<string>());
+            Assert.Equal("Hello", json["text"]!.Value<string>());
+            Assert.Null(json["cache_control"]);
+        }
+
+        [Fact]
+        public void CacheControl_IncludedInJson_WhenSet()
+        {
+            var block = new ContentBlock
+            {
+                Type = "text",
+                Text = "Cached block",
+                CacheControl = new CacheControl { Type = "ephemeral" }
+            };
+            var json = JObject.Parse(JsonConvert.SerializeObject(block));
+
+            Assert.NotNull(json["cache_control"]);
+            Assert.Equal("ephemeral", json["cache_control"]!["type"]!.Value<string>());
+        }
+
+        [Fact]
+        public void Defaults_AreCorrect()
+        {
+            var block = new ContentBlock();
+            Assert.Equal("text", block.Type);
+            Assert.Equal("", block.Text);
+            Assert.Null(block.CacheControl);
+
+            var cache = new CacheControl();
+            Assert.Equal("ephemeral", cache.Type);
+
+            var msg = new Message();
+            Assert.Equal("", msg.Role);
+            Assert.Equal("", msg.Content);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesRequestTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesRequestTests.cs
@@ -1,0 +1,69 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
+{
+    public class MessagesRequestTests
+    {
+        [Fact]
+        public void Defaults_SerializeCorrectly()
+        {
+            var request = new MessagesRequest();
+            var json = JObject.Parse(JsonConvert.SerializeObject(request));
+
+            Assert.Equal("", json["model"]!.Value<string>());
+            Assert.Equal(1024, json["max_tokens"]!.Value<int>());
+            Assert.Equal(0.9, json["temperature"]!.Value<double>());
+            Assert.Empty(json["system"]!);
+            Assert.Empty(json["messages"]!);
+        }
+
+        [Fact]
+        public void FullRequest_SerializesToExpectedJson()
+        {
+            var request = new MessagesRequest
+            {
+                Model = "claude-sonnet-4-20250514",
+                MaxTokens = 1024,
+                Temperature = 0.9,
+                System = new[]
+                {
+                    new ContentBlock
+                    {
+                        Type = "text",
+                        Text = "You are a character.",
+                        CacheControl = new CacheControl { Type = "ephemeral" }
+                    }
+                },
+                Messages = new[]
+                {
+                    new Message { Role = "user", Content = "Generate 4 dialogue options." }
+                }
+            };
+
+            var json = JObject.Parse(JsonConvert.SerializeObject(request));
+
+            Assert.Equal("claude-sonnet-4-20250514", json["model"]!.Value<string>());
+            var system = (JArray)json["system"]!;
+            Assert.Single(system);
+            Assert.Equal("You are a character.", system[0]["text"]!.Value<string>());
+            Assert.Equal("ephemeral", system[0]["cache_control"]!["type"]!.Value<string>());
+
+            var messages = (JArray)json["messages"]!;
+            Assert.Single(messages);
+            Assert.Equal("user", messages[0]["role"]!.Value<string>());
+        }
+
+        [Fact]
+        public void SystemAndMessages_DefaultToEmptyArray_NotNull()
+        {
+            var request = new MessagesRequest();
+            Assert.NotNull(request.System);
+            Assert.Empty(request.System);
+            Assert.NotNull(request.Messages);
+            Assert.Empty(request.Messages);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesResponseTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesResponseTests.cs
@@ -1,0 +1,69 @@
+using Newtonsoft.Json;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
+{
+    public class MessagesResponseTests
+    {
+        [Fact]
+        public void GetText_ReturnsFirstContentBlock()
+        {
+            var json = @"{
+                ""content"": [
+                    { ""type"": ""text"", ""text"": ""Here are your options:\n1. ..."" }
+                ],
+                ""usage"": {
+                    ""input_tokens"": 1500,
+                    ""output_tokens"": 350,
+                    ""cache_creation_input_tokens"": 1200,
+                    ""cache_read_input_tokens"": 0
+                }
+            }";
+
+            var response = JsonConvert.DeserializeObject<MessagesResponse>(json)!;
+
+            Assert.Equal("Here are your options:\n1. ...", response.GetText());
+            Assert.NotNull(response.Usage);
+            Assert.Equal(1500, response.Usage!.InputTokens);
+            Assert.Equal(350, response.Usage.OutputTokens);
+            Assert.Equal(1200, response.Usage.CacheCreationInputTokens);
+            Assert.Equal(0, response.Usage.CacheReadInputTokens);
+        }
+
+        [Fact]
+        public void GetText_ReturnsEmptyString_WhenContentEmpty()
+        {
+            var json = @"{ ""content"": [], ""usage"": null }";
+            var response = JsonConvert.DeserializeObject<MessagesResponse>(json)!;
+
+            Assert.Equal("", response.GetText());
+            Assert.Null(response.Usage);
+        }
+
+        [Fact]
+        public void GetText_ReturnsFirstOnly_WhenMultipleBlocks()
+        {
+            var response = new MessagesResponse
+            {
+                Content = new[]
+                {
+                    new ResponseContent { Type = "text", Text = "First" },
+                    new ResponseContent { Type = "text", Text = "Second" }
+                }
+            };
+
+            Assert.Equal("First", response.GetText());
+        }
+
+        [Fact]
+        public void Defaults_AreCorrect()
+        {
+            var response = new MessagesResponse();
+            Assert.NotNull(response.Content);
+            Assert.Empty(response.Content);
+            Assert.Null(response.Usage);
+            Assert.Equal("", response.GetText());
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
+++ b/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #205

## What was implemented

Created the `Pinder.LlmAdapters` project scaffold with all Anthropic API DTOs, configuration, and exception types per the spec and architect contract.

### Files created
- `src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj` — netstandard2.0, refs Pinder.Core + Newtonsoft.Json 13.0.3
- `src/Pinder.LlmAdapters/Anthropic/Dto/MessagesRequest.cs` — request DTO with JsonProperty attributes
- `src/Pinder.LlmAdapters/Anthropic/Dto/ContentBlock.cs` — ContentBlock, CacheControl, Message DTOs
- `src/Pinder.LlmAdapters/Anthropic/Dto/MessagesResponse.cs` — MessagesResponse, ResponseContent, UsageStats DTOs
- `src/Pinder.LlmAdapters/Anthropic/AnthropicOptions.cs` — configuration carrier with per-method temperature overrides
- `src/Pinder.LlmAdapters/Anthropic/AnthropicApiException.cs` — typed exception with StatusCode and ResponseBody
- `tests/Pinder.LlmAdapters.Tests/` — test project with 15 happy-path tests covering all DTOs
- Updated `Pinder.Core.sln` to include both new projects in correct solution folders

### How to test
```bash
dotnet build Pinder.Core.sln  # 0 errors, 0 warnings (1 pre-existing warning in Core.Tests)
dotnet test tests/Pinder.LlmAdapters.Tests/  # 15 tests pass
dotnet test tests/Pinder.Core.Tests/  # 1118 pass, 1 pre-existing failure
```

### Deviations from contract
None

## DoD Evidence
**Branch:** issue-205-create-pinder-llmadapters-project-csproj
**Commit:** 7f907d8
