### PR TITLE
[Issue #309] Fix: SuccessScale, failure tier, beatDcBy, and MissMargin use FinalTotal

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -572,7 +572,7 @@ namespace Pinder.Core.Conversation
             var deliveryTrapNames = GetActiveTrapNames();
             var deliveryTrapInstructions = GetActiveTrapInstructions();
 
-            int beatDcBy = rollResult.IsSuccess ? rollResult.Total - rollResult.DC : 0;
+            int beatDcBy = rollResult.IsSuccess ? rollResult.FinalTotal - rollResult.DC : 0;
 
             var deliveryContext = new DeliveryContext(
                 playerPrompt: _player.AssembledSystemPrompt,

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -165,8 +165,7 @@ namespace Pinder.Core.Rolls
             }
             else
             {
-                // MissMargin uses Total (not FinalTotal) for backward compatibility
-                int miss = dc - total;
+                int miss = dc - finalTotal;
 
                 if      (miss <= 2) tier = FailureTier.Fumble;
                 else if (miss <= 5) tier = FailureTier.Misfire;

--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -76,8 +76,8 @@ namespace Pinder.Core.Rolls
         /// </summary>
         public RiskTier RiskTier { get; }
 
-        /// <summary>By how much the roll missed the DC. 0 on success.</summary>
-        public int MissMargin => IsSuccess ? 0 : DC - Total;
+        /// <summary>By how much the roll missed the DC (using FinalTotal). 0 on success.</summary>
+        public int MissMargin => IsSuccess ? 0 : DC - FinalTotal;
 
         public RollResult(
             int dieRoll,

--- a/src/Pinder.Core/Rolls/SuccessScale.cs
+++ b/src/Pinder.Core/Rolls/SuccessScale.cs
@@ -22,7 +22,7 @@ namespace Pinder.Core.Rolls
             if (result.IsNatTwenty)
                 return 4;
 
-            int margin = result.Total - result.DC;
+            int margin = result.FinalTotal - result.DC;
 
             if (margin >= 10)
                 return 3;

--- a/tests/Pinder.Core.Tests/Issue309_FinalTotalTests.cs
+++ b/tests/Pinder.Core.Tests/Issue309_FinalTotalTests.cs
@@ -1,0 +1,226 @@
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for Issue #309: SuccessScale, failure tier, beatDcBy, and MissMargin
+    /// must all use FinalTotal (including external bonuses), not base Total.
+    /// </summary>
+    public class Issue309_FinalTotalTests
+    {
+        private class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public FixedDice(params int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private class EmptyTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        private static StatBlock MakeStats(int charm = 0)
+        {
+            var baseStats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm,         charm },
+                { StatType.Rizz,          0     },
+                { StatType.Honesty,       0     },
+                { StatType.Chaos,         0     },
+                { StatType.Wit,           0     },
+                { StatType.SelfAwareness, 0     },
+            };
+            var shadowStats = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness,      0 },
+                { ShadowStatType.Horniness,    0 },
+                { ShadowStatType.Denial,       0 },
+                { ShadowStatType.Fixation,     0 },
+                { ShadowStatType.Dread,        0 },
+                { ShadowStatType.Overthinking, 0 },
+            };
+            return new StatBlock(baseStats, shadowStats);
+        }
+
+        // --- SuccessScale uses FinalTotal ---
+
+        [Fact]
+        public void SuccessScale_ExternalBonus_IncreasesMarginTier()
+        {
+            // Total = 14, DC = 13 → margin 1 → +1 interest (without bonus)
+            // FinalTotal = 14 + 5 = 19, DC = 13 → margin 6 → +2 interest (with bonus)
+            var result = new RollResult(
+                dieRoll: 10, secondDieRoll: null, usedDieRoll: 10,
+                stat: StatType.Charm, statModifier: 4, levelBonus: 0,
+                dc: 13, tier: FailureTier.None, externalBonus: 5);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(14, result.Total);
+            Assert.Equal(19, result.FinalTotal);
+
+            int delta = SuccessScale.GetInterestDelta(result);
+            // margin = 19 - 13 = 6 → +2
+            Assert.Equal(2, delta);
+        }
+
+        [Fact]
+        public void SuccessScale_LargeExternalBonus_ReachesCritTier()
+        {
+            // Total = 14, DC = 13 → margin 1 → +1 (without bonus)
+            // FinalTotal = 14 + 10 = 24 → margin 11 → +3 (crit tier)
+            var result = new RollResult(
+                dieRoll: 10, secondDieRoll: null, usedDieRoll: 10,
+                stat: StatType.Charm, statModifier: 4, levelBonus: 0,
+                dc: 13, tier: FailureTier.None, externalBonus: 10);
+
+            Assert.Equal(3, SuccessScale.GetInterestDelta(result));
+        }
+
+        [Fact]
+        public void SuccessScale_ZeroExternalBonus_SameAsTotal()
+        {
+            // Backward compat: no external bonus, margin = Total - DC
+            var result = new RollResult(
+                dieRoll: 15, secondDieRoll: null, usedDieRoll: 15,
+                stat: StatType.Charm, statModifier: 3, levelBonus: 0,
+                dc: 13, tier: FailureTier.None, externalBonus: 0);
+
+            // Total = 18, FinalTotal = 18, margin = 5 → +2
+            Assert.Equal(2, SuccessScale.GetInterestDelta(result));
+        }
+
+        // --- Failure tier uses FinalTotal ---
+
+        [Fact]
+        public void FailureTier_ExternalBonus_ReducesMissMargin()
+        {
+            // Without bonus: roll 5 + mod 0 + level 0 = 5 vs DC 13 → miss 8 → TropeTrap (6-9)
+            // With +3 bonus: finalTotal = 8 vs DC 13 → miss 5 → Misfire (3-5)
+            var attacker = MakeStats(charm: 0);
+            var defender = MakeStats(); // DC = 13 + 0 = 13
+            var traps = new TrapState();
+            var dice = new FixedDice(5); // roll a 5
+
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, defender, traps, 1,
+                new EmptyTrapRegistry(), dice,
+                externalBonus: 3);
+
+            Assert.False(result.IsSuccess);
+            // miss = 13 - (5 + 0 + 0 + 3) = 5 → Misfire
+            Assert.Equal(FailureTier.Misfire, result.Tier);
+        }
+
+        [Fact]
+        public void FailureTier_ExternalBonus_TurnsMissIntoFumble()
+        {
+            // roll 8 + mod 2 = 10 vs DC 13 → miss 3 → Misfire (without bonus)
+            // With +1 bonus: finalTotal = 11, miss = 2 → Fumble (1-2)
+            var attacker = MakeStats(charm: 2);
+            var defender = MakeStats();
+            var traps = new TrapState();
+            var dice = new FixedDice(8);
+
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, defender, traps, 1,
+                new EmptyTrapRegistry(), dice,
+                externalBonus: 1);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(FailureTier.Fumble, result.Tier);
+        }
+
+        [Fact]
+        public void FailureTier_ZeroExternalBonus_SameAsBefore()
+        {
+            // Backward compat: no bonus, miss = dc - total
+            var attacker = MakeStats(charm: 0);
+            var defender = MakeStats();
+            var traps = new TrapState();
+            var dice = new FixedDice(5); // total = 5, miss = 8 → TropeTrap
+
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, defender, traps, 1,
+                new EmptyTrapRegistry(), dice,
+                externalBonus: 0);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(FailureTier.TropeTrap, result.Tier);
+        }
+
+        [Fact]
+        public void FailureTier_ExternalBonus_CanTurnFailureIntoSuccess()
+        {
+            // roll 8 + mod 2 = 10 vs DC 13 → fail (without bonus)
+            // With +3 bonus: finalTotal = 13 → success
+            var attacker = MakeStats(charm: 2);
+            var defender = MakeStats();
+            var traps = new TrapState();
+            var dice = new FixedDice(8);
+
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, defender, traps, 1,
+                new EmptyTrapRegistry(), dice,
+                externalBonus: 3);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(FailureTier.None, result.Tier);
+        }
+
+        // --- MissMargin uses FinalTotal ---
+
+        [Fact]
+        public void MissMargin_UseFinalTotal()
+        {
+            // Total = 5, ExternalBonus = 3, FinalTotal = 8, DC = 13
+            // MissMargin should be 13 - 8 = 5 (not 13 - 5 = 8)
+            var result = new RollResult(
+                dieRoll: 5, secondDieRoll: null, usedDieRoll: 5,
+                stat: StatType.Charm, statModifier: 0, levelBonus: 0,
+                dc: 13, tier: FailureTier.Misfire, externalBonus: 3);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(5, result.MissMargin);
+        }
+
+        [Fact]
+        public void MissMargin_ZeroOnSuccess()
+        {
+            var result = new RollResult(
+                dieRoll: 15, secondDieRoll: null, usedDieRoll: 15,
+                stat: StatType.Charm, statModifier: 0, levelBonus: 0,
+                dc: 13, tier: FailureTier.None, externalBonus: 0);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(0, result.MissMargin);
+        }
+
+        // --- Catastrophe boundary with external bonus ---
+
+        [Fact]
+        public void FailureTier_ExternalBonus_PreventsLargeMissFromCatastrophe()
+        {
+            // roll 2 + mod 0 = 2 vs DC 13 → miss 11 → Catastrophe (without bonus)
+            // With +2 bonus: finalTotal = 4, miss = 9 → TropeTrap (6-9)
+            var attacker = MakeStats(charm: 0);
+            var defender = MakeStats();
+            var traps = new TrapState();
+            var dice = new FixedDice(2);
+
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, defender, traps, 1,
+                new EmptyTrapRegistry(), dice,
+                externalBonus: 2);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(FailureTier.TropeTrap, result.Tier);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/RollEngineExtensionTests.cs
+++ b/tests/Pinder.Core.Tests/RollEngineExtensionTests.cs
@@ -283,15 +283,15 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void RollResult_MissMargin_UsesTotal_NotFinalTotal()
+        public void RollResult_MissMargin_UsesFinalTotal()
         {
             // Total=10, DC=14, externalBonus=1 → FinalTotal=11 < 14 → fail
-            // MissMargin should be DC - Total = 4, not DC - FinalTotal = 3
+            // MissMargin should be DC - FinalTotal = 3
             var result = new RollResult(10, null, 10, StatType.Charm, 0, 0, 14,
                 FailureTier.Misfire, externalBonus: 1);
 
             Assert.False(result.IsSuccess);
-            Assert.Equal(4, result.MissMargin); // DC(14) - Total(10) = 4
+            Assert.Equal(3, result.MissMargin); // DC(14) - FinalTotal(11) = 3
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -303,13 +303,13 @@ namespace Pinder.Core.Tests
 
         // Mutation: Fails if MissMargin uses FinalTotal instead of Total
         [Fact]
-        public void RollResult_MissMargin_IgnoresExternalBonus()
+        public void RollResult_MissMargin_UsesFinalTotal()
         {
             // Total=10, DC=14, externalBonus=2 → FinalTotal=12 < 14 → fail
-            // MissMargin should be 14 - 10 = 4 (not 14 - 12 = 2)
+            // MissMargin should be 14 - 12 = 2 (uses FinalTotal, not Total)
             var result = new RollResult(10, null, 10, StatType.Charm, 0, 0, 14,
                 FailureTier.Misfire, externalBonus: 2);
-            Assert.Equal(4, result.MissMargin);
+            Assert.Equal(2, result.MissMargin);
         }
 
         // Mutation: Fails if Nat1 with externalBonus somehow succeeds


### PR DESCRIPTION
Fixes #309

## Summary
External bonuses (callback, tell, momentum, triple) are included in `RollResult.FinalTotal` but three downstream calculations were using base `Total`, ignoring these bonuses. This made external bonuses affect only pass/fail determination but not outcome quality.

## Changes
1. **SuccessScale.cs**: `margin = result.FinalTotal - result.DC` (was `result.Total`)
2. **RollEngine.cs**: `miss = dc - finalTotal` (was `dc - total`) — failure tier severity now accounts for external bonuses
3. **GameSession.cs**: `beatDcBy = rollResult.FinalTotal - rollResult.DC` (was `rollResult.Total`) — LLM delivery prompt gets correct margin
4. **RollResult.cs**: `MissMargin` property uses `FinalTotal` (was `Total`)

## Tests
- 10 dedicated tests in `Issue309_FinalTotalTests.cs` covering all four fix areas
- 2 existing tests updated from old behavior expectation to new correct behavior
- All 1793 tests pass (1340 Core + 453 LlmAdapters)

## Backward Compatibility
When `externalBonus = 0` (default), `FinalTotal == Total`, so all existing behavior is unchanged.

## Deviations from contract
None

## DoD Evidence
**Branch:** issue-309-bug-successscale-failure-tier-and-beatdc
**Commit:** ac7d671
**Tests:** Passed! - Failed: 0, Passed: 1340 (Core) + 453 (LlmAdapters) = 1793 total
