### PR TITLE
[Issue #352] Bug: InterestChangeBeat (§3.8) doesn't use character voice — generates generic text

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -619,7 +619,8 @@ namespace Pinder.Core.Conversation
                     opponentName: _opponent.DisplayName,
                     interestBefore: interestBefore,
                     interestAfter: interestAfter,
-                    newState: stateAfter);
+                    newState: stateAfter,
+                    opponentPrompt: _opponent.AssembledSystemPrompt);
 
                 narrativeBeat = await _llm.GetInterestChangeBeatAsync(interestChangeContext).ConfigureAwait(false);
             }

--- a/src/Pinder.Core/Conversation/InterestChangeContext.cs
+++ b/src/Pinder.Core/Conversation/InterestChangeContext.cs
@@ -18,16 +18,25 @@ namespace Pinder.Core.Conversation
         /// <summary>The new interest state after the change.</summary>
         public InterestState NewState { get; }
 
+        /// <summary>
+        /// The opponent's assembled system prompt, used to generate
+        /// interest change beats in the opponent's voice/character.
+        /// Null when not available (e.g. from NullLlmAdapter tests).
+        /// </summary>
+        public string? OpponentPrompt { get; }
+
         public InterestChangeContext(
             string opponentName,
             int interestBefore,
             int interestAfter,
-            InterestState newState)
+            InterestState newState,
+            string? opponentPrompt = null)
         {
             OpponentName = opponentName ?? throw new System.ArgumentNullException(nameof(opponentName));
             InterestBefore = interestBefore;
             InterestAfter = interestAfter;
             NewState = newState;
+            OpponentPrompt = opponentPrompt;
         }
     }
 }

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -147,8 +147,10 @@ namespace Pinder.LlmAdapters.Anthropic
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            // No cached system blocks for interest change beats
-            var systemBlocks = Array.Empty<ContentBlock>();
+            // Include opponent system prompt so the beat is generated in character voice
+            var systemBlocks = !string.IsNullOrEmpty(context.OpponentPrompt)
+                ? CacheBlockBuilder.BuildOpponentOnlySystemBlocks(context.OpponentPrompt)
+                : Array.Empty<ContentBlock>();
 
             var userContent = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
                 context.OpponentName,

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/InterestChangeBeatVoiceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/InterestChangeBeatVoiceTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Pinder.Core.Conversation;
+using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    /// <summary>
+    /// Tests for issue #352: InterestChangeBeat should include opponent system prompt
+    /// so the LLM generates beats in the opponent's character voice.
+    /// </summary>
+    public class InterestChangeBeatVoiceTests
+    {
+        private static AnthropicOptions DefaultOptions() => new AnthropicOptions
+        {
+            ApiKey = "test-key",
+            Model = "claude-sonnet-4-20250514",
+            MaxTokens = 1024,
+        };
+
+        private static string MakeApiResponse(string text) =>
+            JsonConvert.SerializeObject(new
+            {
+                content = new[] { new { type = "text", text } },
+                usage = new { input_tokens = 10, output_tokens = 5 }
+            });
+
+        [Fact]
+        public async Task GetInterestChangeBeatAsync_with_opponent_prompt_includes_system_blocks()
+        {
+            var handler = new VoiceTestHandler
+            {
+                ResponseBody = MakeApiResponse("Brick checks her planner and pencils you in.")
+            };
+            using var client = new HttpClient(handler);
+            using var adapter = new AnthropicLlmAdapter(DefaultOptions(), client);
+
+            var context = new InterestChangeContext(
+                "Brick",
+                20,
+                25,
+                InterestState.DateSecured,
+                opponentPrompt: "You are Brick, a Level 9 M&A professional who color-codes her planner.");
+
+            var result = await adapter.GetInterestChangeBeatAsync(context);
+
+            Assert.Equal("Brick checks her planner and pencils you in.", result);
+
+            var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
+            Assert.NotNull(body);
+            Assert.NotNull(body!.System);
+            Assert.Single(body.System); // Opponent-only system block
+            Assert.Contains("Brick", body.System[0].Text);
+            Assert.Contains("M&A professional", body.System[0].Text);
+            Assert.Equal("ephemeral", body.System[0].CacheControl?.Type);
+        }
+
+        [Fact]
+        public async Task GetInterestChangeBeatAsync_without_opponent_prompt_has_no_system_blocks()
+        {
+            var handler = new VoiceTestHandler
+            {
+                ResponseBody = MakeApiResponse("They lean closer.")
+            };
+            using var client = new HttpClient(handler);
+            using var adapter = new AnthropicLlmAdapter(DefaultOptions(), client);
+
+            // No opponentPrompt (default null) — backward compatible
+            var context = new InterestChangeContext("Velvet", 15, 17, InterestState.VeryIntoIt);
+
+            var result = await adapter.GetInterestChangeBeatAsync(context);
+
+            Assert.Equal("They lean closer.", result);
+
+            var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
+            Assert.NotNull(body);
+            Assert.Empty(body!.System); // No system blocks when no prompt
+        }
+
+        [Fact]
+        public async Task GetInterestChangeBeatAsync_empty_opponent_prompt_has_no_system_blocks()
+        {
+            var handler = new VoiceTestHandler
+            {
+                ResponseBody = MakeApiResponse("Generic beat.")
+            };
+            using var client = new HttpClient(handler);
+            using var adapter = new AnthropicLlmAdapter(DefaultOptions(), client);
+
+            var context = new InterestChangeContext("Test", 10, 16, InterestState.VeryIntoIt, opponentPrompt: "");
+
+            var result = await adapter.GetInterestChangeBeatAsync(context);
+
+            var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
+            Assert.NotNull(body);
+            Assert.Empty(body!.System);
+        }
+
+        [Fact]
+        public void InterestChangeContext_stores_opponent_prompt()
+        {
+            var ctx = new InterestChangeContext("Brick", 20, 25, InterestState.DateSecured,
+                opponentPrompt: "You are Brick.");
+
+            Assert.Equal("You are Brick.", ctx.OpponentPrompt);
+        }
+
+        [Fact]
+        public void InterestChangeContext_opponent_prompt_defaults_to_null()
+        {
+            var ctx = new InterestChangeContext("Brick", 20, 25, InterestState.DateSecured);
+
+            Assert.Null(ctx.OpponentPrompt);
+        }
+
+        /// <summary>Local fake handler to avoid internal visibility issues.</summary>
+        private class VoiceTestHandler : HttpMessageHandler
+        {
+            public string? CapturedRequestBody { get; private set; }
+            public string ResponseBody { get; set; } = "";
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Content != null)
+                {
+                    CapturedRequestBody = await request.Content.ReadAsStringAsync();
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ResponseBody)
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #352

## What changed
- Added `OpponentPrompt` optional parameter to `InterestChangeContext` (default null, backward-compatible)
- `GameSession` now passes `_opponent.AssembledSystemPrompt` when constructing `InterestChangeContext`
- `AnthropicLlmAdapter.GetInterestChangeBeatAsync` includes opponent system block (cached/ephemeral) when `OpponentPrompt` is provided, so the LLM generates beats in the opponent's character voice

## How to test
- Run `dotnet test` — all 1991 tests pass (1502 Core + 489 LlmAdapters)
- New tests in `InterestChangeBeatVoiceTests.cs` verify:
  - System blocks included when opponent prompt provided
  - No system blocks when prompt is null (backward compat)
  - No system blocks when prompt is empty string
  - DTO stores and defaults correctly

## Deviations from contract
None — optional param preserves all existing call sites.

## DoD Evidence
**Branch:** issue-352-bug-interestchangebeat-3-8-doesn-t-use-c
**Commit:** c00247a
**Tests:** Passed: 1991 (1502 + 489), Failed: 0
