### PR TITLE
refactor: SessionDocumentBuilder takes context objects (not individual params)

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -100,20 +100,7 @@ namespace Pinder.LlmAdapters.Anthropic
             var systemBlocks = CacheBlockBuilder.BuildCachedSystemBlocks(
                 context.PlayerPrompt, context.OpponentPrompt);
 
-            var trapsArray = ToStringArray(context.ActiveTraps);
-            var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                context.ConversationHistory,
-                context.OpponentLastMessage,
-                trapsArray,
-                context.CurrentInterest,
-                context.CurrentTurn,
-                FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"),
-                playerShadowThresholds: context.ShadowThresholds,
-                callbackOpportunities: context.CallbackOpportunities,
-                activeTrapInstructions: context.ActiveTrapInstructions,
-                horninessLevel: context.HorninessLevel,
-                requiresRizzOption: context.RequiresRizzOption);
+            var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature);
@@ -129,15 +116,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
             var systemBlocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(context.PlayerPrompt);
 
-            var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(
-                context.ConversationHistory,
-                context.ChosenOption,
-                context.Outcome,
-                context.BeatDcBy,
-                context.ActiveTrapInstructions,
-                FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"),
-                playerShadowThresholds: context.ShadowThresholds);
+            var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.DeliveryTemperature ?? DefaultDeliveryTemperature);
@@ -154,16 +133,7 @@ namespace Pinder.LlmAdapters.Anthropic
             // Per §3.5: only opponent prompt in system (opponent plays themselves)
             var systemBlocks = CacheBlockBuilder.BuildOpponentOnlySystemBlocks(context.OpponentPrompt);
 
-            var userContent = SessionDocumentBuilder.BuildOpponentPrompt(
-                context.ConversationHistory,
-                context.PlayerDeliveredMessage,
-                context.InterestBefore,
-                context.InterestAfter,
-                context.ResponseDelayMinutes,
-                context.ActiveTrapInstructions,
-                FallbackName(context.PlayerName, "Player"),
-                FallbackName(context.OpponentName, "Opponent"),
-                opponentShadowThresholds: context.ShadowThresholds);
+            var userContent = SessionDocumentBuilder.BuildOpponentPrompt(context);
 
             var request = BuildRequest(systemBlocks, userContent,
                 _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature);
@@ -460,18 +430,6 @@ namespace Pinder.LlmAdapters.Anthropic
             return result.ToArray();
         }
 
-        private static string[] ToStringArray(IReadOnlyList<string> list)
-        {
-            if (list is string[] arr) return arr;
-            var result = new string[list.Count];
-            for (int i = 0; i < list.Count; i++)
-                result[i] = list[i];
-            return result;
-        }
 
-        private static string FallbackName(string name, string fallback)
-        {
-            return string.IsNullOrEmpty(name) ? fallback : name;
-        }
     }
 }

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -16,74 +16,61 @@ namespace Pinder.LlmAdapters
         /// <summary>
         /// Builds the user-message content for GetDialogueOptionsAsync (§3.2).
         /// </summary>
-        public static string BuildDialogueOptionsPrompt(
-            IReadOnlyList<(string Sender, string Text)> conversationHistory,
-            string opponentLastMessage,
-            string[] activeTraps,
-            int currentInterest,
-            int currentTurn,
-            string playerName,
-            string opponentName,
-            Dictionary<ShadowStatType, int>? playerShadowThresholds = null,
-            List<CallbackOpportunity>? callbackOpportunities = null,
-            string[]? activeTrapInstructions = null,
-            int horninessLevel = 0,
-            bool requiresRizzOption = false)
+        public static string BuildDialogueOptionsPrompt(DialogueContext context)
         {
-            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
-            if (opponentLastMessage == null) throw new ArgumentNullException(nameof(opponentLastMessage));
-            if (activeTraps == null) throw new ArgumentNullException(nameof(activeTraps));
-            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
-            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var playerName = FallbackName(context.PlayerName, "Player");
+            var opponentName = FallbackName(context.OpponentName, "Opponent");
 
             var sb = new StringBuilder();
 
             sb.AppendLine("CONVERSATION HISTORY");
-            AppendConversationHistory(sb, conversationHistory, playerName);
+            AppendConversationHistory(sb, context.ConversationHistory, playerName);
 
             sb.AppendLine();
             sb.AppendLine("OPPONENT'S LAST MESSAGE");
-            sb.AppendLine($"\"{opponentLastMessage}\"");
+            sb.AppendLine($"\"{context.OpponentLastMessage}\"");
 
             sb.AppendLine();
             sb.AppendLine("GAME STATE");
-            sb.AppendLine($"- Turn: {currentTurn}");
+            sb.AppendLine($"- Turn: {context.CurrentTurn}");
 
             // Interest state label
-            string interestLabel = currentInterest >= 21 ? "Almost There \U0001f525"
-                : currentInterest >= 16 ? "Very Into It \U0001f60d (player has advantage)"
-                : currentInterest >= 10 ? "Interested \U0001f60a"
-                : currentInterest >= 5  ? "Lukewarm \U0001f914"
-                : currentInterest >= 1  ? "Bored \U0001f610 (player has disadvantage)"
+            string interestLabel = context.CurrentInterest >= 21 ? "Almost There \U0001f525"
+                : context.CurrentInterest >= 16 ? "Very Into It \U0001f60d (player has advantage)"
+                : context.CurrentInterest >= 10 ? "Interested \U0001f60a"
+                : context.CurrentInterest >= 5  ? "Lukewarm \U0001f914"
+                : context.CurrentInterest >= 1  ? "Bored \U0001f610 (player has disadvantage)"
                 : "Unmatched \U0001f480";
-            sb.AppendLine($"- Interest: {currentInterest}/25 — {interestLabel}");
+            sb.AppendLine($"- Interest: {context.CurrentInterest}/25 — {interestLabel}");
 
-            if (activeTraps.Length == 0)
+            if (context.ActiveTraps.Count == 0)
             {
                 sb.AppendLine("- Active traps: none");
             }
             else
             {
-                sb.AppendLine($"- Active traps: {string.Join(", ", activeTraps)}");
+                sb.AppendLine($"- Active traps: {string.Join(", ", context.ActiveTraps)}");
             }
 
-            if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+            if (context.ActiveTrapInstructions != null && context.ActiveTrapInstructions.Length > 0)
             {
                 sb.AppendLine("ACTIVE TRAP INSTRUCTIONS (taint ALL generated options regardless of stat):");
-                foreach (var instruction in activeTrapInstructions)
+                foreach (var instruction in context.ActiveTrapInstructions)
                     sb.AppendLine(instruction);
             }
 
-            if (horninessLevel >= 6)
+            if (context.HorninessLevel >= 6)
             {
-                sb.AppendLine($"- Horniness level: {horninessLevel}/10 (Rizz options are more prominent, slightly too forward)");
+                sb.AppendLine($"- Horniness level: {context.HorninessLevel}/10 (Rizz options are more prominent, slightly too forward)");
             }
-            if (requiresRizzOption)
+            if (context.RequiresRizzOption)
             {
                 sb.AppendLine("- \U0001f525 REQUIRED: Include at least one Rizz option — Horniness is forcing it into the lineup.");
             }
 
-            string dialogueTaint = BuildShadowTaintBlock(playerShadowThresholds);
+            string dialogueTaint = BuildShadowTaintBlock(context.ShadowThresholds);
             if (!string.IsNullOrEmpty(dialogueTaint))
             {
                 sb.AppendLine();
@@ -91,14 +78,14 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine(dialogueTaint);
             }
 
-            if (callbackOpportunities != null && callbackOpportunities.Count > 0)
+            if (context.CallbackOpportunities != null && context.CallbackOpportunities.Count > 0)
             {
                 sb.AppendLine();
                 sb.AppendLine("CALLBACK OPPORTUNITIES");
                 sb.AppendLine("Reference these topics naturally in 1-2 options to earn hidden roll bonuses:");
-                foreach (var cb in callbackOpportunities)
+                foreach (var cb in context.CallbackOpportunities)
                 {
-                    int turnsAgo = currentTurn - cb.TurnIntroduced;
+                    int turnsAgo = context.CurrentTurn - cb.TurnIntroduced;
                     string bonus = turnsAgo >= 4 ? "+2 hidden" : turnsAgo >= 2 ? "+1 hidden" : "+3 hidden (opener)";
                     sb.AppendLine($"- \"{cb.TopicKey}\" (introduced T{cb.TurnIntroduced}, {turnsAgo} turns ago, {bonus})");
                 }
@@ -114,27 +101,19 @@ namespace Pinder.LlmAdapters
         /// <summary>
         /// Builds the user-message content for DeliverMessageAsync (§3.3 success / §3.4 failure).
         /// </summary>
-        public static string BuildDeliveryPrompt(
-            IReadOnlyList<(string Sender, string Text)> conversationHistory,
-            DialogueOption chosenOption,
-            FailureTier outcome,
-            int beatDcBy,
-            string[]? activeTrapInstructions,
-            string playerName,
-            string opponentName,
-            Dictionary<ShadowStatType, int>? playerShadowThresholds = null)
+        public static string BuildDeliveryPrompt(DeliveryContext context)
         {
-            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
-            if (chosenOption == null) throw new ArgumentNullException(nameof(chosenOption));
-            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
-            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var playerName = FallbackName(context.PlayerName, "Player");
+            var opponentName = FallbackName(context.OpponentName, "Opponent");
 
             var sb = new StringBuilder();
 
             sb.AppendLine("CONVERSATION HISTORY");
-            AppendConversationHistory(sb, conversationHistory, playerName);
+            AppendConversationHistory(sb, context.ConversationHistory, playerName);
 
-            string deliveryTaint = BuildShadowTaintBlock(playerShadowThresholds);
+            string deliveryTaint = BuildShadowTaintBlock(context.ShadowThresholds);
             if (!string.IsNullOrEmpty(deliveryTaint))
             {
                 sb.AppendLine();
@@ -144,12 +123,12 @@ namespace Pinder.LlmAdapters
 
             sb.AppendLine();
 
-            if (outcome == FailureTier.None)
+            if (context.Outcome == FailureTier.None)
             {
                 // Success path (§3.3)
-                sb.AppendLine($"The player chose option: \"{chosenOption.IntendedText}\"");
-                sb.AppendLine($"Stat used: {chosenOption.Stat.ToString().ToUpperInvariant()}");
-                sb.AppendLine($"They rolled SUCCESS — beat DC by {beatDcBy}.");
+                sb.AppendLine($"The player chose option: \"{context.ChosenOption.IntendedText}\"");
+                sb.AppendLine($"Stat used: {context.ChosenOption.Stat.ToString().ToUpperInvariant()}");
+                sb.AppendLine($"They rolled SUCCESS — beat DC by {context.BeatDcBy}.");
                 sb.AppendLine();
                 sb.Append(PromptTemplates.SuccessDeliveryInstruction
                     .Replace("{player_name}", playerName));
@@ -157,28 +136,28 @@ namespace Pinder.LlmAdapters
             else
             {
                 // Failure path (§3.4)
-                int missMargin = Math.Abs(beatDcBy);
-                string tierName = GetFailureTierName(outcome);
-                string tierInstruction = GetTierInstruction(outcome);
+                int missMargin = Math.Abs(context.BeatDcBy);
+                string tierName = GetFailureTierName(context.Outcome);
+                string tierInstruction = GetTierInstruction(context.Outcome);
 
-                sb.AppendLine($"The player chose option: \"{chosenOption.IntendedText}\"");
-                sb.AppendLine($"Stat used: {chosenOption.Stat.ToString().ToUpperInvariant()}");
+                sb.AppendLine($"The player chose option: \"{context.ChosenOption.IntendedText}\"");
+                sb.AppendLine($"Stat used: {context.ChosenOption.Stat.ToString().ToUpperInvariant()}");
                 sb.AppendLine($"They rolled FAILED — missed DC by {missMargin}.");
                 sb.AppendLine($"Failure tier: {tierName}");
                 sb.AppendLine();
 
                 string failureText = PromptTemplates.FailureDeliveryInstruction
                     .Replace("{player_name}", playerName)
-                    .Replace("{intended_message}", chosenOption.IntendedText)
-                    .Replace("{stat}", chosenOption.Stat.ToString().ToUpperInvariant())
+                    .Replace("{intended_message}", context.ChosenOption.IntendedText)
+                    .Replace("{stat}", context.ChosenOption.Stat.ToString().ToUpperInvariant())
                     .Replace("{miss_margin}", missMargin.ToString())
                     .Replace("{tier}", tierName)
                     .Replace("{tier_instruction}", tierInstruction);
 
-                if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+                if (context.ActiveTrapInstructions != null && context.ActiveTrapInstructions.Length > 0)
                 {
                     failureText = failureText.Replace("{active_trap_llm_instructions}",
-                        "Active trap instructions:\n" + string.Join("\n", activeTrapInstructions));
+                        "Active trap instructions:\n" + string.Join("\n", context.ActiveTrapInstructions));
                 }
                 else
                 {
@@ -194,65 +173,56 @@ namespace Pinder.LlmAdapters
         /// <summary>
         /// Builds the user-message content for GetOpponentResponseAsync (§3.5).
         /// </summary>
-        public static string BuildOpponentPrompt(
-            IReadOnlyList<(string Sender, string Text)> conversationHistory,
-            string playerDeliveredMessage,
-            int interestBefore,
-            int interestAfter,
-            double responseDelayMinutes,
-            string[]? activeTrapInstructions,
-            string playerName,
-            string opponentName,
-            Dictionary<ShadowStatType, int>? opponentShadowThresholds = null)
+        public static string BuildOpponentPrompt(OpponentContext context)
         {
-            if (conversationHistory == null) throw new ArgumentNullException(nameof(conversationHistory));
-            if (playerDeliveredMessage == null) throw new ArgumentNullException(nameof(playerDeliveredMessage));
-            if (string.IsNullOrEmpty(playerName)) throw new ArgumentNullException(nameof(playerName));
-            if (string.IsNullOrEmpty(opponentName)) throw new ArgumentNullException(nameof(opponentName));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var playerName = FallbackName(context.PlayerName, "Player");
+            var opponentName = FallbackName(context.OpponentName, "Opponent");
 
             var sb = new StringBuilder();
 
             sb.AppendLine("CONVERSATION HISTORY");
-            AppendConversationHistory(sb, conversationHistory, playerName);
+            AppendConversationHistory(sb, context.ConversationHistory, playerName);
 
             sb.AppendLine();
             sb.AppendLine("PLAYER'S LAST MESSAGE");
-            sb.AppendLine($"\"{playerDeliveredMessage}\"");
+            sb.AppendLine($"\"{context.PlayerDeliveredMessage}\"");
 
             sb.AppendLine();
             sb.AppendLine("INTEREST CHANGE");
-            int delta = interestAfter - interestBefore;
+            int delta = context.InterestAfter - context.InterestBefore;
             string deltaStr = delta >= 0 ? $"+{delta}" : delta.ToString();
-            sb.AppendLine($"Interest moved from {interestBefore} to {interestAfter} ({deltaStr}).");
-            sb.AppendLine($"Current Interest: {interestAfter}/25");
+            sb.AppendLine($"Interest moved from {context.InterestBefore} to {context.InterestAfter} ({deltaStr}).");
+            sb.AppendLine($"Current Interest: {context.InterestAfter}/25");
 
             sb.AppendLine();
             sb.AppendLine("RESPONSE TIMING");
-            if (responseDelayMinutes < 1.0)
+            if (context.ResponseDelayMinutes < 1.0)
             {
                 sb.AppendLine("Your reply arrives in less than 1 minute.");
             }
             else
             {
-                sb.AppendLine($"Your reply arrives in approximately {responseDelayMinutes:F1} minutes.");
+                sb.AppendLine($"Your reply arrives in approximately {context.ResponseDelayMinutes:F1} minutes.");
             }
             sb.AppendLine("Write in a register consistent with that timing — a 3-minute reply feels different from a 3-hour reply.");
 
             sb.AppendLine();
             sb.AppendLine("CURRENT INTEREST STATE");
-            sb.AppendLine(GetInterestBehaviourBlock(interestAfter));
+            sb.AppendLine(GetInterestBehaviourBlock(context.InterestAfter));
 
-            if (activeTrapInstructions != null && activeTrapInstructions.Length > 0)
+            if (context.ActiveTrapInstructions != null && context.ActiveTrapInstructions.Length > 0)
             {
                 sb.AppendLine();
                 sb.AppendLine("ACTIVE TRAP INSTRUCTIONS");
-                foreach (var instruction in activeTrapInstructions)
+                foreach (var instruction in context.ActiveTrapInstructions)
                 {
                     sb.AppendLine(instruction);
                 }
             }
 
-            string opponentTaint = BuildShadowTaintBlock(opponentShadowThresholds);
+            string opponentTaint = BuildShadowTaintBlock(context.ShadowThresholds);
             if (!string.IsNullOrEmpty(opponentTaint))
             {
                 sb.AppendLine();
@@ -389,6 +359,11 @@ namespace Pinder.LlmAdapters
                 default:
                     return "A failure has occurred. Degrade the message accordingly.";
             }
+        }
+
+        private static string FallbackName(string name, string fallback)
+        {
+            return string.IsNullOrEmpty(name) ? fallback : name;
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Pinder.Core.Conversation;
 using Pinder.Core.Rolls;
@@ -15,6 +16,29 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
     /// </summary>
     public class Issue241_LegendaryFailVoiceTests
     {
+        private static DeliveryContext MakeDeliveryContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            DialogueOption chosenOption = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 0,
+            string[] activeTrapInstructions = null,
+            string playerName = "P",
+            string opponentName = "O")
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: "",
+                chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
         // ==========================================================
         // AC1: FailureDeliveryInstruction explicitly identifies player role
         // ==========================================================
@@ -116,11 +140,10 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
                 hasTellBonus: false, hasWeaknessWindow: false);
 
             string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
-                history, option, FailureTier.Legendary, beatDcBy: 0,
-                activeTrapInstructions: null,
-                playerName: "Sable", opponentName: "Brick");
+                MakeDeliveryContext(conversationHistory: history, chosenOption: option,
+                    outcome: FailureTier.Legendary, beatDcBy: 0,
+                    playerName: "Sable", opponentName: "Brick"));
 
-            // Player identity must be substituted (not raw token)
             Assert.Contains("You are writing as Sable", prompt);
             Assert.Contains("The failure corrupts what Sable says", prompt);
             Assert.DoesNotContain("{player_name}", prompt);
@@ -140,9 +163,9 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
                 hasTellBonus: false, hasWeaknessWindow: false);
 
             string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
-                history, option, FailureTier.None, beatDcBy: 5,
-                activeTrapInstructions: null,
-                playerName: "Sable", opponentName: "Brick");
+                MakeDeliveryContext(conversationHistory: history, chosenOption: option,
+                    outcome: FailureTier.None, beatDcBy: 5,
+                    playerName: "Sable", opponentName: "Brick"));
 
             Assert.Contains("Write as Sable", prompt);
             Assert.DoesNotContain("{player_name}", prompt);
@@ -151,16 +174,14 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         [Fact]
         public void AC4_Catastrophe_fail_delivery_prompt_contains_player_identity()
         {
-            var history = new List<(string, string)>();
             var option = new DialogueOption(
                 StatType.Honesty, "I think we could be great",
                 callbackTurnNumber: null, comboName: null,
                 hasTellBonus: false, hasWeaknessWindow: false);
 
             string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
-                history, option, FailureTier.Catastrophe, beatDcBy: 0,
-                activeTrapInstructions: null,
-                playerName: "Blaze", opponentName: "Jade");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Catastrophe,
+                    playerName: "Blaze", opponentName: "Jade"));
 
             Assert.Contains("You are writing as Blaze", prompt);
             Assert.Contains("Do NOT write as the opponent", prompt);
@@ -169,16 +190,15 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         [Fact]
         public void AC4_Failure_prompt_with_active_traps_still_has_player_identity()
         {
-            var history = new List<(string, string)>();
             var option = new DialogueOption(
                 StatType.Wit, "clever joke",
                 callbackTurnNumber: null, comboName: null,
                 hasTellBonus: false, hasWeaknessWindow: false);
 
             string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(
-                history, option, FailureTier.TropeTrap, beatDcBy: 0,
-                activeTrapInstructions: new[] { "Overthinking trap active" },
-                playerName: "Sable", opponentName: "Brick");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.TropeTrap,
+                    activeTrapInstructions: new[] { "Overthinking trap active" },
+                    playerName: "Sable", opponentName: "Brick"));
 
             Assert.Contains("You are writing as Sable", prompt);
             Assert.Contains("Overthinking trap active", prompt);

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
 using Pinder.LlmAdapters;
 using Xunit;
 
@@ -7,8 +9,36 @@ namespace Pinder.LlmAdapters.Tests
 {
     public class SessionDocumentBuilderPromptTests
     {
-        private static readonly List<(string Sender, string Text)> EmptyHistory =
-            new List<(string, string)>();
+        private static DialogueContext MakeDialogueContext(
+            List<CallbackOpportunity> callbackOpportunities = null,
+            string[] activeTrapInstructions = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false,
+            int currentInterest = 10,
+            int currentTurn = 3,
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            string opponentLastMessage = "hey",
+            string[] activeTraps = null,
+            string playerName = "Player",
+            string opponentName = "Opponent",
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new DialogueContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? Array.Empty<(string, string)>(),
+                opponentLastMessage: opponentLastMessage,
+                activeTraps: activeTraps ?? Array.Empty<string>(),
+                currentInterest: currentInterest,
+                shadowThresholds: shadowThresholds,
+                callbackOpportunities: callbackOpportunities,
+                horninessLevel: horninessLevel,
+                requiresRizzOption: requiresRizzOption,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                currentTurn: currentTurn);
+        }
 
         private static string BuildMinimal(
             List<CallbackOpportunity> callbackOpportunities = null,
@@ -19,17 +49,13 @@ namespace Pinder.LlmAdapters.Tests
             int currentTurn = 3)
         {
             return SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                conversationHistory: EmptyHistory,
-                opponentLastMessage: "hey",
-                activeTraps: new string[0],
-                currentInterest: currentInterest,
-                currentTurn: currentTurn,
-                playerName: "Player",
-                opponentName: "Opponent",
-                callbackOpportunities: callbackOpportunities,
-                activeTrapInstructions: activeTrapInstructions,
-                horninessLevel: horninessLevel,
-                requiresRizzOption: requiresRizzOption);
+                MakeDialogueContext(
+                    callbackOpportunities: callbackOpportunities,
+                    activeTrapInstructions: activeTrapInstructions,
+                    horninessLevel: horninessLevel,
+                    requiresRizzOption: requiresRizzOption,
+                    currentInterest: currentInterest,
+                    currentTurn: currentTurn));
         }
 
         // ── Callback Opportunities ──

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
@@ -16,28 +16,98 @@ namespace Pinder.LlmAdapters.Tests
     /// </summary>
     public class SessionDocumentBuilderSpecTests
     {
+        // ── Helpers ──
+
+        private static DialogueContext MakeDialogueContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            string opponentLastMessage = "",
+            string[] activeTraps = null,
+            int currentInterest = 10,
+            int currentTurn = 1,
+            string playerName = "P",
+            string opponentName = "O")
+        {
+            return new DialogueContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: opponentLastMessage,
+                activeTraps: activeTraps ?? Array.Empty<string>(),
+                currentInterest: currentInterest,
+                playerName: playerName,
+                opponentName: opponentName,
+                currentTurn: currentTurn);
+        }
+
+        private static DeliveryContext MakeDeliveryContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            DialogueOption chosenOption = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 0,
+            string[] activeTrapInstructions = null,
+            string playerName = "P",
+            string opponentName = "O",
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: "",
+                chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
+        private static OpponentContext MakeOpponentContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            string playerDeliveredMessage = "Hey",
+            int interestBefore = 10,
+            int interestAfter = 10,
+            double responseDelayMinutes = 1.0,
+            string[] activeTrapInstructions = null,
+            string playerName = "P",
+            string opponentName = "O",
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new OpponentContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: interestAfter,
+                playerDeliveredMessage: playerDeliveredMessage,
+                interestBefore: interestBefore,
+                interestAfter: interestAfter,
+                responseDelayMinutes: responseDelayMinutes,
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
         // ═══════════════════════════════════════════════════════════════
         // AC2: Conversation History Formatting
         // ═══════════════════════════════════════════════════════════════
 
-        // What: AC2.4 — Empty history produces exactly [CONVERSATION_START]\n[CURRENT_TURN]
-        // Mutation: Would catch if implementation omits [CONVERSATION_START] or [CURRENT_TURN] markers
         [Fact]
         public void BuildDialogueOptionsPrompt_EmptyHistory_NoTurnMarkersBetweenStartAndCurrent()
         {
-            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0], 10, 1, "P", "O");
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
 
             int startEnd = result.IndexOf("[CONVERSATION_START]") + "[CONVERSATION_START]".Length;
             int currentStart = result.IndexOf("[CURRENT_TURN]");
             string between = result.Substring(startEnd, currentStart - startEnd);
 
-            // No [Tn markers should appear between start and current
             Assert.DoesNotContain("[T", between);
         }
 
-        // What: AC2.2 — Turn numbering increments every 2 entries (pair-based)
-        // Mutation: Would catch if turn = i + 1 (per-entry) instead of (i / 2) + 1 (per-pair)
         [Fact]
         public void BuildDialogueOptionsPrompt_FourEntries_TurnNumbersIncrementByPair()
         {
@@ -50,20 +120,17 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "msg3", new string[0], 10, 3, "ALICE", "BOB");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "msg3",
+                    currentTurn: 3, playerName: "ALICE", opponentName: "BOB"));
 
-            // Indices 0,1 = T1; indices 2,3 = T2
             Assert.Contains("[T1|PLAYER|ALICE] \"msg0\"", result);
             Assert.Contains("[T1|OPPONENT|BOB] \"msg1\"", result);
             Assert.Contains("[T2|PLAYER|ALICE] \"msg2\"", result);
             Assert.Contains("[T2|OPPONENT|BOB] \"msg3\"", result);
-            // Should NOT have T3 or T4
             Assert.DoesNotContain("[T3|", result);
             Assert.DoesNotContain("[T4|", result);
         }
 
-        // What: AC2.5 — History is NEVER truncated, even for 20+ turns
-        // Mutation: Would catch if a sliding window or max-history limit is applied
         [Fact]
         public void BuildDialogueOptionsPrompt_TwentyTurnHistory_AllTurnsPresent()
         {
@@ -75,7 +142,8 @@ namespace Pinder.LlmAdapters.Tests
             }
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "msg39", new string[0], 10, 21, "PLAYER_X", "OPP_Y");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "msg39",
+                    currentTurn: 21, playerName: "PLAYER_X", opponentName: "OPP_Y"));
 
             for (int turn = 1; turn <= 20; turn++)
             {
@@ -84,22 +152,18 @@ namespace Pinder.LlmAdapters.Tests
             }
         }
 
-        // What: Edge case — odd number of entries (lone player message at end)
-        // Mutation: Would catch if odd-entry handling crashes or skips the lone entry
         [Fact]
         public void BuildDialogueOptionsPrompt_SingleEntry_FormatsCorrectly()
         {
             var history = new List<(string, string)> { ("GERALD", "Hello!") };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "", new string[0], 10, 1, "GERALD", "V");
+                MakeDialogueContext(conversationHistory: history, playerName: "GERALD", opponentName: "V"));
 
             Assert.Contains("[T1|PLAYER|GERALD] \"Hello!\"", result);
             Assert.Contains("[CURRENT_TURN]", result);
         }
 
-        // What: Edge case — messages containing double quotes
-        // Mutation: Would catch if quotes are escaped or stripped from message text
         [Fact]
         public void BuildDialogueOptionsPrompt_MessageWithDoubleQuotes_PreservedAsIs()
         {
@@ -110,13 +174,11 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Really?", new string[0], 10, 2, "P", "O");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Really?", currentTurn: 2));
 
             Assert.Contains("She said \"wow\" to me", result);
         }
 
-        // What: Edge case — empty message text
-        // Mutation: Would catch if empty strings are filtered out instead of included
         [Fact]
         public void BuildDialogueOptionsPrompt_EmptyMessageText_FormatsAsEmptyQuotes()
         {
@@ -127,13 +189,11 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "response", new string[0], 10, 2, "P", "O");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "response", currentTurn: 2));
 
             Assert.Contains("[T1|PLAYER|P] \"\"", result);
         }
 
-        // What: Edge case — names with spaces
-        // Mutation: Would catch if name is sanitized or truncated at space
         [Fact]
         public void BuildDialogueOptionsPrompt_NamesWithSpaces_UsedAsIs()
         {
@@ -144,32 +204,30 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Hi", new string[0], 10, 2, "Big Gerald", "Lady V");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Hi",
+                    currentTurn: 2, playerName: "Big Gerald", opponentName: "Lady V"));
 
             Assert.Contains("[T1|PLAYER|Big Gerald] \"Hey\"", result);
             Assert.Contains("[T1|OPPONENT|Lady V] \"Hi\"", result);
         }
 
-        // What: AC2.2 — Role determination uses exact match on playerName
-        // Mutation: Would catch if role determination is case-insensitive
         [Fact]
         public void BuildDialogueOptionsPrompt_RoleDetermination_CaseSensitive()
         {
             var history = new List<(string, string)>
             {
                 ("Gerald", "Hey"),
-                ("gerald", "Hi")  // lowercase — should be OPPONENT since playerName is "Gerald"
+                ("gerald", "Hi")
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Hi", new string[0], 10, 2, "Gerald", "gerald");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Hi",
+                    currentTurn: 2, playerName: "Gerald", opponentName: "gerald"));
 
             Assert.Contains("[T1|PLAYER|Gerald] \"Hey\"", result);
             Assert.Contains("[T1|OPPONENT|gerald] \"Hi\"", result);
         }
 
-        // What: AC2.6 — BuildOpponentPrompt history excludes current player message
-        // Mutation: Would catch if opponent prompt includes all history entries including current
         [Fact]
         public void BuildOpponentPrompt_HistoryExcludesCurrentPlayerMessage()
         {
@@ -179,14 +237,12 @@ namespace Pinder.LlmAdapters.Tests
                 ("O", "Turn1Opp")
             };
 
-            // playerDeliveredMessage is the current turn's message, supplied separately
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                history, "Turn2Player", 10, 12, 3.0, null, "P", "O");
+                MakeOpponentContext(conversationHistory: history, playerDeliveredMessage: "Turn2Player",
+                    interestBefore: 10, interestAfter: 12, responseDelayMinutes: 3.0));
 
-            // History section should have T1 entries
             Assert.Contains("[T1|PLAYER|P] \"Turn1Player\"", result);
             Assert.Contains("[T1|OPPONENT|O] \"Turn1Opp\"", result);
-            // The current player message appears in PLAYER'S LAST MESSAGE section, not history
             Assert.Contains("PLAYER'S LAST MESSAGE", result);
             Assert.Contains("\"Turn2Player\"", result);
         }
@@ -195,64 +251,50 @@ namespace Pinder.LlmAdapters.Tests
         // AC1: SessionDocumentBuilder — All 4 builder methods
         // ═══════════════════════════════════════════════════════════════
 
-        // What: AC1 — BuildDialogueOptionsPrompt contains CONVERSATION HISTORY header
-        // Mutation: Would catch if section header is missing or misspelled
         [Fact]
         public void BuildDialogueOptionsPrompt_ContainsConversationHistoryHeader()
         {
-            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0], 10, 1, "P", "O");
-
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
             Assert.Contains("CONVERSATION HISTORY", result);
         }
 
-        // What: AC1 — BuildDialogueOptionsPrompt includes OPPONENT'S LAST MESSAGE section
-        // Mutation: Would catch if opponent's last message section is omitted
         [Fact]
         public void BuildDialogueOptionsPrompt_ContainsOpponentLastMessage()
         {
+            var history = new List<(string, string)>
+            {
+                ("P", "Hey"),
+                ("O", "Whatever")
+            };
+
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>
-                {
-                    ("P", "Hey"),
-                    ("O", "Whatever")
-                },
-                "Whatever", new string[0], 10, 2, "P", "O");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Whatever", currentTurn: 2));
 
             Assert.Contains("OPPONENT'S LAST MESSAGE", result);
             Assert.Contains("\"Whatever\"", result);
         }
 
-        // What: AC1 — BuildDialogueOptionsPrompt includes GAME STATE section
-        // Mutation: Would catch if GAME STATE section is omitted entirely
         [Fact]
         public void BuildDialogueOptionsPrompt_ContainsGameStateSection()
         {
-            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0], 10, 1, "P", "O");
-
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
             Assert.Contains("GAME STATE", result);
         }
 
-        // What: AC1 — Multiple active traps are comma-joined
-        // Mutation: Would catch if traps are newline-separated or omitted
         [Fact]
         public void BuildDialogueOptionsPrompt_MultipleTraps_CommaSeparated()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new[] { "Cringe", "Spiral", "Overexplain" },
-                10, 1, "P", "O");
+                MakeDialogueContext(activeTraps: new[] { "Cringe", "Spiral", "Overexplain" }));
 
             Assert.Contains("Active traps: Cringe, Spiral, Overexplain", result);
         }
 
-        // What: AC1 — BuildDialogueOptionsPrompt YOUR TASK includes player name
-        // Mutation: Would catch if player name placeholder is not replaced
         [Fact]
         public void BuildDialogueOptionsPrompt_TaskIncludesPlayerName()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0], 10, 1, "MEGA_CHAD", "O");
+                MakeDialogueContext(playerName: "MEGA_CHAD"));
 
             Assert.Contains("MEGA_CHAD", result);
             Assert.Contains("Generate exactly 4 dialogue options", result);
@@ -262,51 +304,43 @@ namespace Pinder.LlmAdapters.Tests
         // BuildDeliveryPrompt — Success path
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec §3.3 — Success delivery includes stat name in uppercase
-        // Mutation: Would catch if stat name is lowercase or missing
         [Fact]
         public void BuildDeliveryPrompt_Success_IncludesStatNameUppercase()
         {
             var option = new DialogueOption(StatType.Charm, "Smooth line");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 7, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, beatDcBy: 7));
 
             Assert.Contains("Stat used: CHARM", result);
         }
 
-        // What: Spec §3.3 — Success shows positive beat-DC margin
-        // Mutation: Would catch if beatDcBy is shown as absolute value or negated
         [Fact]
         public void BuildDeliveryPrompt_Success_ShowsBeatDcMargin()
         {
             var option = new DialogueOption(StatType.Honesty, "Truth bomb");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 9, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, beatDcBy: 9));
 
             Assert.Contains("beat DC by 9", result);
         }
 
-        // What: Spec — FailureTier.None triggers SuccessDeliveryInstruction, not failure
-        // Mutation: Would catch if success path uses failure template
         [Fact]
         public void BuildDeliveryPrompt_SuccessPath_DoesNotContainFailureTier()
         {
             var option = new DialogueOption(StatType.Wit, "Clever quip");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 3, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, beatDcBy: 3));
 
             Assert.Contains("SUCCESS", result);
             Assert.DoesNotContain("Failure tier:", result);
         }
 
-        // What: Spec — Success delivery includes "Output only the message text"
-        // Mutation: Would catch if output instruction is missing
         [Fact]
         public void BuildDeliveryPrompt_Success_ContainsOutputInstruction()
         {
             var option = new DialogueOption(StatType.Rizz, "Flirty msg");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 2, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, beatDcBy: 2));
 
             Assert.Contains("Output only the message text", result);
         }
@@ -315,8 +349,6 @@ namespace Pinder.LlmAdapters.Tests
         // BuildDeliveryPrompt — Failure path
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec §3.4 — Each failure tier is labeled correctly
-        // Mutation: Would catch if tier name mapping is wrong (e.g., Fumble shows as Misfire)
         [Theory]
         [InlineData(FailureTier.Fumble, "FUMBLE")]
         [InlineData(FailureTier.Misfire, "MISFIRE")]
@@ -327,70 +359,60 @@ namespace Pinder.LlmAdapters.Tests
         {
             var option = new DialogueOption(StatType.Charm, "Attempt");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, tier, -5, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, outcome: tier, beatDcBy: -5));
 
             Assert.Contains(expectedLabel, result);
         }
 
-        // What: Spec §3.4 — Failure includes "corrupt the CONTENT, not the delivery" principle
-        // Mutation: Would catch if failure principle text is omitted
         [Fact]
         public void BuildDeliveryPrompt_Failure_ContainsCorruptContentPrinciple()
         {
             var option = new DialogueOption(StatType.Chaos, "Wild swing");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.Catastrophe, -12, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Catastrophe, beatDcBy: -12));
 
             Assert.Contains("corrupt the CONTENT", result);
         }
 
-        // What: Spec — Failure shows "FAILED" and "missed DC by" with positive margin
-        // Mutation: Would catch if negative beatDcBy is not converted to positive miss margin
         [Fact]
         public void BuildDeliveryPrompt_Failure_ShowsMissedDcByPositiveMargin()
         {
             var option = new DialogueOption(StatType.SelfAwareness, "Meta comment");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.Fumble, -2, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Fumble, beatDcBy: -2));
 
             Assert.Contains("FAILED", result);
             Assert.Contains("missed DC by 2", result);
         }
 
-        // What: Spec — Active trap instructions appear when provided for failures
-        // Mutation: Would catch if trap instructions are ignored in failure path
         [Fact]
         public void BuildDeliveryPrompt_WithTrapInstructions_IncludesTrapSection()
         {
             var option = new DialogueOption(StatType.Charm, "Line");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.TropeTrap, -7,
-                new[] { "Trap instruction A", "Trap instruction B" }, "P", "O");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.TropeTrap, beatDcBy: -7,
+                    activeTrapInstructions: new[] { "Trap instruction A", "Trap instruction B" }));
 
             Assert.Contains("Trap instruction A", result);
             Assert.Contains("Trap instruction B", result);
         }
 
-        // What: Spec — Null trap instructions omits trap section
-        // Mutation: Would catch if null trap instructions causes crash or empty section
         [Fact]
         public void BuildDeliveryPrompt_NullTrapInstructions_NoTrapSection()
         {
             var option = new DialogueOption(StatType.Wit, "Joke");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.Misfire, -3, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Misfire, beatDcBy: -3));
 
             Assert.DoesNotContain("Active trap instructions:", result);
         }
 
-        // What: Spec — Chosen option text appears in output
-        // Mutation: Would catch if option text is not included
         [Fact]
         public void BuildDeliveryPrompt_IncludesChosenOptionText()
         {
             var option = new DialogueOption(StatType.Honesty, "I really like your vibe");
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 5, null, "P", "O");
+                MakeDeliveryContext(chosenOption: option, beatDcBy: 5));
 
             Assert.Contains("I really like your vibe", result);
         }
@@ -399,136 +421,111 @@ namespace Pinder.LlmAdapters.Tests
         // BuildOpponentPrompt
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec — Interest change shows delta with sign
-        // Mutation: Would catch if delta calculation is wrong or sign is missing
         [Fact]
         public void BuildOpponentPrompt_PositiveDelta_ShowsPlusSign()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 8, 11, 2.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 8, interestAfter: 11, responseDelayMinutes: 2.0));
 
             Assert.Contains("Interest moved from 8 to 11 (+3)", result);
         }
 
-        // What: Spec — Zero interest delta formatted correctly
-        // Mutation: Would catch if zero delta is omitted or shows wrong sign
         [Fact]
         public void BuildOpponentPrompt_ZeroDelta_ShowsPlusZero()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 10, 2.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 10, responseDelayMinutes: 2.0));
 
             Assert.Contains("Interest moved from 10 to 10 (+0)", result);
         }
 
-        // What: Spec — Current Interest shows value out of 25
-        // Mutation: Would catch if max interest is wrong or format is different
         [Fact]
         public void BuildOpponentPrompt_ShowsCurrentInterestOutOf25()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hi", 10, 15, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 15));
 
             Assert.Contains("Current Interest: 15/25", result);
         }
 
-        // What: Spec — Response timing for delay >= 1 minute uses "approximately X.X minutes"
-        // Mutation: Would catch if delay format is wrong (integer instead of decimal)
         [Fact]
         public void BuildOpponentPrompt_NormalDelay_ShowsApproximateMinutes()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 10, 5.5, null, "P", "O");
+                MakeOpponentContext(responseDelayMinutes: 5.5));
 
             Assert.Contains("approximately 5.5 minutes", result);
         }
 
-        // What: Spec — Very small delay (< 1 minute) shows "less than 1 minute"
-        // Mutation: Would catch if small delay uses numeric format instead of special text
         [Fact]
         public void BuildOpponentPrompt_SubMinuteDelay_ShowsLessThanOneMinute()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 10, 0.3, null, "P", "O");
+                MakeOpponentContext(responseDelayMinutes: 0.3));
 
             Assert.Contains("less than 1 minute", result);
         }
 
-        // What: Spec — Interest behaviour block for range 21-25 (extremely interested)
-        // Mutation: Would catch if threshold boundaries are off-by-one
         [Fact]
         public void BuildOpponentPrompt_Interest21_ExtremelyInterested()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 20, 21, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 20, interestAfter: 21));
 
             Assert.Contains("extremely interested", result);
         }
 
-        // What: Spec — Interest behaviour block for range 13-16 (engaged)
-        // Mutation: Would catch if boundary at 13 is wrong
         [Fact]
         public void BuildOpponentPrompt_Interest13_Engaged()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 13, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 13));
 
             Assert.Contains("engaged", result);
         }
 
-        // What: Spec — Interest behaviour block for range 9-12 (lukewarm)
-        // Mutation: Would catch if boundary at 9 is wrong (e.g., <= 8 instead of >= 9)
         [Fact]
         public void BuildOpponentPrompt_Interest9_Lukewarm()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 9, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 9));
 
             Assert.Contains("lukewarm", result);
         }
 
-        // What: Spec — Interest behaviour block for range 5-8 (cooling)
-        // Mutation: Would catch if cooling range boundary is wrong
         [Fact]
         public void BuildOpponentPrompt_Interest5_Cooling()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 5, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 5));
 
             Assert.Contains("cooling", result);
         }
 
-        // What: Spec — Interest 0 triggers "lost all interest" / unmatching
-        // Mutation: Would catch if 0 maps to disengaged instead of unmatching
         [Fact]
         public void BuildOpponentPrompt_Interest0_Unmatching()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 2, 0, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 2, interestAfter: 0));
 
             Assert.Contains("lost all interest", result);
         }
 
-        // What: Spec — BuildOpponentPrompt includes [RESPONSE] and [SIGNALS] markers
-        // Mutation: Would catch if signal output format instructions are missing
         [Fact]
         public void BuildOpponentPrompt_ContainsSignalsInstruction()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 12, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 12));
 
             Assert.Contains("[RESPONSE]", result);
             Assert.Contains("[SIGNALS]", result);
         }
 
-        // What: Spec — Opponent prompt with trap instructions includes them
-        // Mutation: Would catch if activeTrapInstructions are ignored
         [Fact]
         public void BuildOpponentPrompt_WithTrapInstructions_IncludesThem()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 10, 1.0,
-                new[] { "Trap effect: cringe aura" }, "P", "O");
+                MakeOpponentContext(activeTrapInstructions: new[] { "Trap effect: cringe aura" }));
 
             Assert.Contains("Trap effect: cringe aura", result);
         }
@@ -537,8 +534,6 @@ namespace Pinder.LlmAdapters.Tests
         // BuildInterestChangeBeatPrompt
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec §3.8 — Prompt includes opponent name and interest values
-        // Mutation: Would catch if name or values are not interpolated
         [Fact]
         public void BuildInterestChangeBeatPrompt_IncludesNameAndValues()
         {
@@ -550,22 +545,16 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("16", result);
         }
 
-        // What: Spec §3.8 — Generic fallback for non-threshold-crossing changes
-        // Mutation: Would catch if generic fallback is missing or wrong condition
         [Fact]
         public void BuildInterestChangeBeatPrompt_GenericCase_DoesNotCrash()
         {
-            // Interest moved 10→13, crossed no major threshold
             var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
                 "OPP", 10, 13, InterestState.Interested);
 
-            // Should still produce a valid non-empty result
             Assert.False(string.IsNullOrWhiteSpace(result));
             Assert.Contains("OPP", result);
         }
 
-        // What: Spec §3.8 — "Output only the message text" instruction present
-        // Mutation: Would catch if output instruction is missing
         [Fact]
         public void BuildInterestChangeBeatPrompt_ContainsOutputInstruction()
         {
@@ -575,32 +564,24 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("Output only the message", result);
         }
 
-        // What: Spec — Crossed above 15 specifically uses "becoming more invested"
-        // Mutation: Would catch if above-15 threshold instruction uses wrong template
         [Fact]
         public void BuildInterestChangeBeatPrompt_CrossedAbove15FromBelow_ShowsInvested()
         {
-            // before=14 (<=15), after=17 (>15) → crossed above 15
             var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
                 "V", 14, 17, InterestState.VeryIntoIt);
 
             Assert.Contains("becoming more invested", result);
         }
 
-        // What: Spec — Crossed below 8 specifically uses "pulling back"
-        // Mutation: Would catch if below-8 threshold instruction uses wrong template
         [Fact]
         public void BuildInterestChangeBeatPrompt_CrossedBelow8FromAbove_ShowsPullingBack()
         {
-            // before=8 (>=8), after=6 (<8) → crossed below 8
             var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
                 "V", 8, 6, InterestState.Interested);
 
             Assert.Contains("pulling back", result);
         }
 
-        // What: Spec — DateSecured (25) suggests meeting up
-        // Mutation: Would catch if DateSecured doesn't trigger the meeting-up template
         [Fact]
         public void BuildInterestChangeBeatPrompt_DateSecured_SuggestsMeetUp()
         {
@@ -610,8 +591,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("meeting up", result);
         }
 
-        // What: Spec — Unmatched (0) triggers unmatching message
-        // Mutation: Would catch if Unmatched doesn't trigger the unmatching template
         [Fact]
         public void BuildInterestChangeBeatPrompt_Unmatched_ShowsUnmatching()
         {
@@ -625,8 +604,6 @@ namespace Pinder.LlmAdapters.Tests
         // AC3: PromptTemplates
         // ═══════════════════════════════════════════════════════════════
 
-        // What: AC3 — All 5 template fields are non-null, non-empty const strings
-        // Mutation: Would catch if any template is null or empty
         [Fact]
         public void PromptTemplates_AllFiveFieldsAreNonEmpty()
         {
@@ -637,8 +614,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestBeatInstruction));
         }
 
-        // What: AC3.1 — DialogueOptionsInstruction instructs 4 options with metadata tags
-        // Mutation: Would catch if tag format is wrong or count instruction is missing
         [Fact]
         public void PromptTemplates_DialogueOptions_ContainsMetadataTags()
         {
@@ -649,19 +624,14 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("[TELL_BONUS:", t);
         }
 
-        // What: AC3.2 — SuccessDeliveryInstruction includes success tier descriptions
-        // Mutation: Would catch if success tiers are missing from the template
         [Fact]
         public void PromptTemplates_SuccessDelivery_ContainsSuccessTierInfo()
         {
             var t = PromptTemplates.SuccessDeliveryInstruction;
-            // Should mention different success margins
             Assert.False(string.IsNullOrWhiteSpace(t));
             Assert.Contains("Output only the message text", t);
         }
 
-        // What: AC3.3 — FailureDeliveryInstruction includes all 5 tier names
-        // Mutation: Would catch if any failure tier instruction is missing
         [Fact]
         public void PromptTemplates_FailureDelivery_ContainsAllFiveTiers()
         {
@@ -673,16 +643,12 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("LEGENDARY", t);
         }
 
-        // What: AC3.3 — FailureDeliveryInstruction contains corruption principle
-        // Mutation: Would catch if corruption principle is omitted from template
         [Fact]
         public void PromptTemplates_FailureDelivery_ContainsCorruptionPrinciple()
         {
             Assert.Contains("corrupt the CONTENT", PromptTemplates.FailureDeliveryInstruction);
         }
 
-        // What: AC3.4 — OpponentResponseInstruction includes SIGNALS instruction
-        // Mutation: Would catch if SIGNALS format instruction is missing
         [Fact]
         public void PromptTemplates_OpponentResponse_ContainsSignalFormat()
         {
@@ -693,13 +659,10 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("WEAKNESS:", t);
         }
 
-        // What: AC3.4 — OpponentResponseInstruction mentions stat names for TELL/WEAKNESS
-        // Mutation: Would catch if stat names are missing from signal instructions
         [Fact]
         public void PromptTemplates_OpponentResponse_MentionsStatNames()
         {
             var t = PromptTemplates.OpponentResponseInstruction;
-            // Should reference stat types in signal instructions
             Assert.Contains("CHARM", t);
         }
 
@@ -707,8 +670,6 @@ namespace Pinder.LlmAdapters.Tests
         // AC4: CacheBlockBuilder
         // ═══════════════════════════════════════════════════════════════
 
-        // What: AC4.1 — BuildCachedSystemBlocks returns exactly 2 blocks
-        // Mutation: Would catch if wrong number of blocks returned
         [Fact]
         public void CacheBlockBuilder_TwoPrompts_ReturnsTwoBlocks()
         {
@@ -716,8 +677,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal(2, blocks.Length);
         }
 
-        // What: AC4.1 — First block contains player prompt, second contains opponent prompt
-        // Mutation: Would catch if prompts are swapped in order
         [Fact]
         public void CacheBlockBuilder_TwoPrompts_CorrectOrder()
         {
@@ -726,8 +685,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal("OPPONENT_PROMPT", blocks[1].Text);
         }
 
-        // What: AC4.1 — Both blocks have Type="text"
-        // Mutation: Would catch if Type is wrong
         [Fact]
         public void CacheBlockBuilder_TwoPrompts_BothTypeText()
         {
@@ -736,8 +693,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal("text", blocks[1].Type);
         }
 
-        // What: AC4.1 — Both blocks have CacheControl.Type="ephemeral"
-        // Mutation: Would catch if cache control is missing or wrong type
         [Fact]
         public void CacheBlockBuilder_TwoPrompts_BothCacheControlEphemeral()
         {
@@ -748,8 +703,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal("ephemeral", blocks[1].CacheControl!.Type);
         }
 
-        // What: AC4.2 — BuildOpponentOnlySystemBlocks returns exactly 1 block
-        // Mutation: Would catch if wrong number of blocks returned
         [Fact]
         public void CacheBlockBuilder_OpponentOnly_ReturnsSingleBlock()
         {
@@ -757,8 +710,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Single(blocks);
         }
 
-        // What: AC4.2 — Single block has correct content and cache control
-        // Mutation: Would catch if content or cache control is wrong
         [Fact]
         public void CacheBlockBuilder_OpponentOnly_HasCorrectContentAndCache()
         {
@@ -769,8 +720,6 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal("ephemeral", blocks[0].CacheControl!.Type);
         }
 
-        // What: Edge case — Empty prompts return blocks with empty text, no crash
-        // Mutation: Would catch if empty string validation throws
         [Fact]
         public void CacheBlockBuilder_EmptyPrompts_ReturnsBlocksWithEmptyText()
         {
@@ -785,99 +734,27 @@ namespace Pinder.LlmAdapters.Tests
         // Error Conditions
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec error table — null conversationHistory throws ArgumentNullException
-        // Mutation: Would catch if null check is missing
         [Fact]
-        public void BuildDialogueOptionsPrompt_NullHistory_ThrowsArgumentNull()
+        public void BuildDialogueOptionsPrompt_NullContext_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    null!, "", new string[0], 10, 1, "P", "O"));
+                SessionDocumentBuilder.BuildDialogueOptionsPrompt((DialogueContext)null!));
         }
 
-        // What: Spec error table — null playerName throws
-        // Mutation: Would catch if playerName null check is missing
         [Fact]
-        public void BuildDialogueOptionsPrompt_NullPlayerName_ThrowsArgumentNull()
+        public void BuildDeliveryPrompt_NullContext_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), "", new string[0], 10, 1, null!, "O"));
+                SessionDocumentBuilder.BuildDeliveryPrompt((DeliveryContext)null!));
         }
 
-        // What: Spec error table — empty playerName throws
-        // Mutation: Would catch if empty string check is missing (only null checked)
         [Fact]
-        public void BuildDialogueOptionsPrompt_EmptyPlayerName_Throws()
-        {
-            Assert.ThrowsAny<ArgumentException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), "", new string[0], 10, 1, "", "O"));
-        }
-
-        // What: Spec error table — null opponentName throws
-        // Mutation: Would catch if opponentName null check is missing
-        [Fact]
-        public void BuildDialogueOptionsPrompt_NullOpponentName_ThrowsArgumentNull()
+        public void BuildOpponentPrompt_NullContext_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), "", new string[0], 10, 1, "P", null!));
+                SessionDocumentBuilder.BuildOpponentPrompt((OpponentContext)null!));
         }
 
-        // What: Spec error table — null opponentLastMessage throws
-        // Mutation: Would catch if opponentLastMessage null check is missing
-        [Fact]
-        public void BuildDialogueOptionsPrompt_NullOpponentLastMessage_Throws()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), null!, new string[0], 10, 1, "P", "O"));
-        }
-
-        // What: Spec error table — null activeTraps throws
-        // Mutation: Would catch if activeTraps null check is missing
-        [Fact]
-        public void BuildDialogueOptionsPrompt_NullActiveTraps_Throws()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), "", null!, 10, 1, "P", "O"));
-        }
-
-        // What: Spec error table — null chosenOption throws
-        // Mutation: Would catch if chosenOption null check is missing
-        [Fact]
-        public void BuildDeliveryPrompt_NullOption_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDeliveryPrompt(
-                    new List<(string, string)>(), null!, FailureTier.None, 0, null, "P", "O"));
-        }
-
-        // What: Spec error table — null history in delivery prompt
-        // Mutation: Would catch if null check for history is missing in delivery method
-        [Fact]
-        public void BuildDeliveryPrompt_NullHistory_ThrowsArgumentNull()
-        {
-            var option = new DialogueOption(StatType.Charm, "text");
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDeliveryPrompt(
-                    null!, option, FailureTier.None, 0, null, "P", "O"));
-        }
-
-        // What: Spec error table — null playerDeliveredMessage throws
-        // Mutation: Would catch if message null check is missing
-        [Fact]
-        public void BuildOpponentPrompt_NullMessage_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildOpponentPrompt(
-                    new List<(string, string)>(), null!, 10, 10, 1.0, null, "P", "O"));
-        }
-
-        // What: Spec error table — null opponentName in InterestChangeBeat throws
-        // Mutation: Would catch if opponentName null check is missing
         [Fact]
         public void BuildInterestChangeBeatPrompt_NullOpponentName_ThrowsArgumentNull()
         {
@@ -886,8 +763,6 @@ namespace Pinder.LlmAdapters.Tests
                     null!, 10, 12, InterestState.Interested));
         }
 
-        // What: Spec error table — null prompts in CacheBlockBuilder throw
-        // Mutation: Would catch if null checks are missing
         [Fact]
         public void CacheBlockBuilder_NullPlayerPrompt_Throws()
         {
@@ -913,80 +788,66 @@ namespace Pinder.LlmAdapters.Tests
         // Interest behaviour boundary tests
         // ═══════════════════════════════════════════════════════════════
 
-        // What: Spec — Interest 16 falls in 13-16 range (engaged), NOT 17-20 (very interested)
-        // Mutation: Would catch off-by-one at boundary between engaged and very interested
         [Fact]
         public void BuildOpponentPrompt_Interest16_Engaged()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 16, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 16));
 
             Assert.Contains("engaged", result);
             Assert.DoesNotContain("very interested", result);
         }
 
-        // What: Spec — Interest 17 falls in 17-20 range (very interested)
-        // Mutation: Would catch off-by-one at boundary 17
         [Fact]
         public void BuildOpponentPrompt_Interest17_VeryInterested()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 17, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 17));
 
             Assert.Contains("very interested", result);
         }
 
-        // What: Spec — Interest 12 falls in 9-12 range (lukewarm)
-        // Mutation: Would catch off-by-one at boundary between lukewarm and engaged
         [Fact]
         public void BuildOpponentPrompt_Interest12_Lukewarm()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 12, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 12));
 
             Assert.Contains("lukewarm", result);
         }
 
-        // What: Spec — Interest 8 falls in 5-8 range (cooling)
-        // Mutation: Would catch off-by-one at boundary between cooling and lukewarm
         [Fact]
         public void BuildOpponentPrompt_Interest8_Cooling()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 8, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 8));
 
             Assert.Contains("cooling", result);
         }
 
-        // What: Spec — Interest 4 falls in 1-4 range (disengaged)
-        // Mutation: Would catch off-by-one at boundary between disengaged and cooling
         [Fact]
         public void BuildOpponentPrompt_Interest4_Disengaged()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 4, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 4));
 
             Assert.Contains("disengaged", result);
         }
 
-        // What: Spec — Interest 25 falls in 21-25 range (extremely interested)
-        // Mutation: Would catch if 25 is treated as special unmatched case
         [Fact]
         public void BuildOpponentPrompt_Interest25_ExtremelyInterested()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 25, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 25));
 
             Assert.Contains("extremely interested", result);
         }
 
-        // What: Spec — Interest 1 falls in 1-4 range (disengaged), NOT 0 (unmatching)
-        // Mutation: Would catch if 1 maps to unmatching
         [Fact]
         public void BuildOpponentPrompt_Interest1_Disengaged_NotUnmatching()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 2, 1, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 2, interestAfter: 1));
 
             Assert.Contains("disengaged", result);
             Assert.DoesNotContain("lost all interest", result);

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -12,19 +12,99 @@ namespace Pinder.LlmAdapters.Tests
 {
     public class SessionDocumentBuilderTests
     {
+        // ── Helpers ──
+
+        private static DialogueContext MakeDialogueContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            string opponentLastMessage = "",
+            string[] activeTraps = null,
+            int currentInterest = 10,
+            int currentTurn = 1,
+            string playerName = "P",
+            string opponentName = "O",
+            Dictionary<ShadowStatType, int> shadowThresholds = null,
+            List<CallbackOpportunity> callbackOpportunities = null,
+            string[] activeTrapInstructions = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false)
+        {
+            return new DialogueContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: opponentLastMessage,
+                activeTraps: activeTraps ?? Array.Empty<string>(),
+                currentInterest: currentInterest,
+                shadowThresholds: shadowThresholds,
+                callbackOpportunities: callbackOpportunities,
+                horninessLevel: horninessLevel,
+                requiresRizzOption: requiresRizzOption,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                currentTurn: currentTurn);
+        }
+
+        private static DeliveryContext MakeDeliveryContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            DialogueOption chosenOption = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 0,
+            string[] activeTrapInstructions = null,
+            string playerName = "P",
+            string opponentName = "O",
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: "",
+                chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
+        private static OpponentContext MakeOpponentContext(
+            IReadOnlyList<(string Sender, string Text)> conversationHistory = null,
+            string playerDeliveredMessage = "Hey",
+            int interestBefore = 10,
+            int interestAfter = 10,
+            double responseDelayMinutes = 1.0,
+            string[] activeTrapInstructions = null,
+            string playerName = "P",
+            string opponentName = "O",
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new OpponentContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: interestAfter,
+                playerDeliveredMessage: playerDeliveredMessage,
+                interestBefore: interestBefore,
+                interestAfter: interestAfter,
+                responseDelayMinutes: responseDelayMinutes,
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
         // ── AC2: Conversation history formatting ──
 
         [Fact]
         public void BuildDialogueOptionsPrompt_EmptyHistory_ContainsConversationStartAndCurrentTurn()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                conversationHistory: new List<(string, string)>(),
-                opponentLastMessage: "",
-                activeTraps: new string[0],
-                currentInterest: 10,
-                currentTurn: 1,
-                playerName: "GERALD_42",
-                opponentName: "VELVET");
+                MakeDialogueContext(playerName: "GERALD_42", opponentName: "VELVET"));
 
             Assert.Contains("[CONVERSATION_START]", result);
             Assert.Contains("[CURRENT_TURN]", result);
@@ -52,7 +132,8 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Indeed", new string[0], 12, 4, "GERALD_42", "VELVET");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Indeed",
+                    currentInterest: 12, currentTurn: 4, playerName: "GERALD_42", opponentName: "VELVET"));
 
             Assert.Contains("[T1|PLAYER|GERALD_42] \"Hey\"", result);
             Assert.Contains("[T1|OPPONENT|VELVET] \"Hi\"", result);
@@ -73,7 +154,8 @@ namespace Pinder.LlmAdapters.Tests
             }
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Message 15", new string[0], 10, 9, "PLAYER_A", "OPP_B");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Message 15",
+                    currentTurn: 9, playerName: "PLAYER_A", opponentName: "OPP_B"));
 
             for (int turn = 1; turn <= 8; turn++)
             {
@@ -93,7 +175,8 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                history, "Hi", new string[0], 10, 2, "GERALD", "VELVET");
+                MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Hi",
+                    currentTurn: 2, playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("[T1|PLAYER|GERALD] \"Hey\"", result);
             Assert.Contains("[T1|OPPONENT|VELVET] \"Hi\"", result);
@@ -106,8 +189,8 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildDialogueOptionsPrompt_ActiveTraps_FormattedCorrectly()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new[] { "Cringe", "Spiral" },
-                12, 1, "GERALD", "VELVET");
+                MakeDialogueContext(activeTraps: new[] { "Cringe", "Spiral" },
+                    currentInterest: 12, playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("Active traps: Cringe, Spiral", result);
         }
@@ -116,8 +199,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildDialogueOptionsPrompt_NoTraps_ShowsNone()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0],
-                10, 1, "GERALD", "VELVET");
+                MakeDialogueContext(playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("Active traps: none", result);
         }
@@ -126,8 +208,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildDialogueOptionsPrompt_ContainsTaskInstruction()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                new List<(string, string)>(), "", new string[0],
-                10, 1, "GERALD", "VELVET");
+                MakeDialogueContext(playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("YOUR TASK", result);
             Assert.Contains("Generate exactly 4 dialogue options for GERALD", result);
@@ -139,8 +220,8 @@ namespace Pinder.LlmAdapters.Tests
             var option = new DialogueOption(StatType.Wit, "Something clever");
 
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.None, 4, null,
-                "GERALD", "VELVET");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.None, beatDcBy: 4,
+                    playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("SUCCESS", result);
             Assert.Contains("beat DC by 4", result);
@@ -154,9 +235,9 @@ namespace Pinder.LlmAdapters.Tests
             var option = new DialogueOption(StatType.Charm, "Tell me more");
 
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.Misfire, -4,
-                new[] { "You are aware of how you're coming across." },
-                "GERALD", "VELVET");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Misfire, beatDcBy: -4,
+                    activeTrapInstructions: new[] { "You are aware of how you're coming across." },
+                    playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("FAILED", result);
             Assert.Contains("missed DC by 4", result);
@@ -172,8 +253,8 @@ namespace Pinder.LlmAdapters.Tests
             var option = new DialogueOption(StatType.Honesty, "I'm just honest");
 
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                new List<(string, string)>(), option, FailureTier.Fumble, -1, null,
-                "GERALD", "VELVET");
+                MakeDeliveryContext(chosenOption: option, outcome: FailureTier.Fumble, beatDcBy: -1,
+                    playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.DoesNotContain("Active trap instructions:", result);
         }
@@ -188,7 +269,9 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                history, "How are you?", 10, 12, 3.5, null, "GERALD", "VELVET");
+                MakeOpponentContext(conversationHistory: history, playerDeliveredMessage: "How are you?",
+                    interestBefore: 10, interestAfter: 12, responseDelayMinutes: 3.5,
+                    playerName: "GERALD", opponentName: "VELVET"));
 
             Assert.Contains("PLAYER'S LAST MESSAGE", result);
             Assert.Contains("\"How are you?\"", result);
@@ -206,7 +289,8 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildOpponentPrompt_NegativeDelta_FormattedCorrectly()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Bye", 12, 9, 5.0, null, "P", "O");
+                MakeOpponentContext(playerDeliveredMessage: "Bye",
+                    interestBefore: 12, interestAfter: 9, responseDelayMinutes: 5.0));
 
             Assert.Contains("Interest moved from 12 to 9 (-3)", result);
         }
@@ -215,7 +299,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildOpponentPrompt_SmallDelay_ShowsLessThanOneMinute()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 10, 0.5, null, "P", "O");
+                MakeOpponentContext(responseDelayMinutes: 0.5));
 
             Assert.Contains("less than 1 minute", result);
         }
@@ -224,7 +308,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildOpponentPrompt_InterestBehaviourBlock_HighInterest()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 10, 18, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 10, interestAfter: 18));
 
             Assert.Contains("very interested", result);
         }
@@ -233,7 +317,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildOpponentPrompt_InterestBehaviourBlock_LowInterest()
         {
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                new List<(string, string)>(), "Hey", 5, 3, 1.0, null, "P", "O");
+                MakeOpponentContext(interestBefore: 5, interestAfter: 3));
 
             Assert.Contains("disengaged", result);
         }
@@ -342,35 +426,24 @@ namespace Pinder.LlmAdapters.Tests
         // ── Error conditions ──
 
         [Fact]
-        public void BuildDialogueOptionsPrompt_NullHistory_Throws()
+        public void BuildDialogueOptionsPrompt_NullContext_Throws()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    null!, "", new string[0], 10, 1, "P", "O"));
+                SessionDocumentBuilder.BuildDialogueOptionsPrompt((DialogueContext)null!));
         }
 
         [Fact]
-        public void BuildDialogueOptionsPrompt_NullPlayerName_Throws()
+        public void BuildDeliveryPrompt_NullContext_Throws()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                    new List<(string, string)>(), "", new string[0], 10, 1, null!, "O"));
+                SessionDocumentBuilder.BuildDeliveryPrompt((DeliveryContext)null!));
         }
 
         [Fact]
-        public void BuildDeliveryPrompt_NullOption_Throws()
+        public void BuildOpponentPrompt_NullContext_Throws()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildDeliveryPrompt(
-                    new List<(string, string)>(), null!, FailureTier.None, 0, null, "P", "O"));
-        }
-
-        [Fact]
-        public void BuildOpponentPrompt_NullMessage_Throws()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                SessionDocumentBuilder.BuildOpponentPrompt(
-                    new List<(string, string)>(), null!, 10, 10, 1.0, null, "P", "O"));
+                SessionDocumentBuilder.BuildOpponentPrompt((OpponentContext)null!));
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 using Xunit;
 
@@ -6,8 +9,58 @@ namespace Pinder.LlmAdapters.Tests
 {
     public class ShadowTaintTests
     {
-        private static readonly IReadOnlyList<(string Sender, string Text)> MinimalHistory =
-            new List<(string, string)> { ("Opponent", "Hey there") };
+        private static DialogueContext MakeDialogueContext(
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new DialogueContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string, string)> { ("Opponent", "Hey there") },
+                opponentLastMessage: "Hey there",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                shadowThresholds: shadowThresholds,
+                playerName: "Player",
+                opponentName: "Opponent",
+                currentTurn: 1);
+        }
+
+        private static DeliveryContext MakeDeliveryContext(
+            DialogueOption option,
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string, string)> { ("Opponent", "Hey there") },
+                opponentLastMessage: "Hey there",
+                chosenOption: option,
+                outcome: FailureTier.None,
+                beatDcBy: 3,
+                activeTraps: Array.Empty<string>(),
+                shadowThresholds: shadowThresholds,
+                playerName: "Player",
+                opponentName: "Opponent");
+        }
+
+        private static OpponentContext MakeOpponentContext(
+            Dictionary<ShadowStatType, int> shadowThresholds = null)
+        {
+            return new OpponentContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string, string)> { ("Opponent", "Hey there") },
+                opponentLastMessage: "Hey there",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hello",
+                interestBefore: 10,
+                interestAfter: 12,
+                responseDelayMinutes: 2.0,
+                shadowThresholds: shadowThresholds,
+                playerName: "Player",
+                opponentName: "Opponent");
+        }
 
         [Fact]
         public void DialogueOptionsPrompt_HighMadness_ContainsShadowStateSection()
@@ -18,8 +71,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDialogueContext(shadowThresholds: shadows));
 
             Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
             Assert.Contains("Your Madness is elevated", result);
@@ -34,8 +86,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDialogueContext(shadowThresholds: shadows));
 
             Assert.DoesNotContain("SHADOW STATE", result);
         }
@@ -51,8 +102,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDialogueContext(shadowThresholds: shadows));
 
             Assert.Contains("Your Madness is elevated", result);
             Assert.Contains("Your Denial is elevated", result);
@@ -68,8 +118,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDialogueContext(shadowThresholds: shadows));
 
             Assert.DoesNotContain("SHADOW STATE", result);
             Assert.DoesNotContain("Your Horniness is elevated", result);
@@ -84,8 +133,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDialogueContext(shadowThresholds: shadows));
 
             Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
             Assert.Contains("Your Horniness is elevated", result);
@@ -95,8 +143,7 @@ namespace Pinder.LlmAdapters.Tests
         public void DialogueOptionsPrompt_NullShadow_NoShadowStateSection()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                MinimalHistory, "Hey there", new string[0], 10, 1, "Player", "Opponent",
-                playerShadowThresholds: null);
+                MakeDialogueContext(shadowThresholds: null));
 
             Assert.DoesNotContain("SHADOW STATE", result);
         }
@@ -108,13 +155,11 @@ namespace Pinder.LlmAdapters.Tests
             {
                 { ShadowStatType.Overthinking, 7 }
             };
-            var option = new Pinder.Core.Conversation.DialogueOption(
+            var option = new DialogueOption(
                 StatType.Wit, "Test message", null, null, false, false);
 
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
-                MinimalHistory, option, Pinder.Core.Rolls.FailureTier.None, 3, null,
-                "Player", "Opponent",
-                playerShadowThresholds: shadows);
+                MakeDeliveryContext(option, shadowThresholds: shadows));
 
             Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
             Assert.Contains("Your Overthinking is elevated", result);
@@ -129,9 +174,7 @@ namespace Pinder.LlmAdapters.Tests
             };
 
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
-                MinimalHistory, "Hello", 10, 12, 2.0, null,
-                "Player", "Opponent",
-                opponentShadowThresholds: shadows);
+                MakeOpponentContext(shadowThresholds: shadows));
 
             Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
             Assert.Contains("Your Fixation is elevated", result);


### PR DESCRIPTION
Fixes architectural issue where each ILlmAdapter implementation had to manually pass ~12 params to SessionDocumentBuilder. Any adapter that forgot a field (callbacks, shadow thresholds, horniness, etc.) would silently produce incomplete prompts.

Now:
- `BuildDialogueOptionsPrompt(DialogueContext context)` 
- `BuildDeliveryPrompt(DeliveryContext context)`
- `BuildOpponentPrompt(OpponentContext context)`

EigenCoreLlmAdapter (or any future adapter) just calls `Build(context)` — zero risk of missing fields. 1596 tests pass.