### PR TITLE
[Issue #351] Session runner: show pick reasoning in playtest output

### DIFF
--- a/session-runner/PlaytestFormatter.cs
+++ b/session-runner/PlaytestFormatter.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Text;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Formats player agent reasoning and score tables for playtest markdown output.
+    /// </summary>
+    public static class PlaytestFormatter
+    {
+        private static readonly char[] Letters = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' };
+
+        /// <summary>
+        /// Formats the player agent's reasoning as a markdown blockquote.
+        /// Each line of the reasoning string is prefixed with "> ".
+        /// </summary>
+        /// <param name="decision">The PlayerDecision returned by the agent.</param>
+        /// <param name="agentTypeName">The simple class name of the agent (e.g. "ScoringPlayerAgent").</param>
+        /// <returns>A multi-line string containing the formatted reasoning block.</returns>
+        public static string FormatReasoningBlock(PlayerDecision? decision, string agentTypeName)
+        {
+            if (decision == null)
+            {
+                return "";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"**Player reasoning ({agentTypeName}):**");
+
+            string reasoning = decision.Reasoning;
+            if (string.IsNullOrEmpty(reasoning))
+            {
+                sb.AppendLine("> (no reasoning provided)");
+            }
+            else
+            {
+                var lines = reasoning.Split(new[] { '\n' }, StringSplitOptions.None);
+                foreach (var line in lines)
+                {
+                    sb.AppendLine($"> {line}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Formats the option score table as a markdown table.
+        /// The chosen option row is marked with ✓ and its score is bold.
+        /// </summary>
+        /// <param name="decision">The PlayerDecision containing Scores and OptionIndex.</param>
+        /// <param name="options">The DialogueOption[] from TurnStart, used for stat labels.</param>
+        /// <returns>A multi-line string containing the markdown table, or empty if scores are null.</returns>
+        public static string FormatScoreTable(PlayerDecision? decision, DialogueOption[] options)
+        {
+            if (decision == null)
+            {
+                return "";
+            }
+
+            if (decision.Scores == null)
+            {
+                Console.Error.WriteLine("Warning: PlayerDecision.Scores is null — skipping score table.");
+                return "";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine("| Option | Stat | Pct | Expected ΔI | Score |");
+            sb.AppendLine("|---|---|---|---|---|");
+
+            for (int i = 0; i < options.Length; i++)
+            {
+                string letter = i < Letters.Length ? Letters[i].ToString() : i.ToString();
+                bool isChosen = i == decision.OptionIndex;
+
+                string optionLabel = isChosen ? $"{letter} ✓" : letter;
+                string statLabel = StatLabel(options[i].Stat);
+
+                // Find matching score entry
+                OptionScore? score = FindScore(decision.Scores, i);
+
+                string pct;
+                string expectedDelta;
+                string scoreStr;
+
+                if (score != null)
+                {
+                    float successChance = float.IsNaN(score.SuccessChance) || score.SuccessChance < 0
+                        ? 0f : score.SuccessChance;
+                    int pctInt = (int)Math.Round(successChance * 100);
+                    pct = $"{pctInt}%";
+
+                    float gain = float.IsNaN(score.ExpectedInterestGain) ? 0f : score.ExpectedInterestGain;
+                    string bonuses = score.BonusesApplied != null && score.BonusesApplied.Length > 0
+                        ? " " + string.Join("", score.BonusesApplied)
+                        : "";
+                    expectedDelta = $"+{gain:F1}{bonuses}";
+
+                    float scoreVal = float.IsNaN(score.Score) || score.Score < 0 ? 0f : score.Score;
+                    scoreStr = isChosen ? $"**{scoreVal:F1}**" : $"{scoreVal:F1}";
+                }
+                else
+                {
+                    pct = "—";
+                    expectedDelta = "—";
+                    scoreStr = "—";
+                }
+
+                sb.AppendLine($"| {optionLabel} | {statLabel} | {pct} | {expectedDelta} | {scoreStr} |");
+            }
+
+            return sb.ToString();
+        }
+
+        private static OptionScore? FindScore(OptionScore[] scores, int optionIndex)
+        {
+            for (int i = 0; i < scores.Length; i++)
+            {
+                if (scores[i].OptionIndex == optionIndex)
+                    return scores[i];
+            }
+            // Fall back to positional if indices don't match
+            if (optionIndex < scores.Length)
+                return scores[optionIndex];
+            return null;
+        }
+
+        private static string StatLabel(StatType s)
+        {
+            switch (s)
+            {
+                case StatType.Charm: return "CHARM";
+                case StatType.Rizz: return "RIZZ";
+                case StatType.Honesty: return "HONESTY";
+                case StatType.Chaos: return "CHAOS";
+                case StatType.Wit: return "WIT";
+                case StatType.SelfAwareness: return "SA";
+                default: return s.ToString().ToUpperInvariant();
+            }
+        }
+    }
+}

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -303,6 +303,9 @@ class Program
             var chosen = turnStart.Options[pick];
             Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
             Console.WriteLine();
+            Console.WriteLine(PlaytestFormatter.FormatReasoningBlock(decision, agent.GetType().Name));
+            Console.WriteLine(PlaytestFormatter.FormatScoreTable(decision, turnStart.Options));
+            Console.WriteLine();
 
             TurnResult result;
             try { result = await session.ResolveTurnAsync(pick); }

--- a/tests/Pinder.Core.Tests/Issue351_PlaytestFormatterTests.cs
+++ b/tests/Pinder.Core.Tests/Issue351_PlaytestFormatterTests.cs
@@ -1,0 +1,293 @@
+using System;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+
+namespace Pinder.Core.Tests
+{
+    public class Issue351_PlaytestFormatterTests
+    {
+        // ── Helper factories ────────────────────────────────────────────
+
+        private static DialogueOption MakeOption(StatType stat)
+        {
+            return new DialogueOption(stat, "test text");
+        }
+
+        private static OptionScore MakeScore(int index, float score, float successChance, float expectedGain, string[]? bonuses = null)
+        {
+            return new OptionScore(index, score, successChance, expectedGain, bonuses ?? Array.Empty<string>());
+        }
+
+        private static PlayerDecision MakeDecision(int pick, string reasoning, OptionScore[] scores)
+        {
+            return new PlayerDecision(pick, reasoning, scores);
+        }
+
+        // ── FormatReasoningBlock tests ──────────────────────────────────
+
+        [Fact]
+        public void FormatReasoningBlock_ScoringAgent_FormatsAsBlockquote()
+        {
+            var decision = MakeDecision(0, "Line one.\nLine two.\nPick: A", new[]
+            {
+                MakeScore(0, 8.3f, 0.45f, 1.8f),
+            });
+
+            var result = PlaytestFormatter.FormatReasoningBlock(decision, "ScoringPlayerAgent");
+
+            Assert.Contains("**Player reasoning (ScoringPlayerAgent):**", result);
+            Assert.Contains("> Line one.", result);
+            Assert.Contains("> Line two.", result);
+            Assert.Contains("> Pick: A", result);
+        }
+
+        [Fact]
+        public void FormatReasoningBlock_EmptyReasoning_ShowsPlaceholder()
+        {
+            var decision = MakeDecision(0, "", new[]
+            {
+                MakeScore(0, 1.0f, 0.5f, 1.0f),
+            });
+
+            var result = PlaytestFormatter.FormatReasoningBlock(decision, "ScoringPlayerAgent");
+
+            Assert.Contains("> (no reasoning provided)", result);
+        }
+
+        [Fact]
+        public void FormatReasoningBlock_NullDecision_ReturnsEmpty()
+        {
+            var result = PlaytestFormatter.FormatReasoningBlock(null, "ScoringPlayerAgent");
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void FormatReasoningBlock_LlmAgent_ShowsAgentName()
+        {
+            var decision = MakeDecision(0, "LLM reasoning", new[]
+            {
+                MakeScore(0, 5.0f, 0.5f, 1.0f),
+            });
+
+            var result = PlaytestFormatter.FormatReasoningBlock(decision, "LlmPlayerAgent");
+
+            Assert.Contains("**Player reasoning (LlmPlayerAgent):**", result);
+        }
+
+        // ── FormatScoreTable tests ──────────────────────────────────────
+
+        [Fact]
+        public void FormatScoreTable_FourOptions_RendersMarkdownTable()
+        {
+            var options = new[]
+            {
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Honesty),
+                MakeOption(StatType.Chaos),
+            };
+
+            var scores = new[]
+            {
+                MakeScore(0, 8.3f, 0.45f, 1.8f),
+                MakeScore(1, 1.2f, 0.05f, 0.9f),
+                MakeScore(2, 6.1f, 0.30f, 1.4f, new[] { "📖", "🔗" }),
+                MakeScore(3, 0.0f, 0.00f, 0.0f),
+            };
+
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            // Header
+            Assert.Contains("| Option | Stat | Pct | Expected ΔI | Score |", result);
+            Assert.Contains("|---|---|---|---|---|", result);
+
+            // Chosen option has ✓ and bold score
+            Assert.Contains("A ✓", result);
+            Assert.Contains("**8.3**", result);
+
+            // Non-chosen options
+            Assert.Contains("| B | RIZZ | 5% |", result);
+            Assert.Contains("| C | HONESTY | 30% | +1.4 📖🔗 |", result);
+            Assert.Contains("| D | CHAOS | 0% |", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_ChosenOptionC_MarksCorrectRow()
+        {
+            var options = new[]
+            {
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Honesty),
+            };
+
+            var scores = new[]
+            {
+                MakeScore(0, 5.0f, 0.45f, 1.0f),
+                MakeScore(1, 3.0f, 0.20f, 0.5f),
+                MakeScore(2, 7.0f, 0.60f, 2.0f),
+            };
+
+            var decision = MakeDecision(2, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            // A and B should NOT have ✓
+            Assert.Contains("| A |", result);
+            Assert.Contains("| B |", result);
+            // C should have ✓ and bold score
+            Assert.Contains("C ✓", result);
+            Assert.Contains("**7.0**", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_NullDecision_ReturnsEmpty()
+        {
+            var result = PlaytestFormatter.FormatScoreTable(null, new[] { MakeOption(StatType.Charm) });
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_BonusesConcatenatedWithoutSpaces()
+        {
+            var options = new[] { MakeOption(StatType.Honesty) };
+            var scores = new[] { MakeScore(0, 5.0f, 0.30f, 1.4f, new[] { "📖", "🔗" }) };
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            Assert.Contains("📖🔗", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_FewerScoresThanOptions_ShowsDash()
+        {
+            var options = new[]
+            {
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Honesty),
+            };
+
+            // Only 2 scores for 3 options
+            var scores = new[]
+            {
+                MakeScore(0, 5.0f, 0.45f, 1.0f),
+                MakeScore(1, 3.0f, 0.20f, 0.5f),
+            };
+
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            // Third row should have dashes
+            Assert.Contains("| C | HONESTY | — | — | — |", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_PercentageRounding()
+        {
+            var options = new[] { MakeOption(StatType.Charm) };
+            // 0.456 * 100 = 45.6, rounds to 46
+            var scores = new[] { MakeScore(0, 1.0f, 0.456f, 1.0f) };
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            Assert.Contains("46%", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_NegativeScore_ShowsZero()
+        {
+            var options = new[] { MakeOption(StatType.Charm) };
+            var scores = new[] { MakeScore(0, -1.5f, 0.5f, 1.0f) };
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            Assert.Contains("**0.0**", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_TwoOptions_TwoRows()
+        {
+            var options = new[]
+            {
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Chaos),
+            };
+
+            var scores = new[]
+            {
+                MakeScore(0, 4.0f, 0.30f, 1.0f),
+                MakeScore(1, 2.0f, 0.10f, 0.5f),
+            };
+
+            var decision = MakeDecision(1, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            // Should have exactly 2 data rows (A and B)
+            Assert.Contains("| A | RIZZ |", result);
+            Assert.Contains("| B ✓ | CHAOS |", result);
+            Assert.DoesNotContain("| C |", result);
+        }
+
+        [Fact]
+        public void FormatReasoningBlock_MultiParagraph_AllLinesBlockquoted()
+        {
+            var decision = MakeDecision(0, "Para one.\n\nPara two.\nLine three.", new[]
+            {
+                MakeScore(0, 1.0f, 0.5f, 1.0f),
+            });
+
+            var result = PlaytestFormatter.FormatReasoningBlock(decision, "LlmPlayerAgent");
+
+            // Empty line between paragraphs should also be blockquoted
+            Assert.Contains("> Para one.", result);
+            Assert.Contains("> ", result); // empty blockquote line
+            Assert.Contains("> Para two.", result);
+            Assert.Contains("> Line three.", result);
+        }
+
+        [Fact]
+        public void FormatScoreTable_AllStatTypes_CorrectLabels()
+        {
+            var options = new[]
+            {
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Honesty),
+                MakeOption(StatType.Chaos),
+                MakeOption(StatType.Wit),
+                MakeOption(StatType.SelfAwareness),
+            };
+
+            var scores = new[]
+            {
+                MakeScore(0, 1.0f, 0.1f, 0.1f),
+                MakeScore(1, 1.0f, 0.1f, 0.1f),
+                MakeScore(2, 1.0f, 0.1f, 0.1f),
+                MakeScore(3, 1.0f, 0.1f, 0.1f),
+                MakeScore(4, 1.0f, 0.1f, 0.1f),
+                MakeScore(5, 1.0f, 0.1f, 0.1f),
+            };
+
+            var decision = MakeDecision(0, "test", scores);
+
+            var result = PlaytestFormatter.FormatScoreTable(decision, options);
+
+            Assert.Contains("CHARM", result);
+            Assert.Contains("RIZZ", result);
+            Assert.Contains("HONESTY", result);
+            Assert.Contains("CHAOS", result);
+            Assert.Contains("WIT", result);
+            Assert.Contains("SA", result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #351

## What was implemented

Added `PlaytestFormatter` class with two static methods that format player agent reasoning and option score tables as markdown for playtest output:

- `FormatReasoningBlock()` — renders reasoning as blockquoted markdown with agent type name header
- `FormatScoreTable()` — renders a markdown table with Option/Stat/Pct/Expected ΔI/Score columns, chosen option marked with ✓ and bold score

Wired both into `Program.cs` after the pick line so every turn shows why the agent chose that option and the comparative scores.

## Edge cases handled
- Null/empty reasoning → placeholder text
- Fewer scores than options → dash placeholders
- NaN/negative scores → display as 0
- Bonuses concatenated without spaces (📖🔗)
- Works for any number of options (not hardcoded to 4)

## How to test
```bash
dotnet test tests/Pinder.Core.Tests/ --filter Issue351
```

## DoD Evidence
**Branch:** issue-351-session-runner-show-pick-reasoning-in-pl
**Commit:** 20b234d
**Tests:** 14 passed, 0 failed (1704 total suite passes)

## Deviations from contract
- Extracted formatting to `PlaytestFormatter` public class instead of private static methods in `Program` — enables unit testing from the test project. Functionally identical.
