### PR TITLE
[Issue #445] Rules DSL: integrate generated test stubs into pinder-core test suite

### DIFF
--- a/tests/Pinder.Core.Tests/RulesSpec/RulesSpecTests.cs
+++ b/tests/Pinder.Core.Tests/RulesSpec/RulesSpecTests.cs
@@ -7,8 +7,7 @@ using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 using Pinder.Core.Conversation;
 using Pinder.Core.Progression;
-using Pinder.Core.Interfaces;
-using Pinder.Core.Traps;
+
 
 namespace Pinder.Core.Tests.RulesSpec
 {
@@ -209,6 +208,14 @@ namespace Pinder.Core.Tests.RulesSpec
         public void Rule_S5_RiskBonus_Safe_Zero()
         {
             var result = MakeRiskResult(4, true);
+            Assert.Equal(0, RiskTierBonus.GetInterestBonus(result));
+        }
+
+        // Mutation: would catch if Medium returned non-zero bonus
+        [Fact]
+        public void Rule_S5_RiskBonus_Medium_Zero()
+        {
+            var result = MakeRiskResult(8, true);
             Assert.Equal(0, RiskTierBonus.GetInterestBonus(result));
         }
 


### PR DESCRIPTION
Fixes #445

## What was done
Cleaned up RulesSpecTests.cs: removed unused using directives (Pinder.Core.Interfaces, Pinder.Core.Traps) and added missing Medium risk tier bonus test identified in code review.

## How to test
dotnet test tests/Pinder.Core.Tests/ --filter FullyQualifiedName~RulesSpec
Expected: 38 passed, 17 skipped, 0 failed, 55 total.

## DoD Evidence
Branch: issue-445-rules-dsl-integrate-generated-test-stubs
Commit: 9d97ce1
Tests: 38 passed, 17 skipped, 55 total; 2734 total across all projects, 0 failures
Deviations from contract: none