### PR TITLE
[Issue #207] SessionDocumentBuilder + PromptTemplates — format §3.2–3.8 prompts for Anthropic calls

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/CacheBlockBuilder.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/CacheBlockBuilder.cs
@@ -1,0 +1,63 @@
+using System;
+using Pinder.LlmAdapters.Anthropic.Dto;
+
+namespace Pinder.LlmAdapters.Anthropic
+{
+    /// <summary>
+    /// Builds ContentBlock arrays with cache_control: ephemeral annotations
+    /// for Anthropic prompt caching. Character system prompts (~6k tokens)
+    /// are cached so turns 2+ read from cache at ~10% of normal input cost.
+    /// </summary>
+    public static class CacheBlockBuilder
+    {
+        /// <summary>
+        /// Builds system blocks with both character prompts cached.
+        /// Used by dialogue options and delivery calls.
+        /// </summary>
+        /// <param name="playerPrompt">The player's assembled §3.1 system prompt.</param>
+        /// <param name="opponentPrompt">The opponent's assembled §3.1 system prompt.</param>
+        /// <returns>Two ContentBlocks, both with cache_control: ephemeral.</returns>
+        public static ContentBlock[] BuildCachedSystemBlocks(string playerPrompt, string opponentPrompt)
+        {
+            if (playerPrompt == null) throw new ArgumentNullException(nameof(playerPrompt));
+            if (opponentPrompt == null) throw new ArgumentNullException(nameof(opponentPrompt));
+
+            return new[]
+            {
+                new ContentBlock
+                {
+                    Type = "text",
+                    Text = playerPrompt,
+                    CacheControl = new CacheControl { Type = "ephemeral" }
+                },
+                new ContentBlock
+                {
+                    Type = "text",
+                    Text = opponentPrompt,
+                    CacheControl = new CacheControl { Type = "ephemeral" }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Builds system blocks with only the opponent prompt cached.
+        /// Used by opponent response calls.
+        /// </summary>
+        /// <param name="opponentPrompt">The opponent's assembled §3.1 system prompt.</param>
+        /// <returns>One ContentBlock with cache_control: ephemeral.</returns>
+        public static ContentBlock[] BuildOpponentOnlySystemBlocks(string opponentPrompt)
+        {
+            if (opponentPrompt == null) throw new ArgumentNullException(nameof(opponentPrompt));
+
+            return new[]
+            {
+                new ContentBlock
+                {
+                    Type = "text",
+                    Text = opponentPrompt,
+                    CacheControl = new CacheControl { Type = "ephemeral" }
+                }
+            };
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -1,0 +1,126 @@
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Static instruction templates sourced from character-construction.md §3.2–3.8.
+    /// Each template uses {placeholder} tokens filled by SessionDocumentBuilder at call time.
+    /// </summary>
+    public static class PromptTemplates
+    {
+        /// <summary>§3.2 — Instructs the LLM to generate exactly 4 dialogue options with metadata tags.</summary>
+        public const string DialogueOptionsInstruction =
+@"Generate exactly 4 dialogue options for {player_name}.
+
+Each option must:
+1. Be tagged with one of: CHARM, RIZZ, HONESTY, CHAOS, WIT, SELF_AWARENESS
+2. Show what the character INTENDS to say — this is their internal intended message, before any roll outcome is applied
+3. Reflect the player's personality and current shadow state (not the opponent's)
+4. Vary in tone and risk — include at least one safe and one bold option
+5. If a callback opportunity exists, make 1–2 options reference an earlier topic naturally
+6. If a combo is available, one option should use the completing stat
+7. Take the opponent's profile into account — their personality, archetypes, and texting style should inform what would land or fail
+
+For each option include metadata:
+[STAT: X] [CALLBACK: turn_N or none] [COMBO: name or none] [TELL_BONUS: yes/no]
+
+Keep options concise. One to three sentences. Match the opponent's register.";
+
+        /// <summary>§3.3 — Deliver the intended message on a successful roll.</summary>
+        public const string SuccessDeliveryInstruction =
+@"Deliver this message as the character would actually send it.
+- On a clean success (margin 1–5): deliver it essentially as written, with natural voice
+- On a strong success (margin 6–10): add a small flourish or timing that makes it land better
+- On a critical success / Nat 20: deliver it at peak — perfectly timed, resonant, exactly right
+
+Keep it in character. Keep the lowercase voice. Don't explain the success.
+Output only the message text.";
+
+        /// <summary>§3.4 — Degrade the intended message according to failure tier.</summary>
+        public const string FailureDeliveryInstruction =
+@"The player chose option: ""{intended_message}""
+Stat used: {stat}
+They rolled FAILED — missed DC by {miss_margin}.
+Failure tier: {tier}
+
+Failure principle: corrupt the CONTENT, not the delivery. The message always sends intentionally.
+Words are what betray you. The character means to say one thing and something else comes out.
+
+Tier-specific instructions:
+{tier_instruction}
+
+TIER INSTRUCTIONS:
+FUMBLE (miss 1–2): Slight fumble. The intended message mostly gets through but with one awkward word
+  choice, an unnecessary hedge, or a small detail that undermines it. Still readable.
+
+MISFIRE (miss 3–5): The message goes sideways. Key information gets garbled, tone shifts
+  unexpectedly, or a strange tangent appears mid-sentence. The intent is still guessable but
+  the execution is off.
+
+TROPE_TRAP (miss 6–9): A stat-specific social trope failure activates. The message transforms
+  into a recognisable bad-texting archetype (oversharing, going unhinged, being pretentious,
+  spiraling, etc.). The trap is now active.
+
+CATASTROPHE (miss 10+): Spectacular disaster. The intended message has been completely hijacked
+  by the character's worst impulse. What comes out is the thing they would NEVER want to send.
+  Still sounds like them — their disaster is their own.
+
+LEGENDARY (Nat 1): Maximum humiliation. The character's deepest embarrassing quality
+  surfaces fully. This should be funny, specific, and feel earned by the build.
+
+{active_trap_llm_instructions}
+
+Output only the message text. No explanation. The character sent this.";
+
+        /// <summary>
+        /// §3.5 — Generate opponent response with optional [SIGNALS] block.
+        /// Uses {placeholder} tokens for dynamic content.
+        /// </summary>
+        public const string OpponentResponseInstruction =
+@"Generate your next message.
+- Match your personality exactly as established in the system prompt
+- React authentically to what was just said
+- If Interest dropped: show cooling without being melodramatic
+- If Interest rose: show warming without being gushing
+- Keep it to 1–3 sentences. Match the register.
+
+Output format — use EXACTLY this structure:
+
+[RESPONSE]
+""your actual message text""
+
+Occasionally (when it feels natural, roughly 30–40% of turns), include a signals block after your response:
+
+[SIGNALS]
+TELL: {STAT_NAME} ({description of what reveals the tell})
+WEAKNESS: {STAT_NAME} -{reduction} ({description of the opening})
+
+Rules for signals:
+- TELL line format: TELL: CHARM|RIZZ|HONESTY|CHAOS|WIT|SELF_AWARENESS (brief description)
+- WEAKNESS line format: WEAKNESS: CHARM|RIZZ|HONESTY|CHAOS|WIT|SELF_AWARENESS -2 or -3 (brief description)
+- Both lines are independently optional within a [SIGNALS] block
+- Only include signals when the conversation naturally reveals them — do not force them";
+
+        /// <summary>§3.8 — Generate a narrative beat when interest crosses a threshold.</summary>
+        public const string InterestBeatInstruction =
+@"{opponent_name}'s Interest just moved from {interest_before} to {interest_after}.
+
+{threshold_instruction}
+
+Output only the message or gesture text.";
+
+        // Threshold-specific sub-instructions for InterestBeatInstruction
+        internal const string InterestBeatAbove15 =
+@"Generate a brief reaction — one sentence or a small gesture — showing {opponent_name} becoming more invested. Subtle. Not a proclamation. A shift in energy.";
+
+        internal const string InterestBeatBelow8 =
+@"Generate a brief cooling signal — one sentence or a small gesture — showing {opponent_name} pulling back slightly. Not dramatic. Just a temperature change.";
+
+        internal const string InterestBeatDateSecured =
+@"Generate a brief moment where {opponent_name} suggests or implies meeting up. In character. Not ""do you want to go on a date?"" — something specific to them.";
+
+        internal const string InterestBeatUnmatched =
+@"Generate {opponent_name} unmatching — one final message or simply going silent. In character. No villain speech. Just a door closing.";
+
+        internal const string InterestBeatGeneric =
+@"Generate a brief reaction from {opponent_name} reflecting the change in interest. Subtle and in character.";
+    }
+}

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Builds the user-message content for each of the 4 ILlmAdapter method calls.
+    /// Pure static utility — no I/O, no state, no async.
+    /// </summary>
+    public static class SessionDocumentBuilder
+    {
+        /// <summary>
+        /// Builds the user-message content for GetDialogueOptionsAsync (§3.2).
+        /// </summary>
+        public static string BuildDialogueOptionsPrompt(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory,
+            string opponentLastMessage,
+            string[] activeTraps,
+            int currentInterest,
+            int currentTurn,
+            string playerName,
+            string opponentName)
+        {
+            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
+            if (opponentLastMessage == null) throw new ArgumentNullException(nameof(opponentLastMessage));
+            if (activeTraps == null) throw new ArgumentNullException(nameof(activeTraps));
+            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
+            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("CONVERSATION HISTORY");
+            AppendConversationHistory(sb, conversationHistory, playerName);
+
+            sb.AppendLine();
+            sb.AppendLine("OPPONENT'S LAST MESSAGE");
+            sb.AppendLine($"\"{opponentLastMessage}\"");
+
+            sb.AppendLine();
+            sb.AppendLine("GAME STATE");
+            if (activeTraps.Length == 0)
+            {
+                sb.AppendLine("- Active traps: none");
+            }
+            else
+            {
+                sb.AppendLine($"- Active traps: {string.Join(", ", activeTraps)}");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("YOUR TASK");
+            sb.Append(PromptTemplates.DialogueOptionsInstruction.Replace("{player_name}", playerName));
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds the user-message content for DeliverMessageAsync (§3.3 success / §3.4 failure).
+        /// </summary>
+        public static string BuildDeliveryPrompt(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory,
+            DialogueOption chosenOption,
+            FailureTier outcome,
+            int beatDcBy,
+            string[]? activeTrapInstructions,
+            string playerName,
+            string opponentName)
+        {
+            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
+            if (chosenOption == null) throw new ArgumentNullException(nameof(chosenOption));
+            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
+            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("CONVERSATION HISTORY");
+            AppendConversationHistory(sb, conversationHistory, playerName);
+            sb.AppendLine();
+
+            if (outcome == FailureTier.None)
+            {
+                // Success path (§3.3)
+                sb.AppendLine($"The player chose option: \"{chosenOption.IntendedText}\"");
+                sb.AppendLine($"Stat used: {chosenOption.Stat.ToString().ToUpperInvariant()}");
+                sb.AppendLine($"They rolled SUCCESS — beat DC by {beatDcBy}.");
+                sb.AppendLine();
+                sb.Append(PromptTemplates.SuccessDeliveryInstruction);
+            }
+            else
+            {
+                // Failure path (§3.4)
+                int missMargin = Math.Abs(beatDcBy);
+                string tierName = GetFailureTierName(outcome);
+                string tierInstruction = GetTierInstruction(outcome);
+
+                sb.AppendLine($"The player chose option: \"{chosenOption.IntendedText}\"");
+                sb.AppendLine($"Stat used: {chosenOption.Stat.ToString().ToUpperInvariant()}");
+                sb.AppendLine($"They rolled FAILED — missed DC by {missMargin}.");
+                sb.AppendLine($"Failure tier: {tierName}");
+                sb.AppendLine();
+
+                string failureText = PromptTemplates.FailureDeliveryInstruction
+                    .Replace("{intended_message}", chosenOption.IntendedText)
+                    .Replace("{stat}", chosenOption.Stat.ToString().ToUpperInvariant())
+                    .Replace("{miss_margin}", missMargin.ToString())
+                    .Replace("{tier}", tierName)
+                    .Replace("{tier_instruction}", tierInstruction);
+
+                if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+                {
+                    failureText = failureText.Replace("{active_trap_llm_instructions}",
+                        "Active trap instructions:\n" + string.Join("\n", activeTrapInstructions));
+                }
+                else
+                {
+                    failureText = failureText.Replace("{active_trap_llm_instructions}", "");
+                }
+
+                sb.Append(failureText);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds the user-message content for GetOpponentResponseAsync (§3.5).
+        /// </summary>
+        public static string BuildOpponentPrompt(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory,
+            string playerDeliveredMessage,
+            int interestBefore,
+            int interestAfter,
+            double responseDelayMinutes,
+            string[]? activeTrapInstructions,
+            string playerName,
+            string opponentName)
+        {
+            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
+            if (playerDeliveredMessage == null) throw new ArgumentNullException(nameof(playerDeliveredMessage));
+            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
+            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("CONVERSATION HISTORY");
+            AppendConversationHistory(sb, conversationHistory, playerName);
+
+            sb.AppendLine();
+            sb.AppendLine("PLAYER'S LAST MESSAGE");
+            sb.AppendLine($"\"{playerDeliveredMessage}\"");
+
+            sb.AppendLine();
+            sb.AppendLine("INTEREST CHANGE");
+            int delta = interestAfter - interestBefore;
+            string deltaStr = delta >= 0 ? $"+{delta}" : delta.ToString();
+            sb.AppendLine($"Interest moved from {interestBefore} to {interestAfter} ({deltaStr}).");
+            sb.AppendLine($"Current Interest: {interestAfter}/25");
+
+            sb.AppendLine();
+            sb.AppendLine("RESPONSE TIMING");
+            if (responseDelayMinutes < 1.0)
+            {
+                sb.AppendLine("Your reply arrives in less than 1 minute.");
+            }
+            else
+            {
+                sb.AppendLine($"Your reply arrives in approximately {responseDelayMinutes:F1} minutes.");
+            }
+            sb.AppendLine("Write in a register consistent with that timing — a 3-minute reply feels different from a 3-hour reply.");
+
+            sb.AppendLine();
+            sb.AppendLine("CURRENT INTEREST STATE");
+            sb.AppendLine(GetInterestBehaviourBlock(interestAfter));
+
+            if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("ACTIVE TRAP INSTRUCTIONS");
+                foreach (var instruction in activeTrapInstructions)
+                {
+                    sb.AppendLine(instruction);
+                }
+            }
+
+            sb.AppendLine();
+            sb.Append(PromptTemplates.OpponentResponseInstruction);
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds the user-message content for GetInterestChangeBeatAsync (§3.8).
+        /// </summary>
+        public static string BuildInterestChangeBeatPrompt(
+            string opponentName,
+            int interestBefore,
+            int interestAfter,
+            InterestState newState)
+        {
+            if (opponentName == null) throw new ArgumentNullException(nameof(opponentName));
+
+            string thresholdInstruction = GetThresholdInstruction(interestBefore, interestAfter, newState, opponentName);
+
+            return PromptTemplates.InterestBeatInstruction
+                .Replace("{opponent_name}", opponentName)
+                .Replace("{interest_before}", interestBefore.ToString())
+                .Replace("{interest_after}", interestAfter.ToString())
+                .Replace("{threshold_instruction}", thresholdInstruction);
+        }
+
+        /// <summary>
+        /// Formats conversation history with [T{n}|PLAYER|name] markers.
+        /// Full history — never truncated.
+        /// </summary>
+        private static void AppendConversationHistory(
+            StringBuilder sb,
+            IReadOnlyList<(string Sender, string Text)> history,
+            string playerName)
+        {
+            sb.AppendLine("[CONVERSATION_START]");
+
+            for (int i = 0; i < history.Count; i++)
+            {
+                int turn = (i / 2) + 1;
+                var entry = history[i];
+                string role = entry.Sender == playerName ? "PLAYER" : "OPPONENT";
+                sb.AppendLine($"[T{turn}|{role}|{entry.Sender}] \"{entry.Text}\"");
+            }
+
+            sb.AppendLine("[CURRENT_TURN]");
+        }
+
+        private static string GetInterestBehaviourBlock(int interest)
+        {
+            if (interest >= 21)
+                return "You are extremely interested. You're looking for excuses to keep talking. The date is basically happening.";
+            if (interest >= 17)
+                return "You are very interested. Replies come quickly. Tone is warmer, more playful. You might volunteer personal information.";
+            if (interest >= 13)
+                return "You are engaged. Normal pacing. Responsive but not eager. You're seeing where this goes.";
+            if (interest >= 9)
+                return "You are lukewarm. Taking your time. Replies are functional. You might test them a little.";
+            if (interest >= 5)
+                return "You are cooling. Short replies. A little dry. You're not sold. One or two good messages could change that.";
+            if (interest >= 1)
+                return "You are disengaged. Minimal effort. You might send a closing signal or go quiet.";
+            return "You have lost all interest. You are unmatching.";
+        }
+
+        private static string GetThresholdInstruction(int before, int after, InterestState newState, string opponentName)
+        {
+            if (newState == InterestState.Unmatched)
+                return PromptTemplates.InterestBeatUnmatched.Replace("{opponent_name}", opponentName);
+            if (newState == InterestState.DateSecured)
+                return PromptTemplates.InterestBeatDateSecured.Replace("{opponent_name}", opponentName);
+            if (after > before && after > 15 && before <= 15)
+                return PromptTemplates.InterestBeatAbove15.Replace("{opponent_name}", opponentName);
+            if (after < before && after < 8 && before >= 8)
+                return PromptTemplates.InterestBeatBelow8.Replace("{opponent_name}", opponentName);
+
+            // Generic fallback for other threshold crossings
+            return PromptTemplates.InterestBeatGeneric.Replace("{opponent_name}", opponentName);
+        }
+
+        private static string GetFailureTierName(FailureTier tier)
+        {
+            switch (tier)
+            {
+                case FailureTier.Fumble: return "FUMBLE";
+                case FailureTier.Misfire: return "MISFIRE";
+                case FailureTier.TropeTrap: return "TROPE_TRAP";
+                case FailureTier.Catastrophe: return "CATASTROPHE";
+                case FailureTier.Legendary: return "LEGENDARY";
+                default: return "UNKNOWN";
+            }
+        }
+
+        private static string GetTierInstruction(FailureTier tier)
+        {
+            switch (tier)
+            {
+                case FailureTier.Fumble:
+                    return "Slight fumble. The intended message mostly gets through but with one awkward word choice, an unnecessary hedge, or a small detail that undermines it. Still readable.";
+                case FailureTier.Misfire:
+                    return "The message goes sideways. Key information gets garbled, tone shifts unexpectedly, or a strange tangent appears mid-sentence. The intent is still guessable but the execution is off.";
+                case FailureTier.TropeTrap:
+                    return "A stat-specific social trope failure activates. The message transforms into a recognisable bad-texting archetype (oversharing, going unhinged, being pretentious, spiraling, etc.). The trap is now active.";
+                case FailureTier.Catastrophe:
+                    return "Spectacular disaster. The intended message has been completely hijacked by the character's worst impulse. What comes out is the thing they would NEVER want to send. Still sounds like them — their disaster is their own.";
+                case FailureTier.Legendary:
+                    return "Maximum humiliation. The character's deepest embarrassing quality surfaces fully. This should be funny, specific, and feel earned by the build.";
+                default:
+                    return "A failure has occurred. Degrade the message accordingly.";
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class SessionDocumentBuilderTests
+    {
+        // ── AC2: Conversation history formatting ──
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_EmptyHistory_ContainsConversationStartAndCurrentTurn()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: new string[0],
+                currentInterest: 10,
+                currentTurn: 1,
+                playerName: "GERALD_42",
+                opponentName: "VELVET");
+
+            Assert.Contains("[CONVERSATION_START]", result);
+            Assert.Contains("[CURRENT_TURN]", result);
+
+            // No turn markers between start and current
+            int startIdx = result.IndexOf("[CONVERSATION_START]");
+            int currentIdx = result.IndexOf("[CURRENT_TURN]");
+            string between = result.Substring(
+                startIdx + "[CONVERSATION_START]".Length,
+                currentIdx - startIdx - "[CONVERSATION_START]".Length);
+            Assert.DoesNotContain("[T", between.Trim());
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_ThreeTurnHistory_CorrectTurnMarkers()
+        {
+            var history = new List<(string, string)>
+            {
+                ("GERALD_42", "Hey"),
+                ("VELVET", "Hi"),
+                ("GERALD_42", "How are you?"),
+                ("VELVET", "Good"),
+                ("GERALD_42", "Cool"),
+                ("VELVET", "Indeed")
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                history, "Indeed", new string[0], 12, 4, "GERALD_42", "VELVET");
+
+            Assert.Contains("[T1|PLAYER|GERALD_42] \"Hey\"", result);
+            Assert.Contains("[T1|OPPONENT|VELVET] \"Hi\"", result);
+            Assert.Contains("[T2|PLAYER|GERALD_42] \"How are you?\"", result);
+            Assert.Contains("[T2|OPPONENT|VELVET] \"Good\"", result);
+            Assert.Contains("[T3|PLAYER|GERALD_42] \"Cool\"", result);
+            Assert.Contains("[T3|OPPONENT|VELVET] \"Indeed\"", result);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_EightTurnHistory_AllTurnsPresent()
+        {
+            var history = new List<(string, string)>();
+            for (int i = 0; i < 16; i++)
+            {
+                string sender = i % 2 == 0 ? "PLAYER_A" : "OPP_B";
+                history.Add((sender, $"Message {i}"));
+            }
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                history, "Message 15", new string[0], 10, 9, "PLAYER_A", "OPP_B");
+
+            for (int turn = 1; turn <= 8; turn++)
+            {
+                Assert.Contains($"[T{turn}|PLAYER|PLAYER_A]", result);
+                Assert.Contains($"[T{turn}|OPPONENT|OPP_B]", result);
+            }
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_OddEntries_HandlesLonePlayerMessage()
+        {
+            var history = new List<(string, string)>
+            {
+                ("GERALD", "Hey"),
+                ("VELVET", "Hi"),
+                ("GERALD", "So anyway...")
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                history, "Hi", new string[0], 10, 2, "GERALD", "VELVET");
+
+            Assert.Contains("[T1|PLAYER|GERALD] \"Hey\"", result);
+            Assert.Contains("[T1|OPPONENT|VELVET] \"Hi\"", result);
+            Assert.Contains("[T2|PLAYER|GERALD] \"So anyway...\"", result);
+        }
+
+        // ── AC1: All 4 builder methods ──
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_ActiveTraps_FormattedCorrectly()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                new List<(string, string)>(), "", new[] { "Cringe", "Spiral" },
+                12, 1, "GERALD", "VELVET");
+
+            Assert.Contains("Active traps: Cringe, Spiral", result);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_NoTraps_ShowsNone()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                new List<(string, string)>(), "", new string[0],
+                10, 1, "GERALD", "VELVET");
+
+            Assert.Contains("Active traps: none", result);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_ContainsTaskInstruction()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                new List<(string, string)>(), "", new string[0],
+                10, 1, "GERALD", "VELVET");
+
+            Assert.Contains("YOUR TASK", result);
+            Assert.Contains("Generate exactly 4 dialogue options for GERALD", result);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_Success_ContainsSuccessInstruction()
+        {
+            var option = new DialogueOption(StatType.Wit, "Something clever");
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                new List<(string, string)>(), option, FailureTier.None, 4, null,
+                "GERALD", "VELVET");
+
+            Assert.Contains("SUCCESS", result);
+            Assert.Contains("beat DC by 4", result);
+            Assert.Contains("Stat used: WIT", result);
+            Assert.Contains("Output only the message text", result);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_Misfire_ContainsFailureInstruction()
+        {
+            var option = new DialogueOption(StatType.Charm, "Tell me more");
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                new List<(string, string)>(), option, FailureTier.Misfire, -4,
+                new[] { "You are aware of how you're coming across." },
+                "GERALD", "VELVET");
+
+            Assert.Contains("FAILED", result);
+            Assert.Contains("missed DC by 4", result);
+            Assert.Contains("MISFIRE", result);
+            Assert.Contains("corrupt the CONTENT, not the delivery", result);
+            Assert.Contains("Active trap instructions:", result);
+            Assert.Contains("You are aware of how you're coming across.", result);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_NullTrapInstructions_OmitsTrapSection()
+        {
+            var option = new DialogueOption(StatType.Honesty, "I'm just honest");
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                new List<(string, string)>(), option, FailureTier.Fumble, -1, null,
+                "GERALD", "VELVET");
+
+            Assert.DoesNotContain("Active trap instructions:", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_ContainsAllSections()
+        {
+            var history = new List<(string, string)>
+            {
+                ("GERALD", "Hey"),
+                ("VELVET", "Hi")
+            };
+
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                history, "How are you?", 10, 12, 3.5, null, "GERALD", "VELVET");
+
+            Assert.Contains("PLAYER'S LAST MESSAGE", result);
+            Assert.Contains("\"How are you?\"", result);
+            Assert.Contains("INTEREST CHANGE", result);
+            Assert.Contains("Interest moved from 10 to 12 (+2)", result);
+            Assert.Contains("Current Interest: 12/25", result);
+            Assert.Contains("RESPONSE TIMING", result);
+            Assert.Contains("3.5 minutes", result);
+            Assert.Contains("CURRENT INTEREST STATE", result);
+            Assert.Contains("[RESPONSE]", result);
+            Assert.Contains("[SIGNALS]", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_NegativeDelta_FormattedCorrectly()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                new List<(string, string)>(), "Bye", 12, 9, 5.0, null, "P", "O");
+
+            Assert.Contains("Interest moved from 12 to 9 (-3)", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_SmallDelay_ShowsLessThanOneMinute()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                new List<(string, string)>(), "Hey", 10, 10, 0.5, null, "P", "O");
+
+            Assert.Contains("less than 1 minute", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_InterestBehaviourBlock_HighInterest()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                new List<(string, string)>(), "Hey", 10, 18, 1.0, null, "P", "O");
+
+            Assert.Contains("very interested", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_InterestBehaviourBlock_LowInterest()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                new List<(string, string)>(), "Hey", 5, 3, 1.0, null, "P", "O");
+
+            Assert.Contains("disengaged", result);
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_CrossedAbove15_ShowsInvestedReaction()
+        {
+            var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                "VELVET", 14, 16, InterestState.VeryIntoIt);
+
+            Assert.Contains("VELVET", result);
+            Assert.Contains("14", result);
+            Assert.Contains("16", result);
+            Assert.Contains("becoming more invested", result);
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_CrossedBelow8_ShowsCooling()
+        {
+            var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                "VELVET", 9, 6, InterestState.Interested);
+
+            Assert.Contains("pulling back", result);
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_DateSecured_ShowsMeetUp()
+        {
+            var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                "VELVET", 23, 25, InterestState.DateSecured);
+
+            Assert.Contains("meeting up", result);
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_Unmatched_ShowsUnmatching()
+        {
+            var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                "VELVET", 2, 0, InterestState.Unmatched);
+
+            Assert.Contains("unmatching", result);
+        }
+
+        // ── AC4: CacheBlockBuilder ──
+
+        [Fact]
+        public void BuildCachedSystemBlocks_ReturnsTwoBlocksWithEphemeralCache()
+        {
+            var blocks = CacheBlockBuilder.BuildCachedSystemBlocks("player prompt", "opponent prompt");
+
+            Assert.Equal(2, blocks.Length);
+            Assert.Equal("text", blocks[0].Type);
+            Assert.Equal("player prompt", blocks[0].Text);
+            Assert.NotNull(blocks[0].CacheControl);
+            Assert.Equal("ephemeral", blocks[0].CacheControl!.Type);
+
+            Assert.Equal("text", blocks[1].Type);
+            Assert.Equal("opponent prompt", blocks[1].Text);
+            Assert.NotNull(blocks[1].CacheControl);
+            Assert.Equal("ephemeral", blocks[1].CacheControl!.Type);
+        }
+
+        [Fact]
+        public void BuildOpponentOnlySystemBlocks_ReturnsOneBlockWithEphemeralCache()
+        {
+            var blocks = CacheBlockBuilder.BuildOpponentOnlySystemBlocks("opponent prompt");
+
+            Assert.Single(blocks);
+            Assert.Equal("text", blocks[0].Type);
+            Assert.Equal("opponent prompt", blocks[0].Text);
+            Assert.NotNull(blocks[0].CacheControl);
+            Assert.Equal("ephemeral", blocks[0].CacheControl!.Type);
+        }
+
+        [Fact]
+        public void BuildCachedSystemBlocks_EmptyPrompts_ReturnsBlocksWithEmptyText()
+        {
+            var blocks = CacheBlockBuilder.BuildCachedSystemBlocks("", "");
+
+            Assert.Equal(2, blocks.Length);
+            Assert.Equal("", blocks[0].Text);
+            Assert.Equal("", blocks[1].Text);
+        }
+
+        [Fact]
+        public void BuildCachedSystemBlocks_NullPlayerPrompt_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                CacheBlockBuilder.BuildCachedSystemBlocks(null!, "opponent"));
+        }
+
+        [Fact]
+        public void BuildCachedSystemBlocks_NullOpponentPrompt_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                CacheBlockBuilder.BuildCachedSystemBlocks("player", null!));
+        }
+
+        [Fact]
+        public void BuildOpponentOnlySystemBlocks_NullPrompt_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                CacheBlockBuilder.BuildOpponentOnlySystemBlocks(null!));
+        }
+
+        // ── Error conditions ──
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_NullHistory_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                    null!, "", new string[0], 10, 1, "P", "O"));
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_NullPlayerName_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                    new List<(string, string)>(), "", new string[0], 10, 1, null!, "O"));
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_NullOption_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionDocumentBuilder.BuildDeliveryPrompt(
+                    new List<(string, string)>(), null!, FailureTier.None, 0, null, "P", "O"));
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_NullMessage_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionDocumentBuilder.BuildOpponentPrompt(
+                    new List<(string, string)>(), null!, 10, 10, 1.0, null, "P", "O"));
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_NullOpponentName_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                    null!, 10, 12, InterestState.Interested));
+        }
+
+        // ── PromptTemplates existence check ──
+
+        [Fact]
+        public void PromptTemplates_AllFieldsAreDefined()
+        {
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.DialogueOptionsInstruction));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.SuccessDeliveryInstruction));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.FailureDeliveryInstruction));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.OpponentResponseInstruction));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestBeatInstruction));
+        }
+
+        [Fact]
+        public void PromptTemplates_DialogueOptionsInstruction_ContainsKeyContent()
+        {
+            Assert.Contains("[STAT: X]", PromptTemplates.DialogueOptionsInstruction);
+            Assert.Contains("[CALLBACK:", PromptTemplates.DialogueOptionsInstruction);
+            Assert.Contains("[COMBO:", PromptTemplates.DialogueOptionsInstruction);
+            Assert.Contains("[TELL_BONUS:", PromptTemplates.DialogueOptionsInstruction);
+            Assert.Contains("exactly 4", PromptTemplates.DialogueOptionsInstruction);
+        }
+
+        [Fact]
+        public void PromptTemplates_FailureDeliveryInstruction_ContainsAllTiers()
+        {
+            Assert.Contains("FUMBLE", PromptTemplates.FailureDeliveryInstruction);
+            Assert.Contains("MISFIRE", PromptTemplates.FailureDeliveryInstruction);
+            Assert.Contains("TROPE_TRAP", PromptTemplates.FailureDeliveryInstruction);
+            Assert.Contains("CATASTROPHE", PromptTemplates.FailureDeliveryInstruction);
+            Assert.Contains("LEGENDARY", PromptTemplates.FailureDeliveryInstruction);
+        }
+
+        [Fact]
+        public void PromptTemplates_OpponentResponseInstruction_ContainsSignalsBlock()
+        {
+            Assert.Contains("[SIGNALS]", PromptTemplates.OpponentResponseInstruction);
+            Assert.Contains("[RESPONSE]", PromptTemplates.OpponentResponseInstruction);
+            Assert.Contains("TELL:", PromptTemplates.OpponentResponseInstruction);
+            Assert.Contains("WEAKNESS:", PromptTemplates.OpponentResponseInstruction);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #207

## What was implemented

- **SessionDocumentBuilder** (src/Pinder.LlmAdapters/SessionDocumentBuilder.cs): 4 static methods that format conversation history and game state into structured prompts for each ILlmAdapter method call:
  - `BuildDialogueOptionsPrompt` — §3.2 dialogue option generation
  - `BuildDeliveryPrompt` — §3.3 success / §3.4 failure delivery
  - `BuildOpponentPrompt` — §3.5 opponent response generation
  - `BuildInterestChangeBeatPrompt` — §3.8 narrative beat generation

- **PromptTemplates** (src/Pinder.LlmAdapters/PromptTemplates.cs): 5 const string templates sourced from character-construction.md §3.2–3.8 with {placeholder} tokens

- **CacheBlockBuilder** (src/Pinder.LlmAdapters/Anthropic/CacheBlockBuilder.cs): Builds ContentBlock[] with cache_control: ephemeral for Anthropic prompt caching

## How to test

```bash
dotnet test tests/Pinder.LlmAdapters.Tests/
dotnet test tests/Pinder.Core.Tests/
```

## Code Review W1 fix

`BuildDeliveryPrompt` and `BuildOpponentPrompt` include `playerName`/`opponentName` parameters (addresses W1 from PR #221 code review) needed by the conversation history formatting algorithm.

## Deviations from contract

- `BuildDeliveryPrompt` and `BuildOpponentPrompt` have additional `playerName` and `opponentName` parameters not in the original issue spec but required per code review W1 and the spec document's conversation history formatting algorithm.
- The spec's interest scale shows 'Current Interest: X/20' but the game uses 0-25 range, so we use 'X/25' to match InterestMeter.Max.

## DoD Evidence
**Branch:** issue-207-sessiondocumentbuilder-prompttemplates-f
**Commit:** 20edca5
**Tests:** 177 passed (LlmAdapters), 1127 passed (Core)
