### PR TITLE
[Issue #490] Design: opponent is always in opposition below Interest 25

### DIFF
--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -115,7 +115,13 @@ Output only the message text. No explanation. The character sent this.";
         /// Uses {placeholder} tokens for dynamic content.
         /// </summary>
         public const string OpponentResponseInstruction =
-@"INTEREST CONSTRAINT:
+@"FUNDAMENTAL RULE: Below Interest 25, you are not won over. You may agree, warm, laugh — but the resistance is always present underneath. It may be subtle (a withheld thing, a reframe, a slightly cooler tone than expected) but it never fully dissolves. Agreement below 25 is unstable. It can flip.
+
+Your archetype determines HOW you resist, not WHETHER.
+
+{resistance_block}
+
+INTEREST CONSTRAINT:
 - Interest must reach 25 (DateSecured) before any concrete date plans are possible.
 - Below Interest 25: you may express interest, warmth, or curiosity, but NEVER commit to a specific time, place, or logistics. ""We should get coffee sometime"" is fine. ""Coffee shop on Fifth at 6pm Tuesday"" is NOT.
 - At Interest 25: the date is now real. You may suggest a specific venue or time that fits your character.
@@ -187,5 +193,31 @@ Rules:
 
         internal const string InterestBeatGeneric =
 @"Generate a brief reaction from {opponent_name} reflecting the change in interest. Subtle and in character.";
+
+        // ── Resistance descriptors by interest range ──
+
+        /// <summary>Interest 1-4: Active disengagement.</summary>
+        internal const string ResistanceActiveDisengagement =
+            "Active disengagement — short replies, testing, near-silence. You are barely here.";
+
+        /// <summary>Interest 5-9: Skeptical interest.</summary>
+        internal const string ResistanceSkepticalInterest =
+            "Skeptical interest — you engage but visibly evaluate. Tests disguised as questions. You're deciding if this is worth your time.";
+
+        /// <summary>Interest 10-14: Unstable agreement.</summary>
+        internal const string ResistanceUnstableAgreement =
+            "Unstable agreement — you respond warmly to good moments but hold back. One misfire and the warmth vanishes. Agreement is conditional.";
+
+        /// <summary>Interest 15-20: Deliberate approach.</summary>
+        internal const string ResistanceDeliberateApproach =
+            "Deliberate approach — you are invested but still managing the gap. One wrong move still costs. You give more but not everything.";
+
+        /// <summary>Interest 21-24: Almost convinced.</summary>
+        internal const string ResistanceAlmostConvinced =
+            "Almost convinced — warm but the final resistance is visible. You are choosing whether to give it. The holdback is small but real.";
+
+        /// <summary>Interest 25: Resistance dissolved.</summary>
+        internal const string ResistanceDissolved =
+            "Resistance dissolved — the date is real. You are genuinely won over.";
     }
 }

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -248,7 +248,10 @@ namespace Pinder.LlmAdapters
             }
 
             sb.AppendLine();
-            sb.Append(PromptTemplates.OpponentResponseInstruction);
+
+            string resistanceBlock = GetResistanceBlock(context.InterestAfter);
+            sb.Append(PromptTemplates.OpponentResponseInstruction
+                .Replace("{resistance_block}", resistanceBlock));
 
             return sb.ToString();
         }
@@ -397,6 +400,31 @@ namespace Pinder.LlmAdapters
                 default:
                     return "A failure has occurred. Degrade the message accordingly.";
             }
+        }
+
+        /// <summary>
+        /// Returns a resistance descriptor block based on current interest level.
+        /// Below 25, the opponent always maintains some form of resistance.
+        /// </summary>
+        internal static string GetResistanceBlock(int interest)
+        {
+            string descriptor;
+            if (interest >= 25)
+                descriptor = PromptTemplates.ResistanceDissolved;
+            else if (interest >= 21)
+                descriptor = PromptTemplates.ResistanceAlmostConvinced;
+            else if (interest >= 15)
+                descriptor = PromptTemplates.ResistanceDeliberateApproach;
+            else if (interest >= 10)
+                descriptor = PromptTemplates.ResistanceUnstableAgreement;
+            else if (interest >= 5)
+                descriptor = PromptTemplates.ResistanceSkepticalInterest;
+            else if (interest >= 1)
+                descriptor = PromptTemplates.ResistanceActiveDisengagement;
+            else
+                descriptor = PromptTemplates.ResistanceActiveDisengagement;
+
+            return $"Current interest: {interest}/25. Resistance level: {descriptor}";
         }
 
         private static string FallbackName(string name, string fallback)

--- a/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Tests for Issue #490: opponent resistance descriptors based on interest level.
+    /// Verifies that BuildOpponentPrompt includes the fundamental resistance rule
+    /// and interest-appropriate resistance descriptors.
+    /// </summary>
+    public class Issue490_ResistanceDescriptorTests
+    {
+        private static OpponentContext MakeOpponentContext(int interestAfter, int interestBefore = -1)
+        {
+            if (interestBefore < 0) interestBefore = interestAfter;
+            return new OpponentContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
+                opponentLastMessage: "hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: interestAfter,
+                playerDeliveredMessage: "hey there",
+                interestBefore: interestBefore,
+                interestAfter: interestAfter,
+                responseDelayMinutes: 2.0,
+                playerName: "P",
+                opponentName: "O");
+        }
+
+        // ── Fundamental resistance rule present ──
+
+        [Fact]
+        public void BuildOpponentPrompt_ContainsFundamentalResistanceRule()
+        {
+            var ctx = MakeOpponentContext(12);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("FUNDAMENTAL RULE: Below Interest 25, you are not won over", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_ContainsArchetypeResistanceGuidance()
+        {
+            var ctx = MakeOpponentContext(12);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Your archetype determines HOW you resist, not WHETHER", result);
+        }
+
+        // ── Interest 1-4: Active disengagement ──
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(4)]
+        public void BuildOpponentPrompt_Interest1To4_ActiveDisengagement(int interest)
+        {
+            var ctx = MakeOpponentContext(interest);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Active disengagement", result);
+            Assert.Contains($"Current interest: {interest}/25", result);
+        }
+
+        // ── Interest 5-9: Skeptical interest ──
+
+        [Theory]
+        [InlineData(5)]
+        [InlineData(7)]
+        [InlineData(9)]
+        public void BuildOpponentPrompt_Interest5To9_SkepticalInterest(int interest)
+        {
+            var ctx = MakeOpponentContext(interest);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Skeptical interest", result);
+            Assert.Contains($"Current interest: {interest}/25", result);
+        }
+
+        // ── Interest 10-14: Unstable agreement ──
+
+        [Theory]
+        [InlineData(10)]
+        [InlineData(12)]
+        [InlineData(14)]
+        public void BuildOpponentPrompt_Interest10To14_UnstableAgreement(int interest)
+        {
+            var ctx = MakeOpponentContext(interest);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Unstable agreement", result);
+            Assert.Contains($"Current interest: {interest}/25", result);
+        }
+
+        // ── Interest 15-20: Deliberate approach ──
+
+        [Theory]
+        [InlineData(15)]
+        [InlineData(17)]
+        [InlineData(20)]
+        public void BuildOpponentPrompt_Interest15To20_DeliberateApproach(int interest)
+        {
+            var ctx = MakeOpponentContext(interest);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Deliberate approach", result);
+            Assert.Contains($"Current interest: {interest}/25", result);
+        }
+
+        // ── Interest 21-24: Almost convinced ──
+
+        [Theory]
+        [InlineData(21)]
+        [InlineData(23)]
+        [InlineData(24)]
+        public void BuildOpponentPrompt_Interest21To24_AlmostConvinced(int interest)
+        {
+            var ctx = MakeOpponentContext(interest);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Almost convinced", result);
+            Assert.Contains($"Current interest: {interest}/25", result);
+        }
+
+        // ── Interest 25: Resistance dissolved ──
+
+        [Fact]
+        public void BuildOpponentPrompt_Interest25_ResistanceDissolved()
+        {
+            var ctx = MakeOpponentContext(25);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Resistance dissolved", result);
+            Assert.Contains("Current interest: 25/25", result);
+        }
+
+        // ── Interest 0: Active disengagement (edge case) ──
+
+        [Fact]
+        public void BuildOpponentPrompt_Interest0_ActiveDisengagement()
+        {
+            var ctx = MakeOpponentContext(0);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Active disengagement", result);
+        }
+
+        // ── Boundary tests ──
+
+        [Fact]
+        public void BuildOpponentPrompt_BoundaryAt5_SkepticalNotActive()
+        {
+            var ctx = MakeOpponentContext(5);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Skeptical interest", result);
+            Assert.DoesNotContain("Active disengagement", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_BoundaryAt10_UnstableNotSkeptical()
+        {
+            var ctx = MakeOpponentContext(10);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Unstable agreement", result);
+            Assert.DoesNotContain("Skeptical interest", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_BoundaryAt15_DeliberateNotUnstable()
+        {
+            var ctx = MakeOpponentContext(15);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Deliberate approach", result);
+            Assert.DoesNotContain("Unstable agreement", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_BoundaryAt21_AlmostNotDeliberate()
+        {
+            var ctx = MakeOpponentContext(21);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Almost convinced", result);
+            Assert.DoesNotContain("Deliberate approach", result);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_BoundaryAt25_DissolvedNotAlmost()
+        {
+            var ctx = MakeOpponentContext(25);
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("Resistance dissolved", result);
+            Assert.DoesNotContain("Almost convinced", result);
+        }
+
+        // ── GetResistanceBlock unit tests ──
+
+        [Theory]
+        [InlineData(0, "Active disengagement")]
+        [InlineData(1, "Active disengagement")]
+        [InlineData(4, "Active disengagement")]
+        [InlineData(5, "Skeptical interest")]
+        [InlineData(9, "Skeptical interest")]
+        [InlineData(10, "Unstable agreement")]
+        [InlineData(14, "Unstable agreement")]
+        [InlineData(15, "Deliberate approach")]
+        [InlineData(20, "Deliberate approach")]
+        [InlineData(21, "Almost convinced")]
+        [InlineData(24, "Almost convinced")]
+        [InlineData(25, "Resistance dissolved")]
+        public void GetResistanceBlock_ReturnsCorrectDescriptor(int interest, string expectedPhrase)
+        {
+            var block = SessionDocumentBuilder.GetResistanceBlock(interest);
+
+            Assert.Contains(expectedPhrase, block);
+            Assert.Contains($"Current interest: {interest}/25", block);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #490

## What was implemented
Added opponent resistance descriptors to the LLM prompt system. Below Interest 25, the opponent maintains varying resistance scaled by interest level.

### Changes
- **PromptTemplates.cs**: Added fundamental resistance rule to OpponentResponseInstruction + 6 resistance descriptor constants
- **SessionDocumentBuilder.cs**: Added GetResistanceBlock() method + injection into BuildOpponentPrompt via {resistance_block} placeholder
- **36 new tests**: Per-range coverage, boundary tests, GetResistanceBlock unit tests

### Resistance ranges
| Interest | Descriptor |
|----------|-----------|
| 0-4 | Active disengagement |
| 5-9 | Skeptical interest |
| 10-14 | Unstable agreement |
| 15-20 | Deliberate approach |
| 21-24 | Almost convinced |
| 25 | Resistance dissolved |

## How to test
```bash
dotnet test tests/Pinder.LlmAdapters.Tests/ --filter Issue490
```

All 2839 existing tests pass. 0 failures.

## Deviations from contract
None