### PR TITLE
[Issue #241] Fix: Legendary fail delivery generates wrong character voice (opponent instead of player)

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -279,3 +279,6 @@
 {"ts":"2026-04-01T20:04:13+00:00","agent":"architect","issue":"240","component":"","action":"started","detail":"Starting: Architecture Review: LLM Adapter Bug Fixes","commit":null}
 {"ts":"2026-04-01T20:07:55+00:00","agent":"architect","issue":"240","component":"","action":"completed","correlationId":"architect-sprint-decay256-pinder-core-10-1775073428978","detail":"PR opened — correlationId: architect-sprint-decay256-pinder-core-10-1775073428978","commit":"ca43a15"}
 {"ts":"2026-04-01T20:08:55+00:00","agent":"product-visionary","issue":"240","component":"","action":"started","detail":"Starting: Architecture Vision Review (attempt 1): LLM Adapter Bug Fixes","commit":null}
+{"ts":"2026-04-01T20:56:00+00:00","agent":"backend-engineer","issue":"241","component":"","action":"started","detail":"Starting: Bug: Legendary fail delivery generates wrong character voice (opponent instead of player)","commit":null}
+{"ts":"2026-04-01T21:00:24.639Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"Warnings: stalled=, deadPIDs=, longRunning=, unreviewedPRs=215,204,192,142,141,140","commit":null}
+{"ts":"2026-04-01T21:10:46.835Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"Warnings: stalled=, deadPIDs=, longRunning=, unreviewedPRs=215,204,192,142,141,140","commit":null}

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -509,7 +509,10 @@ namespace Pinder.Core.Conversation
                 outcome: rollResult.Tier,
                 beatDcBy: beatDcBy,
                 activeTraps: deliveryTrapNames,
-                activeTrapInstructions: deliveryTrapInstructions);
+                activeTrapInstructions: deliveryTrapInstructions,
+                playerName: _player.DisplayName,
+                opponentName: _opponent.DisplayName,
+                currentTurn: _turnNumber);
 
             string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext).ConfigureAwait(false);
 
@@ -546,7 +549,10 @@ namespace Pinder.Core.Conversation
                 interestBefore: interestBefore,
                 interestAfter: interestAfter,
                 responseDelayMinutes: responseDelayMinutes,
-                activeTrapInstructions: opponentTrapInstructions);
+                activeTrapInstructions: opponentTrapInstructions,
+                playerName: _player.DisplayName,
+                opponentName: _opponent.DisplayName,
+                currentTurn: _turnNumber);
 
             var opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
             if (opponentResponse == null)

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -122,8 +122,7 @@ namespace Pinder.LlmAdapters.Anthropic
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var systemBlocks = CacheBlockBuilder.BuildCachedSystemBlocks(
-                context.PlayerPrompt, context.OpponentPrompt);
+            var systemBlocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(context.PlayerPrompt);
 
             var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(
                 context.ConversationHistory,

--- a/src/Pinder.LlmAdapters/Anthropic/CacheBlockBuilder.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/CacheBlockBuilder.cs
@@ -40,6 +40,27 @@ namespace Pinder.LlmAdapters.Anthropic
         }
 
         /// <summary>
+        /// Builds system blocks with only the player prompt cached.
+        /// Used by delivery calls where only the player speaks.
+        /// </summary>
+        /// <param name="playerPrompt">The player's assembled §3.1 system prompt.</param>
+        /// <returns>One ContentBlock with cache_control: ephemeral.</returns>
+        public static ContentBlock[] BuildPlayerOnlySystemBlocks(string playerPrompt)
+        {
+            if (playerPrompt == null) throw new ArgumentNullException(nameof(playerPrompt));
+
+            return new[]
+            {
+                new ContentBlock
+                {
+                    Type = "text",
+                    Text = playerPrompt,
+                    CacheControl = new CacheControl { Type = "ephemeral" }
+                }
+            };
+        }
+
+        /// <summary>
         /// Builds system blocks with only the opponent prompt cached.
         /// Used by opponent response calls.
         /// </summary>

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -43,7 +43,8 @@ Rules:
 
         /// <summary>§3.3 — Deliver the intended message on a successful roll.</summary>
         public const string SuccessDeliveryInstruction =
-@"Deliver this message as the character would actually send it.
+@"Write as {player_name}.
+Deliver this message as the character would actually send it.
 - On a clean success (margin 1–5): deliver it essentially as written, with natural voice
 - On a strong success (margin 6–10): add a small flourish or timing that makes it land better
 - On a critical success / Nat 20: deliver it at peak — perfectly timed, resonant, exactly right
@@ -53,7 +54,10 @@ Output only the message text.";
 
         /// <summary>§3.4 — Degrade the intended message according to failure tier.</summary>
         public const string FailureDeliveryInstruction =
-@"The player chose option: ""{intended_message}""
+@"You are writing as {player_name}. This is THEIR message, in THEIR voice.
+Do NOT write as the opponent. The failure corrupts what {player_name} says.
+
+The player chose option: ""{intended_message}""
 Stat used: {stat}
 They rolled FAILED — missed DC by {miss_margin}.
 Failure tier: {tier}

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -88,7 +88,8 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine($"Stat used: {chosenOption.Stat.ToString().ToUpperInvariant()}");
                 sb.AppendLine($"They rolled SUCCESS — beat DC by {beatDcBy}.");
                 sb.AppendLine();
-                sb.Append(PromptTemplates.SuccessDeliveryInstruction);
+                sb.Append(PromptTemplates.SuccessDeliveryInstruction
+                    .Replace("{player_name}", playerName));
             }
             else
             {
@@ -104,6 +105,7 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine();
 
                 string failureText = PromptTemplates.FailureDeliveryInstruction
+                    .Replace("{player_name}", playerName)
                     .Replace("{intended_message}", chosenOption.IntendedText)
                     .Replace("{stat}", chosenOption.Stat.ToString().ToUpperInvariant())
                     .Replace("{miss_margin}", missMargin.ToString())

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #241 AC3: Verify GameSession populates PlayerName, OpponentName, CurrentTurn
+    /// on DeliveryContext and OpponentContext when calling ILlmAdapter methods.
+    /// </summary>
+    public class Issue241_GameSessionDeliveryContextTests
+    {
+        [Fact]
+        public async Task ResolveTurnAsync_DeliveryContext_has_player_and_opponent_names()
+        {
+            var llm = new CapturingLlm();
+            var dice = new FixedDice(15, 5); // d20=15 (success), timing=5
+            var session = new GameSession(
+                MakeProfile("Sable"), MakeProfile("Brick"),
+                llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(llm.CapturedDeliveryContext);
+            Assert.Equal("Sable", llm.CapturedDeliveryContext!.PlayerName);
+            Assert.Equal("Brick", llm.CapturedDeliveryContext.OpponentName);
+        }
+
+        [Fact]
+        public async Task ResolveTurnAsync_OpponentContext_has_player_and_opponent_names()
+        {
+            var llm = new CapturingLlm();
+            var dice = new FixedDice(15, 5);
+            var session = new GameSession(
+                MakeProfile("Sable"), MakeProfile("Brick"),
+                llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(llm.CapturedOpponentContext);
+            Assert.Equal("Sable", llm.CapturedOpponentContext!.PlayerName);
+            Assert.Equal("Brick", llm.CapturedOpponentContext.OpponentName);
+        }
+
+        [Fact]
+        public async Task ResolveTurnAsync_DeliveryContext_has_nonzero_turn_on_second_turn()
+        {
+            var llm = new CapturingLlm();
+            // Two turns: d20=15, timing=5 each
+            var dice = new FixedDice(15, 5, 15, 5);
+            var session = new GameSession(
+                MakeProfile("Sable"), MakeProfile("Brick"),
+                llm, dice, new NullTrapRegistry());
+
+            // Turn 1
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(llm.CapturedDeliveryContext);
+            Assert.True(llm.CapturedDeliveryContext!.CurrentTurn > 0,
+                "CurrentTurn should be non-zero on second turn");
+        }
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// LLM adapter that captures the DeliveryContext and OpponentContext for assertion.
+        /// </summary>
+        private sealed class CapturingLlm : ILlmAdapter
+        {
+            public DeliveryContext? CapturedDeliveryContext { get; private set; }
+            public OpponentContext? CapturedOpponentContext { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                return Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, "Hey there"),
+                    new DialogueOption(StatType.Rizz, "Nice"),
+                    new DialogueOption(StatType.Honesty, "Real talk"),
+                    new DialogueOption(StatType.Wit, "Clever")
+                });
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            {
+                CapturedDeliveryContext = context;
+                return Task.FromResult(context.ChosenOption.IntendedText);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            {
+                CapturedOpponentContext = context;
+                return Task.FromResult(new OpponentResponse("Reply from opponent"));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+
+        private sealed class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _rolls = new Queue<int>();
+
+            public FixedDice(params int[] rolls)
+            {
+                foreach (var r in rolls)
+                    _rolls.Enqueue(r);
+            }
+
+            public int Roll(int sides)
+            {
+                return _rolls.Count > 0 ? _rolls.Dequeue() : 10;
+            }
+        }
+
+        private sealed class NullTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
@@ -161,7 +161,7 @@ OPTION_4
         // What: AC2 - DeliverMessageAsync also uses cached system blocks with both prompts
         // Mutation: Would catch if delivery skips caching or uses wrong builder
         [Fact]
-        public async Task DeliverMessageAsync_SystemBlocks_HaveBothPromptsWithCacheControl()
+        public async Task DeliverMessageAsync_SystemBlocks_HavePlayerOnlyPromptWithCacheControl()
         {
             var handler = new CapturingHttpHandler("Delivered text");
             using var client = new HttpClient(handler);
@@ -172,7 +172,8 @@ OPTION_4
             Assert.Single(handler.RequestBodies);
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.RequestBodies[0]);
             Assert.NotNull(body);
-            Assert.Equal(2, body!.System.Length);
+            // Issue #241: delivery uses player-only system blocks to prevent voice contamination
+            Assert.Equal(1, body!.System.Length);
             Assert.All(body.System, block =>
             {
                 Assert.NotNull(block.CacheControl);

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
@@ -571,7 +571,7 @@ OPTION_4
             Assert.Equal("Delivered message text", result);
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
             Assert.Equal(0.7, body!.Temperature, 2);
-            Assert.Equal(2, body.System.Length); // Both prompts cached
+            Assert.Equal(1, body.System.Length); // Player-only prompt cached
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    /// <summary>
+    /// Tests for Issue #241: Legendary fail delivery generates wrong character voice.
+    /// Verifies that failure delivery uses player-only system blocks and
+    /// explicitly identifies the player character in the prompt.
+    /// </summary>
+    public class Issue241_LegendaryFailVoiceTests
+    {
+        // ==========================================================
+        // AC1: FailureDeliveryInstruction explicitly identifies player role
+        // ==========================================================
+
+        [Fact]
+        public void AC1_FailureInstruction_contains_player_name_token()
+        {
+            var instruction = PromptTemplates.FailureDeliveryInstruction;
+            Assert.Contains("{player_name}", instruction);
+        }
+
+        [Fact]
+        public void AC1_FailureInstruction_contains_write_as_player_framing()
+        {
+            var instruction = PromptTemplates.FailureDeliveryInstruction;
+            Assert.Contains("You are writing as {player_name}", instruction);
+        }
+
+        [Fact]
+        public void AC1_FailureInstruction_contains_do_not_write_as_opponent()
+        {
+            var instruction = PromptTemplates.FailureDeliveryInstruction;
+            Assert.Contains("Do NOT write as the opponent", instruction);
+        }
+
+        [Fact]
+        public void AC1_FailureInstruction_identity_framing_appears_before_tier_instructions()
+        {
+            var instruction = PromptTemplates.FailureDeliveryInstruction;
+            int identityIndex = instruction.IndexOf("You are writing as {player_name}");
+            int tierIndex = instruction.IndexOf("Failure principle:");
+            Assert.True(identityIndex >= 0, "Identity framing not found");
+            Assert.True(tierIndex >= 0, "Tier instructions not found");
+            Assert.True(identityIndex < tierIndex,
+                "Identity framing must appear before failure tier instructions");
+        }
+
+        // ==========================================================
+        // AC1 (defense in depth): SuccessDeliveryInstruction also has player_name
+        // ==========================================================
+
+        [Fact]
+        public void AC1_SuccessInstruction_contains_player_name_token()
+        {
+            var instruction = PromptTemplates.SuccessDeliveryInstruction;
+            Assert.Contains("{player_name}", instruction);
+        }
+
+        // ==========================================================
+        // AC2: BuildPlayerOnlySystemBlocks returns single block
+        // ==========================================================
+
+        [Fact]
+        public void AC2_BuildPlayerOnlySystemBlocks_returns_single_block()
+        {
+            var blocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks("You are Sable...");
+            Assert.Single(blocks);
+        }
+
+        [Fact]
+        public void AC2_BuildPlayerOnlySystemBlocks_contains_player_prompt_text()
+        {
+            const string prompt = "You are Sable, a Scorpio sun with Love Bomber energy.";
+            var blocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(prompt);
+            Assert.Equal("text", blocks[0].Type);
+            Assert.Equal(prompt, blocks[0].Text);
+        }
+
+        [Fact]
+        public void AC2_BuildPlayerOnlySystemBlocks_has_ephemeral_cache_control()
+        {
+            var blocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks("prompt");
+            Assert.NotNull(blocks[0].CacheControl);
+            Assert.Equal("ephemeral", blocks[0].CacheControl!.Type);
+        }
+
+        [Fact]
+        public void AC2_BuildPlayerOnlySystemBlocks_throws_on_null()
+        {
+            Assert.Throws<System.ArgumentNullException>(() =>
+                CacheBlockBuilder.BuildPlayerOnlySystemBlocks(null!));
+        }
+
+        // ==========================================================
+        // AC4: BuildDeliveryPrompt substitutes {player_name} in failure path
+        // ==========================================================
+
+        [Fact]
+        public void AC4_Legendary_fail_delivery_prompt_contains_player_name_in_identity()
+        {
+            var history = new List<(string, string)>
+            {
+                ("Sable", "hey there"),
+                ("Brick", "hello")
+            };
+            var option = new DialogueOption(
+                StatType.Charm, "omg you actually work in M&A?? that's so hot",
+                callbackTurnNumber: null, comboName: null,
+                hasTellBonus: false, hasWeaknessWindow: false);
+
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
+                history, option, FailureTier.Legendary, beatDcBy: 0,
+                activeTrapInstructions: null,
+                playerName: "Sable", opponentName: "Brick");
+
+            // Player identity must be substituted (not raw token)
+            Assert.Contains("You are writing as Sable", prompt);
+            Assert.Contains("The failure corrupts what Sable says", prompt);
+            Assert.DoesNotContain("{player_name}", prompt);
+        }
+
+        [Fact]
+        public void AC4_Success_delivery_prompt_contains_player_name()
+        {
+            var history = new List<(string, string)>
+            {
+                ("Sable", "hey there"),
+                ("Brick", "hello")
+            };
+            var option = new DialogueOption(
+                StatType.Charm, "you're really interesting",
+                callbackTurnNumber: null, comboName: null,
+                hasTellBonus: false, hasWeaknessWindow: false);
+
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
+                history, option, FailureTier.None, beatDcBy: 5,
+                activeTrapInstructions: null,
+                playerName: "Sable", opponentName: "Brick");
+
+            Assert.Contains("Write as Sable", prompt);
+            Assert.DoesNotContain("{player_name}", prompt);
+        }
+
+        [Fact]
+        public void AC4_Catastrophe_fail_delivery_prompt_contains_player_identity()
+        {
+            var history = new List<(string, string)>();
+            var option = new DialogueOption(
+                StatType.Honesty, "I think we could be great",
+                callbackTurnNumber: null, comboName: null,
+                hasTellBonus: false, hasWeaknessWindow: false);
+
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
+                history, option, FailureTier.Catastrophe, beatDcBy: 0,
+                activeTrapInstructions: null,
+                playerName: "Blaze", opponentName: "Jade");
+
+            Assert.Contains("You are writing as Blaze", prompt);
+            Assert.Contains("Do NOT write as the opponent", prompt);
+        }
+
+        [Fact]
+        public void AC4_Failure_prompt_with_active_traps_still_has_player_identity()
+        {
+            var history = new List<(string, string)>();
+            var option = new DialogueOption(
+                StatType.Wit, "clever joke",
+                callbackTurnNumber: null, comboName: null,
+                hasTellBonus: false, hasWeaknessWindow: false);
+
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
+                history, option, FailureTier.TropeTrap, beatDcBy: 0,
+                activeTrapInstructions: new[] { "Overthinking trap active" },
+                playerName: "Sable", opponentName: "Brick");
+
+            Assert.Contains("You are writing as Sable", prompt);
+            Assert.Contains("Overthinking trap active", prompt);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #241

## Summary
Legendary fail delivery was generating text in the opponent's voice because:
1. `DeliverMessageAsync` sent both character system prompts to the LLM
2. `FailureDeliveryInstruction` didn't specify which character to write as
3. `GameSession` didn't populate `playerName`/`opponentName`/`currentTurn` on delivery contexts

## Changes
- **CacheBlockBuilder**: Added `BuildPlayerOnlySystemBlocks()` method (mirrors existing opponent-only method)
- **AnthropicLlmAdapter**: `DeliverMessageAsync` now uses player-only system blocks instead of both
- **PromptTemplates**: Added explicit player identity framing to `FailureDeliveryInstruction` and `{player_name}` to `SuccessDeliveryInstruction`
- **SessionDocumentBuilder**: Added `{player_name}` substitution in both success and failure paths
- **GameSession**: Wires `_player.DisplayName`, `_opponent.DisplayName`, `_turnNumber` into `DeliveryContext` and `OpponentContext`
- **Tests**: Updated 2 existing tests (expected system block count 2→1), 13 new tests in `Issue241_LegendaryFailVoiceTests.cs`

## How to Test
```bash
dotnet test
```
All 1564 tests pass (1138 Core + 426 LlmAdapters).

## DoD Evidence
**Branch:** issue-241-bug-legendary-fail-delivery-generates-wr
**Commit:** 3d6c69d
**Deviations from contract**: none
