### PR TITLE
[Issue #416] ScoringPlayerAgent: account for shadow growth risk when picking options

### DIFF
--- a/docs/modules/session-runner.md
+++ b/docs/modules/session-runner.md
@@ -14,6 +14,8 @@ The session runner orchestrates simulated playtest sessions between two `Charact
 - **`session-runner/SessionFileCounter.cs`** — Static utility class that scans a directory for `session-*.md` files and returns the next available session number (`max + 1`). Also provides `ResolvePlaytestDirectory()` with 3-tier directory resolution: env var override → walk-up search for `design/playtests/` → hardcoded fallback path.
 - **`tests/Pinder.Core.Tests/SessionFileCounterTests.cs`** — Tests for `SessionFileCounter`: number extraction, gaps, character names with digits, production write-read flow, large numbers, non-numeric parts, `ResolvePlaytestDirectory` env var/walk-up/null-fallback behavior.
 - **`tests/Pinder.Core.Tests/SessionFileCounterSpecTests.cs`** — Spec-driven tests for issue #418: AC1–AC4 coverage, path resolution with trailing slashes and `..` segments, integration test combining `ResolvePlaytestDirectory` + `GetNextSessionNumber`.
+- **`session-runner/OutcomeProjector.cs`** — Pure static class that projects likely game outcome when a session hits the turn cap without a natural ending. Uses `InterestState`-based heuristic with momentum and interest level to produce a human-readable projection string.
+- **`tests/Pinder.Core.Tests/OutcomeProjectorTests.cs`** — Tests for `OutcomeProjector.Project`: decision table coverage for all five tiers (AlmostThere/VeryIntoIt/Interested/Lukewarm/Bored/Unmatched), boundary values, momentum display, degenerate cases (maxTurns=0/1), out-of-range interest, pure function guarantees (non-null, deterministic).
 - **`tests/Pinder.Core.Tests/ScoringPlayerAgentTests.cs`** (engine-sync tests) — Verifies `ScoringPlayerAgent` uses engine constants correctly: `CallbackBonus.Compute()` for opener (+3) and mid-distance (+1) bonuses, momentum thresholds matching GameSession rules §15 (0–2→+0, 3–4→+2, 5+→+3), and tell bonus (+2) producing exactly 0.1 success chance delta.
 
 ## API / Public Interface
@@ -70,6 +72,54 @@ public static string FormatReasoningBlock(PlayerDecision? decision, string agent
 public static string FormatScoreTable(PlayerDecision? decision, DialogueOption[] options);
 ```
 
+### OutcomeProjector (internal static class)
+
+Projects likely game outcome when a session ends due to the turn cap (no natural `GameOutcome` reached).
+
+```csharp
+internal static class OutcomeProjector
+{
+    /// Projects the likely outcome when the session ends due to turn cap.
+    /// Pure function — no I/O, no exceptions, always returns a non-empty string.
+    /// Uses InterestState-based branching with momentum bonus estimation.
+    internal static string Project(
+        int interest,
+        int momentum,
+        int turnNumber,
+        int maxTurns,
+        InterestState interestState);
+}
+```
+
+**Projection logic by `InterestState`:**
+
+| InterestState | Projection |
+|---|---|
+| `DateSecured` | `"DateSecured already achieved."` |
+| `Unmatched` | `"Unmatched — interest hit 0."` |
+| `AlmostThere` | `"Likely DateSecured..."` with interest/momentum details and estimated turns |
+| `VeryIntoIt` | `"Probable DateSecured..."` with advantage note |
+| `Interested` / `Lukewarm` | `"Possible DateSecured"` (interest ≥ 12) or `"Uncertain outcome"` (interest < 12) |
+| `Bored` | `"Likely Unmatched..."` with disadvantage note |
+
+**Notes:**
+- Momentum bonus displayed when streak ≥ 3 (3–4 → +2, 5+ → +3).
+- Estimated turns to close calculated from `(25 - interest) / avgGainPerTurn`.
+- The spec's original design used pure numeric thresholds; the implementation dispatches on `InterestState` enum instead, which aligns with the same interest ranges but adds state-aware messaging.
+
+### Session Summary — Cutoff Projection
+
+When the game loop exits because `turn >= maxTurns` and no natural `GameOutcome` was reached, the session summary includes:
+
+```
+## Session Summary
+**⏸️ Incomplete ({turnsPlayed}/{maxTurns} turns) | Interest: {n}/25 | Total XP: {xp}**
+
+Projected: {OutcomeProjector.Project(...)}
+```
+
+When the game ends naturally (DateSecured, Unmatched, Ghost), the existing summary format is unchanged.
+
 ### SessionFileCounter (static class)
 
 Manages session file numbering and playtest directory resolution.
@@ -101,6 +151,7 @@ internal static class SessionFileCounter
 | `GameSession` | `Pinder.Core.Conversation` | Core turn-based session engine |
 | `TurnResult.ShadowGrowthEvents` | `Pinder.Core.Conversation` | `IReadOnlyList<string>` populated when `PlayerShadows` is non-null |
 | `ShadowStatType` | `Pinder.Core.Stats` | Enum: Madness, Horniness, Denial, Fixation, Dread, Overthinking |
+| `InterestState` | `Pinder.Core.Conversation` | Enum: Unmatched, Bored, Lukewarm, Interested, VeryIntoIt, AlmostThere, DateSecured — used by `OutcomeProjector` |
 
 ## Architecture Notes
 
@@ -145,3 +196,4 @@ LLM-backed agent that sends full game state and rules context to Anthropic Claud
 | 2026-04-04 | #351 | Added `PlaytestFormatter` static class with `FormatReasoningBlock` and `FormatScoreTable` methods. After each pick, playtest output now shows the agent's reasoning as a blockquote and a score table with all options' metrics. Defensive handling for null decisions, NaN values, missing scores. Tests in `Issue351_PickReasoningTests.cs`. |
 | 2026-04-04 | #386 | Added engine-constant sync tests to `ScoringPlayerAgentTests.cs`: callback bonus (opener +3, mid-distance +1) via `CallbackBonus.Compute()`, momentum threshold verification at all streak values (§15), and tell bonus exactness (+2 → 0.1 success chance delta). Guards against silent drift between agent scoring and engine rules. |
 | 2026-04-04 | #418 | Fixed `SessionFileCounter` to correctly find existing session files. Added `ResolvePlaytestDirectory(string baseDir)` with 3-tier resolution (env var → walk-up → fallback). `Program.WritePlaytestLog` now uses `ResolvePlaytestDirectory(AppContext.BaseDirectory)` instead of a hardcoded path. Added `SessionFileCounterSpecTests.cs` (25 tests) and extended `SessionFileCounterTests.cs` with AC coverage, edge cases, and resolution tests. |
+| 2026-04-04 | #417 | Added `OutcomeProjector` static class for projecting game outcome on turn-cap cutoff. Uses `InterestState`-based dispatch (diverges from spec's pure numeric thresholds but covers same ranges). Session summary shows ⏸️ Incomplete header with projected outcome when no natural game-over reached. Rewrote `OutcomeProjectorTests.cs` with comprehensive coverage: all five decision tiers, boundary values, momentum display, degenerate cases, pure function guarantees. |

--- a/session-runner/PlayerAgentContext.cs
+++ b/session-runner/PlayerAgentContext.cs
@@ -38,6 +38,15 @@ namespace Pinder.SessionRunner
         /// <summary>Current turn number (from GameStateSnapshot.TurnNumber).</summary>
         public int TurnNumber { get; }
 
+        /// <summary>Stat used on the previous turn. Null on first turn.</summary>
+        public StatType? LastStatUsed { get; }
+
+        /// <summary>Stat used two turns ago. Null on first or second turn.</summary>
+        public StatType? SecondLastStatUsed { get; }
+
+        /// <summary>Whether Honesty was available as an option last turn. False on first turn or unknown.</summary>
+        public bool HonestyAvailableLastTurn { get; }
+
         public PlayerAgentContext(
             StatBlock playerStats,
             StatBlock opponentStats,
@@ -47,7 +56,10 @@ namespace Pinder.SessionRunner
             string[] activeTrapNames,
             int sessionHorniness,
             Dictionary<ShadowStatType, int>? shadowValues,
-            int turnNumber)
+            int turnNumber,
+            StatType? lastStatUsed = null,
+            StatType? secondLastStatUsed = null,
+            bool honestyAvailableLastTurn = false)
         {
             PlayerStats = playerStats ?? throw new ArgumentNullException(nameof(playerStats));
             OpponentStats = opponentStats ?? throw new ArgumentNullException(nameof(opponentStats));
@@ -58,6 +70,9 @@ namespace Pinder.SessionRunner
             SessionHorniness = sessionHorniness;
             ShadowValues = shadowValues;
             TurnNumber = turnNumber;
+            LastStatUsed = lastStatUsed;
+            SecondLastStatUsed = secondLastStatUsed;
+            HonestyAvailableLastTurn = honestyAvailableLastTurn;
         }
     }
 }

--- a/session-runner/ScoringPlayerAgent.cs
+++ b/session-runner/ScoringPlayerAgent.cs
@@ -22,6 +22,12 @@ namespace Pinder.SessionRunner
         private const float BoredBoldBias = 1.0f;
         private const float ActiveTrapPenalty = 2.0f;
 
+        // Shadow growth risk constants (§7)
+        private const float FixationGrowthPenalty = 0.5f;
+        private const float DenialGrowthPenalty = 0.3f;
+        private const float FixationT1EvMultiplier = 0.8f;
+        private const float StatVarietyBonus = 0.1f;
+
         // SYNC: GameSession ResolveTurnAsync tellBonus
         private const int TellBonusValue = 2;
 
@@ -166,6 +172,77 @@ namespace Pinder.SessionRunner
                 {
                     score -= ActiveTrapPenalty;
                     strategicReasons.Add($"Active {trapName} trap — penalty applied");
+                }
+
+                // Shadow growth risk: Fixation growth penalty (§7: same stat 3x → +1 Fixation)
+                if (context.LastStatUsed.HasValue
+                    && context.SecondLastStatUsed.HasValue
+                    && option.Stat == context.LastStatUsed.Value
+                    && context.LastStatUsed.Value == context.SecondLastStatUsed.Value)
+                {
+                    score -= FixationGrowthPenalty;
+                    strategicReasons.Add("Fixation growth risk — same stat 3x");
+                }
+
+                // Shadow growth risk: Denial penalty (§7: skip Honesty when available → +1 Denial)
+                bool honestyInOptions = false;
+                for (int j = 0; j < options.Length; j++)
+                {
+                    if (options[j].Stat == StatType.Honesty)
+                    {
+                        honestyInOptions = true;
+                        break;
+                    }
+                }
+                if (option.Stat != StatType.Honesty && honestyInOptions)
+                {
+                    score -= DenialGrowthPenalty;
+                    strategicReasons.Add("Denial growth risk — skipping available Honesty");
+                }
+
+                // Shadow threshold: Fixation effects on Chaos options (§7)
+                if (option.Stat == StatType.Chaos && context.ShadowValues != null)
+                {
+                    int fixation = 0;
+                    context.ShadowValues.TryGetValue(ShadowStatType.Fixation, out fixation);
+                    if (fixation >= 12)
+                    {
+                        // T2+: apply disadvantage to success chance calculation
+                        // Disadvantage: roll 2d20 take lowest → P(success) = 1 - (1 - p)^2... actually P = p^2
+                        // For d20 with threshold: P(both >= need) = p * p
+                        float disadvSuccessChance = successChance * successChance;
+                        float disadvExpectedGain = disadvSuccessChance * expectedGainOnSuccess
+                                                 - (1.0f - disadvSuccessChance) * failCost;
+                        // Replace the EV component of score with disadvantaged version
+                        score = score - expectedInterestGain + disadvExpectedGain;
+                        expectedInterestGain = disadvExpectedGain;
+                        successChance = disadvSuccessChance;
+                        strategicReasons.Add($"Fixation T2 ({fixation}) — Chaos disadvantage applied");
+                    }
+                    else if (fixation >= 6)
+                    {
+                        // T1: reduce expected gain on success by 20% (LLM quality degradation)
+                        float reducedGain = expectedGainOnSuccess * FixationT1EvMultiplier;
+                        float reducedEv = successChance * reducedGain - failChance * failCost;
+                        score = score - expectedInterestGain + reducedEv;
+                        expectedInterestGain = reducedEv;
+                        strategicReasons.Add($"Fixation T1 ({fixation}) — Chaos EV reduced 20%");
+                    }
+                }
+
+                // Stat variety bonus: prefer stats not used recently
+                if (context.LastStatUsed.HasValue || context.SecondLastStatUsed.HasValue)
+                {
+                    bool usedRecently = false;
+                    if (context.LastStatUsed.HasValue && option.Stat == context.LastStatUsed.Value)
+                        usedRecently = true;
+                    if (context.SecondLastStatUsed.HasValue && option.Stat == context.SecondLastStatUsed.Value)
+                        usedRecently = true;
+                    if (!usedRecently)
+                    {
+                        score += StatVarietyBonus;
+                        strategicReasons.Add("Stat variety bonus — not used recently");
+                    }
                 }
 
                 scores[i] = new OptionScore(

--- a/tests/Pinder.Core.Tests/ScoringPlayerAgentShadowTests.cs
+++ b/tests/Pinder.Core.Tests/ScoringPlayerAgentShadowTests.cs
@@ -1,0 +1,570 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for ScoringPlayerAgent shadow growth risk scoring (issue #416).
+    /// Validates Fixation growth penalty, Denial penalty, Fixation threshold effects,
+    /// and stat variety bonus.
+    /// </summary>
+    public class ScoringPlayerAgentShadowTests
+    {
+        private readonly ScoringPlayerAgent _agent = new ScoringPlayerAgent();
+
+        #region Helpers
+
+        private static StatBlock MakeStats(
+            int charm = 0, int rizz = 0, int honesty = 0,
+            int chaos = 0, int wit = 0, int sa = 0,
+            int madness = 0, int horniness = 0, int denial = 0,
+            int fixation = 0, int dread = 0, int overthinking = 0)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm },
+                    { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty },
+                    { StatType.Chaos, chaos },
+                    { StatType.Wit, wit },
+                    { StatType.SelfAwareness, sa }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, madness },
+                    { ShadowStatType.Horniness, horniness },
+                    { ShadowStatType.Denial, denial },
+                    { ShadowStatType.Fixation, fixation },
+                    { ShadowStatType.Dread, dread },
+                    { ShadowStatType.Overthinking, overthinking }
+                });
+        }
+
+        private static DialogueOption MakeOption(
+            StatType stat,
+            int? callbackTurn = null,
+            string? comboName = null,
+            bool hasTellBonus = false)
+        {
+            return new DialogueOption(
+                stat, $"{stat} option",
+                callbackTurnNumber: callbackTurn,
+                comboName: comboName,
+                hasTellBonus: hasTellBonus);
+        }
+
+        private static TurnStart MakeTurn(params DialogueOption[] options)
+        {
+            return new TurnStart(
+                options,
+                new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 5));
+        }
+
+        private static PlayerAgentContext MakeContext(
+            StatBlock? player = null,
+            StatBlock? opponent = null,
+            int interest = 10,
+            InterestState state = InterestState.Interested,
+            int momentum = 0,
+            string[]? traps = null,
+            int turnNumber = 5,
+            StatType? lastStatUsed = null,
+            StatType? secondLastStatUsed = null,
+            bool honestyAvailableLastTurn = false,
+            Dictionary<ShadowStatType, int>? shadowValues = null)
+        {
+            return new PlayerAgentContext(
+                player ?? MakeStats(charm: 3, rizz: 3, honesty: 3, chaos: 3, wit: 3, sa: 3),
+                opponent ?? MakeStats(),
+                interest,
+                state,
+                momentum,
+                traps ?? Array.Empty<string>(),
+                0,
+                shadowValues,
+                turnNumber,
+                lastStatUsed,
+                secondLastStatUsed,
+                honestyAvailableLastTurn);
+        }
+
+        #endregion
+
+        #region AC: Fixation growth penalty
+
+        // Agent avoids third consecutive same-stat pick when alternative is close in EV
+        [Fact]
+        public async Task FixationGrowthPenalty_AvoidsThirdConsecutiveSameStat()
+        {
+            // Both options have similar base EV, but Charm would trigger Fixation growth
+            var player = MakeStats(charm: 3, rizz: 3);
+            var opponent = MakeStats(); // all 0 → DC=13
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz));
+
+            // Last two turns both used Charm → picking Charm again triggers Fixation
+            var context = MakeContext(
+                player: player, opponent: opponent,
+                lastStatUsed: StatType.Charm,
+                secondLastStatUsed: StatType.Charm);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Rizz should win due to -0.5 Fixation penalty on Charm + +0.1 variety bonus on Rizz
+            Assert.Equal(1, decision.OptionIndex);
+        }
+
+        // Penalty only applies when both last two stats match the current option
+        [Fact]
+        public async Task FixationGrowthPenalty_DoesNotApplyWhenOnlyOneMatch()
+        {
+            var player = MakeStats(charm: 3, wit: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Wit));
+
+            // Only last turn was Charm, second-last was Rizz (different)
+            var context = MakeContext(
+                player: player, opponent: opponent,
+                lastStatUsed: StatType.Charm,
+                secondLastStatUsed: StatType.Rizz);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Both have same base EV.
+            // Charm: used last turn (no variety bonus), no Fixation penalty (only 1 consecutive)
+            // Wit: not in recent history → +0.1 variety bonus
+            var charmScore = decision.Scores[0].Score;
+            var witScore = decision.Scores[1].Score;
+            Assert.True(witScore > charmScore, "Wit should score higher due to variety bonus");
+            // The gap should be small (variety only, no Fixation penalty)
+            Assert.True(witScore - charmScore < 0.3f,
+                $"Gap should be small (variety only): {witScore - charmScore}");
+        }
+
+        // Penalty doesn't apply when LastStatUsed is null (first turn)
+        [Fact]
+        public async Task FixationGrowthPenalty_SkippedWhenLastStatNull()
+        {
+            var player = MakeStats(charm: 3, rizz: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz));
+
+            // First turn — no history
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Scores should be identical (no history-based adjustments applicable for Fixation)
+            float diff = Math.Abs(decision.Scores[0].Score - decision.Scores[1].Score);
+            Assert.True(diff < 0.01f, $"Scores should be nearly identical on first turn: {diff}");
+        }
+
+        #endregion
+
+        #region AC: Denial growth penalty
+
+        // Non-Honesty option gets -0.3 when Honesty is available
+        [Fact]
+        public async Task DenialPenalty_AppliedWhenSkippingHonesty()
+        {
+            var player = MakeStats(charm: 3, honesty: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Honesty));
+
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Charm gets -0.3 Denial penalty (skipping Honesty)
+            // Honesty does NOT get Denial penalty (it IS Honesty)
+            // With equal stats, Honesty should win by the 0.3 margin
+            Assert.Equal(1, decision.OptionIndex);
+        }
+
+        // No Denial penalty when Honesty is not in options
+        [Fact]
+        public async Task DenialPenalty_NotAppliedWhenNoHonestyInOptions()
+        {
+            var player = MakeStats(charm: 3, rizz: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz));
+
+            var contextWithHistory = MakeContext(
+                player: player, opponent: opponent,
+                lastStatUsed: StatType.Charm);
+            var contextWithout = MakeContext(
+                player: player, opponent: opponent);
+
+            var decisionWith = await _agent.DecideAsync(turn, contextWithHistory);
+            var decisionWithout = await _agent.DecideAsync(turn, contextWithout);
+
+            // No Denial penalty should be applied to either option since Honesty isn't available
+            // The only difference should be variety bonus
+            float charmDiffWith = decisionWith.Scores[0].Score;
+            float rizzDiffWith = decisionWith.Scores[1].Score;
+            // Without history, both should be equal
+            float charmDiffWithout = decisionWithout.Scores[0].Score;
+            float rizzDiffWithout = decisionWithout.Scores[1].Score;
+            Assert.True(Math.Abs(charmDiffWithout - rizzDiffWithout) < 0.01f,
+                "Without stat history, Charm and Rizz should have equal scores");
+        }
+
+        #endregion
+
+        #region AC: Fixation threshold — Chaos EV reduction
+
+        // T1 (Fixation >= 6): Chaos EV reduced by 20%
+        [Fact]
+        public async Task FixationT1_ChaosEvReduced20Percent()
+        {
+            var player = MakeStats(chaos: 3, charm: 3);
+            var opponent = MakeStats();
+
+            var shadowsT1 = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 6 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            var shadowsNone = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+
+            var turnChaos = MakeTurn(MakeOption(StatType.Chaos));
+
+            var resultT1 = await _agent.DecideAsync(turnChaos,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsT1));
+            var resultNone = await _agent.DecideAsync(turnChaos,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsNone));
+
+            // Chaos EV should be lower with Fixation T1
+            Assert.True(resultT1.Scores[0].Score < resultNone.Scores[0].Score,
+                $"Fixation T1 should reduce Chaos score: T1={resultT1.Scores[0].Score}, None={resultNone.Scores[0].Score}");
+        }
+
+        // T2 (Fixation >= 12): Chaos gets disadvantage
+        [Fact]
+        public async Task FixationT2_ChaosDisadvantageApplied()
+        {
+            var player = MakeStats(chaos: 3, charm: 3);
+            var opponent = MakeStats();
+
+            var shadowsT2 = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 12 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            var shadowsT1 = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 6 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+
+            var turnChaos = MakeTurn(MakeOption(StatType.Chaos));
+
+            var resultT2 = await _agent.DecideAsync(turnChaos,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsT2));
+            var resultT1 = await _agent.DecideAsync(turnChaos,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsT1));
+
+            // T2 disadvantage should reduce score more than T1 reduction
+            Assert.True(resultT2.Scores[0].Score < resultT1.Scores[0].Score,
+                $"Fixation T2 should reduce Chaos score more than T1: T2={resultT2.Scores[0].Score}, T1={resultT1.Scores[0].Score}");
+        }
+
+        // Non-Chaos options unaffected by Fixation threshold
+        [Fact]
+        public async Task FixationThreshold_DoesNotAffectNonChaosOptions()
+        {
+            var player = MakeStats(charm: 3);
+            var opponent = MakeStats();
+
+            var shadowsT2 = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 12 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            var shadowsNone = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+
+            var turnCharm = MakeTurn(MakeOption(StatType.Charm));
+
+            var resultT2 = await _agent.DecideAsync(turnCharm,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsT2));
+            var resultNone = await _agent.DecideAsync(turnCharm,
+                MakeContext(player: player, opponent: opponent, shadowValues: shadowsNone));
+
+            // Charm score should be identical regardless of Fixation level
+            Assert.Equal((double)resultT2.Scores[0].Score, (double)resultNone.Scores[0].Score, 4);
+        }
+
+        // Null shadow values → skip threshold checks
+        [Fact]
+        public async Task FixationThreshold_SkippedWhenShadowValuesNull()
+        {
+            var player = MakeStats(chaos: 3);
+            var opponent = MakeStats();
+
+            var turnChaos = MakeTurn(MakeOption(StatType.Chaos));
+
+            // No shadow values (null) — should not crash or apply any reduction
+            var result = await _agent.DecideAsync(turnChaos,
+                MakeContext(player: player, opponent: opponent, shadowValues: null));
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.OptionIndex);
+        }
+
+        #endregion
+
+        #region AC: Stat variety bonus
+
+        // Picking a stat not used recently gets +0.1
+        [Fact]
+        public async Task StatVarietyBonus_AppliedToUnusedStat()
+        {
+            var player = MakeStats(charm: 3, rizz: 3, wit: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz),
+                MakeOption(StatType.Wit));
+
+            // Last two turns: Charm, Rizz
+            var context = MakeContext(
+                player: player, opponent: opponent,
+                lastStatUsed: StatType.Charm,
+                secondLastStatUsed: StatType.Rizz);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Wit (not used recently) should get +0.1 variety bonus
+            // Charm and Rizz were used recently → no variety bonus
+            float witScore = decision.Scores[2].Score;
+            float charmScore = decision.Scores[0].Score;
+            float rizzScore = decision.Scores[1].Score;
+
+            // Wit should be higher than both due to variety bonus
+            Assert.True(witScore > charmScore,
+                $"Wit should beat Charm with variety bonus: Wit={witScore}, Charm={charmScore}");
+            Assert.True(witScore > rizzScore,
+                $"Wit should beat Rizz with variety bonus: Wit={witScore}, Rizz={rizzScore}");
+        }
+
+        // No variety bonus when stat history is empty
+        [Fact]
+        public async Task StatVarietyBonus_NotAppliedWhenNoHistory()
+        {
+            var player = MakeStats(charm: 3, rizz: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Rizz));
+
+            // No stat history
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Scores should be identical (no variety adjustments)
+            float diff = Math.Abs(decision.Scores[0].Score - decision.Scores[1].Score);
+            Assert.True(diff < 0.01f,
+                $"Scores should be equal without stat history: diff={diff}");
+        }
+
+        #endregion
+
+        #region AC: Agent avoids 3rd consecutive same-stat when close EV
+
+        // Integration test: all shadow adjustments combine correctly
+        [Fact]
+        public async Task CombinedShadowAdjustments_AgentAvoidsThirdSameStat()
+        {
+            // Setup: Honesty was used last 2 turns, Honesty and Charm available
+            // Without shadow risk, Honesty has slightly higher EV (charm: 2, honesty: 3)
+            // With Fixation penalty (-0.5), variety bonus (+0.1 for Charm), and
+            // no Denial penalty (Honesty IS the option), Charm should win
+            var player = MakeStats(charm: 2, honesty: 3);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Honesty),
+                MakeOption(StatType.Charm));
+
+            var context = MakeContext(
+                player: player, opponent: opponent,
+                lastStatUsed: StatType.Honesty,
+                secondLastStatUsed: StatType.Honesty);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // Honesty gets: -0.5 Fixation penalty, no Denial penalty
+            // Charm gets: -0.3 Denial penalty (skipping Honesty), +0.1 variety bonus
+            // Honesty base EV is higher due to +3 vs +2 mod, but -0.5 Fixation should outweigh
+            // Net adjustments: Honesty: -0.5, Charm: -0.3 + 0.1 = -0.2
+            // Difference in adjustments: 0.3 in Charm's favor
+            // This test validates the agent avoids the third consecutive pick
+            Assert.Equal(1, decision.OptionIndex);
+        }
+
+        #endregion
+
+        #region AC: PlayerAgentContext new fields
+
+        [Fact]
+        public void PlayerAgentContext_NewFieldsHaveDefaults()
+        {
+            // Existing constructor call should still work (backward compat)
+            var context = new PlayerAgentContext(
+                MakeStats(),
+                MakeStats(),
+                10,
+                InterestState.Interested,
+                0,
+                Array.Empty<string>(),
+                0,
+                null,
+                3);
+
+            Assert.Null(context.LastStatUsed);
+            Assert.Null(context.SecondLastStatUsed);
+            Assert.False(context.HonestyAvailableLastTurn);
+        }
+
+        [Fact]
+        public void PlayerAgentContext_NewFieldsSetCorrectly()
+        {
+            var context = new PlayerAgentContext(
+                MakeStats(),
+                MakeStats(),
+                10,
+                InterestState.Interested,
+                0,
+                Array.Empty<string>(),
+                0,
+                null,
+                3,
+                lastStatUsed: StatType.Charm,
+                secondLastStatUsed: StatType.Rizz,
+                honestyAvailableLastTurn: true);
+
+            Assert.Equal(StatType.Charm, context.LastStatUsed);
+            Assert.Equal(StatType.Rizz, context.SecondLastStatUsed);
+            Assert.True(context.HonestyAvailableLastTurn);
+        }
+
+        [Fact]
+        public void PlayerAgentContext_ShadowValuesExposed()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 8 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            var context = new PlayerAgentContext(
+                MakeStats(), MakeStats(),
+                10, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, shadows, 3);
+
+            Assert.NotNull(context.ShadowValues);
+            Assert.Equal(8, context.ShadowValues![ShadowStatType.Fixation]);
+        }
+
+        #endregion
+
+        #region Build clean verification
+
+        // Ensures determinism is maintained with new scoring terms
+        [Fact]
+        public async Task Determinism_WithShadowContext_SameInputsSameOutput()
+        {
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Fixation, 7 },
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Horniness, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            var player = MakeStats(charm: 3, chaos: 3, honesty: 2);
+            var opponent = MakeStats();
+
+            var turn = MakeTurn(
+                MakeOption(StatType.Charm),
+                MakeOption(StatType.Chaos),
+                MakeOption(StatType.Honesty));
+
+            var context = MakeContext(
+                player: player, opponent: opponent,
+                shadowValues: shadows,
+                lastStatUsed: StatType.Charm,
+                secondLastStatUsed: StatType.Charm);
+
+            var d1 = await _agent.DecideAsync(turn, context);
+            var d2 = await _agent.DecideAsync(turn, context);
+
+            Assert.Equal(d1.OptionIndex, d2.OptionIndex);
+            for (int i = 0; i < d1.Scores.Length; i++)
+            {
+                Assert.Equal((double)d1.Scores[i].Score, (double)d2.Scores[i].Score, 4);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #416

## What was implemented

**PlayerAgentContext** gains three new optional fields:
- LastStatUsed (StatType?) — stat used on previous turn
- SecondLastStatUsed (StatType?) — stat used two turns ago  
- HonestyAvailableLastTurn (bool) — whether Honesty was available last turn

All new params have defaults (null/false) so existing callers compile unchanged.

**ScoringPlayerAgent** gains four shadow-aware scoring terms:

1. **Fixation growth penalty** (-0.5): When picking a stat used in both of the last 2 turns (would trigger Fixation +1)
2. **Denial growth penalty** (-0.3): When skipping Honesty available in options (Denial +1)  
3. **Fixation threshold EV reduction**: Chaos options penalized at Fixation T1 (>=6, 20% EV reduction) and T2 (>=12, disadvantage on success chance)
4. **Stat variety bonus** (+0.1): For picking stats not used in last 2 turns

## How to test
dotnet test --filter ScoringPlayerAgentShadow

16 new tests. All 2326 tests pass (1837 core + 489 LLM adapter).

**Deviations from contract:** none