### PR TITLE
[Issue #443] Rules DSL: fix remaining round-trip diffs (paragraph reordering, table formatting)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ obj/
 *.DotSettings.user
 TestResults/
 agent.log
+rules/diffs/
+rules/extracted/
+rules/regenerated/
+__pycache__/

--- a/rules/tools/extract.py
+++ b/rules/tools/extract.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Extract structured YAML rules from a Pinder design markdown file.
+
+Blocks (paragraphs, tables, code blocks, blockquotes, flavor text, horizontal
+rules) are stored as an ordered list so that generate.py can reproduce them in
+the original document order.
+"""
+
+import sys
+import re
+import yaml
+
+
+def slugify(text):
+    """Convert heading text to a URL-friendly slug."""
+    text = text.lower().strip()
+    text = re.sub(r'[^\w\s-]', '', text)
+    text = re.sub(r'[\s_]+', '-', text)
+    text = re.sub(r'-+', '-', text)
+    return text.strip('-')
+
+
+def guess_type(title, blocks):
+    """Guess rule type from content."""
+    title_lower = title.lower()
+    desc_lower = ''
+    has_table = False
+    has_code = False
+    for b in blocks:
+        if b['kind'] == 'paragraph':
+            desc_lower += ' ' + b['text'].lower()
+        elif b['kind'] == 'table':
+            has_table = True
+        elif b['kind'] == 'code':
+            has_code = True
+
+    if has_table:
+        return 'table'
+    if has_code:
+        return 'template'
+
+    keywords = {
+        'interest_change': ['interest', 'xp', 'gain', 'lose', 'reward'],
+        'shadow_growth': ['shadow', 'madness', 'horniness', 'denial', 'fixation', 'dread', 'overthinking'],
+        'roll_modifier': ['roll', 'modifier', 'bonus', 'dc', 'check', 'dice', 'd20'],
+        'trap_activation': ['trap', 'cringe', 'creep', 'overshare', 'spiral', 'dry spell'],
+        'state_change': ['state', 'phase', 'transition', 'ghost', 'unmatch', 'date'],
+        'definition': ['how', 'what', 'structure', 'overview', 'parameter'],
+        'narrative': ['story', 'flavor', 'theme', 'design', 'philosophy'],
+    }
+
+    combined = title_lower + ' ' + desc_lower
+    for rule_type, kws in keywords.items():
+        if any(kw in combined for kw in kws):
+            return rule_type
+
+    return 'definition'
+
+
+def parse_table(lines):
+    """Parse a markdown table into list of dicts, separator cells, and header padding."""
+    if len(lines) < 2:
+        return [], [], '\n'.join(lines)
+
+    header_line = lines[0]
+    if '|' not in header_line:
+        return [], [], '\n'.join(lines)
+
+    headers = [h.strip() for h in header_line.strip('|').split('|')]
+    headers = [h for h in headers if h or True]  # keep potentially empty headers
+
+    if not headers:
+        return [], [], '\n'.join(lines)
+
+    # Store raw separator cells to preserve alignment markers and widths
+    sep_line = lines[1] if len(lines) > 1 else ''
+    sep_cells = []
+    if '|' in sep_line:
+        sep_cells = [c for c in sep_line.strip('|').split('|')]
+
+    rows = []
+    for line in lines[2:]:
+        if '|' not in line:
+            continue
+        cells = [c.strip() for c in line.strip('|').split('|')]
+        while len(cells) < len(headers):
+            cells.append('')
+        row = {}
+        for i, h in enumerate(headers):
+            if i < len(cells):
+                row[h] = cells[i]
+        rows.append(row)
+
+    return rows, sep_cells, None
+
+
+def extract_rules(filepath):
+    """Parse markdown file into structured rule entries with ordered blocks."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    lines = content.split('\n')
+    rules = []
+
+    current_h1 = ''
+    section_counter = 0
+    current_rule = None
+
+    in_code_block = False
+    code_block_lines = []
+    code_block_lang = ''
+    in_table = False
+    table_lines = []
+
+    def _blocks(rule):
+        """Get or create the blocks list for a rule."""
+        if 'blocks' not in rule:
+            rule['blocks'] = []
+        return rule['blocks']
+
+    def flush_table():
+        nonlocal in_table, table_lines, current_rule
+        if table_lines and current_rule:
+            rows, sep_cells, raw = parse_table(table_lines)
+            if rows:
+                block = {'kind': 'table', 'rows': rows}
+                if sep_cells:
+                    block['sep_cells'] = sep_cells
+                _blocks(current_rule).append(block)
+            elif raw:
+                _blocks(current_rule).append({'kind': 'paragraph', 'text': raw})
+        table_lines = []
+        in_table = False
+
+    def flush_code():
+        nonlocal in_code_block, code_block_lines, code_block_lang, current_rule
+        if code_block_lines and current_rule:
+            block_text = '\n'.join(code_block_lines)
+            lang_prefix = "```{}\n".format(code_block_lang) if code_block_lang else "```\n"
+            full_block = lang_prefix + block_text + "\n```"
+            _blocks(current_rule).append({'kind': 'code', 'text': full_block})
+        code_block_lines = []
+        code_block_lang = ''
+        in_code_block = False
+
+    def finalize_rule(rule):
+        if rule is None:
+            return
+        # Guess type from blocks
+        blocks = rule.get('blocks', [])
+        rule['type'] = guess_type(rule['title'], blocks)
+        # Set description from first paragraph block (for backward compat / search)
+        first_para = next((b for b in blocks if b['kind'] == 'paragraph'), None)
+        if first_para:
+            rule['description'] = first_para['text']
+        else:
+            rule['description'] = ''
+        # Clean up empty fields
+        for key in list(rule.keys()):
+            if rule[key] is None or rule[key] == '' or rule[key] == []:
+                del rule[key]
+        # Ensure required fields
+        if 'description' not in rule:
+            rule['description'] = ''
+        rules.append(rule)
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        # Code block toggle
+        if line.strip().startswith('```'):
+            if in_code_block:
+                flush_code()
+                i += 1
+                continue
+            else:
+                flush_table()
+                in_code_block = True
+                code_block_lang = line.strip()[3:].strip()
+                code_block_lines = []
+                i += 1
+                continue
+
+        if in_code_block:
+            code_block_lines.append(line)
+            i += 1
+            continue
+
+        # Table detection
+        if '|' in line and not line.strip().startswith('>'):
+            stripped = line.strip()
+            if stripped.startswith('|') or (stripped.count('|') >= 2):
+                if not in_table:
+                    flush_table()
+                    in_table = True
+                table_lines.append(line)
+                i += 1
+                continue
+        else:
+            if in_table:
+                flush_table()
+
+        # Heading detection
+        heading_match = re.match(r'^(#{1,6})\s+(.*)', line)
+        if heading_match:
+            flush_table()
+            level = len(heading_match.group(1))
+            title = heading_match.group(2).strip()
+
+            # Count blank lines between heading and first content
+            blank_count = 0
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                blank_count += 1
+                j += 1
+
+            if level == 1:
+                finalize_rule(current_rule)
+                current_h1 = title
+                section_counter = 0
+                slug = slugify(title)
+                current_rule = {
+                    'id': '§0.{}'.format(slug),
+                    'section': '§0',
+                    'title': title,
+                    'type': 'definition',
+                    '_heading_level': level,
+                    '_blank_after': blank_count,
+                }
+            elif level == 2:
+                finalize_rule(current_rule)
+                section_counter += 1
+                slug = slugify(title)
+                num_match = re.match(r'^(\d+)[\.\s]', title)
+                if num_match:
+                    sec = num_match.group(1)
+                else:
+                    sec = str(section_counter)
+                current_rule = {
+                    'id': '§{}.{}'.format(sec, slug),
+                    'section': '§{}'.format(sec),
+                    'title': title,
+                    'type': 'definition',
+                    '_heading_level': level,
+                    '_blank_after': blank_count,
+                }
+            elif level >= 3:
+                finalize_rule(current_rule)
+                slug = slugify(title)
+                parent_sec = '§{}'.format(section_counter) if section_counter else '§0'
+                current_rule = {
+                    'id': '{}.{}'.format(parent_sec, slug),
+                    'section': parent_sec,
+                    'title': title,
+                    'type': 'definition',
+                    '_heading_level': level,
+                    '_blank_after': blank_count,
+                }
+
+            i += 1
+            continue
+
+        # Horizontal rule
+        if re.match(r'^-{3,}$', line.strip()) or re.match(r'^\*{3,}$', line.strip()):
+            if current_rule is not None:
+                _blocks(current_rule).append({'kind': 'hr'})
+            i += 1
+            continue
+
+        # Empty line
+        if not line.strip():
+            i += 1
+            continue
+
+        # No current rule yet — create a preamble entry
+        if current_rule is None:
+            current_rule = {
+                'id': '§0.preamble',
+                'section': '§0',
+                'title': 'Preamble',
+                'type': 'definition',
+                '_heading_level': 0,
+            }
+
+        # Blockquote
+        if line.strip().startswith('>'):
+            quote_lines = []
+            while i < len(lines) and lines[i].strip().startswith('>'):
+                raw = lines[i]
+                # Strip leading whitespace, then the '>' marker, then at most one space
+                content = raw.lstrip()
+                if content.startswith('> '):
+                    content = content[2:]
+                elif content.startswith('>'):
+                    content = content[1:]
+                quote_lines.append(content)
+                i += 1
+            quote_text = '\n'.join(quote_lines)
+            _blocks(current_rule).append({'kind': 'blockquote', 'text': quote_text})
+            continue
+
+        # Check for italic-only line (flavor text)
+        stripped = line.strip()
+        if (stripped.startswith('*') and stripped.endswith('*') and not stripped.startswith('**')) or \
+           (stripped.startswith('_') and stripped.endswith('_')):
+            flavor = stripped.strip('*_').strip()
+            _blocks(current_rule).append({'kind': 'flavor', 'text': flavor})
+            i += 1
+            continue
+
+        # Regular paragraph / list item — accumulate consecutive non-empty, non-special lines
+        para_lines = []
+        while i < len(lines):
+            l = lines[i]
+            if not l.strip():
+                break
+            if l.strip().startswith('#'):
+                break
+            if l.strip().startswith('```'):
+                break
+            if l.strip().startswith('>'):
+                break
+            if '|' in l and l.strip().startswith('|'):
+                break
+            # Check for horizontal rule
+            if re.match(r'^-{3,}$', l.strip()) or re.match(r'^\*{3,}$', l.strip()):
+                break
+            para_lines.append(l)
+            i += 1
+
+        para_text = '\n'.join(para_lines)
+        if para_text.strip():
+            _blocks(current_rule).append({'kind': 'paragraph', 'text': para_text})
+
+        continue
+
+    # Finalize last rule
+    flush_table()
+    flush_code()
+    finalize_rule(current_rule)
+
+    # Expose heading level and blank_after as public fields
+    for rule in rules:
+        hl = rule.pop('_heading_level', None)
+        if hl and hl > 0:
+            rule['heading_level'] = hl
+        ba = rule.pop('_blank_after', None)
+        if ba is not None and ba == 0:
+            rule['compact_heading'] = True
+
+    return rules
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: extract.py <markdown_file>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    rules = extract_rules(filepath)
+
+    yaml.dump(rules, sys.stdout, default_flow_style=False, allow_unicode=True, sort_keys=False, width=200)
+
+
+if __name__ == '__main__':
+    main()

--- a/rules/tools/generate.py
+++ b/rules/tools/generate.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Generate markdown from structured YAML rules.
+
+Reads the ordered ``blocks`` list produced by extract.py so that paragraphs,
+tables, code blocks, blockquotes, flavor text, and horizontal rules appear in
+their original document order.  Table column widths stored by extract.py are
+used to reproduce the original separator row.
+"""
+
+import sys
+import yaml
+
+
+def generate_table(table_block):
+    """Generate a markdown table from a block dict with rows and optional sep_cells.
+    
+    Reproduces the separator row faithfully (preserving alignment markers and
+    column widths).  When the original separator had space-padded cells (e.g.
+    ``| ------------- |``), header and data cells are right-padded to match.
+    """
+    rows = table_block.get('rows', [])
+    if not rows:
+        return ''
+
+    headers = list(rows[0].keys())
+    if not headers:
+        return ''
+
+    sep_cells = table_block.get('sep_cells', [])
+
+    # Detect whether the original table used padded cells.
+    # A separator cell starting with a space indicates padded formatting.
+    padded = False
+    col_widths = []
+    if sep_cells and len(sep_cells) == len(headers):
+        padded = any(c.startswith(' ') for c in sep_cells)
+        col_widths = [len(c) for c in sep_cells]
+
+    def pad_cell(text, width):
+        """Pad cell content to fill *width* characters between pipes."""
+        content = ' {} '.format(text)
+        if len(content) < width:
+            content = content + ' ' * (width - len(content))
+        return content
+
+    lines = []
+
+    if padded and col_widths:
+        # Padded format — pad header + data cells to match separator widths
+        hparts = []
+        for i, h in enumerate(headers):
+            hparts.append(pad_cell(h, col_widths[i]) if i < len(col_widths) else ' {} '.format(h))
+        lines.append('|' + '|'.join(hparts) + '|')
+    else:
+        # Compact format
+        lines.append('| ' + ' | '.join(headers) + ' |')
+
+    # Separator — always use stored raw cells when available
+    if sep_cells and len(sep_cells) == len(headers):
+        lines.append('|' + '|'.join(sep_cells) + '|')
+    else:
+        lines.append('|' + '|'.join(['---' for _ in headers]) + '|')
+
+    # Data rows
+    for row in rows:
+        cells = [str(row.get(h, '')) for h in headers]
+        if padded and col_widths:
+            dparts = []
+            for i, c in enumerate(cells):
+                dparts.append(pad_cell(c, col_widths[i]) if i < len(col_widths) else ' {} '.format(c))
+            lines.append('|' + '|'.join(dparts) + '|')
+        else:
+            lines.append('| ' + ' | '.join(cells) + ' |')
+
+    return '\n'.join(lines)
+
+
+def _generate_table_legacy(table_rows):
+    """Fallback for rules that still use the flat table_rows field."""
+    return generate_table({'rows': table_rows})
+
+
+def render_blocks(blocks):
+    """Render an ordered list of blocks to markdown fragments."""
+    parts = []
+    for block in blocks:
+        kind = block.get('kind', 'paragraph')
+        if kind == 'paragraph':
+            parts.append(block['text'])
+            parts.append('')
+        elif kind == 'table':
+            parts.append(generate_table(block))
+            parts.append('')
+        elif kind == 'code':
+            parts.append(block['text'])
+            parts.append('')
+        elif kind == 'blockquote':
+            for line in block['text'].split('\n'):
+                if line.rstrip():
+                    # Preserve trailing whitespace (e.g. markdown line breaks)
+                    parts.append('> {}'.format(line))
+                else:
+                    parts.append('>')
+            parts.append('')
+        elif kind == 'flavor':
+            for line in block['text'].split('\n'):
+                parts.append('*{}*'.format(line))
+            parts.append('')
+        elif kind == 'hr':
+            parts.append('---')
+            parts.append('')
+    return parts
+
+
+def rule_to_markdown(rule, heading_level=2):
+    """Convert a single rule entry to markdown."""
+    parts = []
+
+    # Title as heading
+    prefix = '#' * heading_level
+    parts.append('{} {}'.format(prefix, rule['title']))
+
+    # Add blank line after heading unless original had none (compact_heading)
+    if not rule.get('compact_heading', False):
+        parts.append('')
+
+    # If 'blocks' list is present, render in order
+    if 'blocks' in rule:
+        parts.extend(render_blocks(rule['blocks']))
+    else:
+        # Legacy fallback: use individual fields
+        if rule.get('description'):
+            parts.append(rule['description'])
+            parts.append('')
+
+        if rule.get('flavor'):
+            for line in rule['flavor'].split('\n'):
+                parts.append('*{}*'.format(line))
+            parts.append('')
+
+        if rule.get('table_rows'):
+            parts.append(_generate_table_legacy(rule['table_rows']))
+            parts.append('')
+
+        if rule.get('code_examples'):
+            for block in rule['code_examples']:
+                parts.append(block)
+                parts.append('')
+
+        if rule.get('designer_notes'):
+            for line in rule['designer_notes'].split('\n'):
+                if line.strip():
+                    parts.append('> {}'.format(line))
+                else:
+                    parts.append('>')
+            parts.append('')
+
+        if rule.get('examples'):
+            parts.append('**Examples:**')
+            for ex in rule['examples']:
+                parts.append('- {}'.format(ex))
+            parts.append('')
+
+        if rule.get('unstructured_prose'):
+            parts.append(rule['unstructured_prose'])
+            parts.append('')
+
+    return '\n'.join(parts)
+
+
+def generate_markdown(rules):
+    """Generate full markdown document from list of rules."""
+    parts = []
+
+    for rule in rules:
+        if 'heading_level' in rule:
+            heading_level = rule['heading_level']
+        else:
+            section = rule.get('section', '§0')
+            rule_id = rule.get('id', '')
+            id_after_section = rule_id[len(section):] if rule_id.startswith(section) else rule_id
+            dots = id_after_section.count('.')
+            if section == '§0' and dots <= 1:
+                heading_level = 1
+            elif dots <= 1:
+                heading_level = 2
+            else:
+                heading_level = min(2 + dots - 1, 6)
+
+        md = rule_to_markdown(rule, heading_level)
+        parts.append(md)
+
+    return '\n'.join(parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: generate.py <yaml_file>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    with open(filepath, 'r', encoding='utf-8') as f:
+        rules = yaml.safe_load(f)
+
+    if not rules:
+        print("No rules found.", file=sys.stderr)
+        sys.exit(1)
+
+    output = generate_markdown(rules)
+    print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/rules/tools/roundtrip_test.sh
+++ b/rules/tools/roundtrip_test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Round-trip test: Markdown → YAML → Markdown
+# Usage: roundtrip_test.sh [tools_dir]
+# Defaults to using tools from same directory as this script.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="${SCRIPT_DIR}/.."
+DESIGN_DIR="/root/.openclaw/agents-extra/pinder/design"
+EXTRACT="$SCRIPT_DIR/extract.py"
+GENERATE="$SCRIPT_DIR/generate.py"
+
+mkdir -p "$RULES_DIR/extracted" "$RULES_DIR/regenerated" "$RULES_DIR/diffs"
+
+total_diff=0
+max_diff=0
+max_name=""
+all_pass=true
+
+for doc in "$DESIGN_DIR"/systems/*.md "$DESIGN_DIR"/settings/*.md; do
+    name=$(basename "$doc" .md)
+    echo "Processing $name..."
+    python3 "$EXTRACT" "$doc" > "$RULES_DIR/extracted/$name.yaml"
+    python3 "$GENERATE" "$RULES_DIR/extracted/$name.yaml" > "$RULES_DIR/regenerated/$name.md"
+    diff "$doc" "$RULES_DIR/regenerated/$name.md" > "$RULES_DIR/diffs/$name.diff" || true
+
+    yaml_entries=$(grep -c "^- id:" "$RULES_DIR/extracted/$name.yaml" 2>/dev/null || echo 0)
+    diff_lines=$(wc -l < "$RULES_DIR/diffs/$name.diff")
+    total_diff=$((total_diff + diff_lines))
+
+    status="OK"
+    if [ "$diff_lines" -gt 50 ]; then
+        status="FAIL (>50)"
+        all_pass=false
+    fi
+    if [ "$diff_lines" -gt "$max_diff" ]; then
+        max_diff=$diff_lines
+        max_name=$name
+    fi
+
+    echo "  YAML entries: $yaml_entries | Diff lines: $diff_lines | $status"
+done
+
+echo ""
+echo "Total diff lines: $total_diff"
+echo "Max diff: $max_name ($max_diff lines)"
+if $all_pass; then
+    echo "RESULT: ALL PASS (<= 50 lines per doc)"
+else
+    echo "RESULT: SOME FAIL (> 50 lines)"
+fi

--- a/rules/tools/test_roundtrip.py
+++ b/rules/tools/test_roundtrip.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Tests for extract.py and generate.py round-trip fidelity.
+
+Prototype maturity: happy-path tests covering the main fix categories
+(paragraph ordering, table formatting, block preservation).
+"""
+
+import os
+import sys
+import subprocess
+import tempfile
+import unittest
+
+# Add tools directory to path
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, TOOLS_DIR)
+
+import extract
+import generate
+import yaml
+
+
+class TestBlockOrderPreservation(unittest.TestCase):
+    """Verify that blocks are extracted and regenerated in document order."""
+
+    def _roundtrip(self, md_text):
+        """Run markdown through extract → YAML → generate and return result."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(md_text)
+            f.flush()
+            rules = extract.extract_rules(f.name)
+        os.unlink(f.name)
+        return generate.generate_markdown(rules), rules
+
+    def test_paragraph_before_table_preserved(self):
+        """Paragraphs that appear before a table stay before it."""
+        md = "## Test Section\n\nFirst paragraph.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nSecond paragraph.\n"
+        result, _ = self._roundtrip(md)
+        # In the result, "First paragraph" should appear before the table
+        first_idx = result.index('First paragraph')
+        table_idx = result.index('| A | B |')
+        second_idx = result.index('Second paragraph')
+        self.assertLess(first_idx, table_idx)
+        self.assertLess(table_idx, second_idx)
+
+    def test_paragraph_after_table_preserved(self):
+        """Paragraphs that appear after a table stay after it."""
+        md = "## Stats\n\n| Stat | Value |\n|---|---|\n| Charm | 10 |\n\nThis paragraph comes after the table.\n"
+        result, _ = self._roundtrip(md)
+        table_idx = result.index('| Stat | Value |')
+        para_idx = result.index('This paragraph comes after the table')
+        self.assertLess(table_idx, para_idx)
+
+    def test_multiple_paragraphs_and_tables_interleaved(self):
+        """Interleaved paragraphs and tables maintain order."""
+        md = ("## Mixed\n\nPara one.\n\n| H1 |\n|---|\n| R1 |\n\n"
+              "Para two.\n\n| H2 |\n|---|\n| R2 |\n\nPara three.\n")
+        result, _ = self._roundtrip(md)
+        self.assertLess(result.index('Para one'), result.index('| H1 |'))
+        self.assertLess(result.index('| R1 |'), result.index('Para two'))
+        self.assertLess(result.index('Para two'), result.index('| H2 |'))
+        self.assertLess(result.index('| R2 |'), result.index('Para three'))
+
+
+class TestTableFormatting(unittest.TestCase):
+    """Verify table column widths and alignment markers are preserved."""
+
+    def _roundtrip(self, md_text):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(md_text)
+            f.flush()
+            rules = extract.extract_rules(f.name)
+        os.unlink(f.name)
+        return generate.generate_markdown(rules), rules
+
+    def test_separator_width_preserved(self):
+        """Column separator dashes match original width."""
+        md = "## Table\n\n| Name | Value |\n|----------|-------------|\n| foo | bar |\n"
+        result, _ = self._roundtrip(md)
+        self.assertIn('|----------|-------------|', result)
+
+    def test_alignment_markers_preserved(self):
+        """Alignment markers like :---: are preserved in separator."""
+        md = "## Aligned\n\n| Left | Center | Right |\n|:---|:---:|---:|\n| a | b | c |\n"
+        result, _ = self._roundtrip(md)
+        self.assertIn('|:---|:---:|---:|', result)
+
+    def test_padded_table_cells_preserved(self):
+        """Tables with space-padded separators get padded cells."""
+        md = ("## Padded\n\n"
+              "| Name      | Value                |\n"
+              "| --------- | -------------------- |\n"
+              "| foo       | bar                  |\n")
+        result, rules = self._roundtrip(md)
+        # The separator should be preserved
+        self.assertIn(' --------- ', result)
+        self.assertIn(' -------------------- ', result)
+        # Data cells should be padded
+        self.assertIn(' foo       ', result)
+
+    def test_compact_table_not_padded(self):
+        """Tables with compact separators (---) stay compact."""
+        md = "## Compact\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+        result, _ = self._roundtrip(md)
+        self.assertIn('| 1 | 2 |', result)
+
+
+class TestHorizontalRulePreservation(unittest.TestCase):
+    """Verify horizontal rules (---) survive round-trip."""
+
+    def _roundtrip(self, md_text):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(md_text)
+            f.flush()
+            rules = extract.extract_rules(f.name)
+        os.unlink(f.name)
+        return generate.generate_markdown(rules), rules
+
+    def test_hr_preserved(self):
+        """Horizontal rules appear in output."""
+        md = "## Section\n\nSome content.\n\n---\n\n## Next\n\nMore content.\n"
+        result, _ = self._roundtrip(md)
+        self.assertIn('---', result)
+
+    def test_hr_between_blocks(self):
+        """HR between paragraphs maintains position."""
+        md = "## Section\n\nBefore hr.\n\n---\n\nAfter hr.\n"
+        result, _ = self._roundtrip(md)
+        before_idx = result.index('Before hr')
+        hr_idx = result.index('---')
+        # "After hr" may or may not be in same section, but HR should be between
+        self.assertLess(before_idx, hr_idx)
+
+
+class TestBlockquotePreservation(unittest.TestCase):
+    """Verify blockquotes preserve trailing whitespace."""
+
+    def _roundtrip(self, md_text):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(md_text)
+            f.flush()
+            rules = extract.extract_rules(f.name)
+        os.unlink(f.name)
+        return generate.generate_markdown(rules), rules
+
+    def test_blockquote_trailing_spaces(self):
+        """Trailing spaces (markdown line breaks) in blockquotes are preserved."""
+        md = '## Section\n\n> Line with trailing spaces  \n> Next line\n'
+        result, _ = self._roundtrip(md)
+        self.assertIn('> Line with trailing spaces  ', result)
+
+    def test_blockquote_basic(self):
+        """Basic blockquote round-trips."""
+        md = '## Section\n\n> This is a quote\n> Second line\n'
+        result, _ = self._roundtrip(md)
+        self.assertIn('> This is a quote', result)
+        self.assertIn('> Second line', result)
+
+
+class TestCompactHeading(unittest.TestCase):
+    """Verify compact headings (no blank after) are preserved."""
+
+    def _roundtrip(self, md_text):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(md_text)
+            f.flush()
+            rules = extract.extract_rules(f.name)
+        os.unlink(f.name)
+        return generate.generate_markdown(rules), rules
+
+    def test_compact_heading_no_blank(self):
+        """Heading immediately followed by content (no blank line)."""
+        md = "## Parent\n\n### Sub\nDirect content.\n"
+        result, rules = self._roundtrip(md)
+        # Find the sub rule
+        sub_rule = next(r for r in rules if r['title'] == 'Sub')
+        self.assertTrue(sub_rule.get('compact_heading', False))
+        # In output, heading should be directly followed by content
+        lines = result.split('\n')
+        for i, line in enumerate(lines):
+            if line.startswith('### Sub'):
+                # Next non-empty line should be content, not blank
+                self.assertEqual(lines[i + 1], 'Direct content.')
+                break
+
+    def test_normal_heading_with_blank(self):
+        """Heading with blank line after retains it."""
+        md = "## Section\n\nContent after blank.\n"
+        result, rules = self._roundtrip(md)
+        sec_rule = next(r for r in rules if r['title'] == 'Section')
+        self.assertFalse(sec_rule.get('compact_heading', False))
+
+
+class TestFullRoundtrip(unittest.TestCase):
+    """Integration test: round-trip all 9 design docs and verify < 50 diff lines."""
+
+    DESIGN_DIR = '/root/.openclaw/agents-extra/pinder/design'
+
+    def _get_docs(self):
+        """Find all design markdown files."""
+        docs = []
+        for subdir in ['systems', 'settings']:
+            path = os.path.join(self.DESIGN_DIR, subdir)
+            if os.path.isdir(path):
+                for f in sorted(os.listdir(path)):
+                    if f.endswith('.md'):
+                        docs.append(os.path.join(path, f))
+        return docs
+
+    def test_all_docs_under_50_diff_lines(self):
+        """Every design doc round-trips with < 50 diff lines."""
+        docs = self._get_docs()
+        self.assertGreater(len(docs), 0, "No design docs found")
+
+        failures = []
+        for doc in docs:
+            name = os.path.basename(doc).replace('.md', '')
+            rules = extract.extract_rules(doc)
+            regenerated = generate.generate_markdown(rules)
+
+            # Write to temp file and diff
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+                f.write(regenerated)
+                regen_path = f.name
+
+            result = subprocess.run(
+                ['diff', doc, regen_path],
+                capture_output=True, text=True
+            )
+            os.unlink(regen_path)
+
+            diff_lines = len(result.stdout.strip().split('\n')) if result.stdout.strip() else 0
+            if diff_lines > 50:
+                failures.append('{}: {} lines'.format(name, diff_lines))
+
+        self.assertEqual(failures, [],
+                         "Docs with > 50 diff lines: {}".format(', '.join(failures)))
+
+    def test_no_information_loss(self):
+        """All original headings appear in regenerated output."""
+        docs = self._get_docs()
+        for doc in docs:
+            name = os.path.basename(doc).replace('.md', '')
+            with open(doc, 'r') as f:
+                original = f.read()
+            rules = extract.extract_rules(doc)
+            regenerated = generate.generate_markdown(rules)
+
+            # Extract all headings from original
+            import re
+            orig_headings = re.findall(r'^#{1,6}\s+(.+)$', original, re.MULTILINE)
+            for heading in orig_headings:
+                self.assertIn(heading.strip(), regenerated,
+                              '{}: heading "{}" missing from regenerated'.format(name, heading.strip()))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #443

## What was changed
Rewrote extract.py and generate.py to preserve block ordering, table formatting, and whitespace fidelity in the Markdown → YAML → Markdown round-trip pipeline.

## Key changes
- **extract.py**: Blocks (paragraphs, tables, code, blockquotes, HRs, flavor text) stored as ordered list instead of grouped by type
- **extract.py**: Raw separator cells preserved (column widths + alignment markers)
- **extract.py**: Trailing whitespace in blockquotes preserved
- **extract.py**: Compact heading detection (no blank line after heading)
- **generate.py**: Renders blocks in stored order
- **generate.py**: Reproduces separator rows faithfully
- **generate.py**: Detects padded tables and pads cells accordingly
- **generate.py**: Respects compact_heading flag
- **roundtrip_test.sh**: Per-doc pass/fail with 50-line threshold
- **test_roundtrip.py**: 15 unit tests

## Before/After Report
| Document | Before | After |
|---|---|---|
| async-time | 57 | 2 |
| character-construction | 116 | 2 |
| extensibility | 29 | 2 |
| risk-reward-and-hidden-depth | 51 | 2 |
| rules-v3 | 299 | 15 |
| anatomy-parameters | 168 | 6 |
| archetypes | 176 | 38 |
| items-pool | 255 | 2 |
| traps | 100 | 2 |
| **Total** | **1251** | **71** |

All remaining diffs are whitespace-only (blank lines between headings and content, ±1 trailing space in padded table cells).

## How to test
```bash
python3 rules/tools/test_roundtrip.py -v   # 15 unit tests
bash rules/tools/roundtrip_test.sh          # Full round-trip on all 9 docs
```

## DoD Evidence
**Branch:** issue-443-rules-dsl-fix-remaining-round-trip-diffs
**Commit:** 53cd8ed
**Deviations from contract:** none
