### PR TITLE
[Issue #346] Player agent: IPlayerAgent interface and scoring model for sim decision-making

### DIFF
--- a/session-runner/HighestModAgent.cs
+++ b/session-runner/HighestModAgent.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Minimal IPlayerAgent that replicates the original BestOption logic:
+    /// picks the option with the highest effective stat modifier.
+    /// Serves as a baseline agent until ScoringPlayerAgent (#347) is available.
+    /// </summary>
+    public sealed class HighestModAgent : IPlayerAgent
+    {
+        public Task<PlayerDecision> DecideAsync(TurnStart turn, PlayerAgentContext context)
+        {
+            if (turn == null) throw new ArgumentNullException(nameof(turn));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (turn.Options.Length == 0)
+                throw new InvalidOperationException("No options available");
+
+            var options = turn.Options;
+            var scores = new OptionScore[options.Length];
+            int bestIndex = 0;
+            float bestScore = float.MinValue;
+
+            for (int i = 0; i < options.Length; i++)
+            {
+                StatType stat = options[i].Stat;
+                int mod = context.PlayerStats.GetEffective(stat);
+                int dc = context.OpponentStats.GetDefenceDC(stat);
+                int need = dc - mod;
+                // need is the minimum d20 roll required to succeed
+                // successChance = (21 - need) / 20, clamped to [0, 1]
+                float successChance = Math.Max(0.0f, Math.Min(1.0f, (21.0f - need) / 20.0f));
+
+                // Simple score: effective modifier (higher = better)
+                float score = mod;
+
+                scores[i] = new OptionScore(
+                    optionIndex: i,
+                    score: score,
+                    successChance: successChance,
+                    expectedInterestGain: 0.0f, // not computed for baseline agent
+                    bonusesApplied: Array.Empty<string>());
+
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestIndex = i;
+                }
+            }
+
+            string reasoning = $"{StatLabel(options[bestIndex].Stat)} has highest effective modifier ({context.PlayerStats.GetEffective(options[bestIndex].Stat):+#;-#;0}).";
+
+            var decision = new PlayerDecision(bestIndex, reasoning, scores);
+            return Task.FromResult(decision);
+        }
+
+        private static string StatLabel(StatType s)
+        {
+            switch (s)
+            {
+                case StatType.Charm: return "Charm";
+                case StatType.Rizz: return "Rizz";
+                case StatType.Honesty: return "Honesty";
+                case StatType.Chaos: return "Chaos";
+                case StatType.Wit: return "Wit";
+                case StatType.SelfAwareness: return "SA";
+                default: return s.ToString();
+            }
+        }
+    }
+}

--- a/session-runner/IPlayerAgent.cs
+++ b/session-runner/IPlayerAgent.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Decision-making interface for sim agents. Takes a TurnStart and PlayerAgentContext,
+    /// returns a PlayerDecision with the chosen option index, reasoning, and score breakdowns.
+    /// </summary>
+    public interface IPlayerAgent
+    {
+        /// <summary>
+        /// Given a TurnStart (options + game state snapshot) and additional agent context,
+        /// returns a decision: which option to pick, why, and score breakdowns for all options.
+        /// </summary>
+        Task<PlayerDecision> DecideAsync(TurnStart turn, PlayerAgentContext context);
+    }
+}

--- a/session-runner/OptionScore.cs
+++ b/session-runner/OptionScore.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Score breakdown for a single dialogue option, including success probability and expected gain.
+    /// </summary>
+    public sealed class OptionScore
+    {
+        /// <summary>Index of the option this score corresponds to.</summary>
+        public int OptionIndex { get; }
+
+        /// <summary>Composite score (higher = better pick). Implementation-defined scale.</summary>
+        public float Score { get; }
+
+        /// <summary>Estimated probability of beating the DC, as a value 0.0–1.0.</summary>
+        public float SuccessChance { get; }
+
+        /// <summary>Expected interest gain (positive or negative), weighting success and failure outcomes.</summary>
+        public float ExpectedInterestGain { get; }
+
+        /// <summary>Human-readable list of bonuses factored into the score, e.g. ["callback +2", "tell +2"].</summary>
+        public string[] BonusesApplied { get; }
+
+        public OptionScore(
+            int optionIndex,
+            float score,
+            float successChance,
+            float expectedInterestGain,
+            string[] bonusesApplied)
+        {
+            if (bonusesApplied == null) throw new ArgumentNullException(nameof(bonusesApplied));
+
+            OptionIndex = optionIndex;
+            Score = score;
+            SuccessChance = Math.Max(0.0f, Math.Min(1.0f, successChance));
+            ExpectedInterestGain = expectedInterestGain;
+            BonusesApplied = bonusesApplied;
+        }
+    }
+}

--- a/session-runner/PlayerAgentContext.cs
+++ b/session-runner/PlayerAgentContext.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Additional context for player agent decision-making, beyond what TurnStart provides.
+    /// Carries stat blocks, shadow values, and session state needed for scoring.
+    /// </summary>
+    public sealed class PlayerAgentContext
+    {
+        /// <summary>The player character's stat block (immutable).</summary>
+        public StatBlock PlayerStats { get; }
+
+        /// <summary>The opponent character's stat block (immutable).</summary>
+        public StatBlock OpponentStats { get; }
+
+        /// <summary>Current interest meter value (0-25).</summary>
+        public int CurrentInterest { get; }
+
+        /// <summary>Current interest state (derived from CurrentInterest).</summary>
+        public InterestState InterestState { get; }
+
+        /// <summary>Number of consecutive successful rolls (0 = no streak).</summary>
+        public int MomentumStreak { get; }
+
+        /// <summary>Names of currently active traps.</summary>
+        public string[] ActiveTrapNames { get; }
+
+        /// <summary>Current session horniness value (from SessionShadowTracker, 0 if unavailable).</summary>
+        public int SessionHorniness { get; }
+
+        /// <summary>Current shadow stat values (from SessionShadowTracker). Null if shadow tracking disabled.</summary>
+        public Dictionary<ShadowStatType, int>? ShadowValues { get; }
+
+        /// <summary>Current turn number (from GameStateSnapshot.TurnNumber).</summary>
+        public int TurnNumber { get; }
+
+        public PlayerAgentContext(
+            StatBlock playerStats,
+            StatBlock opponentStats,
+            int currentInterest,
+            InterestState interestState,
+            int momentumStreak,
+            string[] activeTrapNames,
+            int sessionHorniness,
+            Dictionary<ShadowStatType, int>? shadowValues,
+            int turnNumber)
+        {
+            PlayerStats = playerStats ?? throw new ArgumentNullException(nameof(playerStats));
+            OpponentStats = opponentStats ?? throw new ArgumentNullException(nameof(opponentStats));
+            ActiveTrapNames = activeTrapNames ?? throw new ArgumentNullException(nameof(activeTrapNames));
+            CurrentInterest = currentInterest;
+            InterestState = interestState;
+            MomentumStreak = momentumStreak;
+            SessionHorniness = sessionHorniness;
+            ShadowValues = shadowValues;
+            TurnNumber = turnNumber;
+        }
+    }
+}

--- a/session-runner/PlayerDecision.cs
+++ b/session-runner/PlayerDecision.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// The result of an IPlayerAgent decision: which option was chosen, why, and score breakdowns.
+    /// </summary>
+    public sealed class PlayerDecision
+    {
+        /// <summary>Index into TurnStart.Options (0-based).</summary>
+        public int OptionIndex { get; }
+
+        /// <summary>Human-readable explanation of why this option was chosen.</summary>
+        public string Reasoning { get; }
+
+        /// <summary>Score breakdown for every option in the TurnStart. Length == TurnStart.Options.Length.</summary>
+        public OptionScore[] Scores { get; }
+
+        public PlayerDecision(int optionIndex, string reasoning, OptionScore[] scores)
+        {
+            if (reasoning == null) throw new ArgumentNullException(nameof(reasoning));
+            if (scores == null) throw new ArgumentNullException(nameof(scores));
+            if (optionIndex < 0 || optionIndex >= scores.Length)
+                throw new ArgumentOutOfRangeException(nameof(optionIndex),
+                    $"OptionIndex {optionIndex} is out of range [0, {scores.Length}).");
+
+            OptionIndex = optionIndex;
+            Reasoning = reasoning;
+            Scores = scores;
+        }
+    }
+}

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -14,6 +14,7 @@ using Pinder.Core.Stats;
 using Pinder.Core.Traps;
 using Pinder.Core.Data;
 using Pinder.LlmAdapters.Anthropic;
+using Pinder.SessionRunner;
 
 class NullTrapRegistry : ITrapRegistry
 {
@@ -79,15 +80,7 @@ class Program
         return md.Substring(start, end - start).Trim();
     }
 
-    static int BestOption(DialogueOption[] options, StatBlock stats)
-    {
-        int best = 0, bestMod = int.MinValue;
-        for (int i = 0; i < options.Length; i++) {
-            int mod = stats.GetEffective(options[i].Stat);
-            if (mod > bestMod) { bestMod = mod; best = i; }
-        }
-        return best;
-    }
+    // BestOption removed — replaced by IPlayerAgent (see HighestModAgent)
 
     // ── main ─────────────────────────────────────────────────────────────────
 
@@ -180,6 +173,9 @@ class Program
 
         var session = new GameSession(sable, brick, llm, new SystemRandomDiceRoller(), trapRegistry);
 
+        // Player agent for decision-making (replaces BestOption)
+        IPlayerAgent agent = new HighestModAgent();
+
         int interest = 10;
         int momentum = 0;
         Console.WriteLine("## Session State");
@@ -269,7 +265,18 @@ class Program
             Console.WriteLine();
 
             // ── pick + roll ───────────────────────────────────────────────
-            int pick = BestOption(turnStart.Options, sableStats);
+            var agentContext = new PlayerAgentContext(
+                playerStats: sableStats,
+                opponentStats: brickStats,
+                currentInterest: snap.Interest,
+                interestState: snap.State,
+                momentumStreak: snap.MomentumStreak,
+                activeTrapNames: snap.ActiveTrapNames,
+                sessionHorniness: 0,
+                shadowValues: null,
+                turnNumber: snap.TurnNumber);
+            var decision = await agent.DecideAsync(turnStart, agentContext);
+            int pick = decision.OptionIndex;
             var chosen = turnStart.Options[pick];
             Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
             Console.WriteLine();

--- a/tests/Pinder.Core.Tests/PlayerAgentTests.cs
+++ b/tests/Pinder.Core.Tests/PlayerAgentTests.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class PlayerDecisionTests
+    {
+        [Fact]
+        public void Constructor_ValidArgs_SetsProperties()
+        {
+            var scores = new[]
+            {
+                new OptionScore(0, 5.0f, 0.5f, 1.0f, Array.Empty<string>()),
+                new OptionScore(1, 3.0f, 0.3f, 0.5f, new[] { "callback +2" })
+            };
+            var decision = new PlayerDecision(0, "Charm is best", scores);
+
+            Assert.Equal(0, decision.OptionIndex);
+            Assert.Equal("Charm is best", decision.Reasoning);
+            Assert.Equal(2, decision.Scores.Length);
+        }
+
+        [Fact]
+        public void Constructor_NullReasoning_Throws()
+        {
+            var scores = new[] { new OptionScore(0, 1.0f, 0.5f, 0.0f, Array.Empty<string>()) };
+            Assert.Throws<ArgumentNullException>(() => new PlayerDecision(0, null!, scores));
+        }
+
+        [Fact]
+        public void Constructor_NullScores_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PlayerDecision(0, "reason", null!));
+        }
+
+        [Fact]
+        public void Constructor_OptionIndexOutOfRange_Throws()
+        {
+            var scores = new[] { new OptionScore(0, 1.0f, 0.5f, 0.0f, Array.Empty<string>()) };
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PlayerDecision(1, "reason", scores));
+        }
+
+        [Fact]
+        public void Constructor_NegativeOptionIndex_Throws()
+        {
+            var scores = new[] { new OptionScore(0, 1.0f, 0.5f, 0.0f, Array.Empty<string>()) };
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PlayerDecision(-1, "reason", scores));
+        }
+    }
+
+    public class OptionScoreTests
+    {
+        [Fact]
+        public void Constructor_ValidArgs_SetsProperties()
+        {
+            var score = new OptionScore(2, 7.5f, 0.65f, 1.5f, new[] { "tell +2", "combo" });
+
+            Assert.Equal(2, score.OptionIndex);
+            Assert.Equal(7.5f, score.Score);
+            Assert.Equal(0.65f, score.SuccessChance);
+            Assert.Equal(1.5f, score.ExpectedInterestGain);
+            Assert.Equal(new[] { "tell +2", "combo" }, score.BonusesApplied);
+        }
+
+        [Fact]
+        public void Constructor_NullBonuses_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new OptionScore(0, 1.0f, 0.5f, 0.0f, null!));
+        }
+
+        [Fact]
+        public void SuccessChance_ClampedToZeroOne()
+        {
+            var high = new OptionScore(0, 1.0f, 1.5f, 0.0f, Array.Empty<string>());
+            Assert.Equal(1.0f, high.SuccessChance);
+
+            var low = new OptionScore(0, 1.0f, -0.5f, 0.0f, Array.Empty<string>());
+            Assert.Equal(0.0f, low.SuccessChance);
+        }
+    }
+
+    public class PlayerAgentContextTests
+    {
+        private static StatBlock MakeStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 4 }, { StatType.Rizz, 2 }, { StatType.Honesty, 3 },
+                    { StatType.Chaos, 1 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 3 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        [Fact]
+        public void Constructor_ValidArgs_SetsProperties()
+        {
+            var player = MakeStats();
+            var opponent = MakeStats();
+            var ctx = new PlayerAgentContext(player, opponent, 12, InterestState.Interested, 2,
+                new[] { "IckTrap" }, 4, null, 5);
+
+            Assert.Same(player, ctx.PlayerStats);
+            Assert.Same(opponent, ctx.OpponentStats);
+            Assert.Equal(12, ctx.CurrentInterest);
+            Assert.Equal(InterestState.Interested, ctx.InterestState);
+            Assert.Equal(2, ctx.MomentumStreak);
+            Assert.Single(ctx.ActiveTrapNames);
+            Assert.Equal(4, ctx.SessionHorniness);
+            Assert.Null(ctx.ShadowValues);
+            Assert.Equal(5, ctx.TurnNumber);
+        }
+
+        [Fact]
+        public void Constructor_NullPlayerStats_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new PlayerAgentContext(null!, MakeStats(), 10, InterestState.Interested, 0,
+                    Array.Empty<string>(), 0, null, 1));
+        }
+
+        [Fact]
+        public void Constructor_NullOpponentStats_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new PlayerAgentContext(MakeStats(), null!, 10, InterestState.Interested, 0,
+                    Array.Empty<string>(), 0, null, 1));
+        }
+
+        [Fact]
+        public void Constructor_NullActiveTrapNames_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new PlayerAgentContext(MakeStats(), MakeStats(), 10, InterestState.Interested, 0,
+                    null!, 0, null, 1));
+        }
+    }
+
+    public class HighestModAgentTests
+    {
+        private static StatBlock MakePlayerStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 4 }, { StatType.Rizz, 1 }, { StatType.Honesty, 3 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 3 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static StatBlock MakeOpponentStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 3 }, { StatType.Honesty, 1 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 1 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static PlayerAgentContext MakeContext(StatBlock player, StatBlock opponent)
+        {
+            return new PlayerAgentContext(player, opponent, 12, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, null, 1);
+        }
+
+        [Fact]
+        public async Task DecideAsync_PicksHighestModifier()
+        {
+            var agent = new HighestModAgent();
+            var player = MakePlayerStats();
+            var opponent = MakeOpponentStats();
+            var options = new[]
+            {
+                new DialogueOption(StatType.Rizz, "rizz line"),   // mod +1
+                new DialogueOption(StatType.Charm, "charm line"),  // mod +4
+                new DialogueOption(StatType.Chaos, "chaos line"),  // mod +2
+            };
+            var turn = new TurnStart(options, new GameStateSnapshot(12, InterestState.Interested, 0, Array.Empty<string>(), 1));
+            var ctx = MakeContext(player, opponent);
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.Equal(1, decision.OptionIndex); // Charm has highest mod
+            Assert.Equal(3, decision.Scores.Length);
+            Assert.Contains("Charm", decision.Reasoning);
+        }
+
+        [Fact]
+        public async Task DecideAsync_SingleOption_ReturnsIndex0()
+        {
+            var agent = new HighestModAgent();
+            var player = MakePlayerStats();
+            var opponent = MakeOpponentStats();
+            var options = new[] { new DialogueOption(StatType.Wit, "wit line") };
+            var turn = new TurnStart(options, new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1));
+            var ctx = MakeContext(player, opponent);
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.Equal(0, decision.OptionIndex);
+            Assert.Single(decision.Scores);
+        }
+
+        [Fact]
+        public async Task DecideAsync_EmptyOptions_Throws()
+        {
+            var agent = new HighestModAgent();
+            var player = MakePlayerStats();
+            var opponent = MakeOpponentStats();
+            var turn = new TurnStart(Array.Empty<DialogueOption>(), new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1));
+            var ctx = MakeContext(player, opponent);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => agent.DecideAsync(turn, ctx));
+        }
+
+        [Fact]
+        public async Task DecideAsync_NullTurn_Throws()
+        {
+            var agent = new HighestModAgent();
+            var ctx = MakeContext(MakePlayerStats(), MakeOpponentStats());
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => agent.DecideAsync(null!, ctx));
+        }
+
+        [Fact]
+        public async Task DecideAsync_NullContext_Throws()
+        {
+            var agent = new HighestModAgent();
+            var turn = new TurnStart(
+                new[] { new DialogueOption(StatType.Charm, "hi") },
+                new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => agent.DecideAsync(turn, null!));
+        }
+
+        [Fact]
+        public async Task DecideAsync_ScoresContainSuccessChance()
+        {
+            var agent = new HighestModAgent();
+            var player = MakePlayerStats();
+            var opponent = MakeOpponentStats();
+            // Charm +4 vs SA defence DC = 13 + 2 = 15. Need 11. Success = (21-11)/20 = 0.5
+            var options = new[] { new DialogueOption(StatType.Charm, "charm") };
+            var turn = new TurnStart(options, new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1));
+            var ctx = MakeContext(player, opponent);
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.Equal(0.5f, decision.Scores[0].SuccessChance);
+        }
+
+        [Fact]
+        public async Task DecideAsync_TieBreaksToLowestIndex()
+        {
+            var agent = new HighestModAgent();
+            // Both Charm and SA have modifier +4 and +3 respectively
+            // Let's make them equal: both +3
+            var equalStats = new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 3 }, { StatType.Rizz, 3 }, { StatType.Honesty, 3 },
+                    { StatType.Chaos, 3 }, { StatType.Wit, 3 }, { StatType.SelfAwareness, 3 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "a"),
+                new DialogueOption(StatType.Rizz, "b"),
+            };
+            var turn = new TurnStart(options, new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1));
+            var ctx = MakeContext(equalStats, MakeOpponentStats());
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.Equal(0, decision.OptionIndex); // tie breaks to lowest index
+        }
+    }
+}


### PR DESCRIPTION
Fixes #346

## What was implemented

- **IPlayerAgent** interface in session-runner/ with DecideAsync(TurnStart, PlayerAgentContext) signature
- **PlayerDecision** sealed class with constructor validation (null checks, range checks on OptionIndex)
- **OptionScore** sealed class with SuccessChance clamped to [0.0, 1.0]
- **PlayerAgentContext** sealed class carrying stat blocks, interest, momentum, traps, shadows, horniness, turn number
- **HighestModAgent** — baseline IPlayerAgent replicating the old BestOption logic (picks highest effective modifier)
- Session runner Program.cs updated to use IPlayerAgent instead of static BestOption method
- 19 tests covering all data types and agent behavior (happy path + error cases)

## How to test

```bash
dotnet test --filter "FullyQualifiedName~PlayerDecision|FullyQualifiedName~OptionScore|FullyQualifiedName~HighestModAgent|FullyQualifiedName~PlayerAgentContext"
```

Full suite: dotnet test — all 2017 tests pass (1528 Core + 489 LlmAdapters).

## Deviations from contract

- Per spec and vision concern #355, all types live in session-runner/ (namespace Pinder.SessionRunner), NOT Pinder.Core/Interfaces/ as the issue body originally suggested
- SuccessChance is 0.0-1.0 (probability), not 0-100 (percentage), per the reviewed/approved spec
