### PR TITLE
feat: inject shadow taint block into LLM prompts (closes #242)

### DIFF
--- a/docs/vision-review-sprint-10-llm-adapter-bug-fixes.md
+++ b/docs/vision-review-sprint-10-llm-adapter-bug-fixes.md
@@ -1,0 +1,58 @@
+# Vision Review — Sprint 10: LLM Adapter Bug Fixes
+
+## Alignment: ✅
+
+This sprint is high-leverage, correctly prioritized work. Sprint 9 shipped the Anthropic LLM adapter — the first real LLM integration. These three bugs represent the first contact with actual LLM output, and all three block the product from producing coherent gameplay. Fixing prompt format (#240), character voice fidelity (#241), and shadow taint injection (#242) are prerequisites for any meaningful playtesting. This is the right work at the right time.
+
+## Data Flow Traces
+
+### #240 — DialogueOptionsInstruction missing output format
+- User action → `GameSession.StartTurnAsync()` → `ILlmAdapter.GetDialogueOptionsAsync(DialogueContext)` → `AnthropicLlmAdapter` → `SessionDocumentBuilder.BuildDialogueOptionsPrompt()` injects `PromptTemplates.DialogueOptionsInstruction` → Anthropic API → freeform response → `ParseDialogueOptions()` splits by `OPTION_\d+` regex → no headers found → pads with 4 `"..."` placeholders
+- Required fields in prompt: OPTION_N headers, `[STAT: X]` metadata tags, quoted `"text"` on next line
+- ⚠️ **Missing**: `DialogueOptionsInstruction` specifies metadata format but omits the `OPTION_1`/`OPTION_2`/`OPTION_3`/`OPTION_4` header structure and the quoted-text-on-next-line requirement that the parser depends on
+- Fix is correctly scoped — template change + parser regression test
+
+### #241 — Legendary fail delivery wrong character voice
+- User action → `GameSession.ResolveTurnAsync()` → creates `DeliveryContext` (line 503) → `ILlmAdapter.DeliverMessageAsync(DeliveryContext)` → `AnthropicLlmAdapter.DeliverMessageAsync()` → `CacheBlockBuilder.BuildCachedSystemBlocks(playerPrompt, opponentPrompt)` (BOTH prompts in system) → `SessionDocumentBuilder.BuildDeliveryPrompt()` → `FailureDeliveryInstruction` template (no `{player_name}` placeholder) → Anthropic API → LLM picks wrong voice
+- Required fields: `PlayerName` in delivery prompt template, player-only system prompt (or explicit voice framing)
+- ⚠️ **BLOCKING**: `GameSession` does NOT pass `playerName` or `opponentName` to `DeliveryContext` (line 503–512). They default to `""`. The adapter's `FallbackName()` resolves to generic `"Player"`. Even if the template adds `{player_name}`, it will say "Player" not "Sable". Filed as #243.
+- ⚠️ **Architectural concern**: `DeliverMessageAsync` uses both system prompts but `GetOpponentResponseAsync` correctly uses opponent-only. Delivery should likely use player-only system blocks. Filed as #245.
+
+### #242 — Shadow threshold taint not injected into LLM prompts
+- `GameSession.StartTurnAsync()` computes `shadowThresholds` dict → passes to `DialogueContext` ✅ → `AnthropicLlmAdapter.GetDialogueOptionsAsync()` → `SessionDocumentBuilder.BuildDialogueOptionsPrompt()` — **has no shadow parameter, ignores thresholds entirely**
+- Required: shadow taint text in `BuildDialogueOptionsPrompt()`, `BuildDeliveryPrompt()`, `BuildOpponentPrompt()` when thresholds ≥ T1
+- ⚠️ **BLOCKING**: `SessionDocumentBuilder` has zero shadow awareness. None of its methods accept shadow thresholds. `PromptTemplates` has no taint text constants. The fix requires: new parameters on builder methods, new template constants, GameSession wiring shadowThresholds to DeliveryContext/OpponentContext. This is more than a template fix — it's a builder API change. Filed as #244.
+
+## Unstated Requirements
+- If shadow taint blocks are added (#242), they must vary per shadow stat AND per threshold tier (T1 = subtle, T2 = pronounced, T3 = overwhelming). The issue only specifies Madness/Dread at T1 — the implementer needs guidance for all 6 shadows × 3 tiers.
+- Players expect that fixing #240 (options format) will also fix downstream delivery quality. The fix chain is: #240 → #241 → meaningful gameplay. If #241 ships without the name wiring (#243), delivery will still be wrong.
+- Integration test AC on #240 ("real Anthropic call") needs an API key in CI. This either needs a secret configured or the AC should be marked as manual/local-only.
+
+## Domain Invariants
+- **Delivery voice must match the player character's identity** — a Legendary fail by Sable must sound like Sable at her worst, not like Brick
+- **Parser and prompt must be symmetric** — any format the prompt instructs the LLM to use, the parser must handle; any format the parser expects, the prompt must specify
+- **Shadow taint is additive to character voice** — it modifies tone, it doesn't replace the character. Taint at T1 should be subtle enough that it feels like the character having a bad day, not a different character
+
+## Gaps
+
+### Missing (should be in this sprint)
+- **#243 (filed)**: GameSession must pass `playerName`, `opponentName`, `currentTurn` to `DeliveryContext` and `OpponentContext`. Without this, #241's fix is incomplete. This partially resolves long-standing #211.
+- **#244 (filed)**: #242's AC implies a template-only fix, but `SessionDocumentBuilder` needs API changes to accept and render shadow thresholds. The scope is underestimated.
+- **#245 (filed)**: `DeliverMessageAsync` should use player-only system blocks (like `GetOpponentResponseAsync` uses opponent-only). This is the root architectural cause of #241.
+
+### Unnecessary
+- Nothing — all three bugs are real and blocking gameplay.
+
+### Assumptions needing validation
+- #240 AC includes "integration test with real Anthropic call" — requires API key availability in CI. Validate this is set up.
+- #242 assumes §3.6 taint text content exists somewhere accessible. If it's only in `design/systems/rules-v3.md` (external repo), the implementer needs it provided or referenced.
+
+## Recommendations
+1. **Add #243 to this sprint** — it's a 5-line fix in `GameSession` (pass names/turn to DeliveryContext and OpponentContext constructors). Without it, #241 is incomplete. This is **BLOCKING** for #241.
+2. **Expand #242 scope or split it** — the current AC underestimates the work. Either update the AC to include SessionDocumentBuilder API changes (#244), or create a separate issue for the builder changes and make #242 depend on it.
+3. **#241 implementer should evaluate player-only system blocks** (#245) — this is the cleaner architectural fix vs. just adding a "write as {player_name}" instruction to the template.
+4. **All three issues have correct role assignment** (backend-engineer). No changes needed.
+
+## Verdict: **ADVISORY**
+
+Three vision concerns filed (#243, #244, #245). The sprint direction is correct and high-priority, but #241 and #242 have data flow gaps that will cause incomplete fixes if not addressed. #243 is the most critical — without name wiring, the template fix for #241 resolves to generic "Player" instead of the actual character name. The sprint should incorporate these concerns before implementation starts.

--- a/docs/vision-review-sprint-2-rpg-rules-complete.md
+++ b/docs/vision-review-sprint-2-rpg-rules-complete.md
@@ -1,0 +1,123 @@
+# Vision Review — Sprint 2: RPG Rules Complete (Attempt 1)
+
+## Alignment: ⚠️
+
+This sprint is the correct strategic direction — implementing the remaining RPG mechanical systems (§7 shadows, §8 non-Speak actions, §10 XP, §15 advanced mechanics, async-time) is the logical next step after the core game loop shipped. However, the sprint carries **significant architectural risk** from unresolved prerequisite decisions. Five open vision concerns from the previous review (#57–#62) remain unaddressed, and this review identifies five additional gaps (#64–#69). The most critical: StatBlock immutability (#58), RollEngine fixed-DC API for Read/Recover (#65), the flat roll bonus API needed by three features (#68), and TurnResult expansion merge conflicts (#69).
+
+The sprint added #63 (ILlmAdapter expansion) as a prerequisite, which correctly addresses #60. That's good engineering. But the same pattern needs to be applied to TurnResult (#69) and RollEngine's API (#65, #68) before feature implementation begins.
+
+## Data Flow Traces
+
+### #42: Risk Tier → Interest Bonus
+- `RollEngine.Resolve()` → `RollResult` → `GameSession.ResolveTurnAsync` computes `need = DC - (StatModifier + LevelBonus)` → maps to RiskTier enum → adds +1 (Hard) or +2 (Bold) on success → `InterestMeter.Apply(totalDelta)`
+- Required new: `RollResult.RiskTier` enum property, computed at construction from `DC - StatModifier - LevelBonus`
+- ✅ Data flows cleanly. `RollResult` already has all fields needed to derive risk tier.
+
+### #43: Read/Recover/Wait → Interest/Trap State
+- Player chooses Read → `GameSession.ReadAsync()` → roll SA vs **fixed DC 12** → success reveals `InterestMeter.Current` + opponent modifiers; fail → `InterestMeter.Apply(-1)` + Overthinking +1
+- ⚠️ **API GAP**: `RollEngine.Resolve()` always computes DC from `defender.GetDefenceDC(stat)`. No fixed DC overload exists. See #65.
+- ⚠️ `TrapState.HasActive` referenced in AC but property doesn't exist. See #64.
+
+### #44: Shadow Growth → StatBlock Mutation
+- `GameSession.ResolveTurnAsync()` → detect growth event → increment shadow stat on `_player.Stats`
+- ⚠️ **BLOCKING**: `StatBlock._shadow` is `private readonly Dictionary`. No public mutation API. See #58.
+- ⚠️ Requires 6+ per-session tracking counters (TropeTrap count, Honesty success flag, stats-used history, etc.) not specified in GameSession. See #66.
+
+### #49/#50: Weakness Windows + Tells → Structured OpponentResponse
+- `ILlmAdapter.GetOpponentResponseAsync()` → `OpponentResponse { MessageText, WeaknessWindow?, Tell? }` → stored in GameSession → applied on next turn's roll
+- ✅ Addressed by #63 (ILlmAdapter expansion). OpponentResponse type includes both fields.
+
+### #46/#47/#50: Flat Roll Bonuses → RollEngine
+- Combo Triple (+1 all rolls), Callback (+1/+2/+3), Tell (+2) all need to inject a flat bonus into the roll
+- ⚠️ **API GAP**: `RollEngine.Resolve` has no `rollBonus` parameter. Three issues need the same capability but none specifies how. See #68.
+
+### #52: Trap Taint → LLM Contexts  
+- `TrapState.AllActive` → `.Definition.LlmInstruction` → injected into `DialogueContext.ActiveTrapInstructions`, `DeliveryContext.ActiveTrapInstructions`, `OpponentContext.ActiveTrapInstructions`
+- ✅ #63 adds `ActiveTrapInstructions` fields to all context types. `DeliveryContext` already uses instructions (not names). #52 just needs to wire DialogueContext and OpponentContext similarly.
+
+### #56: ConversationRegistry → Multi-Session Orchestration
+- `ConversationRegistry.FastForward()` → find earliest pending reply → advance GameClock → check ghost/fizzle on all sessions → apply decay → return active session
+- ⚠️ `GameSession` has no public accessor for `InterestMeter` or last activity timestamp. Registry needs read access to both.
+- ⚠️ Depends on #53 (timing), #54 (clock), #44 (shadow growth) — deepest dependency chain in the sprint.
+
+## Unstated Requirements
+
+- **Unified roll bonus API**: Three features (#46 Triple, #47 Callback, #50 Tell) all need to add flat bonuses to rolls. The player expects these to compose (Triple +1 AND Tell +2 = +3). This API should be designed once, not three times independently.
+- **TurnResult must carry all new fields without merge conflicts**: 7+ issues add fields to TurnResult. Players expect the UI to show combos, XP, shadow events, tell reads — all in one turn summary. A single expansion PR (like #63 for ILlmAdapter) prevents merge hell.
+- **Shadow growth must be visible**: If shadows grow during a session (#44), the player expects to see it ("Dread +1 — you felt the sting of rejection"). `TurnResult.ShadowGrowthEvents` is mentioned in #44 but not defined as a type.
+- **Read action should show opponent's actual stats**: #43 says "reveal exact Interest + opponent modifiers" on successful Read. This implies exposing `StatBlock` data the player hasn't seen before — a UI/UX contract that isn't specified.
+
+## Domain Invariants
+
+- `RollResult` must remain immutable — risk tier, bonuses computed at construction time, not mutated
+- Shadow growth must not affect the current roll's resolution (apply AFTER the roll)
+- Interest delta = SuccessScale/FailureScale + risk bonus + momentum + combo bonus + any future modifiers — these MUST compose additively
+- `GameSession` turn sequencing (StartTurn → Resolve alternation) must hold even with Read/Recover/Wait as alternative actions
+- `RollEngine` remains stateless — no session-aware logic leaks into it
+- A trap's LLM instruction text must be identical regardless of which context type carries it
+
+## Gaps
+
+### Missing (filed as vision concerns)
+- **#64** — `TrapState.HasActive` referenced in #43 but doesn't exist (minor, easy fix)
+- **#65** — `RollEngine.Resolve` has no fixed-DC overload; #43 Read/Recover need DC 12 (architectural)
+- **#66** — #44 shadow growth requires 6+ tracking counters not specified in GameSession design
+- **#67** — GameClock (#54) should be injectable (IGameClock) for deterministic testing
+- **#68** — Three features need flat roll bonus injection into RollEngine — design once, not thrice
+- **#69** — TurnResult needs coordinated expansion like ILlmAdapter got via #63
+
+### Still open from previous review
+- **#58** — StatBlock immutability blocks #44 → #45 → #48 → #51 → #56 chain. **MOST CRITICAL.**
+- **#59** — #53 references Lukewarm InterestState (trivial fix, still not applied)
+- **#61** — Risk tier values (#42) were previously descoped per #30, re-introduced without PO confirmation
+
+### Could defer
+- **#56 (ConversationRegistry)**: Most complex issue, deepest dependency chain (depends on #53, #54, #44). Self-contained subsystem. Deferring to Sprint 3 significantly reduces sprint risk.
+- **#55 (PlayerResponseDelay)**: Depends on #54 (GameClock). Could ship with #56 in a dedicated async-time sprint.
+
+### Assumptions to validate
+- #42 risk tier thresholds (Need ≤5/6-10/11-15/≥16) assumed final — previously explicitly descoped (#30)
+- #43 assumes SA is the attacking stat for Read/Recover — should be explicit about which SA (attacker's SA modifier + level bonus vs DC 12)
+- #44 assumes "same opener twice in a row" is detectable from history — requires cross-session persistence not in scope
+
+## Wave Plan
+
+```
+Wave 1: #63, #38
+Wave 2: #42, #49, #50, #52, #53, #54
+Wave 3: #43, #46, #47, #55
+Wave 4: #44
+Wave 5: #45, #48, #51
+Wave 6: #56
+```
+
+Rationale:
+- **Wave 1**: #63 is the prerequisite (ILlmAdapter expansion). #38 (QA audit) has no dependencies and should run early.
+- **Wave 2**: #42 (risk tier) is root dependency for many features. #49, #50 depend only on #63. #52, #53, #54 are independent subsystems.
+- **Wave 3**: #43 depends on #42 (and needs #65 resolved). #46, #47 depend on #42. #55 depends on #54.
+- **Wave 4**: #44 depends on #43 and needs #58 resolved. Most blocked issue.
+- **Wave 5**: #45 depends on #44. #48 depends on #42+#43+#44. #51 depends on #45.
+- **Wave 6**: #56 depends on #53+#54+#44. Most complex, most dependencies.
+
+## Role Assignment Check
+
+All roles are correctly assigned:
+- #38: qa-engineer ✅ (test audit)
+- All others: backend-engineer ✅ (pure C# engine work)
+
+No corrections needed.
+
+## Recommendations
+
+1. **Resolve #58 (StatBlock mutability) before Wave 4** — this is the longest-blocking decision. Recommend option (b): `SessionShadowTracker` wrapper that holds mutable shadow deltas without touching StatBlock's immutable contract.
+2. **Expand #63 scope (or create #69-fix) to include TurnResult expansion** — add all nullable fields at once before feature PRs land.
+3. **Add `int rollBonus` parameter to `RollEngine.Resolve`** (#68) — design this in Wave 1 so #46, #47, #50 can all use it cleanly in Waves 2-3.
+4. **Add `RollEngine.ResolveFixedDC` overload** (#65) — needed by Wave 3 (#43).
+5. **Fix #53's Lukewarm reference** (#59) — trivial edit, prevents implementer confusion.
+6. **Consider deferring #55 and #56 to Sprint 3** — the async-time subsystem (#53, #54, #55, #56) is self-contained. Shipping core RPG mechanics (#42-#51) without async-time reduces sprint risk while still delivering high value.
+
+## VERDICT: ADVISORY
+
+The sprint direction is correct and the issues are well-specified individually. Six new vision concerns filed (#64–#69). The **StatBlock immutability question (#58)** remains the most critical blocker — it was raised last review and still has no resolution. The **RollEngine API gaps (#65, #68)** are new architectural decisions that must be made before Waves 2-3. The **TurnResult expansion (#69)** is a process concern that prevents merge conflicts.
+
+No single concern is sprint-blocking on its own, but collectively they represent significant architectural decisions that should be resolved in Wave 1 alongside #63. The sprint should proceed with these concerns added to the backlog.

--- a/docs/vision-review-sprint-rpg-rules-complete.md
+++ b/docs/vision-review-sprint-rpg-rules-complete.md
@@ -1,0 +1,90 @@
+# Vision Review — Sprint: RPG Rules Complete
+
+## Alignment: ⚠️
+
+This sprint is the right *direction* — implementing the remaining RPG mechanical systems (§7 shadows, §8 non-Speak actions, §10 XP, §15 advanced mechanics, async-time) is the logical next step after the core game loop shipped in Sprint 6. However, the **scope is 4-8x larger than any previous sprint** (16 issues vs. historical 2-4) and introduces two entirely new architectural layers (shadow mutability, async-time clock system) alongside 10+ feature additions to GameSession. This is a "build the entire rest of the game" sprint, not a focused iteration.
+
+## Data Flow Traces
+
+### #42: Risk Tier Bonus (RollResult → GameSession)
+- `RollEngine.Resolve()` → `RollResult` (currently no RiskTier) → `GameSession.ResolveTurnAsync` → `SuccessScale.GetInterestDelta(result) + riskBonus` → `InterestMeter.Apply(total)`
+- Required new fields: `RollResult.RiskTier` (enum: Safe/Medium/Hard/Bold), computed from `need = dc - (statMod + levelBonus)`
+- ⚠️ `RollResult` currently has `MissMargin` (DC - Total) but no "need" concept pre-roll. The risk tier is based on `need = dc - (statMod + levelBonus)` which is `DC - modifiers` WITHOUT the die roll — this is different from miss margin. Implementer must compute this from existing fields: `RiskTier = DC - StatModifier - LevelBonus` (the "need" to roll).
+
+### #44: Shadow Growth (GameSession → StatBlock)
+- `GameSession.ResolveTurnAsync()` → detect growth event (e.g., Nat1 on Charm) → increment `ShadowStatType.Madness` on `_player.Stats`
+- **⚠️ BLOCKING DATA FLOW GAP**: `StatBlock._shadow` is `private readonly Dictionary`. There is NO public method to modify shadow values. `StatBlock.GetShadow()` is read-only. Shadow growth CANNOT flow through the current API. See #58.
+
+### #52: Trap Taint Injection (TrapState → ILlmAdapter contexts)
+- `GameSession` already passes trap names to `DialogueContext.ActiveTraps` and trap instructions to `DeliveryContext.ActiveTraps`
+- ⚠️ Inconsistency: `DialogueContext.ActiveTraps` carries **names** (`string[]`), `DeliveryContext.ActiveTraps` carries **LLM instructions** (`string[]`). Issue #52 wants ALL contexts to carry instructions, but `DialogueContext` and `OpponentContext` still carry names. This is partially already done for DeliveryContext.
+
+### #49/#50: Weakness Windows + Tells (LLM response → GameSession state)
+- `ILlmAdapter.GetOpponentResponseAsync()` currently returns `string` (just the message text)
+- Both #49 and #50 need structured return data: `WeaknessWindow?` and `Tell?`
+- **⚠️ INTERFACE GAP**: `GetOpponentResponseAsync` returns `Task<string>`, not a structured response object. Both features need it to return something like `OpponentResponse { Message, WeaknessWindow?, Tell? }`. This requires breaking the ILlmAdapter interface. See #60.
+
+### #56: ConversationRegistry → GameSession orchestration
+- `ConversationRegistry.FastForward()` → find earliest pending reply → `GameClock.AdvanceTo()` → check ghost triggers on ALL sessions → check fizzle → apply interest decay → return active session
+- Required: every `GameSession` must expose its `InterestMeter.Current` and last activity timestamp for the registry to evaluate ghost/fizzle conditions
+- ⚠️ `GameSession` currently has NO public property for `InterestMeter` — only exposed via `GameStateSnapshot` after turns. Registry needs continuous read access.
+
+## Unstated Requirements
+
+- **Shadow persistence across sessions**: #44 implements shadow growth within a session, but shadows are character-level state that persists across conversations. The sprint has no issue for shadow serialization/persistence. After a session ends, shadow growth is lost.
+- **UI contract for new TurnResult fields**: Issues #44, #46, #47, #48, #50 all add new fields to `TurnResult` (ShadowGrowthEvents, ComboTriggered, TellReadBonus, XpEarned). Unity consumers will need to handle all these new fields. No documentation issue exists for the expanded UI contract.
+- **Test infrastructure for async-time**: Issues #53-#56 introduce time-dependent logic (delays, clocks, scheduling). Tests will need a deterministic clock abstraction. `GameClock` should probably implement an `IGameClock` interface for testability — but no issue mentions this.
+
+## Domain Invariants
+
+- `RollResult` must be immutable — risk tier is computed at construction time, not mutated later
+- Shadow growth must not affect the current roll's resolution (growth happens AFTER the roll, affecting future rolls only)
+- Interest delta = SuccessScale/FailureScale + risk bonus + momentum + combo bonus — these must compose additively, never multiplicatively
+- `GameSession` turn sequencing invariant (StartTurn → Resolve alternation) must hold even with Read/Recover/Wait added (#43)
+- `ConversationRegistry` must never call `GameSession.StartTurnAsync` — it schedules, the host executes (stated in #56 but must be enforced)
+- A trap's LLM instruction must be the same text regardless of which context type carries it
+
+## Gaps
+
+### Missing
+- **Shadow stat mutability solution** (#58): Architectural decision needed before #44 can be implemented. Currently BLOCKING.
+- **ILlmAdapter structured response**: #49 and #50 both need `GetOpponentResponseAsync` to return structured data, not just a string. No preparatory issue exists for this interface change.
+- **Shadow persistence**: No issue addresses saving shadow growth between sessions.
+- **IGameClock interface**: #54 introduces `GameClock` as a concrete class. For testability, it should be injectable. No mention in the issue.
+
+### Unnecessary (could defer)
+- **#56 (ConversationRegistry)**: This is the most complex issue in the sprint and introduces multi-session orchestration. It depends on #53, #54, #44 — three issues that are themselves complex. Deferring #56 to a separate sprint would reduce risk without blocking any other feature.
+- **#55 (PlayerResponseDelay)**: Depends on #54 (GameClock) which introduces a new subsystem. Could be deferred with the async-time cluster.
+
+### Assumptions to validate
+- #42 assumes risk tier thresholds (Need ≤5/6-10/11-15/≥16) are final — these were previously descoped as undefined (#30)
+- #53 references `InterestState.Lukewarm` which doesn't exist (#59)
+- #44 assumes StatBlock shadow stats can be made mutable — this breaks the immutable snapshot contract (#58)
+- #43 assumes SA is the stat for Read and Recover — the issue says "Roll SA vs DC 12" but doesn't specify which SA (attacker's or a fixed value)
+
+## Wave Plan
+
+Wave 1: #38, #42, #49, #50, #52, #53, #54
+Wave 2: #43, #46, #47, #55
+Wave 3: #44
+Wave 4: #45, #48, #51
+Wave 5: #56
+
+Rationale:
+- Wave 1: No internal dependencies. #38 (QA) runs early to fix test gaps before new features land. #42 (risk tier) is the root dependency. #49, #50 depend only on merged #27. #52, #53, #54 are independent new subsystems.
+- Wave 2: #43 depends on #42. #46, #47 depend on #42. #55 depends on #54.
+- Wave 3: #44 depends on #43. Also needs #58 (shadow mutability) resolved.
+- Wave 4: #45 depends on #44. #48 depends on #42+#43+#44. #51 depends on #44+#45.
+- Wave 5: #56 depends on #53+#54+#44. Most complex issue, most dependencies.
+
+## Recommendations
+
+1. **Resolve #58 (StatBlock mutability) before Wave 3** — this is a design decision that affects #44, #45, #48, #51, #56. The architect should decide: mutable StatBlock vs. SessionShadowTracker wrapper vs. snapshot-per-mutation.
+2. **Fix #53's Lukewarm reference** (#59) before it hits an implementer — trivial edit, prevents confusion.
+3. **Plan the ILlmAdapter expansion** (#60) as a preparatory task in Wave 1 — add all needed fields/return types at once rather than N sequential breaking changes.
+4. **Confirm #42's risk tier values with PO** (#61) — this was explicitly descoped in Sprint 6 and is now the root dependency for 7+ issues.
+5. **Consider deferring async-time cluster** (#53, #54, #55, #56) to a separate sprint — it's a self-contained subsystem that doesn't block core RPG mechanics.
+
+## VERDICT: ADVISORY
+
+The sprint direction is correct and the issues are well-specified. Five vision concerns filed (#57-#62). The **StatBlock immutability gap (#58)** is the most serious — it's an architectural decision that blocks the shadow growth chain (#44→#45→#48→#51). The ILlmAdapter interface expansion (#60) and Lukewarm reference (#59) are fixable with issue edits. The scope concern (#57) is mitigated by the wave plan but remains a risk. No single issue is individually blocking, but the shadow mutability question should be resolved before Wave 3 begins.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1,8 +1,9 @@
 // Pinder Session Runner — real GameSession + AnthropicLlmAdapter
-// Characters and opponent specified via args or default Sable vs Brick
+// Outputs markdown matching the session-001 playtest format
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
@@ -19,7 +20,6 @@ class NullTrapRegistry : ITrapRegistry
     public string? GetLlmInstruction(StatType stat) => null;
 }
 
-// Writes to both Console and a StringBuilder simultaneously
 class TeeWriter : TextWriter
 {
     public readonly TextWriter _console;
@@ -29,26 +29,80 @@ class TeeWriter : TextWriter
     public override void Write(char value) { _console.Write(value); _buffer.Append(value); }
     public override void WriteLine(string? value) { _console.WriteLine(value); _buffer.AppendLine(value); }
     public override void WriteLine() { _console.WriteLine(); _buffer.AppendLine(); }
-    protected override void Dispose(bool disposing) { if (disposing) _console.Flush(); base.Dispose(disposing); }
+    protected override void Dispose(bool d) { if (d) _console.Flush(); base.Dispose(d); }
 }
 
 class Program
 {
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    static string RiskLabel(int need) =>
+        need <= 5  ? "🟢 Safe" :
+        need <= 10 ? "🟡 Medium" :
+        need <= 15 ? "🟠 Hard" : "🔴 Bold";
+
+    static string XpMultiplier(int need) =>
+        need <= 5  ? "1x XP" :
+        need <= 10 ? "1.5x XP" :
+        need <= 15 ? "2x XP" : "3x XP";
+
+    static string RewardRange(int need) =>
+        need <= 5  ? "+1 to +2" :
+        need <= 10 ? "+1 to +2" :
+        need <= 15 ? "+2 to +3" : "+3 to +5";
+
+    static string InterestBar(int val, int max = 25)
+    {
+        int filled = (int)Math.Round((double)val / max * 20);
+        filled = Math.Max(0, Math.Min(20, filled));
+        return new string('█', filled) + new string('░', 20 - filled);
+    }
+
+    static string StatLabel(StatType s) => s switch {
+        StatType.Charm => "CHARM", StatType.Rizz => "RIZZ", StatType.Honesty => "HONESTY",
+        StatType.Chaos => "CHAOS", StatType.Wit => "WIT", StatType.SelfAwareness => "SA",
+        _ => s.ToString().ToUpperInvariant()
+    };
+
+    static string FillLine(string content, int width = 58)
+    {
+        int pad = width - content.Length;
+        return "║  " + content + (pad > 0 ? new string(' ', pad) : "") + "║";
+    }
+
+    static string ExtractSystemPrompt(string md)
+    {
+        int start = md.IndexOf("```\n", StringComparison.Ordinal) + 4;
+        int end   = md.LastIndexOf("\n```", StringComparison.Ordinal);
+        if (start < 4 || end < 0) return md;
+        return md.Substring(start, end - start).Trim();
+    }
+
+    static int BestOption(DialogueOption[] options, StatBlock stats)
+    {
+        int best = 0, bestMod = int.MinValue;
+        for (int i = 0; i < options.Length; i++) {
+            int mod = stats.GetEffective(options[i].Stat);
+            if (mod > bestMod) { bestMod = mod; best = i; }
+        }
+        return best;
+    }
+
+    // ── main ─────────────────────────────────────────────────────────────────
+
     static async Task<int> Main(string[] args)
     {
         var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
         if (string.IsNullOrEmpty(apiKey)) { Console.Error.WriteLine("ANTHROPIC_API_KEY not set"); return 1; }
 
-        // Redirect stdout to tee — writes to both console and buffer for Obsidian
         var buffer = new StringBuilder();
         var tee = new TeeWriter(Console.Out, buffer);
         Console.SetOut(tee);
 
-        Console.WriteLine("=== PINDER SESSION: Sable vs Brick ===");
-        Console.WriteLine("Player: Sable (Level 3) | Opponent: Brick (Level 9)");
-        Console.WriteLine($"Date: {DateTime.UtcNow:yyyy-MM-dd HH:mm UTC}");
-        Console.WriteLine($"Model: claude-sonnet-4-20250514 | Engine: AnthropicLlmAdapter + GameSession");
-        Console.WriteLine();
+        // ── character definitions ──────────────────────────────────────────
+        string player1 = "Sable", player2 = "Brick";
+        int p1Level = 3, p2Level = 9;
+        int p1LevelBonus = 1, p2LevelBonus = 4;
 
         var sableStats = new StatBlock(
             new Dictionary<StatType, int> {
@@ -77,17 +131,65 @@ class Program
         string brickPrompt = ExtractSystemPrompt(File.ReadAllText($"{basePath}/brick-prompt.md"));
 
         var timing = new TimingProfile(0, 1.0f, 0.0f, "neutral");
-        var sable = new CharacterProfile(sableStats, sablePrompt, "Sable", timing, level: 3);
-        var brick  = new CharacterProfile(brickStats, brickPrompt, "Brick", timing, level: 9);
+        var sable = new CharacterProfile(sableStats, sablePrompt, player1, timing, level: p1Level);
+        var brick  = new CharacterProfile(brickStats, brickPrompt, player2, timing, level: p2Level);
 
+        // ── header ────────────────────────────────────────────────────────
+        Console.WriteLine($"# Playtest Session 006 — {player1} × {player2}");
+        Console.WriteLine($"**Date:** {DateTime.UtcNow:yyyy-MM-dd}");
+        Console.WriteLine($"**Engine:** `pinder-core GameSession` + `AnthropicLlmAdapter` → claude-sonnet-4-20250514");
+        Console.WriteLine($"**Player:** {player1} (Level {p1Level}, +{p1LevelBonus} level bonus) | **Opponent:** {player2} (Level {p2Level}, +{p2LevelBonus} level bonus, LLM puppet)");
+        Console.WriteLine();
+
+        // ── character table ───────────────────────────────────────────────
+        Console.WriteLine("## Characters");
+        Console.WriteLine();
+        Console.WriteLine($"| | **{player1}** | **{player2}** |");
+        Console.WriteLine("|---|---|---|");
+        Console.WriteLine($"| Level | {p1Level} | {p2Level} |");
+        foreach (var stat in new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness }) {
+            int p1 = sableStats.GetEffective(stat), p2 = brickStats.GetEffective(stat);
+            Console.WriteLine($"| {StatLabel(stat)} | {p1:+#;-#;0} | {p2:+#;-#;0} |");
+        }
+        Console.WriteLine();
+
+        // ── DC table ──────────────────────────────────────────────────────
+        Console.WriteLine("## DC Reference (Sable attacking, Brick defending)");
+        Console.WriteLine();
+        Console.WriteLine("| Stat | Sable mod | Brick defends | DC | Need | % | Risk |");
+        Console.WriteLine("|---|---|---|---|---|---|---|");
+        foreach (var stat in new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness }) {
+            int atkMod = sableStats.GetEffective(stat);
+            int dc = brickStats.GetDefenceDC(stat);
+            int need = dc - atkMod;
+            int pct = Math.Max(0, Math.Min(100, (21 - need) * 5));
+            Console.WriteLine($"| {StatLabel(stat)} | {atkMod:+#;-#;0} | — | {dc} | {need}+ | {pct}% | {RiskLabel(need)} |");
+        }
+        Console.WriteLine();
+        Console.WriteLine("> DC = 13 + opponent defending stat modifier. Miss by 1–2 = Fumble | 3–5 = Misfire | 6–9 = Trope Trap | 10+ = Catastrophe | Nat 1 = Legendary.");
+        Console.WriteLine();
+
+        // ── LLM + session setup ───────────────────────────────────────────
         var llm = new AnthropicLlmAdapter(new AnthropicOptions {
             ApiKey = apiKey, Model = "claude-sonnet-4-20250514", MaxTokens = 1024, Temperature = 0.9
         });
-
         var session = new GameSession(sable, brick, llm, new SystemRandomDiceRoller(), new NullTrapRegistry());
+
+        int interest = 10;
+        int momentum = 0;
+        Console.WriteLine("## Session State");
+        Console.WriteLine();
+        Console.WriteLine($"```");
+        Console.WriteLine($"Interest: {InterestBar(interest)}  {interest}/25");
+        Console.WriteLine($"Active Traps: none");
+        Console.WriteLine($"Momentum: —");
+        Console.WriteLine($"```");
+        Console.WriteLine();
+        Console.WriteLine("---");
 
         int turn = 0;
         GameOutcome? finalOutcome = null;
+        string lastOpponentMsg = "";
 
         while (turn < 15)
         {
@@ -97,151 +199,166 @@ class Program
             catch (GameEndedException ex) { finalOutcome = ex.Outcome; break; }
 
             var snap = turnStart.State;
-            Console.WriteLine($"\n{'─',64}");
-            Console.WriteLine($"TURN {turn}  |  Interest: {snap.Interest}/25 ({snap.State})  |  Streak: {snap.MomentumStreak}");
-            Console.WriteLine($"{'─',64}");
+            interest = snap.Interest;
+            momentum = snap.MomentumStreak;
 
+            Console.WriteLine();
+            Console.WriteLine($"---");
+            Console.WriteLine();
+            Console.WriteLine($"## ═══ TURN {turn} ═══");
+            if (!string.IsNullOrEmpty(lastOpponentMsg))
+                Console.WriteLine($"**Responding to {player2}'s T{turn-1} reply**");
+            else
+                Console.WriteLine($"**{player1}'s opener | {player2}'s bio**");
+            Console.WriteLine();
+
+            // ── UI panel ──────────────────────────────────────────────────
+            Console.WriteLine("```");
+            Console.WriteLine("╔══════════════════════════════════════════════════════════╗");
+            if (!string.IsNullOrEmpty(lastOpponentMsg)) {
+                var lines = WrapText(lastOpponentMsg, 54);
+                Console.WriteLine($"║  {player2}: {lines[0].PadRight(54)}║");
+                for (int li = 1; li < lines.Count; li++)
+                    Console.WriteLine($"║  {lines[li].PadRight(58)}║");
+            }
+            Console.WriteLine("╠══════════════════════════════════════════════════════════╣");
+            string momentumLine = momentum >= 3 ? $"📈 MOMENTUM +{(momentum>=5?3:momentum>=4?2:2)} active" :
+                                  momentum > 0  ? $"📈 Momentum: {momentum} win{(momentum>1?"s":"")}" : "";
+            if (!string.IsNullOrEmpty(momentumLine))
+                Console.WriteLine(FillLine(momentumLine));
             if (snap.ActiveTrapNames.Length > 0)
-                Console.WriteLine($"⚠️  Active traps: {string.Join(", ", snap.ActiveTrapNames)}");
+                Console.WriteLine(FillLine($"⚠️  Traps: {string.Join(", ", snap.ActiveTrapNames)}"));
+            Console.WriteLine("║                                                          ║");
 
-            // Print options with full text + DC + mechanics
-            int interestBefore = snap.Interest;
-            Console.WriteLine($"\n┌── DIALOGUE OPTIONS ──────────────────────────────────────┐");
-            for (int i = 0; i < turnStart.Options.Length; i++)
-            {
+            char[] letters = { 'A', 'B', 'C', 'D' };
+            for (int i = 0; i < turnStart.Options.Length; i++) {
                 var opt = turnStart.Options[i];
                 int mod = sableStats.GetEffective(opt.Stat);
                 int dc = brickStats.GetDefenceDC(opt.Stat);
                 int need = dc - mod;
-                int pct = Math.Max(0, Math.Min(100, (21 - need) * 5));
-                string risk = need <= 5 ? "🟢 Safe" : need <= 10 ? "🟡 Medium" : need <= 15 ? "🟠 Hard" : "🔴 Bold";
-                string flags = "";
-                if (opt.HasTellBonus)           flags += " 📖+2";
-                if (opt.ComboName != null)       flags += $" ⭐{opt.ComboName}+1";
-                if (opt.CallbackTurnNumber.HasValue) flags += $" 🔗T{opt.CallbackTurnNumber}";
-                Console.WriteLine($"│  {i+1}) [{opt.Stat}] mod{mod:+#;-#;+0} vs DC{dc} | Need {need}+ | {pct}% | {risk}{flags}");
-                if (!string.IsNullOrEmpty(opt.IntendedText) && opt.IntendedText != "...")
-                    Console.WriteLine($"│     \"{opt.IntendedText}\"");
-                else
-                    Console.WriteLine($"│     [intended text unavailable — see bug #240]");
-            }
-            Console.WriteLine($"└──────────────────────────────────────────────────────────┘");
+                int pct = Math.Max(0, Math.Min(100, (21-need)*5));
+                string icons = "";
+                if (opt.HasTellBonus)              icons += " 📖";
+                if (opt.ComboName != null)          icons += " ⭐";
+                if (opt.CallbackTurnNumber.HasValue) icons += " 🔗";
+                if (opt.HasWeaknessWindow)          icons += " 🔓";
 
+                string header = $"{letters[i]}) 🎲 {StatLabel(opt.Stat)} ({mod:+#;-#;0})";
+                string riskStr = $"{RiskLabel(need)}{icons}";
+                // right-align risk label
+                int headerPad = 40 - header.Length - riskStr.Length;
+                Console.WriteLine(FillLine(header + (headerPad > 0 ? new string(' ', headerPad) : "  ") + riskStr));
+
+                if (!string.IsNullOrEmpty(opt.IntendedText) && opt.IntendedText != "...") {
+                    var wrapped = WrapText($"\"{opt.IntendedText}\"", 54);
+                    foreach (var wl in wrapped) Console.WriteLine(FillLine("   " + wl));
+                }
+                Console.WriteLine(FillLine($"   DC {dc}  |  Need: {need}+  |  {pct}%"));
+                Console.WriteLine(FillLine($"   Reward: {RewardRange(need)}  |  {XpMultiplier(need)}"));
+                Console.WriteLine("║                                                          ║");
+            }
+            Console.WriteLine("║  ICONS: 🟢🟡🟠🔴 Risk | 🔓 Window | 🔗 Callback        ║");
+            Console.WriteLine("║         ⭐ Combo | 📈 Momentum | 🔥 Forced | 📖 Tell    ║");
+            Console.WriteLine("╚══════════════════════════════════════════════════════════╝");
+            Console.WriteLine("```");
+            Console.WriteLine();
+
+            // ── pick + roll ───────────────────────────────────────────────
             int pick = BestOption(turnStart.Options, sableStats);
             var chosen = turnStart.Options[pick];
-            int chosenMod = sableStats.GetEffective(chosen.Stat);
-            int chosenDC = brickStats.GetDefenceDC(chosen.Stat);
-            Console.WriteLine($"\n► Pick {pick+1}: [{chosen.Stat}] mod{chosenMod:+#;-#;+0} vs DC{chosenDC}");
+            Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
+            Console.WriteLine();
 
             TurnResult result;
             try { result = await session.ResolveTurnAsync(pick); }
             catch (GameEndedException ex) { finalOutcome = ex.Outcome; break; }
 
             var roll = result.Roll;
-            string rollLine;
-            if (roll.IsNatTwenty)      rollLine = $"NAT 20 ⭐ auto-success";
-            else if (roll.IsNatOne)    rollLine = $"NAT 1 💀 auto-fail — Legendary";
-            else if (roll.Tier == FailureTier.None) rollLine = $"SUCCESS — beat DC by {chosenDC - roll.FinalTotal * -1}";
-            else                       rollLine = $"{roll.Tier} — missed DC by {roll.DC - roll.FinalTotal}";
+            string rollMod = $"{roll.StatModifier:+#;-#;0}";
+            string rollResult;
+            if (roll.IsNatTwenty)     rollResult = "NAT 20 ⭐";
+            else if (roll.IsNatOne)   rollResult = "NAT 1 💀";
+            else if (roll.Tier == FailureTier.None) rollResult = $"SUCCESS";
+            else                      rollResult = roll.Tier.ToString().ToUpperInvariant();
 
-            Console.WriteLine($"\n🎲 d20({roll.UsedDieRoll}) + mod({roll.StatModifier}) = base {roll.Total}");
-            if (roll.ExternalBonus != 0) Console.WriteLine($"   + external bonuses: {roll.ExternalBonus:+#;-#;0} (callback/tell/combo/momentum)");
-            Console.WriteLine($"   = FINAL {roll.FinalTotal} vs DC{roll.DC} → {rollLine}");
-            Console.WriteLine($"\n   Interest: {interestBefore} → {result.StateAfter.Interest} (Δ{result.InterestDelta:+#;-#;0})");
+            Console.WriteLine($"**🎲 Roll:** d20({roll.UsedDieRoll}) + {StatLabel(chosen.Stat)}({rollMod}) = **{roll.FinalTotal}** vs DC {roll.DC} → **Miss: {(roll.FinalTotal>=roll.DC ? $"−{roll.FinalTotal-roll.DC}" : $"+{roll.DC-roll.FinalTotal}")} → {rollResult}**");
+            Console.WriteLine();
 
-            // Explain the delta
-            var reasons = new System.Collections.Generic.List<string>();
-            if (roll.Tier == FailureTier.None) {
-                int margin = roll.FinalTotal - roll.DC;
-                string baseGain = margin >= 10 ? "+3 (crit)" : margin >= 5 ? "+2 (strong)" : "+1 (clean)";
-                reasons.Add(baseGain);
-                if (result.RiskTier == RiskTier.Hard) reasons.Add("+1 Hard tier bonus");
-                if (result.RiskTier == RiskTier.Bold) reasons.Add("+2 Bold tier bonus");
-            } else {
-                reasons.Add($"{result.InterestDelta} ({roll.Tier})");
-            }
-            if (result.ComboTriggered != null) { reasons.Add($"+1 combo ({result.ComboTriggered})"); Console.WriteLine($"   ⭐ COMBO TRIGGERED: {result.ComboTriggered}"); }
-            if (result.TellReadBonus > 0)      { reasons.Add($"+{result.TellReadBonus} tell"); Console.WriteLine($"   📖 TELL READ: +{result.TellReadBonus}"); }
-            Console.WriteLine($"   Why: {string.Join(", ", reasons)}");
+            if (result.ComboTriggered != null) Console.WriteLine($"> *⭐ {result.ComboTriggered} combo fires!*");
+            if (result.TellReadBonus > 0)      Console.WriteLine($"> *📖 Tell read! +{result.TellReadBonus}*");
+            Console.WriteLine();
 
-            Console.WriteLine($"\nSABLE sends:");
-            Console.WriteLine($"  \"{result.DeliveredMessage}\"");
-            Console.WriteLine($"\nBRICK replies:");
-            Console.WriteLine($"  \"{result.OpponentMessage}\"");
+            Console.WriteLine($"**📨 {player1} sends:**");
+            Console.WriteLine($"> \"{result.DeliveredMessage}\"");
+            Console.WriteLine();
 
+            lastOpponentMsg = result.OpponentMessage ?? "";
+            Console.WriteLine($"**📩 {player2} replies:**");
+            Console.WriteLine($"> \"{result.OpponentMessage}\"");
+            Console.WriteLine();
+
+            int newInterest = result.StateAfter.Interest;
+            int delta = result.InterestDelta;
+            string deltaStr = delta >= 0 ? $"+{delta}" : delta.ToString();
+            Console.WriteLine("---");
+            Console.WriteLine();
+            Console.WriteLine("```");
+            Console.WriteLine($"Interest: {InterestBar(newInterest)}  {newInterest}/25  ({deltaStr})");
             if (result.ShadowGrowthEvents?.Count > 0)
-            {
-                Console.WriteLine($"\n⚠️  SHADOW GROWTH:");
-                foreach (var e in result.ShadowGrowthEvents) Console.WriteLine($"   {e}");
-            }
-            if (result.NarrativeBeat != null) Console.WriteLine($"\n✨ {result.NarrativeBeat}");
-            if (result.XpEarned > 0) Console.WriteLine($"   XP +{result.XpEarned} (total: {session.TotalXpEarned})");
+                Console.WriteLine($"Shadow growth: {string.Join(", ", result.ShadowGrowthEvents)}");
+            string trapLine = result.StateAfter.ActiveTrapNames.Length > 0
+                ? string.Join(", ", result.StateAfter.ActiveTrapNames) : "none";
+            Console.WriteLine($"Active Traps: {trapLine}  |  Momentum: {result.StateAfter.MomentumStreak} win{(result.StateAfter.MomentumStreak!=1?"s":"")}");
+            Console.WriteLine("```");
 
+            interest = newInterest;
+            momentum = result.StateAfter.MomentumStreak;
+
+            if (result.NarrativeBeat != null) { Console.WriteLine(); Console.WriteLine($"✨ {result.NarrativeBeat}"); }
             if (result.IsGameOver) { finalOutcome = result.Outcome; break; }
         }
 
-        Console.WriteLine($"\n{'═',64}");
-        Console.WriteLine(finalOutcome.HasValue
-            ? $"SESSION OVER: {finalOutcome} | Total XP: {session.TotalXpEarned}"
-            : $"Session cut at {turn} turns | XP: {session.TotalXpEarned}");
-        Console.WriteLine($"{'═',64}");
+        // ── session summary ───────────────────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("---");
+        Console.WriteLine();
+        Console.WriteLine("## Session Summary");
+        Console.WriteLine();
+        string outcomeIcon = finalOutcome == GameOutcome.DateSecured ? "✅" :
+                             finalOutcome == GameOutcome.Unmatched  ? "💀" : "👻";
+        Console.WriteLine($"**{outcomeIcon} {finalOutcome?.ToString() ?? "Incomplete"} | Turns: {turn} | Total XP: {session.TotalXpEarned}**");
 
         llm.Dispose();
 
-        // Restore console and write to Obsidian vault
         Console.SetOut(tee._console);
-        WritePlaytestLog(buffer.ToString(), "Sable", "Brick", finalOutcome, session.TotalXpEarned, turn);
-
+        WritePlaytestLog(buffer.ToString(), player1, player2, finalOutcome, session.TotalXpEarned, turn);
         return 0;
     }
 
-    static void WritePlaytestLog(string content, string player, string opponent,
-        GameOutcome? outcome, int totalXp, int turns)
+    static List<string> WrapText(string text, int maxLen)
+    {
+        var lines = new List<string>();
+        while (text.Length > maxLen) {
+            int cut = text.LastIndexOf(' ', maxLen);
+            if (cut <= 0) cut = maxLen;
+            lines.Add(text.Substring(0, cut));
+            text = text.Substring(cut).TrimStart();
+        }
+        if (text.Length > 0) lines.Add(text);
+        return lines.Count > 0 ? lines : new List<string> { "" };
+    }
+
+    static void WritePlaytestLog(string content, string p1, string p2, GameOutcome? outcome, int xp, int turns)
     {
         string dir = "/root/.openclaw/agents-extra/pinder/design/playtests";
         if (!Directory.Exists(dir)) { Console.Error.WriteLine("Playtest dir not found"); return; }
-
         int nextNum = 1;
-        foreach (var f in Directory.GetFiles(dir, "session-???.md"))
-        {
-            var name = Path.GetFileNameWithoutExtension(f);
-            if (name.Length >= 11 && int.TryParse(name.Substring(8, 3), out int n))
-                nextNum = Math.Max(nextNum, n + 1);
+        foreach (var f in Directory.GetFiles(dir, "session-???.md")) {
+            var n = Path.GetFileNameWithoutExtension(f);
+            if (n.Length >= 11 && int.TryParse(n.Substring(8, 3), out int num)) nextNum = Math.Max(nextNum, num+1);
         }
-
-        string slug = $"session-{nextNum:D3}-{player.ToLower()}-vs-{opponent.ToLower()}.md";
-        string path = Path.Combine(dir, slug);
-
-        string outcomeStr = outcome.HasValue ? outcome.Value.ToString() : "Incomplete";
-        string header = $"# Playtest Session {nextNum:D3} — {player} × {opponent}\n"
-            + $"**Date:** {DateTime.UtcNow:yyyy-MM-dd}\n"
-            + $"**Engine:** pinder-core `GameSession` + `AnthropicLlmAdapter`\n"
-            + $"**Model:** claude-sonnet-4-20250514\n"
-            + $"**Player:** {player} (Level 3) | **Opponent:** {opponent} (Level 9, LLM puppet)\n"
-            + $"**Outcome:** ✅ {outcomeStr} | **Turns:** {turns} | **XP:** {totalXp}\n\n"
-            + "---\n\n"
-            + "```\n" + content + "\n```\n";
-
-        File.WriteAllText(path, header);
-        Console.WriteLine($"📝 Playtest written → design/playtests/{slug}");
-    }
-
-    static string ExtractSystemPrompt(string md)
-    {
-        int start = md.IndexOf("```\n", StringComparison.Ordinal) + 4;
-        int end   = md.LastIndexOf("\n```", StringComparison.Ordinal);
-        if (start < 4 || end < 0) return md;
-        return md.Substring(start, end - start).Trim();
-    }
-
-    static int BestOption(DialogueOption[] options, StatBlock stats)
-    {
-        int best = 0, bestMod = int.MinValue;
-        for (int i = 0; i < options.Length; i++)
-        {
-            int mod = stats.GetEffective(options[i].Stat);
-            if (mod > bestMod) { bestMod = mod; best = i; }
-        }
-        return best;
+        string slug = $"session-{nextNum:D3}-{p1.ToLower()}-vs-{p2.ToLower()}.md";
+        File.WriteAllText(Path.Combine(dir, slug), content);
+        Console.WriteLine($"\n📝 Written → design/playtests/{slug}");
     }
 }

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1,0 +1,247 @@
+// Pinder Session Runner — real GameSession + AnthropicLlmAdapter
+// Characters and opponent specified via args or default Sable vs Brick
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.LlmAdapters.Anthropic;
+
+class NullTrapRegistry : ITrapRegistry
+{
+    public TrapDefinition? GetTrap(StatType stat) => null;
+    public string? GetLlmInstruction(StatType stat) => null;
+}
+
+// Writes to both Console and a StringBuilder simultaneously
+class TeeWriter : TextWriter
+{
+    public readonly TextWriter _console;
+    private readonly StringBuilder _buffer;
+    public TeeWriter(TextWriter console, StringBuilder buffer) { _console = console; _buffer = buffer; }
+    public override Encoding Encoding => _console.Encoding;
+    public override void Write(char value) { _console.Write(value); _buffer.Append(value); }
+    public override void WriteLine(string? value) { _console.WriteLine(value); _buffer.AppendLine(value); }
+    public override void WriteLine() { _console.WriteLine(); _buffer.AppendLine(); }
+    protected override void Dispose(bool disposing) { if (disposing) _console.Flush(); base.Dispose(disposing); }
+}
+
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+        if (string.IsNullOrEmpty(apiKey)) { Console.Error.WriteLine("ANTHROPIC_API_KEY not set"); return 1; }
+
+        // Redirect stdout to tee — writes to both console and buffer for Obsidian
+        var buffer = new StringBuilder();
+        var tee = new TeeWriter(Console.Out, buffer);
+        Console.SetOut(tee);
+
+        Console.WriteLine("=== PINDER SESSION: Sable vs Brick ===");
+        Console.WriteLine("Player: Sable (Level 3) | Opponent: Brick (Level 9)");
+        Console.WriteLine($"Date: {DateTime.UtcNow:yyyy-MM-dd HH:mm UTC}");
+        Console.WriteLine($"Model: claude-sonnet-4-20250514 | Engine: AnthropicLlmAdapter + GameSession");
+        Console.WriteLine();
+
+        var sableStats = new StatBlock(
+            new Dictionary<StatType, int> {
+                { StatType.Charm, 7 }, { StatType.Rizz, 7 }, { StatType.Honesty, 8 },
+                { StatType.Chaos, 4 }, { StatType.Wit, 1 }, { StatType.SelfAwareness, 4 }
+            },
+            new Dictionary<ShadowStatType, int> {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 3 }, { ShadowStatType.Fixation, 2 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+            });
+
+        var brickStats = new StatBlock(
+            new Dictionary<StatType, int> {
+                { StatType.Charm, 16 }, { StatType.Rizz, 14 }, { StatType.Honesty, 11 },
+                { StatType.Chaos, 10 }, { StatType.Wit, 15 }, { StatType.SelfAwareness, 8 }
+            },
+            new Dictionary<ShadowStatType, int> {
+                { ShadowStatType.Madness, 8 }, { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 4 }, { ShadowStatType.Fixation, 3 },
+                { ShadowStatType.Dread, 5 }, { ShadowStatType.Overthinking, 6 }
+            });
+
+        string basePath = "/root/.openclaw/agents-extra/pinder/design/examples";
+        string sablePrompt = ExtractSystemPrompt(File.ReadAllText($"{basePath}/sable-prompt.md"));
+        string brickPrompt = ExtractSystemPrompt(File.ReadAllText($"{basePath}/brick-prompt.md"));
+
+        var timing = new TimingProfile(0, 1.0f, 0.0f, "neutral");
+        var sable = new CharacterProfile(sableStats, sablePrompt, "Sable", timing, level: 3);
+        var brick  = new CharacterProfile(brickStats, brickPrompt, "Brick", timing, level: 9);
+
+        var llm = new AnthropicLlmAdapter(new AnthropicOptions {
+            ApiKey = apiKey, Model = "claude-sonnet-4-20250514", MaxTokens = 1024, Temperature = 0.9
+        });
+
+        var session = new GameSession(sable, brick, llm, new SystemRandomDiceRoller(), new NullTrapRegistry());
+
+        int turn = 0;
+        GameOutcome? finalOutcome = null;
+
+        while (turn < 15)
+        {
+            turn++;
+            TurnStart turnStart;
+            try { turnStart = await session.StartTurnAsync(); }
+            catch (GameEndedException ex) { finalOutcome = ex.Outcome; break; }
+
+            var snap = turnStart.State;
+            Console.WriteLine($"\n{'─',64}");
+            Console.WriteLine($"TURN {turn}  |  Interest: {snap.Interest}/25 ({snap.State})  |  Streak: {snap.MomentumStreak}");
+            Console.WriteLine($"{'─',64}");
+
+            if (snap.ActiveTrapNames.Length > 0)
+                Console.WriteLine($"⚠️  Active traps: {string.Join(", ", snap.ActiveTrapNames)}");
+
+            // Print options with full text + DC + mechanics
+            int interestBefore = snap.Interest;
+            Console.WriteLine($"\n┌── DIALOGUE OPTIONS ──────────────────────────────────────┐");
+            for (int i = 0; i < turnStart.Options.Length; i++)
+            {
+                var opt = turnStart.Options[i];
+                int mod = sableStats.GetEffective(opt.Stat);
+                int dc = brickStats.GetDefenceDC(opt.Stat);
+                int need = dc - mod;
+                int pct = Math.Max(0, Math.Min(100, (21 - need) * 5));
+                string risk = need <= 5 ? "🟢 Safe" : need <= 10 ? "🟡 Medium" : need <= 15 ? "🟠 Hard" : "🔴 Bold";
+                string flags = "";
+                if (opt.HasTellBonus)           flags += " 📖+2";
+                if (opt.ComboName != null)       flags += $" ⭐{opt.ComboName}+1";
+                if (opt.CallbackTurnNumber.HasValue) flags += $" 🔗T{opt.CallbackTurnNumber}";
+                Console.WriteLine($"│  {i+1}) [{opt.Stat}] mod{mod:+#;-#;+0} vs DC{dc} | Need {need}+ | {pct}% | {risk}{flags}");
+                if (!string.IsNullOrEmpty(opt.IntendedText) && opt.IntendedText != "...")
+                    Console.WriteLine($"│     \"{opt.IntendedText}\"");
+                else
+                    Console.WriteLine($"│     [intended text unavailable — see bug #240]");
+            }
+            Console.WriteLine($"└──────────────────────────────────────────────────────────┘");
+
+            int pick = BestOption(turnStart.Options, sableStats);
+            var chosen = turnStart.Options[pick];
+            int chosenMod = sableStats.GetEffective(chosen.Stat);
+            int chosenDC = brickStats.GetDefenceDC(chosen.Stat);
+            Console.WriteLine($"\n► Pick {pick+1}: [{chosen.Stat}] mod{chosenMod:+#;-#;+0} vs DC{chosenDC}");
+
+            TurnResult result;
+            try { result = await session.ResolveTurnAsync(pick); }
+            catch (GameEndedException ex) { finalOutcome = ex.Outcome; break; }
+
+            var roll = result.Roll;
+            string rollLine;
+            if (roll.IsNatTwenty)      rollLine = $"NAT 20 ⭐ auto-success";
+            else if (roll.IsNatOne)    rollLine = $"NAT 1 💀 auto-fail — Legendary";
+            else if (roll.Tier == FailureTier.None) rollLine = $"SUCCESS — beat DC by {chosenDC - roll.FinalTotal * -1}";
+            else                       rollLine = $"{roll.Tier} — missed DC by {roll.DC - roll.FinalTotal}";
+
+            Console.WriteLine($"\n🎲 d20({roll.UsedDieRoll}) + mod({roll.StatModifier}) = base {roll.Total}");
+            if (roll.ExternalBonus != 0) Console.WriteLine($"   + external bonuses: {roll.ExternalBonus:+#;-#;0} (callback/tell/combo/momentum)");
+            Console.WriteLine($"   = FINAL {roll.FinalTotal} vs DC{roll.DC} → {rollLine}");
+            Console.WriteLine($"\n   Interest: {interestBefore} → {result.StateAfter.Interest} (Δ{result.InterestDelta:+#;-#;0})");
+
+            // Explain the delta
+            var reasons = new System.Collections.Generic.List<string>();
+            if (roll.Tier == FailureTier.None) {
+                int margin = roll.FinalTotal - roll.DC;
+                string baseGain = margin >= 10 ? "+3 (crit)" : margin >= 5 ? "+2 (strong)" : "+1 (clean)";
+                reasons.Add(baseGain);
+                if (result.RiskTier == RiskTier.Hard) reasons.Add("+1 Hard tier bonus");
+                if (result.RiskTier == RiskTier.Bold) reasons.Add("+2 Bold tier bonus");
+            } else {
+                reasons.Add($"{result.InterestDelta} ({roll.Tier})");
+            }
+            if (result.ComboTriggered != null) { reasons.Add($"+1 combo ({result.ComboTriggered})"); Console.WriteLine($"   ⭐ COMBO TRIGGERED: {result.ComboTriggered}"); }
+            if (result.TellReadBonus > 0)      { reasons.Add($"+{result.TellReadBonus} tell"); Console.WriteLine($"   📖 TELL READ: +{result.TellReadBonus}"); }
+            Console.WriteLine($"   Why: {string.Join(", ", reasons)}");
+
+            Console.WriteLine($"\nSABLE sends:");
+            Console.WriteLine($"  \"{result.DeliveredMessage}\"");
+            Console.WriteLine($"\nBRICK replies:");
+            Console.WriteLine($"  \"{result.OpponentMessage}\"");
+
+            if (result.ShadowGrowthEvents?.Count > 0)
+            {
+                Console.WriteLine($"\n⚠️  SHADOW GROWTH:");
+                foreach (var e in result.ShadowGrowthEvents) Console.WriteLine($"   {e}");
+            }
+            if (result.NarrativeBeat != null) Console.WriteLine($"\n✨ {result.NarrativeBeat}");
+            if (result.XpEarned > 0) Console.WriteLine($"   XP +{result.XpEarned} (total: {session.TotalXpEarned})");
+
+            if (result.IsGameOver) { finalOutcome = result.Outcome; break; }
+        }
+
+        Console.WriteLine($"\n{'═',64}");
+        Console.WriteLine(finalOutcome.HasValue
+            ? $"SESSION OVER: {finalOutcome} | Total XP: {session.TotalXpEarned}"
+            : $"Session cut at {turn} turns | XP: {session.TotalXpEarned}");
+        Console.WriteLine($"{'═',64}");
+
+        llm.Dispose();
+
+        // Restore console and write to Obsidian vault
+        Console.SetOut(tee._console);
+        WritePlaytestLog(buffer.ToString(), "Sable", "Brick", finalOutcome, session.TotalXpEarned, turn);
+
+        return 0;
+    }
+
+    static void WritePlaytestLog(string content, string player, string opponent,
+        GameOutcome? outcome, int totalXp, int turns)
+    {
+        string dir = "/root/.openclaw/agents-extra/pinder/design/playtests";
+        if (!Directory.Exists(dir)) { Console.Error.WriteLine("Playtest dir not found"); return; }
+
+        int nextNum = 1;
+        foreach (var f in Directory.GetFiles(dir, "session-???.md"))
+        {
+            var name = Path.GetFileNameWithoutExtension(f);
+            if (name.Length >= 11 && int.TryParse(name.Substring(8, 3), out int n))
+                nextNum = Math.Max(nextNum, n + 1);
+        }
+
+        string slug = $"session-{nextNum:D3}-{player.ToLower()}-vs-{opponent.ToLower()}.md";
+        string path = Path.Combine(dir, slug);
+
+        string outcomeStr = outcome.HasValue ? outcome.Value.ToString() : "Incomplete";
+        string header = $"# Playtest Session {nextNum:D3} — {player} × {opponent}\n"
+            + $"**Date:** {DateTime.UtcNow:yyyy-MM-dd}\n"
+            + $"**Engine:** pinder-core `GameSession` + `AnthropicLlmAdapter`\n"
+            + $"**Model:** claude-sonnet-4-20250514\n"
+            + $"**Player:** {player} (Level 3) | **Opponent:** {opponent} (Level 9, LLM puppet)\n"
+            + $"**Outcome:** ✅ {outcomeStr} | **Turns:** {turns} | **XP:** {totalXp}\n\n"
+            + "---\n\n"
+            + "```\n" + content + "\n```\n";
+
+        File.WriteAllText(path, header);
+        Console.WriteLine($"📝 Playtest written → design/playtests/{slug}");
+    }
+
+    static string ExtractSystemPrompt(string md)
+    {
+        int start = md.IndexOf("```\n", StringComparison.Ordinal) + 4;
+        int end   = md.LastIndexOf("\n```", StringComparison.Ordinal);
+        if (start < 4 || end < 0) return md;
+        return md.Substring(start, end - start).Trim();
+    }
+
+    static int BestOption(DialogueOption[] options, StatBlock stats)
+    {
+        int best = 0, bestMod = int.MinValue;
+        for (int i = 0; i < options.Length; i++)
+        {
+            int mod = stats.GetEffective(options[i].Stat);
+            if (mod > bestMod) { bestMod = mod; best = i; }
+        }
+        return best;
+    }
+}

--- a/session-runner/session-runner.csproj
+++ b/session-runner/session-runner.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Pinder.Core\Pinder.Core.csproj" />
+    <ProjectReference Include="..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -64,6 +64,9 @@ namespace Pinder.Core.Conversation
         // Tell from opponent's last response (#50)
         private Tell? _activeTell;
 
+        // Horniness session roll (#45)
+        private int _sessionHorniness;
+
         // Shadow threshold tracking (#45)
         private StatType? _lastStatUsed;
         private HashSet<StatType>? _shadowDisadvantagedStats;
@@ -128,6 +131,14 @@ namespace Pinder.Core.Conversation
             _playerShadows = config?.PlayerShadows;
             _opponentShadows = config?.OpponentShadows;
             _previousOpener = config?.PreviousOpener;
+
+            // Roll session Horniness (1d10) + time-of-day modifier (async-time feature, requires clock)
+            if (_clock != null)
+            {
+                int horninessRoll = _dice.Roll(10);
+                int todModifier = _clock.GetHorninessModifier();
+                _sessionHorniness = Math.Max(0, horninessRoll + todModifier);
+            }
 
             // XP tracking (#48)
             _xpLedger = new XpLedger();
@@ -268,7 +279,10 @@ namespace Pinder.Core.Conversation
                 currentInterest: _interest.Current,
                 shadowThresholds: shadowThresholds,
                 activeTrapInstructions: activeTrapInstructions,
-                callbackOpportunities: _topics.Count > 0 ? new List<CallbackOpportunity>(_topics) : null);
+                callbackOpportunities: _topics.Count > 0 ? new List<CallbackOpportunity>(_topics) : null,
+                horninessLevel: _sessionHorniness,
+                requiresRizzOption: _sessionHorniness >= 12,
+                currentTurn: _turnNumber);
 
             // Get dialogue options from LLM
             var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
@@ -322,6 +336,17 @@ namespace Pinder.Core.Conversation
                 }
             }
 
+            // Horniness T3 (#45): all options become Rizz
+            if (_sessionHorniness >= 18)
+            {
+                for (int i = 0; i < options.Length; i++)
+                {
+                    var o = options[i];
+                    options[i] = new DialogueOption(StatType.Rizz, o.IntendedText, o.CallbackTurnNumber,
+                        o.ComboName, o.HasTellBonus, o.HasWeaknessWindow);
+                }
+            }
+
             _currentOptions = options;
 
             var snapshot = CreateSnapshot();
@@ -346,6 +371,14 @@ namespace Pinder.Core.Conversation
             if (optionIndex < 0 || optionIndex >= _currentOptions.Length)
                 throw new ArgumentOutOfRangeException(nameof(optionIndex),
                     $"Option index {optionIndex} is out of range. Valid range: 0–{_currentOptions.Length - 1}.");
+
+            // Consume 1 energy from clock if available
+            if (_clock != null && !_clock.ConsumeEnergy(1))
+            {
+                _ended = true;
+                _outcome = GameOutcome.Unmatched;
+                throw new GameEndedException(GameOutcome.Unmatched);
+            }
 
             var chosenOption = _currentOptions[optionIndex];
 

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -109,7 +109,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 context.CurrentTurn,
                 FallbackName(context.PlayerName, "Player"),
                 FallbackName(context.OpponentName, "Opponent"),
-                playerShadowThresholds: context.ShadowThresholds);
+                playerShadowThresholds: context.ShadowThresholds,
+                callbackOpportunities: context.CallbackOpportunities,
+                activeTrapInstructions: context.ActiveTrapInstructions,
+                horninessLevel: context.HorninessLevel,
+                requiresRizzOption: context.RequiresRizzOption);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature);

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -108,7 +108,8 @@ namespace Pinder.LlmAdapters.Anthropic
                 context.CurrentInterest,
                 context.CurrentTurn,
                 FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"));
+                FallbackName(context.OpponentName, "Opponent"),
+                playerShadowThresholds: context.ShadowThresholds);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature);
@@ -131,7 +132,8 @@ namespace Pinder.LlmAdapters.Anthropic
                 context.BeatDcBy,
                 context.ActiveTrapInstructions,
                 FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"));
+                FallbackName(context.OpponentName, "Opponent"),
+                playerShadowThresholds: context.ShadowThresholds);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.DeliveryTemperature ?? DefaultDeliveryTemperature);
@@ -156,7 +158,8 @@ namespace Pinder.LlmAdapters.Anthropic
                 context.ResponseDelayMinutes,
                 context.ActiveTrapInstructions,
                 FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"));
+                FallbackName(context.OpponentName, "Opponent"),
+                opponentShadowThresholds: context.ShadowThresholds);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature);

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -24,7 +24,11 @@ namespace Pinder.LlmAdapters
             int currentTurn,
             string playerName,
             string opponentName,
-            Dictionary<ShadowStatType, int>? playerShadowThresholds = null)
+            Dictionary<ShadowStatType, int>? playerShadowThresholds = null,
+            List<CallbackOpportunity>? callbackOpportunities = null,
+            string[]? activeTrapInstructions = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false)
         {
             if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
             if (opponentLastMessage == null) throw new ArgumentNullException(nameof(opponentLastMessage));
@@ -43,6 +47,17 @@ namespace Pinder.LlmAdapters
 
             sb.AppendLine();
             sb.AppendLine("GAME STATE");
+            sb.AppendLine($"- Turn: {currentTurn}");
+
+            // Interest state label
+            string interestLabel = currentInterest >= 21 ? "Almost There \U0001f525"
+                : currentInterest >= 16 ? "Very Into It \U0001f60d (player has advantage)"
+                : currentInterest >= 10 ? "Interested \U0001f60a"
+                : currentInterest >= 5  ? "Lukewarm \U0001f914"
+                : currentInterest >= 1  ? "Bored \U0001f610 (player has disadvantage)"
+                : "Unmatched \U0001f480";
+            sb.AppendLine($"- Interest: {currentInterest}/25 — {interestLabel}");
+
             if (activeTraps.Length == 0)
             {
                 sb.AppendLine("- Active traps: none");
@@ -52,12 +67,41 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine($"- Active traps: {string.Join(", ", activeTraps)}");
             }
 
+            if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+            {
+                sb.AppendLine("ACTIVE TRAP INSTRUCTIONS (taint ALL generated options regardless of stat):");
+                foreach (var instruction in activeTrapInstructions)
+                    sb.AppendLine(instruction);
+            }
+
+            if (horninessLevel >= 6)
+            {
+                sb.AppendLine($"- Horniness level: {horninessLevel}/10 (Rizz options are more prominent, slightly too forward)");
+            }
+            if (requiresRizzOption)
+            {
+                sb.AppendLine("- \U0001f525 REQUIRED: Include at least one Rizz option — Horniness is forcing it into the lineup.");
+            }
+
             string dialogueTaint = BuildShadowTaintBlock(playerShadowThresholds);
             if (!string.IsNullOrEmpty(dialogueTaint))
             {
                 sb.AppendLine();
                 sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
                 sb.AppendLine(dialogueTaint);
+            }
+
+            if (callbackOpportunities != null && callbackOpportunities.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("CALLBACK OPPORTUNITIES");
+                sb.AppendLine("Reference these topics naturally in 1-2 options to earn hidden roll bonuses:");
+                foreach (var cb in callbackOpportunities)
+                {
+                    int turnsAgo = currentTurn - cb.TurnIntroduced;
+                    string bonus = turnsAgo >= 4 ? "+2 hidden" : turnsAgo >= 2 ? "+1 hidden" : "+3 hidden (opener)";
+                    sb.AppendLine($"- \"{cb.TopicKey}\" (introduced T{cb.TurnIntroduced}, {turnsAgo} turns ago, {bonus})");
+                }
             }
 
             sb.AppendLine();

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -23,7 +23,8 @@ namespace Pinder.LlmAdapters
             int currentInterest,
             int currentTurn,
             string playerName,
-            string opponentName)
+            string opponentName,
+            Dictionary<ShadowStatType, int>? playerShadowThresholds = null)
         {
             if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
             if (opponentLastMessage == null) throw new ArgumentNullException(nameof(opponentLastMessage));
@@ -51,6 +52,14 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine($"- Active traps: {string.Join(", ", activeTraps)}");
             }
 
+            string dialogueTaint = BuildShadowTaintBlock(playerShadowThresholds);
+            if (!string.IsNullOrEmpty(dialogueTaint))
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
+                sb.AppendLine(dialogueTaint);
+            }
+
             sb.AppendLine();
             sb.AppendLine("YOUR TASK");
             sb.Append(PromptTemplates.DialogueOptionsInstruction.Replace("{player_name}", playerName));
@@ -68,7 +77,8 @@ namespace Pinder.LlmAdapters
             int beatDcBy,
             string[]? activeTrapInstructions,
             string playerName,
-            string opponentName)
+            string opponentName,
+            Dictionary<ShadowStatType, int>? playerShadowThresholds = null)
         {
             if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
             if (chosenOption == null) throw new ArgumentNullException(nameof(chosenOption));
@@ -79,6 +89,15 @@ namespace Pinder.LlmAdapters
 
             sb.AppendLine("CONVERSATION HISTORY");
             AppendConversationHistory(sb, conversationHistory, playerName);
+
+            string deliveryTaint = BuildShadowTaintBlock(playerShadowThresholds);
+            if (!string.IsNullOrEmpty(deliveryTaint))
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
+                sb.AppendLine(deliveryTaint);
+            }
+
             sb.AppendLine();
 
             if (outcome == FailureTier.None)
@@ -139,7 +158,8 @@ namespace Pinder.LlmAdapters
             double responseDelayMinutes,
             string[]? activeTrapInstructions,
             string playerName,
-            string opponentName)
+            string opponentName,
+            Dictionary<ShadowStatType, int>? opponentShadowThresholds = null)
         {
             if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
             if (playerDeliveredMessage == null) throw new ArgumentNullException(nameof(playerDeliveredMessage));
@@ -186,6 +206,14 @@ namespace Pinder.LlmAdapters
                 {
                     sb.AppendLine(instruction);
                 }
+            }
+
+            string opponentTaint = BuildShadowTaintBlock(opponentShadowThresholds);
+            if (!string.IsNullOrEmpty(opponentTaint))
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
+                sb.AppendLine(opponentTaint);
             }
 
             sb.AppendLine();
@@ -266,6 +294,25 @@ namespace Pinder.LlmAdapters
 
             // Generic fallback for other threshold crossings
             return PromptTemplates.InterestBeatGeneric.Replace("{opponent_name}", opponentName);
+        }
+
+        private static string BuildShadowTaintBlock(Dictionary<ShadowStatType, int>? thresholds)
+        {
+            if (thresholds == null || thresholds.Count == 0) return string.Empty;
+            var sb = new StringBuilder();
+            if (thresholds.TryGetValue(ShadowStatType.Madness, out int madness) && madness > 5)
+                sb.AppendLine("Your Madness is elevated. Your charm has an uncanny quality — warmth that somehow feels slightly off. Smooth words that land wrong. People can't identify why they feel uneasy. You don't notice.");
+            if (thresholds.TryGetValue(ShadowStatType.Horniness, out int horniness) && horniness > 6)
+                sb.AppendLine("Your Horniness is elevated. You are reading subtext that may not be there. Rizz options surface more often and more forward. You are slightly too aware of the tension.");
+            if (thresholds.TryGetValue(ShadowStatType.Denial, out int denial) && denial > 5)
+                sb.AppendLine("Your Denial is elevated. Your honest options sound rehearsed. You tell truths that are technically true but curated. Emotional availability is performed rather than felt.");
+            if (thresholds.TryGetValue(ShadowStatType.Fixation, out int fixation) && fixation > 5)
+                sb.AppendLine("Your Fixation is elevated. Chaos options feel forced — spontaneity that sounds calculated. You're trying to seem unpredictable. It shows.");
+            if (thresholds.TryGetValue(ShadowStatType.Dread, out int dread) && dread > 5)
+                sb.AppendLine("Your Dread is elevated. Even successful Wit options have melancholy undertones. Jokes land but leave a slightly hollow aftertaste. You're funny because it's easier than being vulnerable.");
+            if (thresholds.TryGetValue(ShadowStatType.Overthinking, out int overthinking) && overthinking > 5)
+                sb.AppendLine("Your Overthinking is elevated. Self-Awareness options are too clinical. You explain your feelings rather than expressing them. You know this. You're doing it anyway.");
+            return sb.ToString().Trim();
         }
 
         private static string GetFailureTierName(FailureTier tier)

--- a/tests/Pinder.Core.Tests/HorninessAndEnergyTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAndEnergyTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class HorninessAndEnergyTests
+    {
+        /// <summary>
+        /// When a clock is present, session horniness = dice roll + clock modifier.
+        /// Clock returns +3, dice returns 7 → sessionHorniness = 10.
+        /// Since 10 < 12, RequiresRizzOption should be false.
+        /// Since 10 < 18, options should NOT all be Rizz.
+        /// </summary>
+        [Fact]
+        public async Task GameSession_HorninessRolledAtSessionStart_WithClock_AppliesModifier()
+        {
+            // Dice queue: 7 (horniness roll), then enough for StartTurnAsync (no rolls needed there)
+            var dice = new FixedDice(7);
+            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            // StartTurnAsync builds the DialogueContext with horninessLevel
+            var turn = await session.StartTurnAsync();
+
+            // horniness = 7 + 3 = 10. < 12, so no RequiresRizzOption.
+            // Options should have their original stats (not all Rizz).
+            Assert.Equal(4, turn.Options.Length);
+            // At least one option should NOT be Rizz (NullLlmAdapter returns Charm, Honesty, Wit, Chaos)
+            bool hasNonRizz = false;
+            for (int i = 0; i < turn.Options.Length; i++)
+            {
+                if (turn.Options[i].Stat != StatType.Rizz)
+                    hasNonRizz = true;
+            }
+            Assert.True(hasNonRizz, "Horniness 10 should not convert all options to Rizz");
+        }
+
+        /// <summary>
+        /// When horniness >= 18 (T3), all dialogue options become Rizz.
+        /// Clock returns +5 (AfterTwoAm), dice returns 10 → horniness = 15 (not T3).
+        /// So we use dice=10 + modifier=+8... but max modifier is +5.
+        /// We need horniness >= 18: use dice=10, modifier=+8? No, IGameClock max is +5.
+        /// So: dice roll must be high enough. dice=10 + 5 = 15. Not enough.
+        /// We can't reach 18 with a d10 + max modifier 5 (max 15).
+        /// Wait — the spec says 1d10. Max roll = 10, max modifier = 5 → max 15.
+        /// But the code uses Math.Max(0, roll + modifier). So 18 is not reachable naturally.
+        /// The T3 threshold is checked against _sessionHorniness which is set in constructor.
+        /// For testing, we need to set it to >= 18 somehow.
+        /// Since we can't modify _sessionHorniness directly, we need a custom dice and clock
+        /// that can produce a total >= 18. But dice.Roll(10) can return any int — it's not
+        /// clamped. The FixedDice just returns queued values.
+        /// So FixedDice(15) + modifier(+3) = 18. That works!
+        /// </summary>
+        [Fact]
+        public async Task GameSession_HorninessT3_AllOptionsBecomeRizz()
+        {
+            // FixedDice returns 15 for the horniness roll (not clamped to 1-10 in FixedDice)
+            var dice = new FixedDice(15);
+            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            // horniness = 15 + 3 = 18 → T3
+            var turn = await session.StartTurnAsync();
+
+            Assert.Equal(4, turn.Options.Length);
+            for (int i = 0; i < turn.Options.Length; i++)
+            {
+                Assert.Equal(StatType.Rizz, turn.Options[i].Stat);
+            }
+        }
+
+        /// <summary>
+        /// When clock.ConsumeEnergy returns false, ResolveTurnAsync should throw GameEndedException
+        /// with Unmatched outcome.
+        /// </summary>
+        [Fact]
+        public async Task GameSession_EnergyDepletion_ThrowsGameEnded()
+        {
+            // Dice queue: 5 (horniness roll), then enough for StartTurnAsync
+            // ResolveTurnAsync will check energy before rolling, so no more dice needed if energy fails.
+            var dice = new FixedDice(5);
+            var clock = new ConfigurableClock(horninessModifier: 0, remainingEnergy: 0);
+
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            var turn = await session.StartTurnAsync();
+            Assert.NotNull(turn);
+
+            var ex = await Assert.ThrowsAsync<GameEndedException>(
+                () => session.ResolveTurnAsync(0));
+            Assert.Equal(GameOutcome.Unmatched, ex.Outcome);
+        }
+
+        /// <summary>
+        /// When horniness < 12, options retain original stats (no T2/T3 effect on options).
+        /// When horniness >= 12 but < 18, RequiresRizzOption is set in context but options aren't all forced to Rizz.
+        /// </summary>
+        [Fact]
+        public async Task GameSession_HorninessT2_DoesNotForceAllRizz()
+        {
+            // dice=10 + modifier(+3) = 13 → T2 (>= 12), but not T3 (< 18)
+            var dice = new FixedDice(10);
+            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+
+            var config = new GameSessionConfig(clock: clock);
+            var session = new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            var turn = await session.StartTurnAsync();
+            Assert.Equal(4, turn.Options.Length);
+
+            // Options should NOT all be Rizz at T2
+            bool hasNonRizz = false;
+            for (int i = 0; i < turn.Options.Length; i++)
+            {
+                if (turn.Options[i].Stat != StatType.Rizz)
+                    hasNonRizz = true;
+            }
+            Assert.True(hasNonRizz, "Horniness T2 (13) should not force all options to Rizz");
+        }
+
+        /// <summary>
+        /// Without a clock, horniness stays at 0 and no energy is consumed.
+        /// </summary>
+        [Fact]
+        public async Task GameSession_NoClock_HorninessZero_NoEnergyCheck()
+        {
+            // No horniness roll consumed from dice (no clock)
+            var dice = new FixedDice(
+                // Turn 1: d20=15 (roll), d100=50 (timing delay)
+                15, 50);
+
+            var session = new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                null);
+
+            var turn = await session.StartTurnAsync();
+            Assert.Equal(4, turn.Options.Length);
+
+            // Should not throw — no energy check without clock
+            var result = await session.ResolveTurnAsync(0);
+            Assert.NotNull(result);
+        }
+
+        // ======================== Helpers ========================
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            var stats = TestHelpers.MakeStatBlock();
+            var timing = new TimingProfile(5, 0.0f, 0.0f, "neutral");
+            return new CharacterProfile(stats, $"You are {name}.", name, timing, 1);
+        }
+
+        private sealed class ConfigurableClock : IGameClock
+        {
+            private readonly int _horninessModifier;
+            private int _remainingEnergy;
+
+            public ConfigurableClock(int horninessModifier, int remainingEnergy)
+            {
+                _horninessModifier = horninessModifier;
+                _remainingEnergy = remainingEnergy;
+            }
+
+            public DateTimeOffset Now => DateTimeOffset.UtcNow;
+            public int RemainingEnergy => _remainingEnergy;
+            public void Advance(TimeSpan amount) { }
+            public void AdvanceTo(DateTimeOffset target) { }
+            public TimeOfDay GetTimeOfDay() => TimeOfDay.LateNight;
+            public int GetHorninessModifier() => _horninessModifier;
+
+            public bool ConsumeEnergy(int amount)
+            {
+                if (_remainingEnergy < amount) return false;
+                _remainingEnergy -= amount;
+                return true;
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class SessionDocumentBuilderPromptTests
+    {
+        private static readonly List<(string Sender, string Text)> EmptyHistory =
+            new List<(string, string)>();
+
+        private static string BuildMinimal(
+            List<CallbackOpportunity> callbackOpportunities = null,
+            string[] activeTrapInstructions = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false,
+            int currentInterest = 10,
+            int currentTurn = 3)
+        {
+            return SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                conversationHistory: EmptyHistory,
+                opponentLastMessage: "hey",
+                activeTraps: new string[0],
+                currentInterest: currentInterest,
+                currentTurn: currentTurn,
+                playerName: "Player",
+                opponentName: "Opponent",
+                callbackOpportunities: callbackOpportunities,
+                activeTrapInstructions: activeTrapInstructions,
+                horninessLevel: horninessLevel,
+                requiresRizzOption: requiresRizzOption);
+        }
+
+        // ── Callback Opportunities ──
+
+        [Fact]
+        public void CallbackOpportunities_Appear_In_Prompt()
+        {
+            var cbs = new List<CallbackOpportunity>
+            {
+                new CallbackOpportunity("cats", 1),
+                new CallbackOpportunity("hiking", 2)
+            };
+
+            var result = BuildMinimal(callbackOpportunities: cbs, currentTurn: 5);
+
+            Assert.Contains("CALLBACK OPPORTUNITIES", result);
+            Assert.Contains("\"cats\"", result);
+            Assert.Contains("\"hiking\"", result);
+            Assert.Contains("+2 hidden", result); // cats: 5-1=4 turns ago
+            Assert.Contains("+1 hidden", result); // hiking: 5-2=3 turns ago
+        }
+
+        [Fact]
+        public void CallbackOpportunities_Opener_Bonus()
+        {
+            var cbs = new List<CallbackOpportunity>
+            {
+                new CallbackOpportunity("opener-topic", 3)
+            };
+
+            var result = BuildMinimal(callbackOpportunities: cbs, currentTurn: 3);
+
+            Assert.Contains("+3 hidden (opener)", result);
+        }
+
+        [Fact]
+        public void CallbackOpportunities_Null_No_Section()
+        {
+            var result = BuildMinimal(callbackOpportunities: null);
+            Assert.DoesNotContain("CALLBACK OPPORTUNITIES", result);
+        }
+
+        // ── Active Trap Instructions ──
+
+        [Fact]
+        public void ActiveTrapInstructions_Appear_In_DialogueOptions_Prompt()
+        {
+            var instructions = new[] { "All options must include a pun about cats." };
+
+            var result = BuildMinimal(activeTrapInstructions: instructions);
+
+            Assert.Contains("ACTIVE TRAP INSTRUCTIONS", result);
+            Assert.Contains("All options must include a pun about cats.", result);
+        }
+
+        [Fact]
+        public void ActiveTrapInstructions_Null_No_Section()
+        {
+            var result = BuildMinimal(activeTrapInstructions: null);
+            Assert.DoesNotContain("ACTIVE TRAP INSTRUCTIONS", result);
+        }
+
+        // ── Horniness & Rizz ──
+
+        [Fact]
+        public void Horniness_GE6_Injects_Note()
+        {
+            var result = BuildMinimal(horninessLevel: 7);
+
+            Assert.Contains("Horniness level: 7/10", result);
+        }
+
+        [Fact]
+        public void Horniness_Below6_No_Note()
+        {
+            var result = BuildMinimal(horninessLevel: 5);
+
+            Assert.DoesNotContain("Horniness level", result);
+        }
+
+        [Fact]
+        public void RequiresRizzOption_True_Injects_Fire_Line()
+        {
+            var result = BuildMinimal(requiresRizzOption: true);
+
+            Assert.Contains("REQUIRED: Include at least one Rizz option", result);
+        }
+
+        [Fact]
+        public void RequiresRizzOption_False_No_Fire_Line()
+        {
+            var result = BuildMinimal(requiresRizzOption: false);
+
+            Assert.DoesNotContain("REQUIRED: Include at least one Rizz option", result);
+        }
+
+        // ── Turn Number & Interest State ──
+
+        [Fact]
+        public void Turn_Number_Appears_In_GameState()
+        {
+            var result = BuildMinimal(currentTurn: 7);
+
+            Assert.Contains("Turn: 7", result);
+        }
+
+        [Fact]
+        public void Interest_High_Shows_AlmostThere()
+        {
+            var result = BuildMinimal(currentInterest: 22);
+
+            Assert.Contains("Interest: 22/25", result);
+            Assert.Contains("Almost There", result);
+        }
+
+        [Fact]
+        public void Interest_Mid_Shows_Interested()
+        {
+            var result = BuildMinimal(currentInterest: 12);
+
+            Assert.Contains("Interest: 12/25", result);
+            Assert.Contains("Interested", result);
+        }
+
+        [Fact]
+        public void Interest_Low_Shows_Bored()
+        {
+            var result = BuildMinimal(currentInterest: 2);
+
+            Assert.Contains("Interest: 2/25", result);
+            Assert.Contains("Bored", result);
+            Assert.Contains("player has disadvantage", result);
+        }
+
+        [Fact]
+        public void Interest_Zero_Shows_Unmatched()
+        {
+            var result = BuildMinimal(currentInterest: 0);
+
+            Assert.Contains("Interest: 0/25", result);
+            Assert.Contains("Unmatched", result);
+        }
+
+        [Fact]
+        public void Interest_VeryIntoIt_Shows_PlayerAdvantage()
+        {
+            var result = BuildMinimal(currentInterest: 18);
+
+            Assert.Contains("Very Into It", result);
+            Assert.Contains("player has advantage", result);
+        }
+
+        [Fact]
+        public void Interest_Lukewarm_Range()
+        {
+            var result = BuildMinimal(currentInterest: 6);
+
+            Assert.Contains("Lukewarm", result);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class ShadowTaintTests
+    {
+        private static readonly IReadOnlyList<(string Sender, string Text)> MinimalHistory =
+            new List<(string, string)> { ("Opponent", "Hey there") };
+
+        [Fact]
+        public void DialogueOptionsPrompt_HighMadness_ContainsShadowStateSection()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 8 }
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Your Madness is elevated", result);
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_LowShadow_NoShadowStateSection()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 3 }
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.DoesNotContain("SHADOW STATE", result);
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_MultipleShadowsAboveThreshold_MultipleLines()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 8 },
+                { ShadowStatType.Denial, 7 },
+                { ShadowStatType.Dread, 6 }
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.Contains("Your Madness is elevated", result);
+            Assert.Contains("Your Denial is elevated", result);
+            Assert.Contains("Your Dread is elevated", result);
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_HorninessAt6_NoTaint()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Horniness, 6 }
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.DoesNotContain("SHADOW STATE", result);
+            Assert.DoesNotContain("Your Horniness is elevated", result);
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_HorninessAt7_HasTaint()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Horniness, 7 }
+            };
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Your Horniness is elevated", result);
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_NullShadow_NoShadowStateSection()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
+                playerShadowThresholds: null);
+
+            Assert.DoesNotContain("SHADOW STATE", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_HighShadow_ContainsShadowStateSection()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Overthinking, 7 }
+            };
+            var option = new Pinder.Core.Conversation.DialogueOption(
+                StatType.Wit, "Test message", null, null, false, false);
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MinimalHistory, option, Pinder.Core.Rolls.FailureTier.None, 3, null,
+                "Player", "Opponent",
+                playerShadowThresholds: shadows);
+
+            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Your Overthinking is elevated", result);
+        }
+
+        [Fact]
+        public void OpponentPrompt_HighShadow_ContainsShadowStateSection()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 9 }
+            };
+
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                MinimalHistory, "Hello", 10, 12, 2.0, null,
+                "Player", "Opponent",
+                opponentShadowThresholds: shadows);
+
+            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Your Fixation is elevated", result);
+        }
+    }
+}


### PR DESCRIPTION
Implements §3.6 shadow taint injection. SessionDocumentBuilder now accepts optional shadow threshold dicts and injects taint blocks when values exceed threshold (>5 for most, >6 for Horniness). AnthropicLlmAdapter passes ShadowThresholds from context to builder.

**Changes:**
- `SessionDocumentBuilder.cs`: Added `BuildShadowTaintBlock` helper + optional shadow params to `BuildDialogueOptionsPrompt`, `BuildDeliveryPrompt`, `BuildOpponentPrompt`
- `AnthropicLlmAdapter.cs`: Passes `context.ShadowThresholds` to all 3 builder calls
- New `ShadowTaintTests.cs`: 8 tests covering high/low thresholds, multiple shadows, Horniness >6 edge case

All 1141 core + 434 adapter tests pass (0 failures).