### PR TITLE
[Issue #307] Fix: Shadow taint block never fires — store raw values instead of tiers

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -256,8 +256,10 @@ namespace Pinder.Core.Conversation
                 foreach (ShadowStatType shadow in Enum.GetValues(typeof(ShadowStatType)))
                 {
                     int effectiveVal = _playerShadows.GetEffectiveShadow(shadow);
+                    // Store raw shadow value (not tier) so LLM prompt builder
+                    // can check fine-grained thresholds (e.g. >5 for T1 taint).
+                    shadowThresholds[shadow] = effectiveVal;
                     int tier = ShadowThresholdEvaluator.GetThresholdLevel(effectiveVal);
-                    shadowThresholds[shadow] = tier;
 
                     // T2+: paired positive stat gets disadvantage
                     if (tier >= 2)
@@ -318,8 +320,8 @@ namespace Pinder.Core.Conversation
             if (_playerShadows != null && shadowThresholds != null)
             {
                 // Fixation T3: force all options to use the same stat as last turn
-                if (shadowThresholds.TryGetValue(ShadowStatType.Fixation, out int fixTier)
-                    && fixTier >= 3 && _lastStatUsed.HasValue)
+                if (shadowThresholds.TryGetValue(ShadowStatType.Fixation, out int fixRaw)
+                    && fixRaw >= 18 && _lastStatUsed.HasValue)
                 {
                     var forcedStat = _lastStatUsed.Value;
                     for (int i = 0; i < options.Length; i++)
@@ -332,8 +334,8 @@ namespace Pinder.Core.Conversation
                 }
 
                 // Denial T3: remove Honesty options
-                if (shadowThresholds.TryGetValue(ShadowStatType.Denial, out int denTier)
-                    && denTier >= 3)
+                if (shadowThresholds.TryGetValue(ShadowStatType.Denial, out int denRaw)
+                    && denRaw >= 18)
                 {
                     var filtered = options.Where(o => o.Stat != StatType.Honesty).ToArray();
                     if (filtered.Length == 0)

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -285,9 +285,10 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
 
             Assert.NotNull(capturedThresholds);
-            Assert.Equal(2, capturedThresholds![ShadowStatType.Dread]);     // 14 → T2
-            Assert.Equal(1, capturedThresholds[ShadowStatType.Denial]);     // 6 → T1
-            Assert.Equal(0, capturedThresholds[ShadowStatType.Fixation]);   // 0 → T0
+            // #307: shadowThresholds now carries raw shadow values, not tier (0-3)
+            Assert.Equal(14, capturedThresholds![ShadowStatType.Dread]);     // raw value 14
+            Assert.Equal(6, capturedThresholds[ShadowStatType.Denial]);      // raw value 6
+            Assert.Equal(0, capturedThresholds[ShadowStatType.Fixation]);    // raw value 0
         }
 
         // ============== AC9: No effects when SessionShadowTracker is null ==============
@@ -368,6 +369,104 @@ namespace Pinder.Core.Tests
 
             // With adv+disadv canceling, should be a single roll = 12
             Assert.Equal(12, result.Roll.UsedDieRoll);
+        }
+
+        // ============== #307: Shadow taint uses raw values ==============
+
+        [Fact]
+        public async Task ShadowThresholds_StoresRawValues_NotTiers()
+        {
+            // Madness=8 is T1 (tier=1). Context should get raw value 8, not tier 1.
+            Dictionary<ShadowStatType, int>? capturedThresholds = null;
+            var shadows = MakeShadowTracker(madness: 8);
+
+            var llm = new CapturingLlmAdapter(ctx =>
+            {
+                capturedThresholds = ctx.ShadowThresholds;
+            });
+
+            var session = MakeSessionWithLlm(
+                diceValues: new[] { 15, 50 },
+                shadows: shadows,
+                llm: llm);
+
+            await session.StartTurnAsync();
+
+            Assert.NotNull(capturedThresholds);
+            // Raw value must be passed, not tier
+            Assert.Equal(8, capturedThresholds![ShadowStatType.Madness]);
+        }
+
+        [Fact]
+        public async Task ShadowThresholds_T0Value_PassedAsRawZero()
+        {
+            // Madness=3 is T0. Context should get raw value 3.
+            Dictionary<ShadowStatType, int>? capturedThresholds = null;
+            var shadows = MakeShadowTracker(madness: 3);
+
+            var llm = new CapturingLlmAdapter(ctx =>
+            {
+                capturedThresholds = ctx.ShadowThresholds;
+            });
+
+            var session = MakeSessionWithLlm(
+                diceValues: new[] { 15, 50 },
+                shadows: shadows,
+                llm: llm);
+
+            await session.StartTurnAsync();
+
+            Assert.NotNull(capturedThresholds);
+            Assert.Equal(3, capturedThresholds![ShadowStatType.Madness]);
+        }
+
+        [Fact]
+        public async Task FixationT3_StillTriggersAt18RawValue()
+        {
+            // Fixation=18 (T3) should still force all options to last stat used
+            var shadows = MakeShadowTracker(fixation: 18);
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hey"),
+                new DialogueOption(StatType.Wit, "Clever"),
+                new DialogueOption(StatType.Honesty, "Truth")
+            };
+
+            var session = MakeSession(
+                diceValues: new[] { 15, 15, 50, 15, 50 },
+                shadows: shadows,
+                llmOptions: options);
+
+            // First turn: no last stat used, so no fixation filtering
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0); // plays Charm
+
+            // Second turn: Fixation T3 should force all options to Charm
+            var turn2 = await session.StartTurnAsync();
+            Assert.All(turn2.Options, o => Assert.Equal(StatType.Charm, o.Stat));
+        }
+
+        [Fact]
+        public async Task DenialT3_StillTriggersAt18RawValue()
+        {
+            // Denial=18 (T3) should still remove Honesty options
+            var shadows = MakeShadowTracker(denial: 18);
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hey"),
+                new DialogueOption(StatType.Honesty, "Truth"),
+                new DialogueOption(StatType.Wit, "Clever")
+            };
+
+            var session = MakeSession(
+                diceValues: new[] { 15, 50 },
+                shadows: shadows,
+                llmOptions: options);
+
+            var turn = await session.StartTurnAsync();
+
+            // Honesty options should be filtered out
+            Assert.DoesNotContain(turn.Options, o => o.Stat == StatType.Honesty);
         }
 
         // ============ Helpers ============

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -503,9 +503,10 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
 
             Assert.NotNull(captured);
-            Assert.Equal(2, captured![ShadowStatType.Dread]);       // 14 → T2
-            Assert.Equal(1, captured[ShadowStatType.Denial]);       // 6 → T1
-            Assert.Equal(0, captured[ShadowStatType.Fixation]);     // 0 → T0
+            // #307: shadowThresholds now carries raw shadow values, not tier (0-3)
+            Assert.Equal(14, captured![ShadowStatType.Dread]);      // raw value 14
+            Assert.Equal(6, captured[ShadowStatType.Denial]);       // raw value 6
+            Assert.Equal(0, captured[ShadowStatType.Fixation]);     // raw value 0
         }
 
         // Mutation: would catch if all 6 shadow stats are not included in dictionary
@@ -659,9 +660,10 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
 
             Assert.NotNull(captured);
-            Assert.Equal(2, captured![ShadowStatType.Dread]);
-            Assert.Equal(1, captured[ShadowStatType.Denial]);
-            Assert.Equal(3, captured[ShadowStatType.Fixation]);
+            // #307: shadowThresholds now carries raw shadow values
+            Assert.Equal(14, captured![ShadowStatType.Dread]);
+            Assert.Equal(6, captured[ShadowStatType.Denial]);
+            Assert.Equal(18, captured[ShadowStatType.Fixation]);
             Assert.Equal(0, captured[ShadowStatType.Madness]);
             Assert.Equal(0, captured[ShadowStatType.Overthinking]);
             Assert.Equal(0, captured[ShadowStatType.Horniness]);


### PR DESCRIPTION
Fixes #307

## Summary
GameSession stored shadow *tier* (0-3) in the `shadowThresholds` dictionary, but `SessionDocumentBuilder.BuildShadowTaintBlock()` checks raw values (`> 5`, `> 6`). Since tier never exceeds 3, shadow taint was **never injected** into any LLM prompt.

## Changes
- **`GameSession.cs`**: Store raw shadow value from `GetEffectiveShadow()` instead of tier from `GetThresholdLevel()`
- **`GameSession.cs`**: Update Fixation T3 and Denial T3 internal checks from `>= 3` (tier) to `>= 18` (raw value)
- **Tests**: Update existing assertions to expect raw values instead of tiers
- **Tests**: Add 4 new tests verifying raw value passthrough and T3 behavior

## How to test
```bash
dotnet test --filter ShadowThreshold
```

## DoD Evidence
**Tests:** 1322 Core + 443 LlmAdapters = 1765 total, 0 failures
**Deviations from contract:** None — Option A (raw values) was the recommended approach.