### PR TITLE
[Issue #209] Fix failing combo test: FixedDice queue exhausted in AC4_Integration_TripleBonusAppliedAsExternalBonus

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -364,6 +364,7 @@ namespace Pinder.Core.Conversation
             if (_comboTracker.HasTripleBonus)
             {
                 externalBonus += 1;
+                _comboTracker.ConsumeTripleBonus(); // Consume after applying (#46 edge case 7)
             }
 
             // Compute DC adjustment from weakness window (#49)

--- a/tests/Pinder.Core.Tests/ComboSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ComboSpecTests.cs
@@ -822,17 +822,18 @@ namespace Pinder.Core.Tests
         {
             // 3 turns with distinct non-overlapping stats, then check external bonus on turn 4
             var dice = new FixedDice(
-                15, 50, // Turn 1: Rizz
-                15, 50, // Turn 2: SA
-                15, 50, // Turn 3: Chaos → Triple
-                15, 50  // Turn 4: should get +1 external
+                15, 50, // Turn 1: Rizz (d20, d100)
+                15, 50, // Turn 2: SA (d20, d100)
+                15, 50, // Turn 3: Chaos → Triple (d20, d100)
+                15, 15, 50  // Turn 4: advantage from VeryIntoIt (d20, d20, d100)
             );
 
             var llm = new ComboTestLlmAdapter();
             llm.EnqueueOptions(new DialogueOption(StatType.Rizz, "R"));
             llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "SA"));
             llm.EnqueueOptions(new DialogueOption(StatType.Chaos, "C"));
-            llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Ch"));
+            // Use SA again to avoid triggering a second Triple (SA,Chaos,SA = not 3 distinct)
+            llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "SA2"));
 
             var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry());
 


### PR DESCRIPTION
Fixes #209

## Summary

The test `AC4_Integration_TripleBonusAppliedAsExternalBonus` failed with two root causes:

1. **FixedDice queue exhausted**: Turn 4 reaches interest=18 (VeryIntoIt), triggering advantage, which rolls 2 d20s instead of 1. The queue had 8 values but needed 9.

2. **Re-triggered Triple combo**: Turn 4 (Charm) combined with turns 2-3 (SA, Chaos) formed a new Triple (3 distinct stats), causing `TripleBonusActive` to be true in the snapshot even after consumption.

## Changes

### Test fix (`ComboSpecTests.cs`)
- Added 9th dice value: Turn 4 now has `15, 15, 50` (two d20s for advantage + d100 for ComputeDelay)
- Changed Turn 4 stat from `Charm` to `SelfAwareness` to avoid triggering a second Triple (SA, Chaos, SA = not 3 distinct)

### Production fix (`GameSession.cs`)
- Added explicit `ConsumeTripleBonus()` in `ResolveTurnAsync` after applying the bonus, matching the pattern already used in Read/Recover/Wait paths

## Testing
All 1201 tests pass (1119 Core + 82 LlmAdapters).

## DoD Evidence
**Branch:** issue-209-fix-failing-combo-test-fixeddice-queue-e
**Commit:** 7bc3899
