### PR TITLE
[Issue #353] Fix NullTrapRegistry: extract TrapRegistryLoader with env var config

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -176,35 +176,7 @@ class Program
         });
 
         // Load real trap definitions — fallback to NullTrapRegistry if file missing/corrupt
-        ITrapRegistry trapRegistry;
-        string trapsPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "data", "traps", "traps.json");
-        // Also check the absolute path used in playtesting environments
-        string altTrapsPath = "/root/.openclaw/agents-extra/pinder/data/traps/traps.json";
-        string repoTrapsPath = "/root/.openclaw/workspace/pinder-core/data/traps/traps.json";
-        string? resolvedPath = null;
-        if (File.Exists(trapsPath)) resolvedPath = trapsPath;
-        else if (File.Exists(repoTrapsPath)) resolvedPath = repoTrapsPath;
-        else if (File.Exists(altTrapsPath)) resolvedPath = altTrapsPath;
-
-        if (resolvedPath != null)
-        {
-            try
-            {
-                string trapsJson = File.ReadAllText(resolvedPath);
-                trapRegistry = new JsonTrapRepository(trapsJson);
-                Console.Error.WriteLine($"[INFO] Loaded traps from {resolvedPath}");
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[WARN] Failed to load traps from {resolvedPath}: {ex.Message} — traps disabled");
-                trapRegistry = new NullTrapRegistry();
-            }
-        }
-        else
-        {
-            Console.Error.WriteLine("[WARN] traps.json not found — traps disabled");
-            trapRegistry = new NullTrapRegistry();
-        }
+        ITrapRegistry trapRegistry = TrapRegistryLoader.Load(AppContext.BaseDirectory, Console.Error);
 
         var session = new GameSession(sable, brick, llm, new SystemRandomDiceRoller(), trapRegistry);
 

--- a/session-runner/TrapRegistryLoader.cs
+++ b/session-runner/TrapRegistryLoader.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using Pinder.Core.Data;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+
+/// <summary>
+/// Loads an ITrapRegistry from traps.json, with graceful fallback to NullTrapRegistry.
+/// Extracted from Program.cs for testability (issue #353).
+/// </summary>
+internal static class TrapRegistryLoader
+{
+    /// <summary>
+    /// Environment variable that overrides default trap file search paths.
+    /// </summary>
+    internal const string EnvVarName = "PINDER_TRAPS_PATH";
+
+    /// <summary>
+    /// Attempts to load a JsonTrapRepository from traps.json.
+    /// Search order:
+    ///   1. PINDER_TRAPS_PATH env var (if set)
+    ///   2. Relative path: {baseDir}/data/traps/traps.json
+    ///   3. Repo root path (walking up from baseDir)
+    /// Falls back to NullTrapRegistry on any failure.
+    /// </summary>
+    /// <param name="baseDir">Base directory to search relative to (typically AppContext.BaseDirectory).</param>
+    /// <param name="warningWriter">TextWriter for warnings (typically Console.Error).</param>
+    /// <returns>A loaded ITrapRegistry — either JsonTrapRepository or NullTrapRegistry fallback.</returns>
+    internal static ITrapRegistry Load(string baseDir, TextWriter warningWriter)
+    {
+        // 1. Check environment variable override
+        string? envPath = Environment.GetEnvironmentVariable(EnvVarName);
+        if (!string.IsNullOrEmpty(envPath))
+        {
+            return TryLoadFromPath(envPath!, warningWriter);
+        }
+
+        // 2. Relative path from base directory
+        string relativePath = Path.Combine(baseDir, "data", "traps", "traps.json");
+        if (File.Exists(relativePath))
+        {
+            return TryLoadFromPath(relativePath, warningWriter);
+        }
+
+        // 3. Walk up from base directory looking for repo root with data/traps/traps.json
+        string? resolvedPath = FindTrapsJsonUpward(baseDir);
+        if (resolvedPath != null)
+        {
+            return TryLoadFromPath(resolvedPath, warningWriter);
+        }
+
+        warningWriter.WriteLine("[WARN] traps.json not found — traps disabled");
+        return new NullTrapRegistry();
+    }
+
+    /// <summary>
+    /// Loads a JsonTrapRepository from a specific file path.
+    /// Falls back to NullTrapRegistry if the file is missing, unreadable, or corrupt.
+    /// </summary>
+    private static ITrapRegistry TryLoadFromPath(string path, TextWriter warningWriter)
+    {
+        try
+        {
+            string json = File.ReadAllText(path);
+            var repo = new JsonTrapRepository(json);
+            warningWriter.WriteLine($"[INFO] Loaded traps from {path}");
+            return repo;
+        }
+        catch (Exception ex)
+        {
+            warningWriter.WriteLine($"[WARN] Failed to load traps from {path}: {ex.Message} — traps disabled");
+            return new NullTrapRegistry();
+        }
+    }
+
+    /// <summary>
+    /// Walks up from the given directory looking for data/traps/traps.json.
+    /// </summary>
+    private static string? FindTrapsJsonUpward(string startDir)
+    {
+        string? dir = startDir;
+        while (dir != null)
+        {
+            string candidate = Path.Combine(dir, "data", "traps", "traps.json");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return null;
+    }
+}

--- a/tests/Pinder.Core.Tests/SessionRunnerTrapLoadingTests.cs
+++ b/tests/Pinder.Core.Tests/SessionRunnerTrapLoadingTests.cs
@@ -10,12 +10,28 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     /// <summary>
-    /// Tests that validate the session runner's trap loading pattern:
-    /// JsonTrapRepository loaded from data/traps/traps.json replaces NullTrapRegistry.
+    /// Tests that validate the session runner's trap loading via TrapRegistryLoader.
     /// Issue #353: NullTrapRegistry disables all traps in the session runner.
     /// </summary>
-    public sealed class SessionRunnerTrapLoadingTests
+    public sealed class SessionRunnerTrapLoadingTests : IDisposable
     {
+        private readonly string? _originalEnvVar;
+
+        public SessionRunnerTrapLoadingTests()
+        {
+            // Preserve original env var value for cleanup
+            _originalEnvVar = Environment.GetEnvironmentVariable(TrapRegistryLoader.EnvVarName);
+        }
+
+        public void Dispose()
+        {
+            // Restore original env var
+            if (_originalEnvVar != null)
+                Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, _originalEnvVar);
+            else
+                Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, null);
+        }
+
         private static string FindTrapsJson()
         {
             var dir = Directory.GetCurrentDirectory();
@@ -27,19 +43,88 @@ namespace Pinder.Core.Tests
             return Path.Combine(dir!, "data", "traps", "traps.json");
         }
 
-        [Fact]
-        public void JsonTrapRepository_ReturnsTraps_UnlikeNullTrapRegistry()
+        private static string FindRepoRoot()
         {
-            // NullTrapRegistry returns null for all stats — this was the bug
-            var nullRegistry = new NullTrapRegistryStub();
-            Assert.Null(nullRegistry.GetTrap(StatType.Rizz));
-            Assert.Null(nullRegistry.GetLlmInstruction(StatType.Rizz));
+            var dir = Directory.GetCurrentDirectory();
+            while (dir != null && !File.Exists(Path.Combine(dir, "data", "traps", "traps.json")))
+            {
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            Assert.NotNull(dir);
+            return dir!;
+        }
 
-            // JsonTrapRepository loaded from real data returns actual traps
-            var json = File.ReadAllText(FindTrapsJson());
-            var realRegistry = new JsonTrapRepository(json);
-            Assert.NotNull(realRegistry.GetTrap(StatType.Rizz));
-            Assert.NotNull(realRegistry.GetLlmInstruction(StatType.Rizz));
+        [Fact]
+        public void Load_WithEnvVar_LoadsFromSpecifiedPath()
+        {
+            // Arrange: point env var to real traps.json
+            string trapsPath = FindTrapsJson();
+            Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, trapsPath);
+            var warnings = new StringWriter();
+
+            // Act
+            ITrapRegistry registry = TrapRegistryLoader.Load("/nonexistent", warnings);
+
+            // Assert: loaded real traps, not fallback
+            Assert.NotNull(registry.GetTrap(StatType.Rizz));
+            Assert.Contains("[INFO] Loaded traps", warnings.ToString());
+        }
+
+        [Fact]
+        public void Load_WithUpwardSearch_FindsTrapsJson()
+        {
+            // Arrange: clear env var so it uses upward search
+            Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, null);
+            string repoRoot = FindRepoRoot();
+            // Start from a subdirectory — loader should walk up
+            string subDir = Path.Combine(repoRoot, "session-runner", "bin");
+            var warnings = new StringWriter();
+
+            // Act
+            ITrapRegistry registry = TrapRegistryLoader.Load(subDir, warnings);
+
+            // Assert
+            Assert.NotNull(registry.GetTrap(StatType.Charm));
+            Assert.Contains("[INFO] Loaded traps", warnings.ToString());
+        }
+
+        [Fact]
+        public void Load_WithMissingFile_FallsBackToNullRegistry()
+        {
+            // Arrange: point env var to nonexistent path
+            Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, "/nonexistent/traps.json");
+            var warnings = new StringWriter();
+
+            // Act
+            ITrapRegistry registry = TrapRegistryLoader.Load("/also-nonexistent", warnings);
+
+            // Assert: graceful fallback — returns null for all stats
+            Assert.Null(registry.GetTrap(StatType.Charm));
+            Assert.Contains("[WARN]", warnings.ToString());
+        }
+
+        [Fact]
+        public void Load_WithCorruptJson_FallsBackToNullRegistry()
+        {
+            // Arrange: write corrupt JSON to temp file
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempFile, "{ this is not valid json [[[");
+                Environment.SetEnvironmentVariable(TrapRegistryLoader.EnvVarName, tempFile);
+                var warnings = new StringWriter();
+
+                // Act
+                ITrapRegistry registry = TrapRegistryLoader.Load("/nonexistent", warnings);
+
+                // Assert
+                Assert.Null(registry.GetTrap(StatType.Rizz));
+                Assert.Contains("[WARN]", warnings.ToString());
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
         }
 
         [Fact]
@@ -82,34 +167,6 @@ namespace Pinder.Core.Tests
 
             trapState.Activate(trapDef);
             Assert.True(trapState.HasActive);
-        }
-
-        [Fact]
-        public void FallbackToNullRegistry_WhenFileNotFound()
-        {
-            // Verify that the fallback pattern works — invalid JSON path
-            // should not crash, just return a registry that returns null
-            ITrapRegistry fallback;
-            try
-            {
-                string badJson = File.ReadAllText("/nonexistent/path/traps.json");
-                fallback = new JsonTrapRepository(badJson);
-            }
-            catch
-            {
-                // Expected: file not found → fall back gracefully
-                fallback = new NullTrapRegistryStub();
-            }
-
-            // Fallback still implements ITrapRegistry (returns null, but doesn't crash)
-            Assert.Null(fallback.GetTrap(StatType.Charm));
-        }
-
-        /// <summary>Stub matching the NullTrapRegistry in session-runner.</summary>
-        private sealed class NullTrapRegistryStub : ITrapRegistry
-        {
-            public TrapDefinition? GetTrap(StatType stat) => null;
-            public string? GetLlmInstruction(StatType stat) => null;
         }
     }
 }


### PR DESCRIPTION
Fixes #353

## What Changed

Addresses all 3 code review findings from PR #372:

1. **ERROR fix**: Extracted trap-loading logic from `Program.cs` into `TrapRegistryLoader` (internal static class in session-runner). Tests now exercise the production `TrapRegistryLoader.Load()` method directly — no more testing a local stub.

2. **WARNING fix**: Replaced hardcoded absolute paths with `PINDER_TRAPS_PATH` env var override + upward directory search from `AppContext.BaseDirectory`. No absolute paths remain in `Program.cs`.

3. **WARNING fix**: Removed `NullTrapRegistryStub` from tests. Tests use the production `NullTrapRegistry` (via fallback behavior) and `TrapRegistryLoader.Load()` directly.

## How to Test

```bash
dotnet test tests/Pinder.Core.Tests --filter SessionRunnerTrapLoadingTests
```

Or set the env var:
```bash
PINDER_TRAPS_PATH=/path/to/traps.json dotnet run --project session-runner
```

## Tests
- 6 tests covering: env var loading, upward search, missing file fallback, corrupt JSON fallback, all-6-stats coverage, TropeTrap activation
- All 1996 existing tests pass (1507 Core + 489 LlmAdapters)

## Deviations from contract
None — this is a bug fix in session-runner, no contract applies.

## DoD Evidence
**Commit**: 94a3853
**Branch**: issue-353-bug-nulltrapregistry-in-session-runner-d
