### PR TITLE
[Issue #313] Add Lukewarm (5-9) as distinct InterestState

### DIFF
--- a/src/Pinder.Core/Conversation/InterestMeter.cs
+++ b/src/Pinder.Core/Conversation/InterestMeter.cs
@@ -42,13 +42,14 @@ namespace Pinder.Core.Conversation
 
         /// <summary>
         /// Returns the current interest state based on rules v3.4 §6 boundaries:
-        /// 0 = Unmatched, 1–4 = Bored, 5–15 = Interested,
+        /// 0 = Unmatched, 1–4 = Bored, 5–9 = Lukewarm, 10–15 = Interested,
         /// 16–20 = VeryIntoIt, 21–24 = AlmostThere, 25 = DateSecured.
         /// </summary>
         public InterestState GetState()
         {
             if (Current <= 0)  return InterestState.Unmatched;
             if (Current <= 4)  return InterestState.Bored;
+            if (Current <= 9)  return InterestState.Lukewarm;
             if (Current <= 15) return InterestState.Interested;
             if (Current <= 20) return InterestState.VeryIntoIt;
             if (Current <= 24) return InterestState.AlmostThere;

--- a/src/Pinder.Core/Conversation/InterestState.cs
+++ b/src/Pinder.Core/Conversation/InterestState.cs
@@ -12,7 +12,10 @@ namespace Pinder.Core.Conversation
         /// <summary>Interest 1–4. Player rolls with disadvantage.</summary>
         Bored,
 
-        /// <summary>Interest 5–15. No modifier.</summary>
+        /// <summary>Interest 5–9. No modifier.</summary>
+        Lukewarm,
+
+        /// <summary>Interest 10–15. No modifier.</summary>
         Interested,
 
         /// <summary>Interest 16–20. Player rolls with advantage.</summary>

--- a/src/Pinder.Core/Conversation/OpponentTimingCalculator.cs
+++ b/src/Pinder.Core/Conversation/OpponentTimingCalculator.cs
@@ -113,6 +113,7 @@ namespace Pinder.Core.Conversation
             switch (state)
             {
                 case InterestState.Bored:       return 5.0;
+                case InterestState.Lukewarm:    return 2.0;
                 case InterestState.Interested:  return 1.0;
                 case InterestState.VeryIntoIt:  return 0.5;
                 case InterestState.AlmostThere: return 0.3;

--- a/tests/Pinder.Core.Tests/InterestMeterTests.cs
+++ b/tests/Pinder.Core.Tests/InterestMeterTests.cs
@@ -28,9 +28,19 @@ namespace Pinder.Core.Tests
 
         [Theory]
         [InlineData(5)]
+        [InlineData(7)]
+        [InlineData(9)]
+        public void GetState_Between5And9_ReturnsLukewarm(int value)
+        {
+            var meter = CreateAtValue(value);
+            Assert.Equal(InterestState.Lukewarm, meter.GetState());
+        }
+
+        [Theory]
         [InlineData(10)]
+        [InlineData(12)]
         [InlineData(15)]
-        public void GetState_Between5And15_ReturnsInterested(int value)
+        public void GetState_Between10And15_ReturnsInterested(int value)
         {
             var meter = CreateAtValue(value);
             Assert.Equal(InterestState.Interested, meter.GetState());
@@ -97,10 +107,19 @@ namespace Pinder.Core.Tests
         // --- Boundary transitions ---
 
         [Fact]
-        public void Boundary_4To5_BoredToInterested()
+        public void Boundary_4To5_BoredToLukewarm()
         {
             var meter = CreateAtValue(4);
             Assert.Equal(InterestState.Bored, meter.GetState());
+            meter.Apply(1);
+            Assert.Equal(InterestState.Lukewarm, meter.GetState());
+        }
+
+        [Fact]
+        public void Boundary_9To10_LukewarmToInterested()
+        {
+            var meter = CreateAtValue(9);
+            Assert.Equal(InterestState.Lukewarm, meter.GetState());
             meter.Apply(1);
             Assert.Equal(InterestState.Interested, meter.GetState());
         }

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -458,12 +458,14 @@ namespace Pinder.Core.Tests
             Assert.True(meter.IsZero);
         }
 
-        // Mutation: Fails if Interested state boundaries are wrong (5-15 range)
+        // Mutation: Fails if interest state boundaries are wrong
         [Fact]
         public void InterestMeter_CustomStart_Boundaries()
         {
             Assert.Equal(InterestState.Bored, new InterestMeter(4).GetState());
-            Assert.Equal(InterestState.Interested, new InterestMeter(5).GetState());
+            Assert.Equal(InterestState.Lukewarm, new InterestMeter(5).GetState());
+            Assert.Equal(InterestState.Lukewarm, new InterestMeter(9).GetState());
+            Assert.Equal(InterestState.Interested, new InterestMeter(10).GetState());
             Assert.Equal(InterestState.Interested, new InterestMeter(15).GetState());
             Assert.Equal(InterestState.VeryIntoIt, new InterestMeter(16).GetState());
             Assert.Equal(InterestState.VeryIntoIt, new InterestMeter(20).GetState());


### PR DESCRIPTION
Fixes #313

## Summary
Rules §6 defines 7 interest states including Lukewarm (5-9) and Interested (10-15) as separate states. The code previously merged them into one `Interested` state (5-15). This PR splits them.

## Changes
- **InterestState.cs**: Added `Lukewarm` enum value between `Bored` and `Interested`
- **InterestMeter.cs**: Updated `GetState()` to return `Lukewarm` for 5-9, `Interested` for 10-15
- **OpponentTimingCalculator.cs**: Added `Lukewarm` case with 2.0x multiplier (between Bored 5.0x and Interested 1.0x)
- **Tests**: Updated InterestMeterTests and Wave0SpecTests for new boundaries

## How to test
```bash
dotnet test
```

All 1867 tests pass (1383 Core + 484 LlmAdapters).

## Deviations from contract
None. `GrantsAdvantage` and `GrantsDisadvantage` unaffected — Lukewarm has no modifiers per rules §6. `SessionDocumentBuilder.GetInterestBehaviourBlock()` already handles the 5-9 range correctly with lukewarm text.