### PR TITLE
[Issue #346] Spec: IPlayerAgent interface and scoring model

### DIFF
--- a/docs/specs/issue-346-spec.md
+++ b/docs/specs/issue-346-spec.md
@@ -1,0 +1,361 @@
+# Spec: IPlayerAgent Interface and Scoring Model
+
+**Issue:** #346 — Player agent: IPlayerAgent interface and scoring model for sim decision-making  
+**Module:** docs/modules/session-runner.md (create new)
+
+---
+
+## Overview
+
+The simulation runner currently selects dialogue options using a naive `BestOption` function that picks whichever option has the highest effective stat modifier. This issue introduces an `IPlayerAgent` abstraction and supporting data types so that the session runner can delegate turn decisions to pluggable agents — a deterministic scoring agent (#347) and an LLM-backed agent (#348). All new types live in `session-runner/`, NOT in `Pinder.Core`, per vision concern #355.
+
+---
+
+## Function Signatures
+
+All types are in the `session-runner/` project (namespace TBD by implementer; suggested `Pinder.SessionRunner`). The project targets `net8.0` but uses **LangVersion 8.0** per the existing `.csproj`.
+
+### IPlayerAgent
+
+```csharp
+public interface IPlayerAgent
+{
+    /// <summary>
+    /// Given a TurnStart (options + game state snapshot) and additional agent context,
+    /// returns a decision: which option to pick, why, and score breakdowns for all options.
+    /// </summary>
+    Task<PlayerDecision> DecideAsync(TurnStart turn, PlayerAgentContext context);
+}
+```
+
+- `TurnStart` is `Pinder.Core.Conversation.TurnStart` (already exists). It contains `Options` (`DialogueOption[]`) and `State` (`GameStateSnapshot`).
+- `PlayerAgentContext` carries additional data not available on `TurnStart` (see below).
+- Returns `Task<PlayerDecision>` because LLM-backed agents need async I/O. Synchronous agents (like `ScoringPlayerAgent`) return `Task.FromResult(...)`.
+
+### PlayerDecision
+
+```csharp
+public sealed class PlayerDecision
+{
+    /// <summary>Index into TurnStart.Options (0-based).</summary>
+    public int OptionIndex { get; }
+
+    /// <summary>Human-readable explanation of why this option was chosen.</summary>
+    public string Reasoning { get; }
+
+    /// <summary>Score breakdown for every option in the TurnStart. Length == TurnStart.Options.Length.</summary>
+    public OptionScore[] Scores { get; }
+
+    public PlayerDecision(int optionIndex, string reasoning, OptionScore[] scores);
+}
+```
+
+**Invariants:**
+- `OptionIndex` is in range `[0, Scores.Length)`.
+- `Scores` is never null and has one entry per dialogue option.
+- `Reasoning` is never null (may be empty string for deterministic agents).
+
+### OptionScore
+
+```csharp
+public sealed class OptionScore
+{
+    /// <summary>Index of the option this score corresponds to.</summary>
+    public int OptionIndex { get; }
+
+    /// <summary>Composite score (higher = better pick). Implementation-defined scale.</summary>
+    public float Score { get; }
+
+    /// <summary>Estimated probability of beating the DC, as a percentage 0–100.</summary>
+    public float SuccessChance { get; }
+
+    /// <summary>Expected interest gain (positive or negative), weighting success and failure outcomes.</summary>
+    public float ExpectedInterestGain { get; }
+
+    /// <summary>Human-readable list of bonuses factored into the score, e.g. ["callback +2", "tell +2"].</summary>
+    public string[] BonusesApplied { get; }
+
+    public OptionScore(
+        int optionIndex,
+        float score,
+        float successChance,
+        float expectedInterestGain,
+        string[] bonusesApplied);
+}
+```
+
+**Invariants:**
+- `SuccessChance` is clamped to `[0, 100]`.
+- `BonusesApplied` is never null (may be empty array).
+
+### PlayerAgentContext
+
+```csharp
+public sealed class PlayerAgentContext
+{
+    /// <summary>The player character's stat block (immutable).</summary>
+    public StatBlock PlayerStats { get; }
+
+    /// <summary>The opponent character's stat block (immutable).</summary>
+    public StatBlock OpponentStats { get; }
+
+    /// <summary>Current interest meter value (0-25).</summary>
+    public int CurrentInterest { get; }
+
+    /// <summary>Current interest state (derived from CurrentInterest).</summary>
+    public InterestState InterestState { get; }
+
+    /// <summary>Number of consecutive successful rolls (0 = no streak).</summary>
+    public int MomentumStreak { get; }
+
+    /// <summary>Names of currently active traps.</summary>
+    public string[] ActiveTrapNames { get; }
+
+    /// <summary>Current session horniness value (from SessionShadowTracker, 0 if unavailable).</summary>
+    public int SessionHorniness { get; }
+
+    /// <summary>Current shadow stat values (from SessionShadowTracker). Null if shadow tracking disabled.</summary>
+    public Dictionary<ShadowStatType, int>? ShadowValues { get; }
+
+    /// <summary>Current turn number (from GameStateSnapshot.TurnNumber).</summary>
+    public int TurnNumber { get; }
+
+    public PlayerAgentContext(
+        StatBlock playerStats,
+        StatBlock opponentStats,
+        int currentInterest,
+        InterestState interestState,
+        int momentumStreak,
+        string[] activeTrapNames,
+        int sessionHorniness,
+        Dictionary<ShadowStatType, int>? shadowValues,
+        int turnNumber);
+}
+```
+
+**Invariants:**
+- `PlayerStats` and `OpponentStats` are never null.
+- `ActiveTrapNames` is never null (may be empty array).
+- `CurrentInterest` is in `[0, 25]`.
+- `MomentumStreak` is `>= 0`.
+
+---
+
+## Input/Output Examples
+
+### Example 1: Basic decision with 4 options
+
+**Input — TurnStart.Options:**
+
+| Index | Stat    | CallbackTurnNumber | ComboName    | HasTellBonus | HasWeaknessWindow |
+|-------|---------|--------------------|--------------|--------------|-------------------|
+| 0     | Charm   | null               | null         | false        | false             |
+| 1     | Rizz    | null               | null         | false        | false             |
+| 2     | Honesty | 3                  | null         | false        | false             |
+| 3     | Chaos   | null               | "WitChaosSA" | true         | false             |
+
+**Input — PlayerAgentContext:**
+
+- PlayerStats: Charm +4, Rizz +1, Honesty +3, Chaos +2, Wit +2, SA +3 (shadows all 0)
+- OpponentStats: Charm +2, Rizz +3, Honesty +1, Chaos +2, Wit +1, SA +2 (shadows all 0)
+- CurrentInterest: 12
+- InterestState: Interested
+- MomentumStreak: 2
+- ActiveTrapNames: `[]`
+- SessionHorniness: 4
+- ShadowValues: null
+- TurnNumber: 5
+
+**DC calculations (for reference):**
+- Charm attacks, opponent defends with SA: DC = 13 + 2 = 15. Player mod = +4. Need = 11. Success% = 50%
+- Rizz attacks, opponent defends with Wit: DC = 13 + 1 = 14. Player mod = +1. Need = 13. Success% = 40%
+- Honesty attacks, opponent defends with Chaos: DC = 13 + 2 = 15. Player mod = +3. Need = 12. Success% = 45%
+- Chaos attacks, opponent defends with Charm: DC = 13 + 2 = 15. Player mod = +2. Need = 13. Success% = 40%
+
+**Expected output — PlayerDecision:**
+
+```
+OptionIndex: 0
+Reasoning: "Charm has highest success chance at 50%. Momentum streak at 2, one more success triggers +2 bonus."
+Scores: [
+  { OptionIndex: 0, Score: ~6.5,  SuccessChance: 50.0, ExpectedInterestGain: ~0.8, BonusesApplied: [] },
+  { OptionIndex: 1, Score: ~3.2,  SuccessChance: 40.0, ExpectedInterestGain: ~0.3, BonusesApplied: [] },
+  { OptionIndex: 2, Score: ~5.0,  SuccessChance: 45.0, ExpectedInterestGain: ~0.6, BonusesApplied: ["callback"] },
+  { OptionIndex: 3, Score: ~5.8,  SuccessChance: 40.0, ExpectedInterestGain: ~0.5, BonusesApplied: ["tell +2", "combo"] }
+]
+```
+
+(Exact score values depend on the scoring formula implementation in #347. The `~` prefix indicates approximate illustrative values.)
+
+### Example 2: Bored state — prefer bold options
+
+**Input — PlayerAgentContext (partial):**
+- CurrentInterest: 3
+- InterestState: Bored
+- MomentumStreak: 0
+
+**Expected behavior:** The agent should weight Bold/Hard risk-tier options higher because there is little to lose (already near Unmatched) and the risk tier bonus (+1/+2 interest) provides needed uplift.
+
+### Example 3: AlmostThere — prefer safe options
+
+**Input — PlayerAgentContext (partial):**
+- CurrentInterest: 22
+- InterestState: AlmostThere
+- MomentumStreak: 4
+
+**Expected behavior:** The agent should prefer options with highest success probability regardless of risk tier bonus, because a single success at +1 interest may be enough to reach DateSecured.
+
+---
+
+## Acceptance Criteria
+
+### AC1: IPlayerAgent interface defined
+
+The `IPlayerAgent` interface must be defined in `session-runner/` with the exact signature shown above. It must:
+- Accept `TurnStart` (from `Pinder.Core.Conversation`) and `PlayerAgentContext` as parameters.
+- Return `Task<PlayerDecision>`.
+- Be a public interface so it can be referenced by any code in the session-runner project.
+
+**Location:** Per vision concern #355, this interface lives in `session-runner/`, NOT `Pinder.Core/Interfaces/`. The issue body suggests `Pinder.Core/Interfaces/` but #355 overrides this.
+
+### AC2: PlayerDecision and OptionScore types defined
+
+Both must be `sealed class` types (not records — LangVersion 8.0) with:
+- Read-only properties (get-only, set in constructor).
+- Constructor validation: null checks on `Reasoning`, `Scores`, `BonusesApplied`.
+- `PlayerDecision.Scores.Length` must equal the number of options in the `TurnStart` that produced it.
+- `PlayerDecision.OptionIndex` must be in `[0, Scores.Length)`.
+
+### AC3: PlayerAgentContext type defined
+
+Must be a `sealed class` with:
+- All properties shown above, with types exactly as specified.
+- Constructor that validates non-null for `PlayerStats`, `OpponentStats`, `ActiveTrapNames`.
+- `ShadowValues` is nullable (null when shadow tracking is not wired).
+
+**Referenced types from Pinder.Core:**
+- `Pinder.Core.Stats.StatBlock`
+- `Pinder.Core.Stats.ShadowStatType`
+- `Pinder.Core.Conversation.InterestState`
+
+### AC4: Session runner updated to use IPlayerAgent
+
+The `BestOption()` static method in `session-runner/Program.cs` must be replaced with a call to `IPlayerAgent.DecideAsync()`. The wiring looks like:
+
+```csharp
+var snapshot = turnStart.State;
+var agentContext = new PlayerAgentContext(
+    playerStats: sableStats,
+    opponentStats: brickStats,
+    currentInterest: snapshot.Interest,
+    interestState: snapshot.State,
+    momentumStreak: snapshot.MomentumStreak,
+    activeTrapNames: snapshot.ActiveTrapNames,
+    sessionHorniness: 0,
+    shadowValues: null,
+    turnNumber: snapshot.TurnNumber);
+
+var decision = await agent.DecideAsync(turnStart, agentContext);
+int pick = decision.OptionIndex;
+```
+
+Where `agent` is an `IPlayerAgent` instance created during session runner setup. For this issue, the concrete agent can be a minimal wrapper replicating the current `BestOption` logic (pick highest `context.PlayerStats.GetEffective(option.Stat)`) or the `ScoringPlayerAgent` from #347 if implemented together.
+
+The `BestOption()` static method should be removed once the agent is wired.
+
+### AC5: Build clean
+
+The solution must compile with zero errors. All 1977+ existing tests must pass unchanged. No new NuGet packages.
+
+---
+
+## Edge Cases
+
+### Zero options
+If `TurnStart.Options` is empty (length 0), `DecideAsync` should throw `InvalidOperationException("No options available")`. This should never occur in normal gameplay but the agent must not crash with an index-out-of-range.
+
+### Single option
+If only one option is provided (e.g., all replaced by Horniness-forced Rizz), the agent must return `OptionIndex = 0`. Score computation still runs to populate reasoning and scores.
+
+### All options have identical stats
+When all four options use the same `StatType` (possible under Horniness T3 >= 18), all `OptionScore.SuccessChance` values will be identical. The agent should pick index 0 (deterministic tiebreak: lowest index wins).
+
+### Null or missing shadow values
+`PlayerAgentContext.ShadowValues` may be null. Agents must treat missing shadows as zero for any scoring that factors in shadow state.
+
+### Extreme interest values
+- `CurrentInterest = 0` (Unmatched): Game should already be over. Agent still returns a valid decision.
+- `CurrentInterest = 25` (DateSecured): Same — agent still returns valid output.
+
+### Momentum streak edge values
+- `MomentumStreak = 0`: No momentum bonus.
+- `MomentumStreak = 2`: Close to triggering +2 bonus. Strategic agents may favor high-success options.
+- `MomentumStreak >= 5`: Maximum momentum bonus (+3).
+
+### All bonuses stacked
+An option can have `HasTellBonus = true`, `CallbackTurnNumber != null`, `ComboName != null`, and `HasWeaknessWindow = true` simultaneously. All bonuses stack.
+
+### PlayerDecision construction validation
+If `OptionIndex >= scores.Length` or `scores` is null, the constructor must throw immediately, catching agent bugs early.
+
+---
+
+## Error Conditions
+
+| Condition | Expected behavior |
+|---|---|
+| `turn` is null | `DecideAsync` throws `ArgumentNullException("turn")` |
+| `context` is null | `DecideAsync` throws `ArgumentNullException("context")` |
+| `turn.Options` is empty (length 0) | `DecideAsync` throws `InvalidOperationException("No options available")` |
+| `PlayerDecision` optionIndex < 0 or >= scores.Length | Constructor throws `ArgumentOutOfRangeException("optionIndex")` |
+| `PlayerDecision` reasoning is null | Constructor throws `ArgumentNullException("reasoning")` |
+| `PlayerDecision` scores is null | Constructor throws `ArgumentNullException("scores")` |
+| `OptionScore` bonusesApplied is null | Constructor throws `ArgumentNullException("bonusesApplied")` |
+| `PlayerAgentContext` playerStats is null | Constructor throws `ArgumentNullException("playerStats")` |
+| `PlayerAgentContext` opponentStats is null | Constructor throws `ArgumentNullException("opponentStats")` |
+| `PlayerAgentContext` activeTrapNames is null | Constructor throws `ArgumentNullException("activeTrapNames")` |
+
+---
+
+## Dependencies
+
+### Pinder.Core types consumed (read-only — no changes to Core)
+
+| Type | Namespace | Usage |
+|---|---|---|
+| `TurnStart` | `Pinder.Core.Conversation` | Input to `DecideAsync` |
+| `DialogueOption` | `Pinder.Core.Conversation` | Via `TurnStart.Options` — provides `Stat`, `HasTellBonus`, `CallbackTurnNumber`, `ComboName`, `HasWeaknessWindow`, `IsUnhingedReplacement` |
+| `GameStateSnapshot` | `Pinder.Core.Conversation` | Via `TurnStart.State` — provides `Interest`, `State`, `MomentumStreak`, `ActiveTrapNames`, `TurnNumber`, `TripleBonusActive` |
+| `InterestState` | `Pinder.Core.Conversation` | Enum field on `PlayerAgentContext` |
+| `StatBlock` | `Pinder.Core.Stats` | On `PlayerAgentContext` — provides `GetEffective(StatType)`, `GetDefenceDC(StatType)` |
+| `StatType` | `Pinder.Core.Stats` | Enum — accessed via `DialogueOption.Stat` |
+| `ShadowStatType` | `Pinder.Core.Stats` | Enum — key type for `ShadowValues` dictionary |
+
+### Downstream consumers
+
+| Consumer | Usage |
+|---|---|
+| `session-runner/Program.cs` | Creates agent, calls `DecideAsync` per turn, uses `OptionIndex` for `ResolveTurnAsync` |
+| `ScoringPlayerAgent` (#347) | Implements `IPlayerAgent` with deterministic EV scoring |
+| `LlmPlayerAgent` (#348) | Implements `IPlayerAgent` via Anthropic API + ScoringPlayerAgent fallback |
+| Pick reasoning output (#351) | Reads `Reasoning` and `Scores` for markdown display |
+
+### External dependencies
+
+None. All types in `session-runner/` (net8.0) referencing `Pinder.Core` (netstandard2.0). No new NuGet packages.
+
+---
+
+## Notes for Implementers
+
+1. **Location override:** Issue body says `Pinder.Core/Interfaces/`. Vision concern #355 overrides this — all player agent types go in `session-runner/`. Core gains zero new public types.
+
+2. **LangVersion 8.0:** No C# 9+ features (records, init-only setters). Use `sealed class` with constructor + get-only properties.
+
+3. **Temporary agent for AC4:** If `ScoringPlayerAgent` (#347) is not yet available, create a minimal agent replicating `BestOption` logic (pick highest `context.PlayerStats.GetEffective(option.Stat)`) wrapped in `IPlayerAgent`. This satisfies AC4 independently.
+
+4. **Snapshot sourcing:** `GameStateSnapshot` comes from `TurnStart.State`. The session runner has `sableStats` and `brickStats` as local variables. `PlayerAgentContext` bridges both.
+
+5. **Dictionary<ShadowStatType, int>:** `ShadowStatType` has 6 values. When shadow tracking is not wired (#350), pass `null`.
+
+6. **Success probability formula:** `need = DC - modifier`, `successChance = max(0, min(100, (21 - need) * 5))`. Natural 20 always succeeds, natural 1 always fails — captured by the clamp.

--- a/docs/specs/issue-351-spec.md
+++ b/docs/specs/issue-351-spec.md
@@ -1,0 +1,249 @@
+# Spec: Session Runner — Show Pick Reasoning in Playtest Output
+
+**Issue:** #351  
+**Module:** docs/modules/session-runner.md (create new)
+
+---
+
+## Overview
+
+After each turn in the session runner's playtest markdown output, display the player agent's reasoning for its pick and a compact score table showing all options with their computed metrics. This makes the sim output useful for understanding game balance and agent decision quality, rather than just showing which option was chosen.
+
+This issue depends on #347 (ScoringPlayerAgent) and #348 (LlmPlayerAgent), which define the `PlayerDecision` type containing `Reasoning` (string) and `Scores` (array of `OptionScore`).
+
+---
+
+## Function Signatures
+
+All changes are in `session-runner/Program.cs`. No new public types are introduced by this issue — it consumes types defined by #346/#347/#348.
+
+### Formatting Functions (new, in Program.cs)
+
+```csharp
+/// <summary>
+/// Formats the player agent's reasoning as a markdown blockquote.
+/// Each line of the reasoning string is prefixed with "> ".
+/// </summary>
+/// <param name="decision">The PlayerDecision returned by the agent.</param>
+/// <param name="agentTypeName">The simple class name of the agent (e.g. "ScoringPlayerAgent").</param>
+/// <returns>A multi-line string containing the formatted reasoning block.</returns>
+static string FormatReasoningBlock(PlayerDecision decision, string agentTypeName);
+
+/// <summary>
+/// Formats the option score table as a markdown table.
+/// The chosen option row is marked with ✓ and its score is bold.
+/// </summary>
+/// <param name="decision">The PlayerDecision containing Scores and OptionIndex.</param>
+/// <param name="options">The DialogueOption[] from TurnStart, used for stat labels.</param>
+/// <returns>A multi-line string containing the markdown table.</returns>
+static string FormatScoreTable(PlayerDecision decision, DialogueOption[] options);
+```
+
+### Types Consumed (defined by #346/#347/#348, NOT by this issue)
+
+```csharp
+// From IPlayerAgent pipeline:
+public sealed class PlayerDecision
+{
+    public int OptionIndex { get; }       // 0-based index of chosen option
+    public string Reasoning { get; }      // Free-text reasoning from agent
+    public OptionScore[] Scores { get; }  // One per option, ordered by option index
+}
+
+public sealed class OptionScore
+{
+    public int OptionIndex { get; }              // 0-based
+    public float Score { get; }                  // Overall score (higher = better)
+    public float SuccessChance { get; }          // 0.0–1.0 probability
+    public float ExpectedInterestGain { get; }   // Expected interest delta
+    public string[] BonusesApplied { get; }      // e.g. ["📖", "🔗"]
+}
+```
+
+---
+
+## Input/Output Examples
+
+### Example 1: ScoringPlayerAgent pick
+
+**Input state:**
+- `PlayerDecision.OptionIndex` = 0
+- `PlayerDecision.Reasoning` = `"Charm +7 at DC19 (45%) vs Honesty +7 at DC22 (30%) — 15pp advantage.\n🔗 Callback on Honesty (+2) narrows gap to 40% vs 45% — Charm still wins.\nMomentum at 2 — prioritize success to reach streak bonus.\nPick: A"`
+- `PlayerDecision.Scores`:
+  - `{ OptionIndex: 0, Score: 8.3, SuccessChance: 0.45, ExpectedInterestGain: 1.8, BonusesApplied: [] }`
+  - `{ OptionIndex: 1, Score: 1.2, SuccessChance: 0.05, ExpectedInterestGain: 0.9, BonusesApplied: [] }`
+  - `{ OptionIndex: 2, Score: 6.1, SuccessChance: 0.30, ExpectedInterestGain: 1.4, BonusesApplied: ["📖", "🔗"] }`
+  - `{ OptionIndex: 3, Score: 0.0, SuccessChance: 0.00, ExpectedInterestGain: 0.0, BonusesApplied: [] }`
+- `TurnStart.Options`: 4 options with stats CHARM, RIZZ, HONESTY, CHAOS
+- Agent type name: `"ScoringPlayerAgent"`
+
+**Expected output (appended after the `► Player picks: A (CHARM)` line):**
+
+```markdown
+**Player reasoning (ScoringPlayerAgent):**
+> Charm +7 at DC19 (45%) vs Honesty +7 at DC22 (30%) — 15pp advantage.
+> 🔗 Callback on Honesty (+2) narrows gap to 40% vs 45% — Charm still wins.
+> Momentum at 2 — prioritize success to reach streak bonus.
+> Pick: A
+
+| Option | Stat | Pct | Expected ΔI | Score |
+|---|---|---|---|---|
+| A ✓ | CHARM | 45% | +1.8 | **8.3** |
+| B | RIZZ | 5% | +0.9 | 1.2 |
+| C | HONESTY | 30% | +1.4 📖🔗 | 6.1 |
+| D | CHAOS | 0% | +0.0 | 0.0 |
+```
+
+### Example 2: LlmPlayerAgent pick
+
+**Input state:**
+- `PlayerDecision.OptionIndex` = 2
+- `PlayerDecision.Reasoning` = `"The 🔗 callback on option C (Honesty) closes the probability gap to near-tie. But Charm is Safe tier — Honesty is Hard. At Interest 19 I need one more win, not a risky bet. Going Charm — cleaner, lower trap exposure, gets us home.\nPick: C"`
+- Agent type name: `"LlmPlayerAgent"`
+
+**Expected output:**
+
+```markdown
+**Player reasoning (LlmPlayerAgent):**
+> The 🔗 callback on option C (Honesty) closes the probability gap to near-tie. But Charm is Safe
+> tier — Honesty is Hard. At Interest 19 I need one more win, not a risky bet. Going Charm —
+> cleaner, lower trap exposure, gets us home.
+> Pick: C
+
+| Option | Stat | Pct | Expected ΔI | Score |
+|---|---|---|---|---|
+| A | CHARM | 45% | +1.8 | 8.3 |
+| B | RIZZ | 5% | +0.9 | 1.2 |
+| C ✓ | HONESTY | 30% | +1.4 📖🔗 | **6.1** |
+| D | CHAOS | 0% | +0.0 | 0.0 |
+```
+
+---
+
+## Acceptance Criteria
+
+### AC1: Playtest output includes reasoning block after each pick
+
+After the existing line `**► Player picks: {letter} ({STAT})**`, the output must include a reasoning block formatted as:
+
+```
+**Player reasoning ({AgentTypeName}):**
+> {line 1 of reasoning}
+> {line 2 of reasoning}
+> ...
+```
+
+- Each line of `PlayerDecision.Reasoning` is prefixed with `> ` (markdown blockquote).
+- The reasoning text is split on `\n` characters.
+- A blank line separates the pick line from the reasoning block.
+- A blank line separates the reasoning block from the score table.
+
+### AC2: Option score table shown for each turn
+
+After the reasoning block, a markdown table is rendered with columns: `Option`, `Stat`, `Pct`, `Expected ΔI`, `Score`.
+
+- One row per option in `TurnStart.Options`, ordered by index (A, B, C, D).
+- `Option` column: letter label (A/B/C/D). The chosen option has ` ✓` appended (e.g. `A ✓`).
+- `Stat` column: uppercase stat name from `DialogueOption.Stat` (e.g. `CHARM`, `RIZZ`).
+- `Pct` column: `OptionScore.SuccessChance` formatted as integer percentage (e.g. `45%`). Use `Math.Round(score.SuccessChance * 100)` — no decimal places.
+- `Expected ΔI` column: `OptionScore.ExpectedInterestGain` formatted as `+{value:F1}` (one decimal, always with sign). If `BonusesApplied` is non-empty, append the bonus emoji strings concatenated (e.g. `+1.4 📖🔗`).
+- `Score` column: `OptionScore.Score` formatted to one decimal. The chosen option's score is wrapped in `**bold**`.
+
+### AC3: Reasoning reflects actual decision logic (not hardcoded text)
+
+The reasoning string comes directly from `PlayerDecision.Reasoning` as returned by the `IPlayerAgent.DecideAsync()` call. The session runner MUST NOT generate or substitute its own reasoning text. It is a pass-through display of whatever the agent produced.
+
+### AC4: Works for both ScoringPlayerAgent and LlmPlayerAgent
+
+- The agent type name is derived from the runtime type of the `IPlayerAgent` instance: `agent.GetType().Name`.
+- The formatting code must not branch on agent type — it uses the same `PlayerDecision` shape regardless of which agent produced it.
+- Both agent types populate `Reasoning` and `Scores` (ScoringPlayerAgent generates structured reasoning; LlmPlayerAgent uses the LLM response text).
+
+### AC5: Build clean
+
+- `dotnet build session-runner/` succeeds with zero errors and zero warnings.
+- No new NuGet dependencies.
+
+---
+
+## Integration Point: Where to Insert in Program.cs
+
+The current flow around line 267–270 of `Program.cs` is:
+
+```csharp
+int pick = BestOption(turnStart.Options, sableStats);
+var chosen = turnStart.Options[pick];
+Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
+Console.WriteLine();
+```
+
+After this issue (and its dependencies #347/#348), this becomes:
+
+```
+var decision = await agent.DecideAsync(turnStart, agentContext);
+int pick = decision.OptionIndex;
+var chosen = turnStart.Options[pick];
+Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
+Console.WriteLine();
+Console.WriteLine(FormatReasoningBlock(decision, agent.GetType().Name));
+Console.WriteLine(FormatScoreTable(decision, turnStart.Options));
+Console.WriteLine();
+```
+
+The `BestOption()` static method is replaced by `IPlayerAgent.DecideAsync()` (from #346/#348). This issue (#351) is specifically about the two `Format*` calls and their output — the agent wiring is done by #348.
+
+---
+
+## Edge Cases
+
+### Empty reasoning string
+If `PlayerDecision.Reasoning` is `null` or empty, emit:
+```
+**Player reasoning ({AgentTypeName}):**
+> (no reasoning provided)
+```
+
+### Fewer than 4 options
+If `TurnStart.Options` has fewer than 4 entries (e.g. due to Horniness forced Rizz replacing options), the score table should have exactly as many rows as there are options. Letter labels still follow A, B, C, D sequence for the indices present.
+
+### Scores array mismatch
+If `PlayerDecision.Scores` has fewer entries than `TurnStart.Options` (defensive case), show `—` for missing score data in that row. If `Scores` is `null`, skip the score table entirely and log a warning to stderr.
+
+### OptionIndex out of range
+If `PlayerDecision.OptionIndex` is outside `[0, Options.Length)`, this is an error from the agent. The session runner should still render the table (no row gets ✓) and log a warning to stderr. The pick line should show the raw index.
+
+### Very long reasoning text
+LlmPlayerAgent may return multi-paragraph reasoning. No truncation — display the full text. Each line is blockquoted. The output is markdown, so length is acceptable.
+
+### BonusesApplied contains multiple entries
+Concatenate them without separators: `📖🔗` not `📖 🔗`. This matches the issue example.
+
+---
+
+## Error Conditions
+
+| Condition | Behavior |
+|---|---|
+| `PlayerDecision` is null | Should not happen (agent contract requires non-null return). If it does, skip reasoning + table, write warning to stderr. |
+| `PlayerDecision.Scores` is null | Skip score table. Still show reasoning block. Write warning to stderr. |
+| `PlayerDecision.Reasoning` is null or empty | Show `(no reasoning provided)` in blockquote. |
+| `OptionScore.SuccessChance` is NaN or negative | Display as `0%`. |
+| `OptionScore.Score` is NaN or negative | Display as `0.0`. |
+
+No exceptions should be thrown from the formatting functions. They are display-only and must be defensive.
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status |
+|---|---|---|
+| #346 — IPlayerAgent interface + types | Hard (defines `PlayerDecision`, `OptionScore`) | Must be implemented first |
+| #347 — ScoringPlayerAgent | Hard (first concrete agent) | Must be implemented first |
+| #348 — LlmPlayerAgent | Hard (second agent, wires into Program.cs) | Must be implemented first |
+| `session-runner/Program.cs` | File being modified | Shared with #354, #353, #350, #348 |
+| `Pinder.Core.Conversation.DialogueOption` | Read-only dependency | Existing, stable |
+| `Pinder.Core.Conversation.TurnStart` | Read-only dependency | Existing, stable |
+| `Pinder.Core.Stats.StatType` | Read-only dependency (for stat labels) | Existing, stable |
+
+No external services or new libraries required.


### PR DESCRIPTION
Refs #346

## Summary
Specification document for the IPlayerAgent interface and supporting types (PlayerDecision, OptionScore, PlayerAgentContext). Defines the contract for pluggable player agents in the session runner.

## Key decisions
- All types live in session-runner/ per vision concern #355 (NOT in Pinder.Core)
- LangVersion 8.0 constraint: sealed classes, no records
- Temporary BestOption-wrapping agent acceptable until ScoringPlayerAgent (#347)

## Spec file
docs/specs/issue-346-spec.md

## DoD Evidence
**Branch:** spec-346-iplayer
**Commit:** ef1d547
