### PR TITLE
[Issue #272] Denial +1 when player skips available Honesty option (§7)

### DIFF
--- a/docs/modules/conversation.md
+++ b/docs/modules/conversation.md
@@ -1,0 +1,69 @@
+# Conversation
+
+## Overview
+The Conversation module implements the core game loop for Pinder's dating-conversation mechanic. It manages turn flow (Speak, Read, Recover, Wait), interest tracking, dice rolls with advantage/disadvantage, traps, combos, timing, and game outcome resolution. The central class is `GameSession`, which orchestrates all player actions and NPC responses.
+
+## Key Components
+
+| File | Description |
+|------|-------------|
+| `GameSession.cs` | Core session state machine — manages turns, rolls, interest, traps, and game outcome |
+| `GameSessionConfig.cs` | Configuration parameters for a game session (starting interest, etc.) |
+| `InterestMeter.cs` | Tracks NPC interest level (0–25) and computes interest state, advantage/disadvantage |
+| `InterestState.cs` | Enum for interest bands (Bored, Neutral, Interested, VeryIntoIt, AlmostThere, etc.) |
+| `TurnStart.cs` | Data returned by `StartTurnAsync()` — dialogue options, current state |
+| `TurnResult.cs` | Data returned by `ResolveTurnAsync()` — roll result, interest change, outcome |
+| `ReadResult.cs` | Data returned by `ReadAsync()` — SA roll result, interest reveal |
+| `RecoverResult.cs` | Data returned by `RecoverAsync()` — roll result, trap recovery |
+| `DialogueOption.cs` | A selectable dialogue choice for a Speak turn |
+| `DialogueContext.cs` | Context passed to the LLM adapter for generating dialogue options |
+| `DeliveryContext.cs` | Context for evaluating delivery/timing of player responses |
+| `ComboTracker.cs` | Tracks consecutive successes for combo bonuses |
+| `ComboResult.cs` | Result of a combo evaluation |
+| `CallbackOpportunity.cs` | Represents a callback opportunity during conversation |
+| `CallbackBonus.cs` | Bonus granted from callbacks |
+| `DelayPenalty.cs` | Penalty applied for slow player responses |
+| `GameClock.cs` | Tracks in-game time progression |
+| `GameOutcome.cs` | Final outcome of a session (DateSecured, Ghosted, etc.) |
+| `GameEndedException.cs` | Exception thrown when actions are attempted after game end |
+| `OpponentContext.cs` | NPC opponent configuration and state |
+| `OpponentResponse.cs` | NPC response data |
+| `OpponentTimingCalculator.cs` | Calculates NPC response timing |
+| `PlayerResponseDelayEvaluator.cs` | Evaluates player response delay for penalty calculation |
+| `Tell.cs` | Represents a behavioral tell from the NPC |
+| `TimingProfile.cs` | Timing configuration for opponent responses |
+| `WeaknessWindow.cs` | Represents a window where the NPC is vulnerable |
+| `NullLlmAdapter.cs` | No-op LLM adapter for testing |
+| `InterestChangeContext.cs` | Context for interest change events |
+| `GameStateSnapshot.cs` | Serializable snapshot of game state |
+
+## API / Public Interface
+
+### `GameSession`
+
+- **`StartTurnAsync() → Task<TurnStart>`** — Begins a Speak turn. Computes advantage from interest state and `_pendingCritAdvantage`. Returns dialogue options.
+- **`ResolveTurnAsync(int optionIndex) → Task<TurnResult>`** — Resolves the selected dialogue option with a dice roll. Sets `_pendingCritAdvantage` if the roll is a Nat 20.
+- **`ReadAsync() → Task<ReadResult>`** — Self-contained action: rolls SA against DC 12 to reveal interest. Consumes and sets `_pendingCritAdvantage` independently.
+- **`RecoverAsync() → Task<RecoverResult>`** — Self-contained action: rolls to recover from an active trap. Consumes and sets `_pendingCritAdvantage` independently.
+- **`Wait()`** — Skips a turn: applies −1 interest, advances trap timers. Does **not** consume `_pendingCritAdvantage`.
+
+### `InterestMeter`
+
+- **`GrantsAdvantage`** — `true` when interest state is VeryIntoIt or AlmostThere.
+- **`GrantsDisadvantage`** — `true` when interest state is Bored.
+
+### `GameSessionConfig`
+
+- Constructor accepts `startingInterest` and other session parameters.
+
+## Architecture Notes
+
+- **Turn flow:** The player calls `StartTurnAsync()` → `ResolveTurnAsync()` for Speak actions, or calls `ReadAsync()` / `RecoverAsync()` / `Wait()` as standalone actions.
+- **Advantage sources:** Advantage is boolean (not cumulative). Sources include interest-based (`InterestMeter.GrantsAdvantage`) and crit-based (`_pendingCritAdvantage`). When both advantage and disadvantage are active, they cancel out to a normal roll.
+- **Crit advantage (`_pendingCritAdvantage`):** A private boolean flag on `GameSession`. Set to `true` after any roll produces a Nat 20 (`RollResult.IsNatTwenty`). Consumed (grants advantage, then cleared to `false`) at the start of the next roll in `StartTurnAsync`, `ReadAsync`, or `RecoverAsync`. `Wait()` does not consume it. The flag is per-session and does not persist across sessions.
+- **Roll mechanics:** Delegated to `RollEngine.Resolve()` and `RollEngine.ResolveFixedDC()` in the Rolls module. When advantage is active, two dice are rolled and the higher is used.
+
+## Change Log
+| Date | Issue | Summary |
+|------|-------|---------|
+| 2026-04-03 | #271 | Initial creation — Added `_pendingCritAdvantage` flag to `GameSession`: Nat 20 on any roll grants advantage on the next roll (§4). Consumed in `StartTurnAsync`, `ReadAsync`, `RecoverAsync`; persists through `Wait()`. Tests cover Speak→Speak, Speak→Read, Read→Speak, Recover→Speak, consecutive Nat 20s, Wait persistence, and advantage+disadvantage cancellation. |

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -395,6 +395,15 @@ namespace Pinder.Core.Conversation
 
             var chosenOption = _currentOptions[optionIndex];
 
+            // Denial +1 when Honesty was available but player chose a different stat (#272 — §7)
+            if (_playerShadows != null
+                && chosenOption.Stat != StatType.Honesty
+                && _currentOptions.Any(o => o.Stat == StatType.Honesty))
+            {
+                _playerShadows.ApplyGrowth(ShadowStatType.Denial, 1,
+                    "Skipped Honesty option");
+            }
+
             // Compute callback bonus (#47)
             int callbackBonus = 0;
             if (chosenOption.CallbackTurnNumber.HasValue)

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for issue #272: Denial +1 when player skips available Honesty option (§7).
+    /// Maturity: Prototype — happy-path per AC.
+    /// </summary>
+    public class DenialSkipHonestyTests
+    {
+        // AC1: Denial +1 when Honesty option available and player chose different stat
+        [Fact]
+        public async Task SkippingHonesty_GrowsDenialByOne()
+        {
+            var shadows = MakeTracker();
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "smooth line"),
+                new DialogueOption(StatType.Honesty, "truth bomb"),
+                new DialogueOption(StatType.Wit, "clever quip")
+            };
+            var session = BuildSession(dice: Dice(15, 50), shadows: shadows, options: options);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0); // picks Charm, skipping Honesty
+
+            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // AC2: No Denial growth when no Honesty option was in the lineup
+        [Fact]
+        public async Task NoHonestyInLineup_NoDenialGrowth()
+        {
+            var shadows = MakeTracker();
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "smooth line"),
+                new DialogueOption(StatType.Wit, "clever quip"),
+                new DialogueOption(StatType.Rizz, "rizz move")
+            };
+            var session = BuildSession(dice: Dice(15, 50), shadows: shadows, options: options);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0); // picks Charm, no Honesty available
+
+            Assert.Equal(0, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // AC3: No Denial growth when player chose Honesty
+        [Fact]
+        public async Task ChoosingHonesty_NoDenialGrowth()
+        {
+            var shadows = MakeTracker();
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "smooth line"),
+                new DialogueOption(StatType.Honesty, "truth bomb"),
+                new DialogueOption(StatType.Wit, "clever quip")
+            };
+            var session = BuildSession(dice: Dice(15, 50), shadows: shadows, options: options);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(1); // picks Honesty
+
+            Assert.Equal(0, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // Edge: Denial grows each turn Honesty is skipped (per turn)
+        [Fact]
+        public async Task SkippingHonestyTwice_GrowsDenialByTwo()
+        {
+            var shadows = MakeTracker();
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "smooth line"),
+                new DialogueOption(StatType.Honesty, "truth bomb"),
+                new DialogueOption(StatType.Wit, "clever quip")
+            };
+            var session = BuildSession(
+                dice: Dice(15, 50, 15, 50),
+                shadows: shadows,
+                options: options);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0); // skip Honesty turn 1
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(2); // skip Honesty turn 2 (pick Wit)
+
+            Assert.Equal(2, shadows.GetDelta(ShadowStatType.Denial));
+        }
+
+        // Edge: No shadows tracker → no crash
+        [Fact]
+        public async Task NoShadowTracker_NoCrash()
+        {
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "smooth line"),
+                new DialogueOption(StatType.Honesty, "truth bomb")
+            };
+            var session = BuildSession(dice: Dice(15, 50), shadows: null, options: options);
+
+            await session.StartTurnAsync();
+            // Should not throw
+            await session.ResolveTurnAsync(0);
+        }
+
+        // =====================================================================
+        // Helpers
+        // =====================================================================
+
+        private static SessionShadowTracker MakeTracker()
+            => new SessionShadowTracker(MakeStats());
+
+        private static StatBlock MakeStats(
+            int charm = 3, int rizz = 2, int honesty = 1,
+            int chaos = 0, int wit = 4, int sa = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm }, { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty }, { StatType.Chaos, chaos },
+                    { StatType.Wit, wit }, { StatType.SelfAwareness, sa }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock? stats = null)
+            => new CharacterProfile(
+                stats ?? MakeStats(),
+                "system prompt",
+                name,
+                new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                1);
+
+        private static TestDice Dice(params int[] values) => new TestDice(values);
+
+        private static GameSession BuildSession(
+            TestDice? dice = null,
+            SessionShadowTracker? shadows = null,
+            DialogueOption[]? options = null)
+        {
+            var d = dice ?? Dice(15, 50);
+            ILlmAdapter llm = options != null
+                ? (ILlmAdapter)new StubLlmAdapter(options)
+                : new NullLlmAdapter();
+
+            var config = new GameSessionConfig(playerShadows: shadows);
+
+            // PrependedDice: first roll is ghost check (need non-ghost value)
+            var wrappedDice = new PrependedDice(5, d);
+
+            return new GameSession(
+                MakeProfile("player"),
+                MakeProfile("opponent"),
+                llm,
+                wrappedDice,
+                new NullTrapRegistry(),
+                config);
+        }
+
+        private sealed class PrependedDice : IDiceRoller
+        {
+            private int? _first;
+            private readonly IDiceRoller _inner;
+            public PrependedDice(int firstValue, IDiceRoller inner)
+            {
+                _first = firstValue;
+                _inner = inner;
+            }
+            public int Roll(int sides)
+            {
+                if (_first.HasValue) { var v = _first.Value; _first = null; return v; }
+                return _inner.Roll(sides);
+            }
+        }
+
+        private sealed class TestDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public TestDice(int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides)
+            {
+                if (_values.Count == 0)
+                    throw new InvalidOperationException("TestDice ran out of values");
+                return _values.Dequeue();
+            }
+        }
+
+        private sealed class StubLlmAdapter : ILlmAdapter
+        {
+            private readonly DialogueOption[] _options;
+            public StubLlmAdapter(DialogueOption[] options) => _options = options;
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+                => Task.FromResult(_options);
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(context.ChosenOption.IntendedText);
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse("..."));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -228,12 +228,13 @@ namespace Pinder.Core.Tests
             shadows.ApplyGrowth(ShadowStatType.Denial, 3, "setup");
             shadows.DrainGrowthEvents();
 
+            // Use options without Honesty to isolate from #272 Denial skip-Honesty growth
             var session = BuildSession(
                 dice: Dice(18, 50),
                 playerStats: MakeStats(charm: 5),
                 shadows: shadows,
-                startingInterest: 16);
-            // Default options use Charm
+                startingInterest: 16,
+                options: new[] { new DialogueOption(StatType.Charm, "Hey, you come here often?") });
 
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -177,14 +177,16 @@ namespace Pinder.Core.Tests
             shadows.DrainGrowthEvents();
 
             // Charm success at interest ≥15 should NOT reduce Denial
+            // Use options without Honesty to isolate from #272 Denial skip-Honesty growth
             var session = BuildSession(
                 dice: Dice(18, 50),
                 playerStats: Stats(charm: 5),
                 shadows: shadows,
-                startingInterest: 15);
+                startingInterest: 15,
+                options: new[] { new DialogueOption(StatType.Charm, "Hey, you come here often?") });
 
             await session.StartTurnAsync();
-            var result = await session.ResolveTurnAsync(0); // Charm, not Honesty
+            var result = await session.ResolveTurnAsync(0); // Charm, no Honesty available
 
             Assert.True(result.Roll.IsSuccess);
             Assert.Equal(2, shadows.GetDelta(ShadowStatType.Denial));


### PR DESCRIPTION
Fixes #272

## What was implemented

§7 rule: 'Choosing a non-Honesty option when Honesty was available → Denial +1 (per turn)'.

Added a check in `ResolveTurnAsync` after the option is chosen: if `_playerShadows` is available, the chosen stat is not Honesty, and any option in `_currentOptions` has `StatType.Honesty`, then `ApplyGrowth(ShadowStatType.Denial, 1, ...)` is called.

## How to test

```bash
dotnet test tests/Pinder.Core.Tests/ --filter DenialSkipHonestyTests
```

5 tests cover all acceptance criteria:
- Skipping Honesty grows Denial by 1
- No Honesty in lineup → no Denial growth  
- Choosing Honesty → no Denial growth
- Multi-turn accumulation (2 skips = +2 Denial)
- Null shadow tracker → no crash

## Files changed
- `src/Pinder.Core/Conversation/GameSession.cs` — added denial growth check in ResolveTurnAsync
- `tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs` — new test file (5 tests)
- `tests/Pinder.Core.Tests/ShadowReductionTests.cs` — updated 1 test to use explicit options (isolate from new rule)
- `tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs` — updated 1 test to use explicit options (isolate from new rule)

## Deviations from contract
None
