### PR TITLE
[Issue #514] Fix DC Reference table header hardcoded as 'Sable attacking, Brick defending'

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -305,9 +305,9 @@ class Program
         Console.WriteLine();
 
         // ── DC table ──────────────────────────────────────────────────────
-        Console.WriteLine("## DC Reference (Sable attacking, Brick defending)");
+        Console.WriteLine($"## DC Reference ({player1} attacking, {player2} defending)");
         Console.WriteLine();
-        Console.WriteLine("| Stat | Sable mod | Brick defends | DC | Need | % | Risk |");
+        Console.WriteLine($"| Stat | {player1} mod | {player2} defends | DC | Need | % | Risk |");
         Console.WriteLine("|---|---|---|---|---|---|---|");
         foreach (var stat in new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness }) {
             int atkMod = sableStats.GetEffective(stat);

--- a/tests/Pinder.Core.Tests/DcTableHeaderTests.cs
+++ b/tests/Pinder.Core.Tests/DcTableHeaderTests.cs
@@ -1,0 +1,79 @@
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Verifies that DC Reference table formatting uses dynamic character names,
+    /// not hardcoded values. Tests the interpolation pattern from Program.cs.
+    /// </summary>
+    public class DcTableHeaderTests
+    {
+        [Fact]
+        public void DcTableHeader_UsesActualCharacterNames()
+        {
+            // Simulate the interpolation pattern from Program.cs line 308
+            string player1 = "Velvet";
+            string player2 = "Gerald";
+            string header = $"## DC Reference ({player1} attacking, {player2} defending)";
+
+            Assert.Equal("## DC Reference (Velvet attacking, Gerald defending)", header);
+            Assert.DoesNotContain("Sable", header);
+            Assert.DoesNotContain("Brick", header);
+        }
+
+        [Fact]
+        public void DcTableColumnHeader_UsesActualCharacterNames()
+        {
+            string player1 = "Velvet";
+            string player2 = "Gerald";
+            string columnHeader = $"| Stat | {player1} mod | {player2} defends | DC | Need | % | Risk |";
+
+            Assert.Equal("| Stat | Velvet mod | Gerald defends | DC | Need | % | Risk |", columnHeader);
+            Assert.DoesNotContain("Sable", columnHeader);
+            Assert.DoesNotContain("Brick", columnHeader);
+        }
+
+        [Fact]
+        public void DcTableHeader_WorksWithDefaultCharacters()
+        {
+            // Even with the original characters, it should use the variable names
+            string player1 = "Sable";
+            string player2 = "Brick";
+            string header = $"## DC Reference ({player1} attacking, {player2} defending)";
+
+            Assert.Equal("## DC Reference (Sable attacking, Brick defending)", header);
+        }
+
+        [Fact]
+        public void ProgramCs_DoesNotContainHardcodedDcHeader()
+        {
+            // Read the actual source file and verify no hardcoded header remains
+            string programPath = FindProgramCs();
+            string content = System.IO.File.ReadAllText(programPath);
+
+            // The old hardcoded strings should NOT appear
+            Assert.DoesNotContain("\"## DC Reference (Sable attacking, Brick defending)\"", content);
+            Assert.DoesNotContain("\"| Stat | Sable mod | Brick defends |", content);
+
+            // The dynamic interpolated strings SHOULD appear
+            Assert.Contains("$\"## DC Reference ({player1} attacking, {player2} defending)\"", content);
+            Assert.Contains($"$\"| Stat | {{player1}} mod | {{player2}} defends | DC | Need | % | Risk |\"", content);
+        }
+
+        private static string FindProgramCs()
+        {
+            // Walk up from test output dir to find session-runner/Program.cs
+            string dir = System.AppContext.BaseDirectory;
+            while (dir != null)
+            {
+                string candidate = System.IO.Path.Combine(dir, "session-runner", "Program.cs");
+                if (System.IO.File.Exists(candidate))
+                    return candidate;
+                string? parent = System.IO.Path.GetDirectoryName(dir);
+                if (parent == dir) break;
+                dir = parent!;
+            }
+            throw new System.IO.FileNotFoundException("Could not find session-runner/Program.cs");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #514

## What Changed
Replaced hardcoded character names in the DC Reference table header and column header in `session-runner/Program.cs` with interpolated `player1`/`player2` variables.

### Before
```
## DC Reference (Sable attacking, Brick defending)
| Stat | Sable mod | Brick defends | DC | Need | % | Risk |
```

### After (interpolated)
```csharp
$"## DC Reference ({player1} attacking, {player2} defending)"
$"| Stat | {player1} mod | {player2} defends | DC | Need | % | Risk |"
```

## How to Test
```bash
dotnet test tests/Pinder.Core.Tests --filter DcTableHeaderTests
```

## DoD Evidence
- **Tests**: 4 new tests passing, 2109 total passed, 0 failed
- **Branch**: issue-514-bug-dc-reference-table-header-hardcoded-
- **Deviations from contract**: none
