### PR TITLE
[Issue #308] Critical: DeliveryContext and OpponentContext missing shadowThresholds — taint only reaches option generation

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -74,6 +74,7 @@ namespace Pinder.Core.Conversation
         // Shadow threshold tracking (#45)
         private StatType? _lastStatUsed;
         private HashSet<StatType>? _shadowDisadvantagedStats;
+        private Dictionary<ShadowStatType, int>? _currentShadowThresholds;
 
         // Stored between StartTurnAsync and ResolveTurnAsync
         private DialogueOption[]? _currentOptions;
@@ -276,6 +277,9 @@ namespace Pinder.Core.Conversation
                     }
                 }
             }
+
+            // Store player shadow thresholds for use in ResolveTurnAsync (#308)
+            _currentShadowThresholds = shadowThresholds;
 
             // Get trap names and LLM instructions for context
             var activeTrapNames = GetActiveTrapNames();
@@ -599,7 +603,8 @@ namespace Pinder.Core.Conversation
                 activeTrapInstructions: deliveryTrapInstructions,
                 playerName: _player.DisplayName,
                 opponentName: _opponent.DisplayName,
-                currentTurn: _turnNumber);
+                currentTurn: _turnNumber,
+                shadowThresholds: _currentShadowThresholds);
 
             string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext).ConfigureAwait(false);
 
@@ -625,6 +630,17 @@ namespace Pinder.Core.Conversation
             // 11. Generate opponent response
             var opponentTrapInstructions = GetActiveTrapInstructions();
 
+            // Compute opponent shadow thresholds for opponent prompt taint (#308)
+            Dictionary<ShadowStatType, int>? opponentShadowThresholds = null;
+            if (_opponentShadows != null)
+            {
+                opponentShadowThresholds = new Dictionary<ShadowStatType, int>();
+                foreach (ShadowStatType shadow in Enum.GetValues(typeof(ShadowStatType)))
+                {
+                    opponentShadowThresholds[shadow] = _opponentShadows.GetEffectiveShadow(shadow);
+                }
+            }
+
             var opponentContext = new OpponentContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -639,7 +655,8 @@ namespace Pinder.Core.Conversation
                 activeTrapInstructions: opponentTrapInstructions,
                 playerName: _player.DisplayName,
                 opponentName: _opponent.DisplayName,
-                currentTurn: _turnNumber);
+                currentTurn: _turnNumber,
+                shadowThresholds: opponentShadowThresholds);
 
             var opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
             if (opponentResponse == null)

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #308: GameSession must pass shadowThresholds to DeliveryContext and OpponentContext,
+    /// not just DialogueContext. Player shadows go to DeliveryContext, opponent shadows to OpponentContext.
+    /// Maturity: Prototype (happy-path per AC).
+    /// </summary>
+    public class Issue308_DeliveryOpponentShadowThresholdsTests
+    {
+        // AC: DeliveryContext receives player shadowThresholds
+        [Fact]
+        public async Task DeliveryContext_ReceivesPlayerShadowThresholds_WhenMadness8()
+        {
+            Dictionary<ShadowStatType, int>? capturedDelivery = null;
+            var playerShadows = MakeShadowTracker(madness: 8);
+            var llm = new FullCapturingLlmAdapter(
+                onDeliver: ctx => capturedDelivery = ctx.ShadowThresholds);
+
+            var session = MakeSession(new[] { 5, 15, 15 }, playerShadows, null, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(capturedDelivery);
+            Assert.True(capturedDelivery!.ContainsKey(ShadowStatType.Madness));
+            Assert.Equal(8, capturedDelivery[ShadowStatType.Madness]);
+        }
+
+        // AC: OpponentContext receives opponent shadowThresholds
+        [Fact]
+        public async Task OpponentContext_ReceivesOpponentShadowThresholds_WhenMadness8()
+        {
+            Dictionary<ShadowStatType, int>? capturedOpponent = null;
+            var opponentShadows = MakeShadowTracker(madness: 8);
+            var llm = new FullCapturingLlmAdapter(
+                onOpponent: ctx => capturedOpponent = ctx.ShadowThresholds);
+
+            var session = MakeSession(new[] { 5, 15, 15 }, null, opponentShadows, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(capturedOpponent);
+            Assert.True(capturedOpponent!.ContainsKey(ShadowStatType.Madness));
+            Assert.Equal(8, capturedOpponent[ShadowStatType.Madness]);
+        }
+
+        // Edge: DeliveryContext gets player shadows, OpponentContext gets opponent shadows (different values)
+        [Fact]
+        public async Task DeliveryAndOpponent_GetDifferentShadows()
+        {
+            Dictionary<ShadowStatType, int>? capturedDelivery = null;
+            Dictionary<ShadowStatType, int>? capturedOpponent = null;
+            var playerShadows = MakeShadowTracker(madness: 10, dread: 5);
+            var opponentShadows = MakeShadowTracker(madness: 3, dread: 14);
+            var llm = new FullCapturingLlmAdapter(
+                onDeliver: ctx => capturedDelivery = ctx.ShadowThresholds,
+                onOpponent: ctx => capturedOpponent = ctx.ShadowThresholds);
+
+            var session = MakeSession(new[] { 5, 15, 15 }, playerShadows, opponentShadows, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Player shadows in delivery
+            Assert.NotNull(capturedDelivery);
+            Assert.Equal(10, capturedDelivery![ShadowStatType.Madness]);
+            Assert.Equal(5, capturedDelivery[ShadowStatType.Dread]);
+
+            // Opponent shadows in opponent context
+            Assert.NotNull(capturedOpponent);
+            Assert.Equal(3, capturedOpponent![ShadowStatType.Madness]);
+            Assert.Equal(14, capturedOpponent[ShadowStatType.Dread]);
+        }
+
+        // Edge: No player shadows -> DeliveryContext.ShadowThresholds is null
+        [Fact]
+        public async Task NoPlayerShadows_DeliveryContextThresholdsNull()
+        {
+            Dictionary<ShadowStatType, int>? capturedDelivery = null;
+            bool called = false;
+            var llm = new FullCapturingLlmAdapter(
+                onDeliver: ctx => { capturedDelivery = ctx.ShadowThresholds; called = true; });
+
+            var session = MakeSession(new[] { 5, 15, 15 }, null, null, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.True(called);
+            Assert.Null(capturedDelivery);
+        }
+
+        // Edge: No opponent shadows -> OpponentContext.ShadowThresholds is null
+        [Fact]
+        public async Task NoOpponentShadows_OpponentContextThresholdsNull()
+        {
+            Dictionary<ShadowStatType, int>? capturedOpponent = null;
+            bool called = false;
+            var llm = new FullCapturingLlmAdapter(
+                onOpponent: ctx => { capturedOpponent = ctx.ShadowThresholds; called = true; });
+
+            var session = MakeSession(new[] { 5, 15, 15 }, null, null, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.True(called);
+            Assert.Null(capturedOpponent);
+        }
+
+        // AC: All shadow stats pass through to DeliveryContext
+        [Fact]
+        public async Task AllShadowStats_PassedToDeliveryContext()
+        {
+            Dictionary<ShadowStatType, int>? capturedDelivery = null;
+            var playerShadows = MakeShadowTracker(
+                dread: 14, denial: 7, fixation: 3,
+                madness: 10, overthinking: 5, horniness: 12);
+            var llm = new FullCapturingLlmAdapter(
+                onDeliver: ctx => capturedDelivery = ctx.ShadowThresholds);
+
+            var session = MakeSession(new[] { 5, 15, 15 }, playerShadows, null, llm);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(capturedDelivery);
+            Assert.Equal(14, capturedDelivery![ShadowStatType.Dread]);
+            Assert.Equal(7, capturedDelivery[ShadowStatType.Denial]);
+            Assert.Equal(3, capturedDelivery[ShadowStatType.Fixation]);
+            Assert.Equal(10, capturedDelivery[ShadowStatType.Madness]);
+            Assert.Equal(5, capturedDelivery[ShadowStatType.Overthinking]);
+            Assert.Equal(12, capturedDelivery[ShadowStatType.Horniness]);
+        }
+
+        // ============ Helpers ============
+
+        private static SessionShadowTracker MakeShadowTracker(
+            int dread = 0, int denial = 0, int fixation = 0,
+            int madness = 0, int overthinking = 0, int horniness = 0)
+        {
+            var stats = new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 2 }, { StatType.Honesty, 2 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Dread, dread }, { ShadowStatType.Denial, denial },
+                    { ShadowStatType.Fixation, fixation }, { ShadowStatType.Madness, madness },
+                    { ShadowStatType.Overthinking, overthinking }, { ShadowStatType.Horniness, horniness }
+                });
+            return new SessionShadowTracker(stats);
+        }
+
+        private static StatBlock MakeStatBlock()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 2 }, { StatType.Honesty, 2 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            var timing = new TimingProfile(5, 1.0f, 0.0f, "neutral");
+            return new CharacterProfile(MakeStatBlock(), "system prompt", name, timing, 1);
+        }
+
+        private static GameSession MakeSession(
+            int[] diceValues,
+            SessionShadowTracker? playerShadows,
+            SessionShadowTracker? opponentShadows,
+            ILlmAdapter llm)
+        {
+            var config = new GameSessionConfig(
+                playerShadows: playerShadows,
+                opponentShadows: opponentShadows);
+
+            // dice[0] = ghost check, rest = roll dice
+            var allDice = new int[diceValues.Length + 1];
+            allDice[0] = 5; // ghost check (not triggered)
+            Array.Copy(diceValues, 0, allDice, 1, diceValues.Length);
+
+            return new GameSession(
+                MakeProfile("player"),
+                MakeProfile("opponent"),
+                llm,
+                new SafeQueueDice(allDice),
+                new NullTrapRegistry(),
+                config);
+        }
+
+        private sealed class SafeQueueDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public SafeQueueDice(int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        /// <summary>
+        /// LLM adapter that captures DeliveryContext and OpponentContext for assertion.
+        /// </summary>
+        private sealed class FullCapturingLlmAdapter : ILlmAdapter
+        {
+            private readonly Action<DeliveryContext>? _onDeliver;
+            private readonly Action<OpponentContext>? _onOpponent;
+
+            public FullCapturingLlmAdapter(
+                Action<DeliveryContext>? onDeliver = null,
+                Action<OpponentContext>? onOpponent = null)
+            {
+                _onDeliver = onDeliver;
+                _onOpponent = onOpponent;
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                return Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, "Hey there"),
+                    new DialogueOption(StatType.Wit, "Clever line")
+                });
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            {
+                _onDeliver?.Invoke(context);
+                return Task.FromResult(context.ChosenOption.IntendedText);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            {
+                _onOpponent?.Invoke(context);
+                return Task.FromResult(new OpponentResponse("reply"));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            {
+                return Task.FromResult<string?>(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #308

## What was changed
GameSession now passes shadow thresholds to DeliveryContext (player shadows) and OpponentContext (opponent shadows), so shadow taint colors ALL LLM outputs — not just dialogue option generation.

## Changes
- **GameSession.cs**: Added `_currentShadowThresholds` field to persist player shadow thresholds between StartTurnAsync and ResolveTurnAsync. Pass player shadows to DeliveryContext constructor. Compute opponent shadow thresholds from `_opponentShadows` and pass to OpponentContext constructor.
- **Issue308_DeliveryOpponentShadowThresholdsTests.cs**: 6 tests covering:
  - DeliveryContext receives player shadows (Madness=8)
  - OpponentContext receives opponent shadows (Madness=8)
  - Different shadow values for player vs opponent
  - Null shadows when no tracker configured
  - All 6 shadow stats propagated

## How to test
```bash
dotnet test tests/Pinder.Core.Tests --filter Issue308
```

## DoD Evidence
**Tests**: 1469 core + 484 adapter = 1953 total, 0 failures
**Commit**: 73c1729
**Deviations from contract**: none
