### PR TITLE
[Issue #270] Write tests: Missing: 5 shadow reduction events from §7 not implemented

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -490,6 +490,17 @@ namespace Pinder.Core.Conversation
             // ---- Shadow growth evaluation (#44) ----
             EvaluatePerTurnShadowGrowth(chosenOption, optionIndex, rollResult, interestAfter);
 
+            // Shadow reduction: Winning despite Overthinking disadvantage → Overthinking −1
+            if (rollResult.IsSuccess
+                && _playerShadows != null
+                && _shadowDisadvantagedStats != null
+                && _shadowDisadvantagedStats.Contains(chosenOption.Stat)
+                && StatBlock.ShadowPairs[chosenOption.Stat] == ShadowStatType.Overthinking)
+            {
+                _playerShadows.ApplyOffset(ShadowStatType.Overthinking, -1,
+                    "Succeeded despite Overthinking disadvantage");
+            }
+
             // Check end conditions for end-of-game triggers
             bool isGameOver = false;
             GameOutcome? outcome = null;
@@ -779,10 +790,17 @@ namespace Pinder.Core.Conversation
                 }
             }
 
-            // Trigger 6: Honesty success tracking
+            // Trigger 6: Honesty success tracking + Denial reduction at high interest
             if (chosenOption.Stat == StatType.Honesty && rollResult.IsSuccess)
             {
                 _honestySuccessCount++;
+
+                // Shadow reduction: Honesty success at Interest ≥15 → Denial −1
+                if (interestAfter >= 15)
+                {
+                    _playerShadows.ApplyOffset(ShadowStatType.Denial, -1,
+                        "Honesty success at high interest");
+                }
             }
 
             // Trigger 7: Interest hits 0 → +2 Dread
@@ -827,6 +845,13 @@ namespace Pinder.Core.Conversation
         {
             if (_playerShadows == null)
                 return;
+
+            // Shadow reduction: Date secured → Dread −1
+            if (outcome == GameOutcome.DateSecured)
+            {
+                _playerShadows.ApplyOffset(ShadowStatType.Dread, -1,
+                    "Date secured");
+            }
 
             // Trigger 11: Date secured without Honesty success → +1 Denial
             if (outcome == GameOutcome.DateSecured && _honestySuccessCount == 0)
@@ -1057,6 +1082,13 @@ namespace Pinder.Core.Conversation
 
                 // Record trap recovery XP (#48 AC-5)
                 _xpLedger.Record("TrapRecovery", 15);
+
+                // Shadow reduction: Recovering from trope trap → Madness −1
+                if (_playerShadows != null)
+                {
+                    _playerShadows.ApplyOffset(ShadowStatType.Madness, -1,
+                        "Recovered from trope trap");
+                }
             }
             else
             {

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -1,0 +1,676 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Spec-driven tests for issue #270: 5 shadow reduction events from §7.
+    /// These tests verify behavior from the spec document (docs/specs/issue-270-spec.md)
+    /// and cover edge cases, boundary values, and error conditions.
+    /// </summary>
+    public class ShadowReductionSpecTests
+    {
+        // =====================================================================
+        // AC-1: Date Secured → Dread −1
+        // =====================================================================
+
+        // What: AC-1 — Dread reduction fires on DateSecured outcome
+        // Mutation: Would catch if Dread reduction is missing from EvaluateEndOfGameShadowGrowth
+        [Fact]
+        public async Task AC1_DateSecured_DreadDeltaDecreasedByOne()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 5, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 50), // Nat20 → guaranteed success → +4 interest → 24+4=28→clamped 25 → DateSecured
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            // Mutation: Fails if Dread reduction omitted (would remain 5)
+            Assert.Equal(4, shadows.GetDelta(ShadowStatType.Dread));
+        }
+
+        // What: AC-1 — Growth event string contains expected text
+        // Mutation: Would catch if reason string is wrong or event not recorded
+        [Fact]
+        public async Task AC1_DateSecured_GrowthEventContainsDreadDateSecured()
+        {
+            var shadows = MakeTracker();
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            // Mutation: Fails if "Date secured" reason text is wrong
+            Assert.Contains(result.ShadowGrowthEvents,
+                e => e.Contains("Dread") && e.Contains("-1") && e.Contains("Date secured"));
+        }
+
+        // What: Edge case — Dread delta goes negative (from 0 to -1)
+        // Mutation: Would catch if ApplyGrowth is used instead of ApplyOffset (throws on negative)
+        [Fact]
+        public async Task AC1_DateSecured_DreadCanGoNegative()
+        {
+            var shadows = MakeTracker(); // Dread starts at 0
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            // Mutation: Fails if ApplyGrowth used (throws on negative) or reduction skipped when delta=0
+            Assert.Equal(-1, shadows.GetDelta(ShadowStatType.Dread));
+        }
+
+        // What: AC-1 negative — Non-DateSecured game-over does NOT reduce Dread
+        // Mutation: Would catch if Dread reduction fires on all outcomes
+        [Fact]
+        public async Task AC1_NonDateSecured_NoDreadReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Start at low interest, fail → interest drops to 0 → Unmatched
+            // Use ghost-safe dice: 4 for ghost check (not 1), then 1 for Nat1 attack
+            var session = BuildSession(
+                dice: Dice(4, 1, 50), // ghost check=4 (no ghost), attack Nat1 → big fail
+                playerStats: MakeStats(charm: 0),
+                opponentStats: MakeStats(sa: 5),
+                shadows: shadows,
+                startingInterest: 2);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.IsGameOver);
+            Assert.NotEqual(GameOutcome.DateSecured, result.Outcome);
+            // Mutation: Fails if Dread reduction fires on non-DateSecured outcomes
+            Assert.True(shadows.GetDelta(ShadowStatType.Dread) >= 3,
+                "Dread should not decrease on non-DateSecured outcome");
+        }
+
+        // What: Edge case — DateSecured + Denial growth can co-exist with Dread reduction
+        // Mutation: Would catch if Dread reduction blocks other shadow events
+        [Fact]
+        public async Task AC1_DateSecured_DreadReductionCoexistsWithOtherShadowEvents()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            // Dread reduced
+            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Dread));
+            // Other shadow events (like Denial +1 for no Honesty date) may also fire
+            // The key assertion: Dread reduction is independent of other events
+        }
+
+        // =====================================================================
+        // AC-2: Honesty Success at Interest ≥ 15 → Denial −1
+        // =====================================================================
+
+        // What: AC-2 — Denial reduction on Honesty success at interest exactly 15 (boundary)
+        // Mutation: Would catch if condition uses > 15 instead of >= 15
+        [Fact]
+        public async Task AC2_HonestySuccessAtExactly15_DenialReduced()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 4, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Interest starts at 15, Honesty success keeps it ≥15
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: MakeStats(honesty: 5),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth bomb") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if >= 15 replaced with > 15
+            Assert.Equal(3, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // What: AC-2 — Growth event string for Denial reduction
+        // Mutation: Would catch if reason string is wrong
+        [Fact]
+        public async Task AC2_HonestySuccessAtHighInterest_GrowthEventRecorded()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: MakeStats(honesty: 5),
+                shadows: shadows,
+                startingInterest: 16,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if event not recorded or reason text is wrong
+            Assert.Contains(result.ShadowGrowthEvents,
+                e => e.Contains("Denial") && e.Contains("Honesty success at high interest"));
+        }
+
+        // What: AC-2 negative — Honesty failure does NOT reduce Denial
+        // Mutation: Would catch if reduction fires regardless of IsSuccess
+        [Fact]
+        public async Task AC2_HonestyFailureAtHighInterest_NoDenialReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Interest at 15 (Interested, no advantage), low roll → failure
+            var session = BuildSession(
+                dice: Dice(2, 50), // low roll → failure
+                playerStats: MakeStats(honesty: 0),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess);
+            // Mutation: Fails if IsSuccess check is missing
+            Assert.Equal(3, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // What: AC-2 negative — Non-Honesty stat at high interest does NOT reduce Denial
+        // Mutation: Would catch if stat type check is missing
+        [Fact]
+        public async Task AC2_CharmSuccessAtHighInterest_NoDenialReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows,
+                startingInterest: 16);
+            // Default options use Charm
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if stat type check is omitted (fires for any stat)
+            Assert.Equal(3, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // What: Edge case — Denial reduction stacks across turns
+        // Mutation: Would catch if reduction is capped to once per session
+        [Fact]
+        public async Task AC2_DenialReductionStacksAcrossTurns()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 5, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Two turns of Honesty success at high interest
+            var session = BuildSession(
+                dice: Dice(18, 50, 18, 50),
+                playerStats: MakeStats(honesty: 5),
+                shadows: shadows,
+                startingInterest: 16,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            // Denial should be 4 after first turn
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+            // Denial should be 3 after second turn (two reductions)
+
+            // Mutation: Fails if reduction only fires once per session
+            Assert.True(shadows.GetDelta(ShadowStatType.Denial) < 4,
+                "Denial should stack reductions across turns");
+        }
+
+        // =====================================================================
+        // AC-3: Successful Recover → Madness −1
+        // =====================================================================
+
+        // What: AC-3 — Successful recovery reduces Madness by 1
+        // Mutation: Would catch if Madness reduction is missing from RecoverAsync success branch
+        [Fact]
+        public async Task AC3_SuccessfulRecover_MadnessReduced()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Madness, 4, "setup");
+            shadows.DrainGrowthEvents();
+
+            var trapDef = new TrapDefinition("trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "t", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(18), // SA vs DC 12 → success
+                playerStats: MakeStats(sa: 5),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.True(result.Success);
+            // Mutation: Fails if Madness ApplyOffset is missing
+            Assert.Equal(3, shadows.GetDelta(ShadowStatType.Madness));
+        }
+
+        // What: AC-3 negative — Failed recovery does NOT reduce Madness
+        // Mutation: Would catch if reduction fires on both success and failure branches
+        [Fact]
+        public async Task AC3_FailedRecover_NoMadnessReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Madness, 4, "setup");
+            shadows.DrainGrowthEvents();
+
+            var trapDef = new TrapDefinition("trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "t", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(2), // low roll → failure
+                playerStats: MakeStats(sa: 0),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.False(result.Success);
+            // Mutation: Fails if Madness reduction fires on failure
+            Assert.Equal(4, shadows.GetDelta(ShadowStatType.Madness));
+        }
+
+        // What: AC-3 — Failed recovery DOES add Overthinking +1 (existing behavior preserved)
+        // Mutation: Would catch if Overthinking growth was accidentally removed
+        [Fact]
+        public async Task AC3_FailedRecover_OverthinkingStillGrows()
+        {
+            var shadows = MakeTracker();
+            shadows.DrainGrowthEvents();
+
+            var trapDef = new TrapDefinition("trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "t", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(2),
+                playerStats: MakeStats(sa: 0),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.False(result.Success);
+            // Mutation: Fails if Overthinking +1 on failed recover was removed
+            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // What: Edge case — Madness delta goes negative on successful recovery
+        // Mutation: Would catch if ApplyGrowth used instead of ApplyOffset
+        [Fact]
+        public async Task AC3_SuccessfulRecover_MadnessCanGoNegative()
+        {
+            var shadows = MakeTracker(); // Madness starts at 0
+
+            var trapDef = new TrapDefinition("trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "t", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(18),
+                playerStats: MakeStats(sa: 5),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.True(result.Success);
+            // Mutation: Fails if ApplyGrowth is used (throws) or negative delta prevented
+            Assert.Equal(-1, shadows.GetDelta(ShadowStatType.Madness));
+        }
+
+        // What: Edge case — _playerShadows is null → no exception
+        // Mutation: Would catch if null-conditional operator (?.) is missing
+        [Fact]
+        public async Task AC3_SuccessfulRecover_NullShadows_NoException()
+        {
+            var trapDef = new TrapDefinition("trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "t", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(18),
+                playerStats: MakeStats(sa: 5),
+                shadows: null, // No shadow tracking
+                trapDef: trapDef);
+
+            // Should not throw NullReferenceException
+            var result = await session.RecoverAsync();
+            Assert.True(result.Success);
+        }
+
+        // =====================================================================
+        // AC-4: Success with Overthinking Disadvantage → Overthinking −1
+        // =====================================================================
+
+        // What: AC-4 — Success despite Overthinking disadvantage reduces Overthinking
+        // Mutation: Would catch if Overthinking reduction is missing from ResolveTurnAsync
+        [Fact]
+        public async Task AC4_SuccessWithOverthinkingDisadvantage_OverthinkingReduced()
+        {
+            // Overthinking at 12 (T2) → SA gets disadvantage
+            var shadows = new SessionShadowTracker(MakeStats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 20, 50), // Nat20 succeeds despite disadvantage
+                playerStats: MakeStats(sa: 5),
+                shadows: shadows,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "insightful") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if Overthinking reduction is omitted
+            Assert.Equal(11, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // What: AC-4 — Growth event recorded for Overthinking reduction
+        // Mutation: Would catch if event text is wrong or not recorded
+        [Fact]
+        public async Task AC4_SuccessWithOverthinkingDisadvantage_GrowthEventRecorded()
+        {
+            var shadows = new SessionShadowTracker(MakeStats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 20, 50),
+                playerStats: MakeStats(sa: 5),
+                shadows: shadows,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if reason text is wrong
+            Assert.Contains(result.ShadowGrowthEvents,
+                e => e.Contains("Overthinking") && e.Contains("Succeeded despite"));
+        }
+
+        // What: AC-4 negative — Failure with Overthinking disadvantage does NOT reduce
+        // Mutation: Would catch if IsSuccess check is missing
+        [Fact]
+        public async Task AC4_FailureWithOverthinkingDisadvantage_NoReduction()
+        {
+            var shadows = new SessionShadowTracker(MakeStats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(2, 3, 50), // low rolls → failure
+                playerStats: MakeStats(sa: 0),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess);
+            // Mutation: Fails if reduction fires regardless of success
+            Assert.Equal(12, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // What: AC-4 negative — Success WITHOUT Overthinking disadvantage does NOT reduce
+        // Mutation: Would catch if disadvantage check is missing
+        [Fact]
+        public async Task AC4_SuccessWithSA_NoOverthinkingDisadvantage_NoReduction()
+        {
+            // Overthinking at 5 (below T2 threshold of 12) → no disadvantage
+            var shadows = new SessionShadowTracker(MakeStats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 5, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: MakeStats(sa: 5),
+                shadows: shadows,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if reduction fires without disadvantage being active
+            Assert.Equal(5, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // What: AC-4 negative — Success with Charm (not SA) while Overthinking is high
+        // Mutation: Would catch if stat check is missing (reduces on any successful roll)
+        [Fact]
+        public async Task AC4_SuccessWithCharm_OverthinkingHigh_NoReduction()
+        {
+            var shadows = new SessionShadowTracker(MakeStats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: shadows);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0); // Charm, not SA
+
+            Assert.True(result.Roll.IsSuccess);
+            // Mutation: Fails if any success triggers Overthinking reduction
+            Assert.Equal(12, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // =====================================================================
+        // AC-6: Build clean — null shadow tracker doesn't crash
+        // =====================================================================
+
+        // What: Edge case — No shadow tracker configured → reductions silently skip
+        // Mutation: Would catch if null check is missing before ApplyOffset calls
+        [Fact]
+        public async Task NullShadowTracker_DateSecured_NoException()
+        {
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: MakeStats(charm: 5),
+                shadows: null, // No shadow tracking
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            // Should not throw NullReferenceException
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+        }
+
+        // What: Edge case — No shadow tracker → Honesty success at high interest doesn't crash
+        // Mutation: Would catch if null check missing in EvaluatePerTurnShadowGrowth
+        [Fact]
+        public async Task NullShadowTracker_HonestySuccessHighInterest_NoException()
+        {
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: MakeStats(honesty: 5),
+                shadows: null,
+                startingInterest: 16,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+            Assert.True(result.Roll.IsSuccess);
+        }
+
+        // =====================================================================
+        // Helpers (test-only utilities — not imported from implementation)
+        // =====================================================================
+
+        private static SessionShadowTracker MakeTracker()
+            => new SessionShadowTracker(MakeStats());
+
+        private static StatBlock MakeStats(
+            int charm = 3, int rizz = 2, int honesty = 1,
+            int chaos = 0, int wit = 4, int sa = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm }, { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty }, { StatType.Chaos, chaos },
+                    { StatType.Wit, wit }, { StatType.SelfAwareness, sa }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+            => new CharacterProfile(stats, "system prompt", name,
+                new TimingProfile(5, 1.0f, 0.0f, "neutral"), 1);
+
+        private static TestDice Dice(params int[] values) => new TestDice(values);
+
+        private static GameSession BuildSession(
+            TestDice? dice = null,
+            StatBlock? playerStats = null,
+            StatBlock? opponentStats = null,
+            SessionShadowTracker? shadows = null,
+            DialogueOption[]? options = null,
+            int? startingInterest = null)
+        {
+            playerStats ??= MakeStats();
+            opponentStats ??= MakeStats();
+            ILlmAdapter llm = options != null
+                ? (ILlmAdapter)new StubLlmAdapter(options)
+                : new NullLlmAdapter();
+
+            var config = new GameSessionConfig(
+                playerShadows: shadows,
+                startingInterest: startingInterest);
+
+            // Prepend horniness roll (1d10) consumed by constructor
+            var wrappedDice = new PrependedDice(5, dice ?? Dice(15, 50));
+
+            return new GameSession(
+                MakeProfile("player", playerStats),
+                MakeProfile("opponent", opponentStats),
+                llm,
+                wrappedDice,
+                new NullTrapRegistry(),
+                config);
+        }
+
+        private static GameSession BuildSessionWithTrap(
+            TestDice dice,
+            StatBlock? playerStats = null,
+            SessionShadowTracker? shadows = null,
+            TrapDefinition? trapDef = null)
+        {
+            playerStats ??= MakeStats();
+            var config = new GameSessionConfig(playerShadows: shadows);
+
+            var wrappedDice = new PrependedDice(5, dice);
+
+            var session = new GameSession(
+                MakeProfile("player", playerStats),
+                MakeProfile("opponent", MakeStats()),
+                new NullLlmAdapter(),
+                wrappedDice,
+                new NullTrapRegistry(),
+                config);
+
+            if (trapDef != null)
+            {
+                var trapsField = typeof(GameSession).GetField("_traps",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var trapState = (TrapState)trapsField!.GetValue(session)!;
+                trapState.Activate(trapDef);
+            }
+
+            return session;
+        }
+
+        private sealed class PrependedDice : IDiceRoller
+        {
+            private int? _first;
+            private readonly IDiceRoller _inner;
+            public PrependedDice(int firstValue, IDiceRoller inner)
+            {
+                _first = firstValue;
+                _inner = inner;
+            }
+            public int Roll(int sides)
+            {
+                if (_first.HasValue) { var v = _first.Value; _first = null; return v; }
+                return _inner.Roll(sides);
+            }
+        }
+
+        private sealed class TestDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public TestDice(int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private sealed class StubLlmAdapter : ILlmAdapter
+        {
+            private readonly DialogueOption[] _options;
+            public StubLlmAdapter(DialogueOption[] options) => _options = options;
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+                => Task.FromResult(_options);
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(context.ChosenOption.IntendedText);
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse("..."));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for issue #270: 5 shadow reduction events from §7.
+    /// 4 reductions are new; the 5th (Fixation −1 for 4+ distinct stats) already existed.
+    /// </summary>
+    public class ShadowReductionTests
+    {
+        // =====================================================================
+        // Reduction 1: Date secured → Dread −1
+        // =====================================================================
+
+        [Fact]
+        public async Task DateSecured_ReducesDreadByOne()
+        {
+            var shadows = MakeTracker();
+            // Pre-grow Dread so we can see reduction
+            shadows.ApplyGrowth(ShadowStatType.Dread, 3, "setup");
+            shadows.DrainGrowthEvents(); // clear setup events
+
+            // Start at 24, success → DateSecured
+            var session = BuildSession(
+                dice: Dice(15, 50),
+                playerStats: Stats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0); // Charm success
+
+            Assert.True(result.IsGameOver);
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            // Dread was 3, should be 3 - 1 = 2
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Dread));
+            Assert.Contains(result.ShadowGrowthEvents, e => e.Contains("Dread") && e.Contains("Date secured"));
+        }
+
+        [Fact]
+        public async Task DateSecured_DreadReductionCanGoNegative()
+        {
+            var shadows = MakeTracker();
+            // No pre-growth — Dread delta starts at 0, reduction takes it to -1
+            var session = BuildSession(
+                dice: Dice(15, 50),
+                playerStats: Stats(charm: 5),
+                shadows: shadows,
+                startingInterest: 24);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.IsGameOver);
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+            Assert.Equal(-1, shadows.GetDelta(ShadowStatType.Dread));
+        }
+
+        [Fact]
+        public async Task Unmatched_NoDreadReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Start at 1, failure → interest drops to 0 → Unmatched
+            var session = BuildSession(
+                dice: Dice(2, 50),
+                playerStats: Stats(charm: 0),
+                opponentStats: Stats(sa: 0),
+                shadows: shadows,
+                startingInterest: 1);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.IsGameOver);
+            Assert.Equal(GameOutcome.Unmatched, result.Outcome);
+            // Dread should have +2 for hitting 0, NOT -1 reduction (that's DateSecured only)
+            Assert.True(shadows.GetDelta(ShadowStatType.Dread) > 3);
+            Assert.DoesNotContain(result.ShadowGrowthEvents, e => e.Contains("Date secured") && e.Contains("Dread"));
+        }
+
+        // =====================================================================
+        // Reduction 2: Honesty success at Interest ≥15 → Denial −1
+        // =====================================================================
+
+        [Fact]
+        public async Task HonestySuccessAtHighInterest_ReducesDenialByOne()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Interest starts at 15 (Interested), Honesty success
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: Stats(honesty: 5),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Denial was 2, should be 2 - 1 = 1
+            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Denial));
+            Assert.Contains(result.ShadowGrowthEvents, e => e.Contains("Denial") && e.Contains("Honesty success at high interest"));
+        }
+
+        [Fact]
+        public async Task HonestySuccessAtInterest14_NoDenialReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Interest at 14 (just under threshold) — need to check what interest is AFTER the roll
+            // With a success of +1, interest goes from 14 to 15. interestAfter is 15 → should trigger.
+            // So let's use interest 13 where even after success it stays at 14
+            var session = BuildSession(
+                dice: Dice(14, 50), // roll 14 + honesty 5 = 19 vs DC ~14 → just beats by 5 → +2 interest
+                playerStats: Stats(honesty: 5),
+                opponentStats: Stats(chaos: 1), // defence for Honesty is Chaos → DC = 13 + 1 = 14
+                shadows: shadows,
+                startingInterest: 12, // after +2 = 14 < 15
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // interestAfter should be < 15, no reduction
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Denial));
+            Assert.DoesNotContain(result.ShadowGrowthEvents, e => e.Contains("Honesty success at high interest"));
+        }
+
+        [Fact]
+        public async Task HonestyFailure_NoDenialReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(2, 50), // low roll → failure
+                playerStats: Stats(honesty: 0),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.Honesty, "truth") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess);
+            // No reduction on failure
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Denial));
+            Assert.DoesNotContain(result.ShadowGrowthEvents, e => e.Contains("Honesty success at high interest"));
+        }
+
+        [Fact]
+        public async Task NonHonestySuccessAtHighInterest_NoDenialReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Denial, 2, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Charm success at interest ≥15 should NOT reduce Denial
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: Stats(charm: 5),
+                shadows: shadows,
+                startingInterest: 15);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0); // Charm, not Honesty
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // =====================================================================
+        // Reduction 3: Recovering from trope trap → Madness −1
+        // =====================================================================
+
+        [Fact]
+        public async Task SuccessfulRecover_ReducesMadnessByOne()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Madness, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            // Need an active trap for Recover
+            var trapDef = new TrapDefinition("test-trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "test", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(18), // high roll → SA success vs DC 12
+                playerStats: Stats(sa: 5),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.ClearedTrapName);
+            // Madness was 3, should be 3 - 1 = 2
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Madness));
+        }
+
+        [Fact]
+        public async Task FailedRecover_NoMadnessReduction()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Madness, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            var trapDef = new TrapDefinition("test-trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "test", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(2), // low roll → failure vs DC 12
+                playerStats: Stats(sa: 0),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.False(result.Success);
+            // Madness should still be 3 (no reduction), +1 Overthinking on failure
+            Assert.Equal(3, shadows.GetDelta(ShadowStatType.Madness));
+            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        [Fact]
+        public async Task SuccessfulRecover_MadnessReductionCanGoNegative()
+        {
+            var shadows = MakeTracker();
+            // No pre-growth — Madness delta starts at 0
+
+            var trapDef = new TrapDefinition("test-trap", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "test", "", "");
+            var session = BuildSessionWithTrap(
+                dice: Dice(18),
+                playerStats: Stats(sa: 5),
+                shadows: shadows,
+                trapDef: trapDef);
+
+            var result = await session.RecoverAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(-1, shadows.GetDelta(ShadowStatType.Madness));
+        }
+
+        // =====================================================================
+        // Reduction 4: Winning despite Overthinking disadvantage → Overthinking −1
+        // =====================================================================
+
+        [Fact]
+        public async Task SuccessWithOverthinkingDisadvantage_ReducesOverthinkingByOne()
+        {
+            // Overthinking at 12 (T2) → SA gets disadvantage
+            var shadows = new SessionShadowTracker(Stats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            // SA option, high roll to succeed despite disadvantage
+            var session = BuildSession(
+                dice: Dice(20, 20, 50), // adv: takes lower of two d20s, but Nat20 always succeeds
+                playerStats: Stats(sa: 5),
+                shadows: shadows,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // Overthinking was 12, should be 12 - 1 = 11
+            Assert.Equal(11, shadows.GetDelta(ShadowStatType.Overthinking));
+            Assert.Contains(result.ShadowGrowthEvents, e => e.Contains("Overthinking") && e.Contains("Succeeded despite"));
+        }
+
+        [Fact]
+        public async Task FailureWithOverthinkingDisadvantage_NoReduction()
+        {
+            var shadows = new SessionShadowTracker(Stats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            // SA option, low roll → failure
+            var session = BuildSession(
+                dice: Dice(2, 2, 50),
+                playerStats: Stats(sa: 0),
+                shadows: shadows,
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess);
+            // Overthinking should still be 12 (no reduction on failure)
+            // +1 from SA usage count if 3+ uses, but only 1 use here
+            Assert.Equal(12, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        [Fact]
+        public async Task SuccessWithCharm_NoOverthinkingReduction()
+        {
+            // Overthinking at 12 but using Charm (not SA) → no Overthinking reduction
+            var shadows = new SessionShadowTracker(Stats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 12, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(20, 50),
+                playerStats: Stats(charm: 5),
+                shadows: shadows);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0); // Charm
+
+            Assert.True(result.Roll.IsSuccess);
+            // Overthinking unchanged — Charm's paired shadow is Madness, not Overthinking
+            Assert.Equal(12, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        [Fact]
+        public async Task SuccessWithSA_NoOverthinkingDisadvantage_NoReduction()
+        {
+            // Overthinking at 5 (below T2) → no disadvantage on SA
+            var shadows = new SessionShadowTracker(Stats());
+            shadows.ApplyGrowth(ShadowStatType.Overthinking, 5, "setup");
+            shadows.DrainGrowthEvents();
+
+            var session = BuildSession(
+                dice: Dice(18, 50),
+                playerStats: Stats(sa: 5),
+                shadows: shadows,
+                options: new[] { new DialogueOption(StatType.SelfAwareness, "aware") });
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            // No reduction because Overthinking wasn't high enough to cause disadvantage
+            Assert.Equal(5, shadows.GetDelta(ShadowStatType.Overthinking));
+        }
+
+        // =====================================================================
+        // Reduction 5: 4+ different stats → Fixation −1 (already implemented, verify)
+        // =====================================================================
+
+        [Fact]
+        public async Task FourDistinctStats_ReducesFixation()
+        {
+            var shadows = MakeTracker();
+            shadows.ApplyGrowth(ShadowStatType.Fixation, 3, "setup");
+            shadows.DrainGrowthEvents();
+
+            var diceValues = new List<int>();
+            for (int i = 0; i < 6; i++) { diceValues.Add(20); diceValues.Add(50); }
+
+            var session = BuildSession(
+                dice: new TestDice(diceValues.ToArray()),
+                playerStats: Stats(charm: 5, honesty: 5, wit: 5, chaos: 5),
+                shadows: shadows,
+                startingInterest: 10);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0); // Charm
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(1); // Honesty
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(2); // Wit
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(3); // Chaos — 4 distinct
+
+            if (!result.IsGameOver)
+            {
+                await session.StartTurnAsync();
+                result = await session.ResolveTurnAsync(0);
+            }
+
+            // At end of game: 4+ stats → -1 Fixation
+            Assert.True(result.IsGameOver);
+            Assert.Contains(result.ShadowGrowthEvents, e => e.Contains("4+ different stats"));
+        }
+
+        // =====================================================================
+        // Helpers
+        // =====================================================================
+
+        private static SessionShadowTracker MakeTracker()
+            => new SessionShadowTracker(Stats());
+
+        private static StatBlock Stats(
+            int charm = 3, int rizz = 2, int honesty = 1,
+            int chaos = 0, int wit = 4, int sa = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm }, { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty }, { StatType.Chaos, chaos },
+                    { StatType.Wit, wit }, { StatType.SelfAwareness, sa }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+            => new CharacterProfile(stats, "system prompt", name, new TimingProfile(5, 1.0f, 0.0f, "neutral"), 1);
+
+        private static TestDice Dice(params int[] values) => new TestDice(values);
+
+        private static GameSession BuildSession(
+            TestDice? dice = null,
+            StatBlock? playerStats = null,
+            StatBlock? opponentStats = null,
+            SessionShadowTracker? shadows = null,
+            DialogueOption[]? options = null,
+            string? previousOpener = null,
+            int? startingInterest = null)
+        {
+            playerStats ??= Stats();
+            opponentStats ??= Stats();
+            ILlmAdapter llm = options != null
+                ? (ILlmAdapter)new StubLlmAdapter(options)
+                : new NullLlmAdapter();
+
+            var config = new GameSessionConfig(
+                playerShadows: shadows,
+                previousOpener: previousOpener,
+                startingInterest: startingInterest);
+
+            // Prepend horniness roll (1d10) consumed by constructor
+            var wrappedDice = new PrependedDice(5, dice ?? Dice(15, 50));
+
+            return new GameSession(
+                MakeProfile("player", playerStats),
+                MakeProfile("opponent", opponentStats),
+                llm,
+                wrappedDice,
+                new NullTrapRegistry(),
+                config);
+        }
+
+        private static GameSession BuildSessionWithTrap(
+            TestDice dice,
+            StatBlock? playerStats = null,
+            SessionShadowTracker? shadows = null,
+            TrapDefinition? trapDef = null)
+        {
+            playerStats ??= Stats();
+            var config = new GameSessionConfig(playerShadows: shadows);
+
+            // Prepend horniness roll (1d10) consumed by constructor
+            var wrappedDice = new PrependedDice(5, dice);
+
+            var session = new GameSession(
+                MakeProfile("player", playerStats),
+                MakeProfile("opponent", Stats()),
+                new NullLlmAdapter(),
+                wrappedDice,
+                new NullTrapRegistry(),
+                config);
+
+            // Activate a trap so Recover is possible
+            if (trapDef != null)
+            {
+                // Use reflection to access private _traps field, or use a Speak turn to trigger trap
+                // Instead, let's manually activate via TrapState
+                var trapsField = typeof(GameSession).GetField("_traps",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var trapState = (TrapState)trapsField!.GetValue(session)!;
+                trapState.Activate(trapDef);
+            }
+
+            return session;
+        }
+
+        private sealed class PrependedDice : IDiceRoller
+        {
+            private int? _first;
+            private readonly IDiceRoller _inner;
+            public PrependedDice(int firstValue, IDiceRoller inner) { _first = firstValue; _inner = inner; }
+            public int Roll(int sides)
+            {
+                if (_first.HasValue) { var v = _first.Value; _first = null; return v; }
+                return _inner.Roll(sides);
+            }
+        }
+
+        private sealed class TestDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public TestDice(int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private sealed class StubLlmAdapter : ILlmAdapter
+        {
+            private readonly DialogueOption[] _options;
+            public StubLlmAdapter(DialogueOption[] options) => _options = options;
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+                => Task.FromResult(_options);
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(context.ChosenOption.IntendedText);
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse("..."));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #270

## DoD Evidence
**Branch:** issue-270-write-tests-missing-5-shadow-reduction-e
**Commit:** e6ad986

## Test Summary
22 spec-driven tests in `ShadowReductionSpecTests.cs` covering all 5 acceptance criteria:

| AC | Reduction | Tests |
|----|-----------|-------|
| AC-1 | Dread −1 on DateSecured | 5 tests (positive, negative delta, non-DateSecured, co-existing events, growth event text) |
| AC-2 | Denial −1 on Honesty success ≥15 | 5 tests (boundary at 15, failure, wrong stat, stacking, growth event) |
| AC-3 | Madness −1 on Recover | 5 tests (success, failure, negative delta, null shadows, Overthinking still grows) |
| AC-4 | Overthinking −1 on disadvantage success | 5 tests (success, failure, wrong stat, low threshold, growth event) |
| AC-6 | Null shadow tracker safety | 2 tests (DateSecured, Honesty) |

Each test has a mutation comment explaining what specific code change would cause it to fail.
