### PR TITLE
[Issue #354] Bug: Session runner file counter writes session-001 when session-005 already exists

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -385,13 +385,7 @@ class Program
     {
         string dir = "/root/.openclaw/agents-extra/pinder/design/playtests";
         if (!Directory.Exists(dir)) { Console.Error.WriteLine("Playtest dir not found"); return; }
-        int nextNum = 1;
-        foreach (var f in Directory.GetFiles(dir, "session-*.md")) {
-            var n = Path.GetFileNameWithoutExtension(f);
-            // name = "session-005-sable-vs-brick" → Split('-') = ["session","005","sable","vs","brick"]
-            var parts = n.Split('-');
-            if (parts.Length >= 2 && int.TryParse(parts[1], out int num)) nextNum = Math.Max(nextNum, num + 1);
-        }
+        int nextNum = SessionFileCounter.GetNextSessionNumber(dir);
         string slug = $"session-{nextNum:D3}-{p1.ToLower()}-vs-{p2.ToLower()}.md";
         File.WriteAllText(Path.Combine(dir, slug), content);
         Console.WriteLine($"\n📝 Written → design/playtests/{slug}");

--- a/session-runner/SessionFileCounter.cs
+++ b/session-runner/SessionFileCounter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+/// <summary>
+/// Extracts the next session number from a directory of session markdown files.
+/// Files are expected to follow the naming convention: session-NNN-name-vs-name.md
+/// </summary>
+internal static class SessionFileCounter
+{
+    /// <summary>
+    /// Scans the given directory for session-*.md files and returns the next
+    /// available session number (highest existing + 1, or 1 if none exist).
+    /// </summary>
+    /// <param name="directory">Directory to scan for session files.</param>
+    /// <returns>The next session number to use.</returns>
+    public static int GetNextSessionNumber(string directory)
+    {
+        int nextNum = 1;
+        foreach (var f in Directory.GetFiles(directory, "session-*.md"))
+        {
+            var name = Path.GetFileNameWithoutExtension(f);
+            // name = "session-005-sable-vs-brick" → Split('-') = ["session","005","sable","vs","brick"]
+            var parts = name.Split('-');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int num))
+                nextNum = Math.Max(nextNum, num + 1);
+        }
+        return nextNum;
+    }
+}

--- a/session-runner/session-runner.csproj
+++ b/session-runner/session-runner.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Pinder.Core.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\src\Pinder.Core\Pinder.Core.csproj" />
     <ProjectReference Include="..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
   </ItemGroup>

--- a/tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
+++ b/tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Pinder.Core\Pinder.Core.csproj" />
+    <ProjectReference Include="..\..\session-runner\session-runner.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Pinder.Core.Tests/SessionFileCounterTests.cs
+++ b/tests/Pinder.Core.Tests/SessionFileCounterTests.cs
@@ -5,28 +5,11 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     /// <summary>
-    /// Tests the session file counter logic used in session-runner/Program.cs.
+    /// Tests the SessionFileCounter.GetNextSessionNumber method used in session-runner.
     /// Validates the glob pattern and number extraction from session filenames.
     /// </summary>
     public class SessionFileCounterTests
     {
-        /// <summary>
-        /// Extracts the next session number from a directory of session files.
-        /// This mirrors the logic in session-runner/Program.cs WritePlaytestLog.
-        /// </summary>
-        static int GetNextSessionNumber(string dir)
-        {
-            int nextNum = 1;
-            foreach (var f in Directory.GetFiles(dir, "session-*.md"))
-            {
-                var n = Path.GetFileNameWithoutExtension(f);
-                var parts = n.Split('-');
-                if (parts.Length >= 2 && int.TryParse(parts[1], out int num))
-                    nextNum = Math.Max(nextNum, num + 1);
-            }
-            return nextNum;
-        }
-
         [Fact]
         public void EmptyDirectory_Returns1()
         {
@@ -34,7 +17,7 @@ namespace Pinder.Core.Tests
             Directory.CreateDirectory(dir);
             try
             {
-                Assert.Equal(1, GetNextSessionNumber(dir));
+                Assert.Equal(1, SessionFileCounter.GetNextSessionNumber(dir));
             }
             finally
             {
@@ -50,7 +33,7 @@ namespace Pinder.Core.Tests
             try
             {
                 File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
-                Assert.Equal(6, GetNextSessionNumber(dir));
+                Assert.Equal(6, SessionFileCounter.GetNextSessionNumber(dir));
             }
             finally
             {
@@ -68,7 +51,7 @@ namespace Pinder.Core.Tests
                 File.WriteAllText(Path.Combine(dir, "session-001-sable-vs-brick.md"), "");
                 File.WriteAllText(Path.Combine(dir, "session-003-sable-vs-brick.md"), "");
                 File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
-                Assert.Equal(6, GetNextSessionNumber(dir));
+                Assert.Equal(6, SessionFileCounter.GetNextSessionNumber(dir));
             }
             finally
             {
@@ -83,9 +66,8 @@ namespace Pinder.Core.Tests
             Directory.CreateDirectory(dir);
             try
             {
-                // Character names with hyphens should not confuse the parser
                 File.WriteAllText(Path.Combine(dir, "session-010-mary-jane-vs-peter-parker.md"), "");
-                Assert.Equal(11, GetNextSessionNumber(dir));
+                Assert.Equal(11, SessionFileCounter.GetNextSessionNumber(dir));
             }
             finally
             {
@@ -103,7 +85,7 @@ namespace Pinder.Core.Tests
                 File.WriteAllText(Path.Combine(dir, "session-005-sable-vs-brick.md"), "");
                 File.WriteAllText(Path.Combine(dir, "notes.md"), "");
                 File.WriteAllText(Path.Combine(dir, "readme.txt"), "");
-                Assert.Equal(6, GetNextSessionNumber(dir));
+                Assert.Equal(6, SessionFileCounter.GetNextSessionNumber(dir));
             }
             finally
             {


### PR DESCRIPTION
Fixes #354

## Changes

- Extracted file counter logic from `Program.WritePlaytestLog` into `SessionFileCounter.GetNextSessionNumber()` (internal static method in session-runner)
- `Program.cs` now calls the extracted method instead of inlining the logic
- Tests call the **real production method** instead of reimplementing logic locally (addresses code review feedback from PR #371)
- Added `InternalsVisibleTo` on session-runner.csproj so test project can access internal types
- Glob pattern `session-*.md` and `Split('-')[1]` parsing correctly handles filenames with character name suffixes

## How to test

```bash
dotnet test tests/Pinder.Core.Tests --filter SessionFileCounter
```

## DoD Evidence
**Branch:** issue-354-bug-session-runner-file-counter-writes-s
**Commit:** 8a8e5ac
**Tests:** 5 passed (SessionFileCounter), 1505 total passed, 0 failed
**Deviations from contract:** none
