### PR TITLE
[Issue #444] Rules DSL: enrich all 9 YAML files with explicit condition/outcome fields

### DIFF
--- a/docs/specs/issue-444-spec.md
+++ b/docs/specs/issue-444-spec.md
@@ -135,9 +135,10 @@ These keys describe **what happens** when a rule fires:
 | `horniness_modifier` | `int` | Horniness modifier | `+3` |
 | `delay_penalty` | `int` | Interest penalty for delay | `-2` |
 | `stat_modifier` | `int` | Stat modifier value | `+2` |
+| `stat_modifiers` | `dict<string, int>` | Flat stat→modifier map | `{"charm": 1, "rizz": -1}` |
 | `quality_boost` | `string` | LLM prompt quality instruction | `"improved"` |
 
-New keys may be introduced for document-specific mechanics (e.g., anatomy tiers, item slots) as long as they follow the pattern of `snake_case` names with primitive values (`int`, `float`, `string`, `bool`, `[int, int]`).
+New keys may be introduced for document-specific mechanics (e.g., anatomy tiers, item slots) as long as they follow the pattern of `snake_case` names with primitive values (`int`, `float`, `string`, `bool`, `[int, int]`) or flat `string→int` dicts for stat modifier maps (`stat_modifiers`).
 
 ---
 


### PR DESCRIPTION
Fixes #444

## Summary

Addresses code reviewer feedback from PR #475 (REQUEST_CHANGES): the spec's outcome key vocabulary stated values must be 'primitive values only' but `stat_modifiers` uses flat `string→int` dicts. This PR:

1. Adds `stat_modifiers` (`dict<string, int>`) as an explicit outcome key in the vocabulary table
2. Updates the schema description to include flat `string→int` dicts as an allowed value type alongside primitives

The actual enrichment implementation (PR #457, merged) already correctly uses `stat_modifiers` as flat dicts in items-pool and anatomy-parameters enriched YAML files. This change reconciles the spec documentation with the implemented behavior.

## Verification

- All 9 enriched YAML files exist with 351 enriched entries (unchanged from PR #457)
- 58 enrichment tests pass (test_enrichment.py + test_issue444_enrichment.py)
- Accuracy check: 0 INACCURATE findings
- Vocabulary check: PASS

## How to test

```bash
python3 -m pytest rules/tools/test_enrichment.py rules/tools/test_issue444_enrichment.py -v
python3 rules/tools/accuracy_check.py
```

## DoD Evidence
**Branch:** issue-444-rules-dsl-enrich-all-9-yaml-files-with-e
**Commit:** cd77f87

## Deviations from contract
None — this is a spec documentation fix addressing reviewer feedback.
