### PR TITLE
[Issue #268] Bug: Momentum should be a roll bonus, not an interest delta (rules §15)

### DIFF
--- a/docs/modules/rolls.md
+++ b/docs/modules/rolls.md
@@ -57,7 +57,8 @@ public enum FailureTier
 ## Architecture Notes
 
 - **FailureScale is pure logic** — no state, no dependencies. It takes a `RollResult` and returns an `int`.
-- **Side effects (trap activation, shadow growth) are handled by `GameSession`**, not by FailureScale. The scale only computes the interest delta.
+- **Trap activation on failure**: `RollEngine` activates traps for both `TropeTrap` (miss 6–9) and `Catastrophe` (miss 10+) tiers per rules §5. If a trap is already active on the stat, no new trap is activated. Trap lookup uses `ITrapRegistry.GetTrap(stat)`.
+- **Side effects (shadow growth) are handled by `GameSession`**, not by FailureScale. The scale only computes the interest delta.
 - **Interest is clamped to [0, 25] by GameSession** — FailureScale itself does not clamp.
 - The delta values were updated in issue #266 to match rules-v3.4 §5. The previous (prototype) values from issue #28 were steeper: Misfire −2, TropeTrap −3, Catastrophe −4, Legendary −5.
 
@@ -66,3 +67,4 @@ public enum FailureTier
 | Date | Issue | Summary |
 |------|-------|---------|
 | 2026-04-02 | #266 | Initial creation — documented FailureScale interest deltas updated to rules-v3.4 §5: Misfire −2→−1, TropeTrap −3→−2, Catastrophe −4→−3, Legendary −5→−4. Tests updated across GameSessionTests, ComboGameSessionTests, FullConversationIntegrationTest, ShadowGrowthEventTests, ShadowGrowthSpecTests. |
+| 2026-04-02 | #267 | Bug fix: Catastrophe tier (miss 10+) now also activates a trap via `RollEngine`, matching rules §5 (miss 10+ = −3 + trap). Previously only TropeTrap activated traps. Added `SingleTrapRegistry` test helper and three new tests in `RollEngineTests`. |

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -51,6 +51,7 @@ namespace Pinder.Core.Conversation
         private string? _sessionOpener;
 
         private int _momentumStreak;
+        private int _pendingMomentumBonus;
         private int _turnNumber;
         private bool _ended;
         private GameOutcome? _outcome;
@@ -349,6 +350,9 @@ namespace Pinder.Core.Conversation
 
             _currentOptions = options;
 
+            // Compute pending momentum bonus for the upcoming roll (#268)
+            _pendingMomentumBonus = GetMomentumBonus(_momentumStreak);
+
             var snapshot = CreateSnapshot();
             return new TurnStart(options, snapshot);
         }
@@ -392,8 +396,8 @@ namespace Pinder.Core.Conversation
             // Compute tell bonus (#50)
             int tellBonus = (_activeTell != null && chosenOption.Stat == _activeTell.Stat) ? 2 : 0;
 
-            // Compute external bonus: tell + callback + Triple combo (#46, #47, #50)
-            int externalBonus = tellBonus + callbackBonus;
+            // Compute external bonus: tell + callback + Triple combo + momentum (#46, #47, #50, #268)
+            int externalBonus = tellBonus + callbackBonus + _pendingMomentumBonus;
             if (_comboTracker.HasTripleBonus)
             {
                 externalBonus += 1;
@@ -447,11 +451,11 @@ namespace Pinder.Core.Conversation
                 interestDelta = FailureScale.GetInterestDelta(rollResult);
             }
 
-            // 3. Apply momentum
+            // 3. Update momentum streak (bonus was already applied as externalBonus in the roll, #268)
+            _pendingMomentumBonus = 0;
             if (rollResult.IsSuccess)
             {
                 _momentumStreak++;
-                interestDelta += GetMomentumBonus(_momentumStreak);
             }
             else
             {

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -173,12 +173,12 @@ namespace Pinder.Core.Tests
             Assert.Equal("The Triple", r3.ComboTriggered);
             Assert.True(r3.StateAfter.TripleBonusActive);
 
-            // Turn 4: should have +1 external bonus on roll
+            // Turn 4: should have +1 external bonus from triple + +2 from momentum (streak=3 at start, #268)
             var start4 = await session.StartTurnAsync();
             Assert.True(start4.State.TripleBonusActive);
             var r4 = await session.ResolveTurnAsync(0);
-            // Roll: 15+2+0=17 base, +1 external = 18 final total
-            Assert.Equal(1, r4.Roll.ExternalBonus);
+            // Roll: 15+2+0=17 base, +1 triple + 2 momentum = 3 external
+            Assert.Equal(3, r4.Roll.ExternalBonus);
             Assert.False(r4.StateAfter.TripleBonusActive); // consumed
         }
 
@@ -279,11 +279,11 @@ namespace Pinder.Core.Tests
             // Need to check interest won't be in Bored state
             session.Wait();
 
-            // Next turn should NOT have triple bonus
+            // Next turn should NOT have triple bonus, but still has momentum (streak=3 → +2 roll bonus, #268)
             var start5 = await session.StartTurnAsync();
             Assert.False(start5.State.TripleBonusActive);
             var r5 = await session.ResolveTurnAsync(0);
-            Assert.Equal(0, r5.Roll.ExternalBonus);
+            Assert.Equal(2, r5.Roll.ExternalBonus); // momentum only, triple was consumed by Wait
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ComboSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ComboSpecTests.cs
@@ -849,11 +849,11 @@ namespace Pinder.Core.Tests
             Assert.Equal("The Triple", r3.ComboTriggered);
             Assert.True(r3.StateAfter.TripleBonusActive);
 
-            // Turn 4: verify external bonus applied
+            // Turn 4: verify external bonus applied (triple +1 + momentum +2 from streak=3 at start, #268)
             var start4 = await session.StartTurnAsync();
             Assert.True(start4.State.TripleBonusActive);
             var r4 = await session.ResolveTurnAsync(0);
-            Assert.Equal(1, r4.Roll.ExternalBonus);
+            Assert.Equal(3, r4.Roll.ExternalBonus);
             Assert.False(r4.StateAfter.TripleBonusActive); // consumed
         }
 

--- a/tests/Pinder.Core.Tests/GameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionTests.cs
@@ -149,7 +149,7 @@ namespace Pinder.Core.Tests
 
             var result1 = await session.ResolveTurnAsync(0); // Charm
             Assert.True(result1.Roll.IsSuccess);
-            // beat by 2 → SuccessScale +1, need=13 → Hard → RiskTierBonus +1, no momentum at streak=1
+            // beat by 2 → SuccessScale +1, need=13 → Hard → RiskTierBonus +1, momentum bonus=0 (streak was 0)
             Assert.Equal(2, result1.InterestDelta);
             Assert.Equal(12, result1.StateAfter.Interest);
             Assert.False(result1.IsGameOver);
@@ -159,7 +159,7 @@ namespace Pinder.Core.Tests
             var start2 = await session.StartTurnAsync();
             var result2 = await session.ResolveTurnAsync(0);
             Assert.True(result2.Roll.IsSuccess);
-            Assert.Equal(2, result2.InterestDelta); // streak=2, no momentum; SuccessScale +1 + RiskTier +1
+            Assert.Equal(2, result2.InterestDelta); // streak=1 at start, no momentum; SuccessScale +1 + RiskTier +1
             Assert.Equal(14, result2.StateAfter.Interest);
             Assert.Equal(2, result2.StateAfter.TurnNumber);
 
@@ -167,9 +167,10 @@ namespace Pinder.Core.Tests
             var start3 = await session.StartTurnAsync();
             var result3 = await session.ResolveTurnAsync(0);
             Assert.True(result3.Roll.IsSuccess);
-            // streak=3 → +2 momentum bonus, SuccessScale +1, RiskTier +1, so delta = 1 + 1 + 2 = 4
-            Assert.Equal(4, result3.InterestDelta);
-            Assert.Equal(18, result3.StateAfter.Interest);
+            // streak=2 at start → momentum bonus=0 (applied as roll bonus, not interest delta #268)
+            // SuccessScale +1, RiskTier +1 = 2
+            Assert.Equal(2, result3.InterestDelta);
+            Assert.Equal(16, result3.StateAfter.Interest);
             Assert.Equal(3, result3.StateAfter.TurnNumber);
         }
 
@@ -266,32 +267,35 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public async Task MomentumBonus_AppliedCorrectly()
+        public async Task MomentumBonus_AppliedAsRollBonus()
         {
             // 5 consecutive successes with roll=15, each beating DC by 2 → +1 base
             // need = 15-(2+0) = 13 → Hard → +1 risk tier bonus per success
-            // streak 1: +1 base +1 risk +0 momentum = 2
-            // streak 2: +1 base +1 risk +0 momentum = 2
-            // streak 3: +1 base +1 risk +2 momentum = 4
-            // streak 4: +1 base +1 risk +2 momentum = 4 (advantage from VeryIntoIt)
-            // streak 5: +1 base +1 risk +3 momentum = 5 (advantage from AlmostThere, clamped to 25)
-            // Interest progression: 10→12→14→18→22→25 (clamped)
-            // At turn 4 start, interest=18 (VeryIntoIt) → advantage → 2x d20
-            // At turn 5 start, interest=22 (AlmostThere) → advantage → 2x d20
+            // Momentum is a roll bonus (ExternalBonus), not an interest delta (#268).
+            // SuccessScale uses Total (not FinalTotal), so momentum doesn't change the scale tier.
+            // streak 0→1: pending momentum=0, interestDelta = +1 scale +1 risk = 2
+            // streak 1→2: pending momentum=0, interestDelta = 2
+            // streak 2→3: pending momentum=0, interestDelta = 2. After: interest=16 (VeryIntoIt → advantage)
+            // streak 3→4: pending momentum=+2 (roll bonus), interestDelta = 2
+            // streak 4→5: pending momentum=+2 (roll bonus), interestDelta = 2
+            // Interest progression: 10→12→14→16→18→20
+            // At turn 4 start, interest=16 (VeryIntoIt) → advantage → 2x d20
+            // At turn 5 start, interest=18 (VeryIntoIt) → advantage → 2x d20
             var dice = new FixedDice(
                 15, 50,        // Turn 1: d20, d100 (timing)
                 15, 50,        // Turn 2: d20, d100
-                15, 50,        // Turn 3: d20, d100. After: 18 (VeryIntoIt)
-                15, 15, 50,    // Turn 4: 2x d20 (advantage), d100. After: 22 (AlmostThere)
-                15, 15, 50     // Turn 5: 2x d20 (advantage), d100. After: 25 (clamped)
+                15, 50,        // Turn 3: d20, d100. After: 16 (VeryIntoIt)
+                15, 15, 50,    // Turn 4: 2x d20 (advantage), d100
+                15, 15, 50     // Turn 5: 2x d20 (advantage), d100
             );
 
             var session = new GameSession(
                 MakeProfile("P"), MakeProfile("O"),
                 new NullLlmAdapter(), dice, new NullTrapRegistry());
 
-            // Note: interest is clamped to 25, so effective delta at turn 5 may be less
-            int[] expectedDeltas = { 2, 2, 4, 4, 5 };
+            // Every turn has the same interestDelta; momentum is in ExternalBonus
+            int[] expectedDeltas = { 2, 2, 2, 2, 2 };
+            int[] expectedMomentumBonus = { 0, 0, 0, 2, 2 };
             int expectedInterest = 10;
 
             for (int i = 0; i < 5; i++)
@@ -299,10 +303,47 @@ namespace Pinder.Core.Tests
                 await session.StartTurnAsync();
                 var result = await session.ResolveTurnAsync(0);
                 Assert.Equal(expectedDeltas[i], result.InterestDelta);
+                Assert.Equal(expectedMomentumBonus[i], result.Roll.ExternalBonus);
                 expectedInterest += expectedDeltas[i];
-                if (expectedInterest > 25) expectedInterest = 25; // clamp
                 Assert.Equal(expectedInterest, result.StateAfter.Interest);
             }
+        }
+
+        [Fact]
+        public async Task MomentumBonus_CanChangeOutcomeTier()
+        {
+            // AC: 3-win streak → next roll has +2 external bonus → can change outcome tier
+            // Setup: 3 successes with roll=15 (Total=17, DC=15, success), then
+            // turn 4 with roll=12 (Total=14, DC=15 → normally fail). With +2 momentum,
+            // FinalTotal=16 → success.
+            var dice = new FixedDice(
+                15, 50,   // Turn 1: success
+                15, 50,   // Turn 2: success
+                15, 50,   // Turn 3: success. After: interest=16 (VeryIntoIt → advantage)
+                12, 12, 50  // Turn 4: advantage → 2 d20s, both 12. Total=14, DC=15. Without momentum: fail. With +2: success.
+            );
+
+            var session = new GameSession(
+                MakeProfile("P"), MakeProfile("O"),
+                new NullLlmAdapter(), dice, new NullTrapRegistry());
+
+            // Build a 3-win streak
+            for (int i = 0; i < 3; i++)
+            {
+                await session.StartTurnAsync();
+                var r = await session.ResolveTurnAsync(0);
+                Assert.True(r.Roll.IsSuccess);
+            }
+
+            // Turn 4: roll that would fail without momentum but succeeds with it
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // Momentum bonus of +2 is in ExternalBonus
+            Assert.Equal(2, result.Roll.ExternalBonus);
+            // Total=14 (12+2+0), FinalTotal=16 (14+2) >= DC=15 → success
+            Assert.Equal(14, result.Roll.Total);
+            Assert.True(result.Roll.IsSuccess, "Momentum +2 should make this roll succeed (FinalTotal 16 >= DC 15)");
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -282,18 +282,19 @@ namespace Pinder.Core.Tests.Integration
             var gerald = new CharacterProfile(geraldStats, "Test", "Gerald", timing, level: 5);
             var velvet = new CharacterProfile(velvetStats, "Test", "Velvet", timing, level: 7);
 
-            // Start at 5 (Interested) — successes add interest but won't reach 16 (VeryIntoIt)
-            // with small beat margins. Charm DC=18, +15 modifier.
-            // T1: d20=3 → total=18, beat by 0 → +1. Interest 5→6. Momentum=1.
-            // T2: d20=3 → total=18, beat by 0 → +1. Interest 6→7. Momentum=2.
-            // T3: d20=3 → total=18, beat by 0 → +1. Momentum=3→bonus +2. Interest 7→10.
-            // T4: d20=1 → Nat1 fail. Interest 10→6 (Legendary -4). Momentum=0.
-            // T5: d20=3 → total=18, success. Interest 6→7. Momentum=1.
+            // Start at 10 (Interested) — successes add interest but won't reach Bored.
+            // Momentum is a roll bonus (#268), not interest delta — it appears in ExternalBonus.
+            // Charm DC=18, Gerald has +15 modifier.
+            // T1: streak=0→pending=0. d20=3 → total=18, beat by 0 → +1. Interest 10→11. Momentum=1.
+            // T2: streak=1→pending=0. d20=3 → total=18, beat by 0 → +1. Interest 11→12. Momentum=2.
+            // T3: streak=2→pending=0. d20=3 → total=18, beat by 0 → +1. Interest 12→13. Momentum=3.
+            // T4: streak=3→pending=+2. d20=1 → Nat1 fail (ExternalBonus=2 but Nat1 always fails). Interest 13→9 (Legendary -4). Momentum=0.
+            // T5: streak=0→pending=0. d20=3 → total=18, success. Interest 9→10. Momentum=1.
             var config = new GameSessionConfig(
                 clock: null,
                 playerShadows: new SessionShadowTracker(geraldStats),
                 opponentShadows: new SessionShadowTracker(velvetStats),
-                startingInterest: 5,
+                startingInterest: 10,
                 previousOpener: null);
 
             var llm = new ScriptedLlmAdapter(Enumerable.Range(0, 5).Select(_ =>
@@ -322,18 +323,23 @@ namespace Pinder.Core.Tests.Integration
             Assert.True(t2.Roll.IsSuccess);
             Assert.Equal(2, t2.StateAfter.MomentumStreak);
 
-            // T3: success → momentum 3 (bonus of +2 kicks in at streak 3)
+            // T3: success → momentum 3 (streak 3 bonus applied as roll bonus next turn)
             await session.StartTurnAsync();
             var t3 = await session.ResolveTurnAsync(0);
             Assert.True(t3.Roll.IsSuccess);
             // Mutation: Fails if momentum streak count is wrong
             Assert.Equal(3, t3.StateAfter.MomentumStreak);
+            // Momentum bonus is 0 this turn (streak was 2 at StartTurn)
+            Assert.Equal(0, t3.Roll.ExternalBonus);
 
             // T4: Nat1 → always fail → momentum resets to 0
+            // Pending momentum was +2 (streak=3 at start), but Nat1 overrides
             await session.StartTurnAsync();
             var t4 = await session.ResolveTurnAsync(0);
             Assert.False(t4.Roll.IsSuccess);
             Assert.True(t4.Roll.IsNatOne);
+            // Momentum bonus of +2 was in the roll but didn't help (Nat1 always fails)
+            Assert.Equal(2, t4.Roll.ExternalBonus);
             // Mutation: Fails if momentum doesn't reset to 0 on failure
             Assert.Equal(0, t4.StateAfter.MomentumStreak);
 

--- a/tests/Pinder.Core.Tests/Issue209_DiceQueueExhaustionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue209_DiceQueueExhaustionTests.cs
@@ -131,7 +131,8 @@ namespace Pinder.Core.Tests
             Assert.True(start4.State.TripleBonusActive, "TripleBonusActive should be visible at start of turn 4");
 
             var r4 = await session.ResolveTurnAsync(0);
-            Assert.Equal(1, r4.Roll.ExternalBonus);
+            // ExternalBonus = triple(+1) + momentum(+2 from streak=3 at start, #268)
+            Assert.Equal(3, r4.Roll.ExternalBonus);
             Assert.False(r4.StateAfter.TripleBonusActive, "TripleBonusActive should be consumed after turn 4");
         }
 
@@ -141,7 +142,8 @@ namespace Pinder.Core.Tests
         public async Task InterestProgression_ThreeSuccessfulTurns_ReachesVeryIntoIt()
         {
             // With allStats=2, DC=15. Roll 15: total=17, beat by 2 → +1 success + +1 risk(Hard)
-            // Turn 1: +2 → 12, Turn 2: +2 → 14, Turn 3: +2 + momentum(+2) = +4 → 18 (VeryIntoIt)
+            // Momentum is a roll bonus (#268), not interest delta. Streak < 3 at start of each turn → no momentum bonus.
+            // Turn 1: +2 → 12, Turn 2: +2 → 14, Turn 3: +2 → 16 (VeryIntoIt)
             var dice = new FixedDice(
                 15, 50,
                 15, 50,
@@ -167,12 +169,12 @@ namespace Pinder.Core.Tests
             var r2 = await session.ResolveTurnAsync(0);
             Assert.Equal(14, r2.StateAfter.Interest);
 
-            // Turn 3: interest 14 → 18 (momentum kicks in at streak 3)
+            // Turn 3: interest 14 → 16 (momentum bonus=0 as streak was 2 at start; applied as roll bonus #268)
             await session.StartTurnAsync();
             var r3 = await session.ResolveTurnAsync(0);
-            Assert.Equal(18, r3.StateAfter.Interest);
+            Assert.Equal(16, r3.StateAfter.Interest);
 
-            // VeryIntoIt is interest 16-20; 18 is in that range
+            // VeryIntoIt is interest 16-20; 16 is in that range
             Assert.True(r3.StateAfter.Interest >= 16 && r3.StateAfter.Interest <= 20,
                 $"Interest {r3.StateAfter.Interest} should be in VeryIntoIt range (16-20)");
         }
@@ -212,7 +214,7 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var r4 = await session.ResolveTurnAsync(0);
 
-            // Roll should still succeed (max(15,15) + 2 + externalBonus(1) = 18 >= 15)
+            // Roll should still succeed (max(15,15) + 2 + momentum bonus(2) = 19 >= 15)
             Assert.True(r4.Roll.IsSuccess);
         }
 
@@ -228,7 +230,7 @@ namespace Pinder.Core.Tests
             Assert.Contains("no more values", ex.Message);
         }
 
-        // What: AC1 — ExternalBonus is exactly 1 from Triple bonus (not 0 or 2)
+        // What: AC1 — ExternalBonus includes +1 from Triple bonus (not 0 or 2)
         // Mutation: would catch if Triple bonus applied +2 instead of +1
         [Fact]
         public async Task TripleBonus_AppliesExactlyPlusOne_AsExternalBonus()
@@ -257,7 +259,8 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var r4 = await session.ResolveTurnAsync(0);
 
-            Assert.Equal(1, r4.Roll.ExternalBonus);
+            // ExternalBonus = triple(+1) + momentum(+2 from streak=3 at start, #268) = 3
+            Assert.Equal(3, r4.Roll.ExternalBonus);
         }
 
         // What: Edge case — Turns before VeryIntoIt consume exactly 2 dice each (no advantage)


### PR DESCRIPTION
Fixes #268

## Summary
Momentum bonus is now applied as a roll bonus (ExternalBonus on RollEngine.Resolve) instead of being added directly to interestDelta. This matches rules §15: 'MOMENTUM active (+2 to next roll)'.

## Changes
- **GameSession**: Added _pendingMomentumBonus field. Computed in StartTurnAsync() based on current streak via GetMomentumBonus(). Added to externalBonus parameter in ResolveTurnAsync(). Cleared after roll resolution.
- **Tests**: Updated 8 existing tests to reflect new behavior (momentum appears in Roll.ExternalBonus, not InterestDelta). Added new MomentumBonus_CanChangeOutcomeTier test demonstrating momentum turning a would-fail roll into a success.

## How to test
```bash
dotnet test tests/Pinder.Core.Tests/ --filter Momentum
dotnet test  # full suite
```

## DoD Evidence
**Branch:** issue-268-bug-momentum-should-be-a-roll-bonus-not-
**Commit:** bd2dd2b
**Tests:** 1205 Core + 443 LlmAdapters = 1648 passed, 0 failed
**Deviations from contract:** none
