### PR TITLE
[Issue #354] Fix session runner file counter glob and parsing

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -353,9 +353,11 @@ class Program
         string dir = "/root/.openclaw/agents-extra/pinder/design/playtests";
         if (!Directory.Exists(dir)) { Console.Error.WriteLine("Playtest dir not found"); return; }
         int nextNum = 1;
-        foreach (var f in Directory.GetFiles(dir, "session-???.md")) {
+        foreach (var f in Directory.GetFiles(dir, "session-*.md")) {
             var n = Path.GetFileNameWithoutExtension(f);
-            if (n.Length >= 11 && int.TryParse(n.Substring(8, 3), out int num)) nextNum = Math.Max(nextNum, num+1);
+            // name = "session-005-sable-vs-brick" → Split('-') = ["session","005","sable","vs","brick"]
+            var parts = n.Split('-');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int num)) nextNum = Math.Max(nextNum, num + 1);
         }
         string slug = $"session-{nextNum:D3}-{p1.ToLower()}-vs-{p2.ToLower()}.md";
         File.WriteAllText(Path.Combine(dir, slug), content);

--- a/tests/Pinder.Core.Tests/SessionFileCounterTests.cs
+++ b/tests/Pinder.Core.Tests/SessionFileCounterTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests the session file counter logic used in session-runner/Program.cs.
+    /// Validates the glob pattern and number extraction from session filenames.
+    /// </summary>
+    public class SessionFileCounterTests
+    {
+        /// <summary>
+        /// Extracts the next session number from a directory of session files.
+        /// This mirrors the logic in session-runner/Program.cs WritePlaytestLog.
+        /// </summary>
+        static int GetNextSessionNumber(string dir)
+        {
+            int nextNum = 1;
+            foreach (var f in Directory.GetFiles(dir, "session-*.md"))
+            {
+                var n = Path.GetFileNameWithoutExtension(f);
+                var parts = n.Split('-');
+                if (parts.Length >= 2 && int.TryParse(parts[1], out int num))
+                    nextNum = Math.Max(nextNum, num + 1);
+            }
+            return nextNum;
+        }
+
+        [Fact]
+        public void EmptyDirectory_Returns1()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                Assert.Equal(1, GetNextSessionNumber(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void SessionWithCharacterNames_ParsesCorrectly()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
+                Assert.Equal(6, GetNextSessionNumber(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void MultipleSessionFiles_ReturnsHighestPlusOne()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "session-001-sable-vs-brick.md"), "");
+                File.WriteAllText(Path.Combine(dir, "session-003-sable-vs-brick.md"), "");
+                File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
+                Assert.Equal(6, GetNextSessionNumber(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void HyphenatedCharacterNames_ParsesNumberCorrectly()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Character names with hyphens should not confuse the parser
+                File.WriteAllText(Path.Combine(dir, "session-010-mary-jane-vs-peter-parker.md"), "");
+                Assert.Equal(11, GetNextSessionNumber(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void NonSessionFiles_AreIgnored()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
+                File.WriteAllText(Path.Combine(dir, "notes.md"), "");
+                File.WriteAllText(Path.Combine(dir, "readme.txt"), "");
+                Assert.Equal(6, GetNextSessionNumber(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #354

## What Changed
- Changed glob from `session-???.md` to `session-*.md` to match files like `session-005-sable-vs-brick.md`
- Changed number extraction from `Substring(8,3)` to `Split('-')[1]` to correctly parse the number portion
- Added 5 tests covering: empty dir, named sessions, multiple files, hyphenated names, non-session files

## How to Test
```bash
dotnet test tests/Pinder.Core.Tests --filter SessionFileCounter
```

## DoD Evidence
**Branch:** issue-354-bug-session-runner-file-counter-writes-s
**Commit:** 32300fb
**Deviations from contract:** none
