### PR TITLE
[Issue #487] Bug: character voice bleed — both prompts in system causes player to adopt opponent's register

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -97,9 +97,10 @@ namespace Pinder.LlmAdapters.Anthropic
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var systemBlocks = CacheBlockBuilder.BuildCachedSystemBlocks(
-                context.PlayerPrompt, context.OpponentPrompt);
+            // Only the player's identity in system — prevents voice bleed from opponent's register
+            var systemBlocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(context.PlayerPrompt);
 
+            // Opponent profile is passed as informational context in the user message
             var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
 
             var request = BuildRequest(systemBlocks, userContent,

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -25,6 +25,15 @@ namespace Pinder.LlmAdapters
 
             var sb = new StringBuilder();
 
+            // Opponent profile as informational context (not system identity)
+            // so the LLM knows what kind of messages would land with this opponent
+            if (!string.IsNullOrWhiteSpace(context.OpponentPrompt))
+            {
+                sb.AppendLine($"OPPONENT PROFILE (for context — this is who you are talking to, NOT who you are):");
+                sb.AppendLine(context.OpponentPrompt);
+                sb.AppendLine();
+            }
+
             sb.AppendLine("CONVERSATION HISTORY");
             AppendConversationHistory(sb, context.ConversationHistory, playerName);
 

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
@@ -162,9 +162,9 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         }
 
         // What: AC2 — Both player and opponent prompts in system for dialogue options
-        // Mutation: Would catch if only one prompt is included in system blocks
+        // Mutation: Would catch if opponent prompt leaks into system blocks (voice bleed fix #487)
         [Fact]
-        public async Task AC2_DialogueOptions_SystemBlocks_ContainBothPrompts()
+        public async Task AC2_DialogueOptions_SystemBlocks_ContainPlayerOnly()
         {
             var handler = new MockHttpHandler
             {
@@ -180,9 +180,17 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             var body = JObject.Parse(handler.LastRequestBody!);
             var system = body["system"] as JArray;
             Assert.NotNull(system);
+            // Only player prompt in system — opponent is in user message
+            Assert.Single(system!);
             var systemText = string.Join(" ", system!.Select(s => s["text"]?.ToString() ?? ""));
             Assert.Contains("Thundercock", systemText);
-            Assert.Contains("Velvet", systemText);
+            Assert.DoesNotContain("Velvet", systemText);
+            // Opponent profile is in user message instead
+            var messages = body["messages"] as JArray;
+            Assert.NotNull(messages);
+            var userContent = messages![0]["content"]?.ToString() ?? "";
+            Assert.Contains("Velvet", userContent);
+            Assert.Contains("OPPONENT PROFILE", userContent);
         }
 
         // ======================================================================

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
@@ -549,11 +549,14 @@ OPTION_4
             Assert.NotNull(body);
             Assert.Equal("claude-sonnet-4-20250514", body!.Model);
             Assert.Equal(0.9, body.Temperature, 2);
-            Assert.Equal(2, body.System.Length); // Both player + opponent prompts
+            // Only player prompt in system (fix for voice bleed #487)
+            Assert.Single(body.System);
             Assert.Equal("ephemeral", body.System[0].CacheControl?.Type);
-            Assert.Equal("ephemeral", body.System[1].CacheControl?.Type);
             Assert.Contains("Thundercock", body.System[0].Text);
-            Assert.Contains("Velvet", body.System[1].Text);
+            // Opponent profile appears in user message, not system
+            Assert.Single(body.Messages);
+            Assert.Contains("Velvet", body.Messages[0].Content);
+            Assert.Contains("OPPONENT PROFILE", body.Messages[0].Content);
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -101,6 +101,48 @@ namespace Pinder.LlmAdapters.Tests
         // ── AC2: Conversation history formatting ──
 
         [Fact]
+        public void BuildDialogueOptionsPrompt_OpponentProfileInUserMessage_NotSystem()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MakeDialogueContext(playerName: "GERALD_42", opponentName: "VELVET"));
+
+            // Opponent profile appears as informational context in user message
+            Assert.Contains("OPPONENT PROFILE", result);
+            Assert.Contains("opponent prompt", result);
+            Assert.Contains("NOT who you are", result);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_EmptyOpponentPrompt_OmitsOpponentProfile()
+        {
+            var ctx = new DialogueContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "",
+                conversationHistory: new List<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerName: "P",
+                opponentName: "O");
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
+
+            Assert.DoesNotContain("OPPONENT PROFILE", result);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_OpponentProfileBeforeConversationHistory()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
+                MakeDialogueContext(playerName: "GERALD_42", opponentName: "VELVET"));
+
+            int opponentIdx = result.IndexOf("OPPONENT PROFILE");
+            int historyIdx = result.IndexOf("CONVERSATION HISTORY");
+            Assert.True(opponentIdx < historyIdx,
+                "Opponent profile should appear before conversation history");
+        }
+
+        [Fact]
         public void BuildDialogueOptionsPrompt_EmptyHistory_ContainsConversationStartAndCurrentTurn()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(


### PR DESCRIPTION
Fixes #487

## What changed

`GetDialogueOptionsAsync` was putting both player and opponent character prompts in the Anthropic system block, causing the LLM to blend both character voices when generating dialogue options. For example, Velvet would write in Sable's register (😭, omg, long warm spirals) instead of her own (precise, ironic, lowercase-with-intent).

### Fix

- **AnthropicLlmAdapter**: Switched from `BuildCachedSystemBlocks(player, opponent)` to `BuildPlayerOnlySystemBlocks(player)` for `GetDialogueOptionsAsync`
- **SessionDocumentBuilder**: Added opponent profile as informational context in the user message (`OPPONENT PROFILE (for context — this is who you are talking to, NOT who you are)`)
- `GetOpponentResponseAsync` and `DeliverMessageAsync` are unchanged (already use correct single-prompt system blocks)

### How to test

- Run: `dotnet test` — all 2770 tests pass (0 failures, 17 expected skips)
- Key test: `GetDialogueOptionsAsync_sends_correct_request_shape` verifies only 1 system block (player) and opponent profile in user message
- Key test: `AC2_DialogueOptions_SystemBlocks_ContainPlayerOnly` verifies no voice bleed in system blocks

## DoD Evidence
**Branch:** issue-487-bug-character-voice-bleed-both-prompts-i
**Commit:** 7cf497e
**Tests:** 2770 passed, 0 failed, 17 skipped

## Deviations from contract
None
