### PR TITLE
[Issue #491] Spec: success delivery prompt — improve existing sentiment, not add new ideas

### DIFF
--- a/docs/specs/issue-489-spec.md
+++ b/docs/specs/issue-489-spec.md
@@ -1,0 +1,257 @@
+# Spec: Issue #489 — Prompt: voice distinctness — explicit texting style constraint before option generation
+
+**Module**: `docs/modules/llm-adapters.md`
+
+---
+
+## Overview
+
+When generating dialogue options for a player character, the LLM can drift away from the character's established texting style, producing generic Gen-Z text instead of the character's unique voice. This feature adds the character's texting style fragment to `CharacterProfile`, threads it through `DialogueContext` into `SessionDocumentBuilder`, and injects it as an explicit constraint block immediately before the task instruction in the dialogue-options user message. A voice-check reminder is also appended to `PromptTemplates.DialogueOptionsInstruction`.
+
+This issue depends on #487 (voice bleed fix — player-only system blocks for dialogue options) being implemented first, as the texting style reinforcement amplifies the prompt separation that #487 establishes.
+
+---
+
+## Function Signatures
+
+### 1. `CharacterProfile` (Pinder.Core.Characters)
+
+**Existing class — new property and constructor parameter.**
+
+```csharp
+public sealed class CharacterProfile
+{
+    // ... all existing properties unchanged ...
+
+    /// <summary>
+    /// The texting style fragment(s) joined, for injection into
+    /// option-generation prompts. Empty string if not available.
+    /// </summary>
+    public string TextingStyleFragment { get; }
+
+    public CharacterProfile(
+        StatBlock stats,
+        string assembledSystemPrompt,
+        string displayName,
+        TimingProfile timing,
+        int level,
+        string bio = "",
+        string textingStyleFragment = ""   // NEW — optional, backward-compatible
+    )
+}
+```
+
+- `TextingStyleFragment` is set to `textingStyleFragment ?? string.Empty` in the constructor body.
+- The parameter MUST have a default value of `""` so all existing callers compile unchanged.
+
+### 2. `DialogueContext` (Pinder.Core.Conversation)
+
+**Existing class — new property and constructor parameter.**
+
+```csharp
+public sealed class DialogueContext
+{
+    // ... all existing properties unchanged ...
+
+    /// <summary>
+    /// The player character's texting style text, for voice reinforcement.
+    /// Empty string means no texting style available.
+    /// </summary>
+    public string PlayerTextingStyle { get; }
+
+    public DialogueContext(
+        // ... all existing parameters unchanged ...
+        string playerTextingStyle = ""     // NEW — appended after existing params
+    )
+}
+```
+
+- `PlayerTextingStyle` is set to `playerTextingStyle ?? ""` in the constructor body.
+- The parameter MUST be appended after all existing optional parameters to preserve backward compatibility.
+
+### 3. `GameSession.StartTurnAsync()` (Pinder.Core.Conversation)
+
+**Existing method — wiring change only.**
+
+When constructing the `DialogueContext` inside `StartTurnAsync()`, pass `_player.TextingStyleFragment` as the `playerTextingStyle` argument:
+
+```csharp
+var context = new DialogueContext(
+    // ... all existing args ...
+    playerTextingStyle: _player.TextingStyleFragment
+);
+```
+
+No signature change to `StartTurnAsync()` itself.
+
+### 4. `SessionDocumentBuilder.BuildDialogueOptionsPrompt()` (Pinder.LlmAdapters)
+
+**Existing static method — no signature change.**
+
+After all game-state sections and before the `"YOUR TASK"` line, inject the texting style block:
+
+```
+If context.PlayerTextingStyle is not null/empty:
+
+  YOUR TEXTING STYLE — follow this exactly, no deviations:
+  {context.PlayerTextingStyle}
+
+```
+
+The block MUST appear immediately before the `"YOUR TASK"` heading. If `PlayerTextingStyle` is empty or null, the block is omitted entirely.
+
+### 5. `PromptTemplates.DialogueOptionsInstruction` (Pinder.LlmAdapters)
+
+**Existing constant — text appended.**
+
+Append the following voice-check instruction to the end of the existing `DialogueOptionsInstruction` constant:
+
+```
+Before writing each option, verify: does this sound exactly like
+the texting style above? If not, rewrite it.
+```
+
+This text is appended after the existing rules/format block.
+
+### 6. Session-runner loaders (session-runner/)
+
+**`CharacterLoader`** — When parsing a pre-assembled prompt `.md` file, extract the `TEXTING STYLE` section content and pass it as the `textingStyleFragment` parameter to the `CharacterProfile` constructor. The `TEXTING STYLE` section is emitted by `PromptBuilder.BuildSystemPrompt()` at line 57-59 of `PromptBuilder.cs`.
+
+**`CharacterDefinitionLoader`** — When running the full `CharacterAssembler` → `PromptBuilder` pipeline, join `FragmentCollection.TextingStyleFragments` with `" | "` and pass the result as `textingStyleFragment` to the `CharacterProfile` constructor.
+
+---
+
+## Input/Output Examples
+
+### Example 1: Velvet character with texting style
+
+**Input** — `CharacterProfile` constructed with:
+```
+textingStyleFragment: "lowercase-with-intent, precise, ironic, uses ellipses for dramatic pauses, never uses exclamation marks"
+```
+
+**DialogueContext constructed with:**
+```
+playerTextingStyle: "lowercase-with-intent, precise, ironic, uses ellipses for dramatic pauses, never uses exclamation marks"
+```
+
+**User message output** (relevant section, appearing after GAME STATE and before YOUR TASK):
+```
+YOUR TEXTING STYLE — follow this exactly, no deviations:
+lowercase-with-intent, precise, ironic, uses ellipses for dramatic pauses, never uses exclamation marks
+
+YOUR TASK
+Generate exactly 4 dialogue options for Velvet.
+...
+Before writing each option, verify: does this sound exactly like
+the texting style above? If not, rewrite it.
+```
+
+### Example 2: No texting style available (backward compat)
+
+**Input** — `CharacterProfile` constructed with default (no `textingStyleFragment`):
+```
+textingStyleFragment: ""  (default)
+```
+
+**User message output**: No `YOUR TEXTING STYLE` block appears. The `YOUR TASK` section follows directly after game state. The voice-check line in `DialogueOptionsInstruction` still appears but has no effect since there is no style block above it.
+
+### Example 3: Sable character
+
+**Input** — `CharacterProfile` constructed with:
+```
+textingStyleFragment: "omg, 😭, fast-talk, run-on sentences, excessive emoji, ALL CAPS for emphasis"
+```
+
+**User message output** (relevant section):
+```
+YOUR TEXTING STYLE — follow this exactly, no deviations:
+omg, 😭, fast-talk, run-on sentences, excessive emoji, ALL CAPS for emphasis
+
+YOUR TASK
+Generate exactly 4 dialogue options for Sable.
+...
+```
+
+---
+
+## Acceptance Criteria
+
+### AC1: TEXTING STYLE block injected in BuildDialogueOptionsPrompt
+
+**Given** `BuildDialogueOptionsPrompt` is called with a `DialogueContext` where `PlayerTextingStyle` is non-empty,
+**When** the user message is assembled,
+**Then** the block `YOUR TEXTING STYLE — follow this exactly, no deviations:` followed by the texting style text appears immediately before the `YOUR TASK` heading.
+
+### AC2: TextingStyleFragment accessible on CharacterProfile
+
+**Given** a `CharacterProfile` is constructed with `textingStyleFragment: "some style"`,
+**When** `TextingStyleFragment` is read,
+**Then** it returns `"some style"`.
+
+**Given** a `CharacterProfile` is constructed without providing `textingStyleFragment`,
+**When** `TextingStyleFragment` is read,
+**Then** it returns `""` (empty string).
+
+### AC3: Voice distinctness in generated options
+
+**Given** a Velvet vs Sable session,
+**When** options are generated for Velvet,
+**Then** Velvet's texting style fragment is in the prompt (not Sable's). This is a qualitative verification via session playtest — the spec only requires the texting style to be correctly threaded into the prompt.
+
+### AC4: Build clean, all tests pass
+
+**Given** the changes are applied,
+**When** the solution is built and all existing tests are run,
+**Then** there are zero compilation errors and all existing tests pass unchanged. No new tests are required for prompt text content (qualitative), but structural tests verifying `CharacterProfile.TextingStyleFragment` property existence and `DialogueContext.PlayerTextingStyle` threading are expected.
+
+---
+
+## Edge Cases
+
+| Case | Expected Behavior |
+|------|-------------------|
+| `textingStyleFragment` is `null` | `CharacterProfile.TextingStyleFragment` returns `""` (null-coalesced in constructor) |
+| `textingStyleFragment` is `""` (empty) | No `YOUR TEXTING STYLE` block injected in user message |
+| `textingStyleFragment` is whitespace-only (e.g. `"   "`) | Block IS injected (whitespace is non-empty). Implementer may optionally use `string.IsNullOrWhiteSpace` check — both behaviors are acceptable at prototype maturity |
+| `playerTextingStyle` is `null` on `DialogueContext` | Coalesced to `""` in constructor; no block injected |
+| `CharacterProfile` constructed with old signature (no `textingStyleFragment`) | Default `""` — fully backward-compatible |
+| `DialogueContext` constructed with old signature (no `playerTextingStyle`) | Default `""` — fully backward-compatible |
+| Multiple texting style fragments joined with `" | "` | Entire joined string is a single `TextingStyleFragment` value — no special handling needed |
+| Very long texting style fragment (>1000 chars) | No truncation. Passed through verbatim. LLM context window is the only practical limit. |
+
+---
+
+## Error Conditions
+
+| Condition | Expected Behavior |
+|-----------|-------------------|
+| `CharacterProfile` constructor receives `null` for `stats`, `assembledSystemPrompt`, `displayName`, or `timing` | Throws `ArgumentNullException` (existing behavior, unchanged) |
+| `CharacterProfile` constructor receives `null` for `textingStyleFragment` | Coalesced to `""` — NO exception |
+| `DialogueContext` constructor receives `null` for `playerTextingStyle` | Coalesced to `""` — NO exception |
+| `SessionDocumentBuilder.BuildDialogueOptionsPrompt` receives `null` context | Throws `ArgumentNullException` (existing behavior, unchanged) |
+
+There are no new exception types or error paths introduced by this feature. All changes are additive and null-safe.
+
+---
+
+## Dependencies
+
+| Dependency | Type | Details |
+|------------|------|---------|
+| Issue #487 (voice bleed fix) | Must be implemented first | #487 switches `GetDialogueOptionsAsync` to player-only system blocks and moves opponent profile to user message. Texting style reinforcement (#489) layers on top of this prompt structure. Without #487, the texting style block would compete with the opponent's voice in the system prompt. |
+| `Pinder.Core.Characters.CharacterProfile` | Modified | Gains `TextingStyleFragment` property |
+| `Pinder.Core.Conversation.DialogueContext` | Modified | Gains `PlayerTextingStyle` property |
+| `Pinder.Core.Conversation.GameSession` | Modified | Wires `_player.TextingStyleFragment` to `DialogueContext` |
+| `Pinder.LlmAdapters.SessionDocumentBuilder` | Modified | Injects texting style block in `BuildDialogueOptionsPrompt` |
+| `Pinder.LlmAdapters.PromptTemplates` | Modified | Voice-check text appended to `DialogueOptionsInstruction` |
+| `session-runner/CharacterLoader` | Modified | Extracts texting style from prompt file |
+| `session-runner/CharacterDefinitionLoader` | Modified | Joins `FragmentCollection.TextingStyleFragments` for `CharacterProfile` |
+| `Pinder.Core.Characters.FragmentCollection` | Read-only | `TextingStyleFragments` property already exists — source data for the fragment |
+| `Pinder.Core.Prompts.PromptBuilder` | Read-only | Already emits `TEXTING STYLE` section in system prompt (lines 57-59) — informs parsing strategy for `CharacterLoader` |
+
+### Platform Constraints
+
+- **netstandard2.0 + LangVersion 8.0** in Pinder.Core — no `record` types
+- **Zero NuGet dependencies** in Pinder.Core
+- **All existing tests must pass unchanged** — constructor changes use optional params with defaults

--- a/docs/specs/issue-490-spec.md
+++ b/docs/specs/issue-490-spec.md
@@ -1,0 +1,278 @@
+# Spec: Opponent Resistance Below Interest 25
+
+**Issue**: #490  
+**Module**: `docs/modules/llm-adapters.md` (existing — `Pinder.LlmAdapters` prompt engineering)
+
+---
+
+## Overview
+
+The opponent character in a Pinder conversation should maintain varying degrees of resistance at all interest levels below 25 (DateSecured). Currently, the opponent prompt includes a `GetInterestBehaviourBlock()` that describes engagement level but does not explicitly frame the opponent as being *in opposition* to the player. This feature adds a **resistance rule** and **per-interest-band resistance descriptors** to the opponent prompt so that the LLM generates responses with dramatic tension — the opponent is never a willing collaborator until the player earns Interest 25.
+
+This is a prompt engineering change. No game mechanics, roll math, or interest system logic are modified. All changes are confined to `Pinder.LlmAdapters` (`PromptTemplates` and `SessionDocumentBuilder`).
+
+---
+
+## Function Signatures
+
+### `PromptTemplates` (static class in `Pinder.LlmAdapters`)
+
+```csharp
+/// <summary>
+/// Fundamental resistance rule text injected into every opponent response prompt.
+/// States that below Interest 25, the opponent has NOT been won over and must
+/// maintain resistance appropriate to the current interest level.
+/// </summary>
+public const string OpponentResistanceRule;
+```
+
+**Type**: `string` (compile-time constant)
+
+**Content requirements**: The constant must communicate these principles:
+1. Below Interest 25, the opponent is not won over. They are evaluating, skeptical, guarded, or at best cautiously warming.
+2. Resistance is not hostility — it is the natural social friction of someone who hasn't decided yet.
+3. The opponent should never volunteer vulnerability, make plans, or signal commitment below 25.
+4. At Interest 25 (DateSecured), resistance dissolves genuinely — not as a switch flip, but as earned arrival.
+
+---
+
+```csharp
+/// <summary>
+/// Returns a resistance descriptor string appropriate for the given interest level.
+/// The descriptor tells the LLM how much resistance the opponent should express.
+/// </summary>
+/// <param name="interest">Current interest value (0–25).</param>
+/// <returns>A multi-sentence string describing the opponent's resistance posture.</returns>
+public static string GetResistanceDescriptor(int interest);
+```
+
+**Return type**: `string`  
+**Parameter**: `int interest` — the current interest meter value (0–25 inclusive)
+
+**Interest band → resistance descriptor mapping**:
+
+| Interest | Band Name | Resistance Posture |
+|----------|-----------|-------------------|
+| 0 | Unmatched | No resistance — already gone. Opponent is unmatching or has left. |
+| 1–4 | Bored | Active disengagement. Short replies, visible disinterest. The opponent is looking for a reason to stop talking. They may test the player or send closing signals. |
+| 5–9 | Lukewarm | Polite but unconvinced. The opponent engages minimally, keeps things surface-level. There's no hostility but no warmth either. They're giving the player a chance but aren't investing. |
+| 10–14 | Interested (lower) | Warmth with visible holdback. The opponent is engaged and responsive but catches themselves — pulls back from anything too eager, deflects personal questions, keeps a slight guard up. |
+| 15–20 | Interested (upper) / VeryIntoIt | Genuinely enjoying the conversation but still maintains boundaries. Flirtation is present but the opponent doesn't fully commit. They test the player, create small challenges, hold back just enough to preserve tension. |
+| 21–24 | AlmostThere | Resistance is subtle but present. The opponent is clearly into it — replies are longer, warmer, more personal — but there's a last layer of self-protection. They won't be the one to suggest the date. The player must earn the final step. |
+| 25 | DateSecured | Resistance dissolves genuinely. The opponent has been won over. They can now be fully warm, suggest plans, express real enthusiasm. This feels earned, not sudden. |
+
+---
+
+### `SessionDocumentBuilder` (static class in `Pinder.LlmAdapters`)
+
+**Modified method**:
+
+```csharp
+/// <summary>
+/// Builds the user-message content for GetOpponentResponseAsync (§3.5).
+/// Now includes a RESISTANCE STANCE section between CURRENT INTEREST STATE
+/// and the OpponentResponseInstruction.
+/// </summary>
+/// <param name="context">The OpponentContext carrying all turn data.</param>
+/// <returns>Assembled user-message string for the LLM.</returns>
+public static string BuildOpponentPrompt(OpponentContext context);
+```
+
+**Return type**: `string`  
+**Parameter**: `OpponentContext context` (unchanged — no new fields needed for this feature; `InterestAfter` already exists on the DTO)
+
+The method injects a new **RESISTANCE STANCE** section into the user message. The section is placed after the existing "CURRENT INTEREST STATE" block and before the final `OpponentResponseInstruction`.
+
+---
+
+## Input/Output Examples
+
+### Example 1: Interest = 3 (Bored)
+
+**Input**: `OpponentContext` with `InterestAfter = 3`
+
+**Injected block in user message** (after CURRENT INTEREST STATE):
+
+```
+RESISTANCE STANCE
+Below Interest 25, you have NOT been won over. You are evaluating this person.
+Your resistance is not hostility — it is the natural friction of someone who hasn't decided.
+Do not volunteer vulnerability, make concrete plans, or signal commitment.
+
+Current interest: 3/25. Resistance level: Active disengagement. Short replies, visible disinterest. You are looking for a reason to stop talking. You may test the player or send closing signals.
+```
+
+### Example 2: Interest = 12 (Interested, lower band)
+
+**Input**: `OpponentContext` with `InterestAfter = 12`
+
+**Injected block**:
+
+```
+RESISTANCE STANCE
+Below Interest 25, you have NOT been won over. You are evaluating this person.
+Your resistance is not hostility — it is the natural friction of someone who hasn't decided.
+Do not volunteer vulnerability, make concrete plans, or signal commitment.
+
+Current interest: 12/25. Resistance level: Warmth with visible holdback. You are engaged and responsive but catch yourself — pull back from anything too eager, deflect personal questions, keep a slight guard up.
+```
+
+### Example 3: Interest = 22 (AlmostThere)
+
+**Input**: `OpponentContext` with `InterestAfter = 22`
+
+**Injected block**:
+
+```
+RESISTANCE STANCE
+Below Interest 25, you have NOT been won over. You are evaluating this person.
+Your resistance is not hostility — it is the natural friction of someone who hasn't decided.
+Do not volunteer vulnerability, make concrete plans, or signal commitment.
+
+Current interest: 22/25. Resistance level: Resistance is subtle but present. You are clearly into it — replies are longer, warmer, more personal — but there's a last layer of self-protection. You won't be the one to suggest the date. The player must earn the final step.
+```
+
+### Example 4: Interest = 25 (DateSecured)
+
+**Input**: `OpponentContext` with `InterestAfter = 25`
+
+**Injected block**:
+
+```
+RESISTANCE STANCE
+You have been won over. Interest is 25/25.
+Resistance dissolves genuinely. You can now be fully warm, suggest plans, express real enthusiasm. This feels earned, not sudden.
+```
+
+---
+
+## Acceptance Criteria
+
+### AC1: OpponentResponseInstruction includes fundamental resistance rule
+
+**Given** `PromptTemplates.OpponentResistanceRule` exists as a public constant,  
+**When** `SessionDocumentBuilder.BuildOpponentPrompt()` assembles the user message,  
+**Then** the `OpponentResistanceRule` text is included in the RESISTANCE STANCE section of the output string.
+
+**Verification**: Assert that the return value of `BuildOpponentPrompt()` contains `PromptTemplates.OpponentResistanceRule` (or its key phrases).
+
+### AC2: Interest 1–4 shows active disengagement
+
+**Given** `OpponentContext.InterestAfter` is in the range 1–4,  
+**When** `BuildOpponentPrompt()` is called,  
+**Then** the output contains a resistance descriptor indicating active disengagement (e.g., the string returned by `GetResistanceDescriptor(interestValue)` for values 1–4 must mention disengagement, short replies, or looking for a reason to stop talking).
+
+### AC3: Interest 10–14 shows warmth with holdback
+
+**Given** `OpponentContext.InterestAfter` is in the range 10–14,  
+**When** `BuildOpponentPrompt()` is called,  
+**Then** the output contains a resistance descriptor indicating warmth with visible holdback.
+
+### AC4: Interest 21–24 shows subtle resistance
+
+**Given** `OpponentContext.InterestAfter` is in the range 21–24,  
+**When** `BuildOpponentPrompt()` is called,  
+**Then** the output contains a resistance descriptor indicating subtle but present resistance — the opponent won't suggest the date.
+
+### AC5: Interest 25 dissolves resistance
+
+**Given** `OpponentContext.InterestAfter` is 25,  
+**When** `BuildOpponentPrompt()` is called,  
+**Then** the output contains a descriptor indicating resistance has dissolved genuinely and the opponent can express full warmth and suggest plans.
+
+### AC6: Build clean, all tests pass
+
+**Given** the changes are applied,  
+**When** `dotnet build` and `dotnet test` are run,  
+**Then** the build succeeds with no errors and all existing tests (2295+) pass unchanged. New tests for resistance descriptor logic also pass.
+
+---
+
+## Edge Cases
+
+### Interest exactly at band boundaries
+
+| Interest | Expected Band |
+|----------|--------------|
+| 0 | Unmatched (gone) |
+| 1 | Bored (active disengagement) |
+| 4 | Bored (active disengagement) |
+| 5 | Lukewarm |
+| 9 | Lukewarm |
+| 10 | Interested (lower — warmth with holdback) |
+| 14 | Interested (lower — warmth with holdback) |
+| 15 | Interested (upper) / VeryIntoIt (boundaries, testing) |
+| 20 | VeryIntoIt |
+| 21 | AlmostThere (subtle resistance) |
+| 24 | AlmostThere (subtle resistance) |
+| 25 | DateSecured (resistance dissolves) |
+
+### Interest outside expected range
+
+- `interest < 0`: Should be treated as 0 (Unmatched). `InterestMeter` clamps to `[0, 25]`, so this is unlikely but `GetResistanceDescriptor` should handle it gracefully (return the Unmatched descriptor).
+- `interest > 25`: Should be treated as 25 (DateSecured). Same clamping logic applies.
+
+### Empty or null OpponentContext fields
+
+- `OpponentContext.InterestAfter` is always an `int` (non-nullable), so no null check needed.
+- The resistance block is always injected — there is no "skip" condition other than the content varying by interest level.
+
+### Existing `GetInterestBehaviourBlock()` interaction
+
+- The existing `GetInterestBehaviourBlock()` already produces engagement-level descriptions. The new RESISTANCE STANCE section is **additive** — it appears as a separate block after CURRENT INTEREST STATE. Both blocks are present in the output. They serve complementary purposes: `GetInterestBehaviourBlock` describes engagement *behavior* (reply speed, length), while the resistance descriptor frames *opposition posture* (guard level, what the opponent will/won't do).
+
+---
+
+## Error Conditions
+
+### No new error paths
+
+- `GetResistanceDescriptor(int interest)` is a pure function that returns a string for any integer input. It cannot fail.
+- `OpponentResistanceRule` is a compile-time constant. It cannot be null.
+- `BuildOpponentPrompt()` already validates `context != null` via `ArgumentNullException`. No additional validation is needed.
+
+### Backward compatibility
+
+- No DTO changes are required — `OpponentContext.InterestAfter` already exists.
+- No constructor signature changes to any DTO.
+- No changes to `ILlmAdapter` interface.
+- The only behavioral change is that `BuildOpponentPrompt()` returns a longer string with the RESISTANCE STANCE section included. Existing callers (`AnthropicLlmAdapter.GetOpponentResponseAsync()`) pass this string as the user message to the Anthropic API — the additional content is transparently included.
+
+---
+
+## Dependencies
+
+### Internal (Pinder.Core)
+
+- `OpponentContext` (Conversation/) — read-only dependency on `InterestAfter` property. **No changes to this class.**
+- `InterestState` enum (Conversation/) — not directly used by this feature (resistance bands are defined independently in `GetResistanceDescriptor`), but the bands should align conceptually with `InterestState` values.
+
+### Internal (Pinder.LlmAdapters)
+
+- `PromptTemplates` — modified (new constant + new static method)
+- `SessionDocumentBuilder.BuildOpponentPrompt()` — modified (new section injected)
+
+### External
+
+- None. No new NuGet packages. No new projects. No new files beyond the changes to existing `PromptTemplates.cs` and `SessionDocumentBuilder.cs`.
+
+### Sprint dependencies
+
+- This issue (#490) has **no dependencies** on other issues in the sprint. It can be implemented in Wave 1 (parallel with #487, #491, #493).
+- #489 (texting style) and #492 (LlmPlayerAgent) do NOT depend on this issue.
+
+---
+
+## Section Placement in `BuildOpponentPrompt` Output
+
+For clarity, the full section order after implementation:
+
+1. `CONVERSATION HISTORY` (existing)
+2. `PLAYER'S LAST MESSAGE` (existing)
+3. `INTEREST CHANGE` (existing)
+4. `RESPONSE TIMING` (existing)
+5. `CURRENT INTEREST STATE` (existing — `GetInterestBehaviourBlock`)
+6. `ACTIVE TRAP INSTRUCTIONS` (existing, conditional)
+7. `SHADOW STATE` (existing, conditional)
+8. **`RESISTANCE STANCE`** (NEW — always present, content varies by interest)
+9. `OpponentResponseInstruction` (existing — final instruction block)

--- a/docs/specs/issue-491-spec.md
+++ b/docs/specs/issue-491-spec.md
@@ -1,0 +1,149 @@
+# Issue #491 — Prompt: success delivery — additions must improve existing sentiment, not add new ideas
+
+**Module**: docs/modules/llm-adapters.md
+
+## Overview
+
+The current `SuccessDeliveryInstruction` in `PromptTemplates` uses vague margin bands (1–5, 6–10) that don't align with the game's actual `SuccessScale` tiers (1–4, 5–9, 10+, Nat 20) and instructs the LLM to "add a small flourish" on strong successes — which causes the LLM to inject new ideas the player never wrote. This issue revises the instruction text so that success delivery **improves the quality of what the player already said** (sharper phrasing, better timing, tighter wording) without adding new content. Every idea in the delivered message must have a counterpart in the intended message.
+
+## Function Signatures
+
+No new functions are introduced. The change is confined to a single constant:
+
+```csharp
+// File: src/Pinder.LlmAdapters/PromptTemplates.cs
+namespace Pinder.LlmAdapters
+{
+    public static class PromptTemplates
+    {
+        /// <summary>§3.3 — Deliver the intended message on a successful roll.</summary>
+        public const string SuccessDeliveryInstruction = @"..."; // revised text
+    }
+}
+```
+
+**Type**: `public const string`
+**Consumer**: `SessionDocumentBuilder.BuildDeliveryPrompt(DeliveryContext context)` — already references `PromptTemplates.SuccessDeliveryInstruction` via string replacement of `{player_name}`. No changes needed in `SessionDocumentBuilder`.
+
+## Input/Output Examples
+
+### Context available to the instruction
+
+The instruction is injected into the user message by `SessionDocumentBuilder.BuildDeliveryPrompt()` on the **success path** (when `DeliveryContext.Outcome == FailureTier.None`). The surrounding context includes:
+
+- `DeliveryContext.ChosenOption.IntendedText` — the player's chosen message (e.g., `"honestly? you're kind of funny for someone who tries this hard"`)
+- `DeliveryContext.BeatDcBy` — integer, how much the roll beat the DC by (e.g., `3`, `7`, `14`)
+- `DeliveryContext.ChosenOption.Stat` — the stat used (e.g., `StatType.Honesty`)
+- Player name (resolved from `DeliveryContext.PlayerName`)
+
+### Example: Clean success (margin 1–4)
+
+**Input**: Intended text = `"honestly? you're kind of funny for someone who tries this hard"`, BeatDcBy = `3`
+
+**Expected LLM behavior**: Deliver the message essentially as-is. Minor natural-voice adjustments only. No new ideas, no flourishes.
+
+**Acceptable output**: `"honestly? you're kind of funny for someone who tries this hard"`
+
+### Example: Strong success (margin 5–9)
+
+**Input**: Intended text = `"honestly? you're kind of funny for someone who tries this hard"`, BeatDcBy = `7`
+
+**Expected LLM behavior**: Sharpen the phrasing — tighter word choice, better rhythm, more precise tone. Every idea in the output must map to an idea in the input.
+
+**Acceptable output**: `"honestly? you're pretty funny for someone trying that hard"`
+**Unacceptable output**: `"honestly? you're funny for someone who tries this hard. we should grab coffee sometime"` (added a new idea — the coffee suggestion)
+
+### Example: Critical success / Nat 20 (margin 10+)
+
+**Input**: Intended text = `"honestly? you're kind of funny for someone who tries this hard"`, BeatDcBy = `14`
+
+**Expected LLM behavior**: The message lands with precision — every word earns its place, timing is perfect. Still the same ideas, just at peak execution.
+
+**Acceptable output**: `"you're funny for someone who tries this hard"`
+**Unacceptable output**: `"you're funny for someone who tries this hard 😏 maybe I should see how hard you try in person"` (added new flirtatious content)
+
+## Acceptance Criteria
+
+### AC1: SuccessDeliveryInstruction specifies margin-based delivery tiers
+
+The revised `SuccessDeliveryInstruction` constant in `PromptTemplates.cs` must define three tiers that match the game's `SuccessScale` margins:
+
+| Tier | Margin (BeatDcBy) | Delivery behavior |
+|------|-------------------|-------------------|
+| Clean | 1–4 | Deliver essentially as written with natural voice |
+| Strong | 5–9 | Sharpen phrasing — tighter wording, better rhythm, more precise |
+| Critical / Nat 20 | 10+ | Peak execution — every word earns its place, lands with precision |
+
+The instruction must **not** use the old bands (1–5, 6–10) which don't align with `SuccessScale`.
+
+### AC2: Strong success sharpens without adding new ideas
+
+The instruction text must explicitly state that on a strong success, the LLM should **improve the existing sentiment** — sharper phrasing, better timing, tighter word choice — without introducing new ideas, topics, or content that wasn't in the intended message.
+
+### AC3: Critical success lands with precision, not expansion
+
+The instruction text must explicitly state that on a critical success (including Nat 20), the message should be at its absolute best version — but still contain only the ideas present in the intended message. Precision, not expansion.
+
+### AC4: Every idea in delivered has a counterpart in intended
+
+The instruction text must include a rule or constraint stating that every idea or topic in the delivered message must have a corresponding idea in the intended message. The LLM may refine, condense, or sharpen — but not add.
+
+### AC5: Build clean, all tests pass
+
+- The project must compile without errors or warnings related to this change.
+- All existing tests (2295+) must continue to pass unchanged.
+- No changes are needed outside `PromptTemplates.cs` since `SessionDocumentBuilder.BuildDeliveryPrompt()` already references `SuccessDeliveryInstruction` and performs `{player_name}` substitution.
+
+## Edge Cases
+
+### Margin exactly at tier boundaries
+
+- `BeatDcBy = 4` → Clean tier (1–4 range, inclusive upper bound)
+- `BeatDcBy = 5` → Strong tier (5–9 range, inclusive lower bound)
+- `BeatDcBy = 9` → Strong tier (5–9 range, inclusive upper bound)
+- `BeatDcBy = 10` → Critical tier (10+ range)
+
+Note: These boundaries are enforced by the `SuccessScale` class in game logic — the prompt instruction must use the same boundaries so the LLM's behavior matches the mechanical tier.
+
+### Nat 20 vs high margin
+
+A Nat 20 always maps to `+4` interest in `SuccessScale` regardless of margin. The delivery instruction should treat Nat 20 identically to the critical tier (10+). The current instruction already mentions "critical success / Nat 20" — the revised version should preserve this grouping.
+
+### Very short intended messages
+
+If the intended text is a single word or very short phrase (e.g., `"hey"`), the instruction should not encourage the LLM to pad it. A clean success on `"hey"` should still be `"hey"` — there's nothing to sharpen.
+
+### Intended message already at peak quality
+
+If the player's intended text is already excellent, the instruction should not force changes. "Improve existing sentiment" means "make it better if possible" — not "always change something."
+
+## Error Conditions
+
+### No new error paths
+
+This change modifies a string constant only. No runtime errors are introduced. The existing error handling in `SessionDocumentBuilder.BuildDeliveryPrompt()` (null checks on `DeliveryContext`) is unaffected.
+
+### LLM non-compliance
+
+The LLM may still add new ideas despite the instruction. This is a prompt engineering limitation, not a code error. Mitigation is through instruction clarity — the stronger the constraint language, the better compliance. This is verified via session playtesting, not automated tests.
+
+## Dependencies
+
+### Internal
+
+- **`PromptTemplates.cs`** (`src/Pinder.LlmAdapters/PromptTemplates.cs`) — the only file modified.
+- **`SessionDocumentBuilder.BuildDeliveryPrompt()`** — consumer of `SuccessDeliveryInstruction`. Already performs `{player_name}` substitution. No changes needed.
+- **`DeliveryContext`** (`src/Pinder.Core/Conversation/DeliveryContext.cs`) — provides `BeatDcBy`, `Outcome`, `ChosenOption`. No changes needed.
+- **`SuccessScale`** (`src/Pinder.Core/Rolls/SuccessScale.cs`) — defines the canonical margin tiers (1–4, 5–9, 10+, Nat 20). The instruction must align with these bands.
+
+### External
+
+- None. No new libraries, services, or dependencies.
+
+### Issue dependencies
+
+- None. This is a standalone prompt text change with no dependencies on other sprint issues. Per the sprint contract, this is in Wave 1 (parallel, no interdependencies).
+
+### Placeholder token
+
+The instruction must retain the `{player_name}` placeholder token. `SessionDocumentBuilder` replaces this at runtime with the resolved player display name. If the placeholder is removed or renamed, delivery prompts will contain a literal `{player_name}` string.


### PR DESCRIPTION
Refs #491

## Summary

Specification document for issue #491. Revises `PromptTemplates.SuccessDeliveryInstruction` to align margin tiers with `SuccessScale` (1–4, 5–9, 10+) and enforce the principle that success delivery improves the player's existing message quality without adding new ideas.

## Spec Location

`docs/specs/issue-491-spec.md`

## DoD Evidence
**Branch:** issue-491-write-spec-document-prompt-success-deliv
**Commit:** 6261366

Part of sprint issue — Dramatic Arc + Voice Fixes sprint.