### PR TITLE
[Issue #545] Spec: Create game-definition.yaml with Pinder game vision, world rules, and meta contract

### DIFF
--- a/docs/specs/issue-541-spec.md
+++ b/docs/specs/issue-541-spec.md
@@ -1,0 +1,341 @@
+# Issue #541 — AnthropicLlmAdapter: Add Stateful Conversation Mode
+
+**Module**: docs/modules/llm-adapters.md
+
+## Overview
+
+Add a `ConversationSession` class to `Pinder.LlmAdapters` that accumulates user/assistant messages across multiple LLM calls within a single game session. Extend `AnthropicLlmAdapter` with a `StartConversation(string systemPrompt)` method that activates stateful mode, causing all subsequent `ILlmAdapter` method calls to append to and read from the accumulated message history rather than building fresh single-message requests each time.
+
+This enables natural multi-turn conversation context: instead of each Anthropic API call receiving only a single user message (rebuilt from scratch), the adapter sends the full message history. The Anthropic Messages API is stateless (full history must be sent each call), so the adapter accumulates messages client-side.
+
+## Function Signatures
+
+### ConversationSession (new class in `Pinder.LlmAdapters`)
+
+```csharp
+namespace Pinder.LlmAdapters
+{
+    public sealed class ConversationSession
+    {
+        /// <summary>
+        /// The system prompt blocks (with cache_control: ephemeral) persisted for the session.
+        /// Set once at construction, immutable thereafter.
+        /// </summary>
+        public ContentBlock[] SystemBlocks { get; }
+
+        /// <summary>
+        /// All accumulated messages in conversation order (user/assistant alternating).
+        /// Grows unbounded within a session. Read-only view of internal list.
+        /// </summary>
+        public IReadOnlyList<Message> Messages { get; }
+
+        /// <summary>
+        /// Creates a new conversation session with the given system prompt text.
+        /// The system prompt is wrapped in a single ContentBlock with
+        /// cache_control: { type: "ephemeral" } for Anthropic prompt caching.
+        /// </summary>
+        /// <param name="systemPrompt">
+        /// Full system prompt text (character bibles, game vision, etc.).
+        /// Must not be null or empty.
+        /// </param>
+        /// <exception cref="ArgumentException">If systemPrompt is null or whitespace.</exception>
+        public ConversationSession(string systemPrompt);
+
+        /// <summary>
+        /// Append a user-role message to the conversation history.
+        /// </summary>
+        /// <param name="content">Message text. Must not be null.</param>
+        /// <exception cref="ArgumentNullException">If content is null.</exception>
+        public void AppendUser(string content);
+
+        /// <summary>
+        /// Append an assistant-role message to the conversation history.
+        /// </summary>
+        /// <param name="content">Message text. Must not be null.</param>
+        /// <exception cref="ArgumentNullException">If content is null.</exception>
+        public void AppendAssistant(string content);
+
+        /// <summary>
+        /// Build a MessagesRequest using accumulated state:
+        /// system blocks + all messages + specified parameters.
+        /// </summary>
+        /// <param name="model">Anthropic model identifier (e.g. "claude-sonnet-4-20250514").</param>
+        /// <param name="maxTokens">Maximum tokens in the response.</param>
+        /// <param name="temperature">Sampling temperature (0.0–1.0).</param>
+        /// <returns>
+        /// A MessagesRequest with SystemBlocks as system, all Messages as messages array,
+        /// and the given model/maxTokens/temperature.
+        /// </returns>
+        public MessagesRequest BuildRequest(string model, int maxTokens, double temperature);
+    }
+}
+```
+
+### AnthropicLlmAdapter (extended)
+
+The adapter gains a `StartConversation` method. It does NOT implement a new interface in this issue (that is #542's responsibility with `IStatefulLlmAdapter`). This issue adds the internal capability.
+
+```csharp
+// Added to existing AnthropicLlmAdapter class:
+
+/// <summary>
+/// Start a stateful conversation session with the given system prompt.
+/// After calling this, all ILlmAdapter method calls will append to and
+/// read from the accumulated message history instead of building
+/// fresh single-message requests.
+///
+/// Calling this when a session is already active replaces it (no error).
+/// </summary>
+/// <param name="systemPrompt">
+/// Full system prompt (both character profiles, game vision, etc.).
+/// Must not be null or empty.
+/// </param>
+/// <exception cref="ArgumentException">If systemPrompt is null or whitespace.</exception>
+public void StartConversation(string systemPrompt);
+
+/// <summary>
+/// Whether a stateful conversation session is currently active.
+/// When true, all ILlmAdapter calls route through the accumulated session.
+/// When false, behavior is identical to current stateless mode.
+/// </summary>
+public bool HasActiveConversation { get; }
+```
+
+### Existing types referenced (no changes)
+
+- `ContentBlock` (`Pinder.LlmAdapters.Anthropic.Dto`) — system block with optional `CacheControl`.
+- `Message` (`Pinder.LlmAdapters.Anthropic.Dto`) — `{ Role: string, Content: string }`.
+- `MessagesRequest` (`Pinder.LlmAdapters.Anthropic.Dto`) — `{ Model, MaxTokens, Temperature, System: ContentBlock[], Messages: Message[] }`.
+- `ILlmAdapter` (`Pinder.Core.Interfaces`) — `GetDialogueOptionsAsync`, `DeliverMessageAsync`, `GetOpponentResponseAsync`, `GetInterestChangeBeatAsync`.
+
+## Input/Output Examples
+
+### Example 1: Creating a ConversationSession
+
+```
+Input:
+  systemPrompt = "You are Velvet, a sardonic music critic..."
+
+Result:
+  session.SystemBlocks = [
+    { Type: "text", Text: "You are Velvet, a sardonic music critic...", CacheControl: { Type: "ephemeral" } }
+  ]
+  session.Messages = [] (empty)
+```
+
+### Example 2: Accumulating messages across turns
+
+```
+session.AppendUser("[ENGINE — Turn 1: Option Generation]\nInterest: 10/25...")
+// Messages.Count == 1, Messages[0] = { Role: "user", Content: "[ENGINE — Turn 1...]" }
+
+session.AppendAssistant("OPTION_1\n[STAT: Charm]\n\"hey there gorgeous\"...")
+// Messages.Count == 2, Messages[1] = { Role: "assistant", Content: "OPTION_1..." }
+
+session.AppendUser("[ENGINE — Turn 1: Delivery]\nRoll: d20(14)...")
+// Messages.Count == 3, Messages[2] = { Role: "user", Content: "[ENGINE — Turn 1: Delivery]..." }
+
+session.AppendAssistant("hey there gorgeous 😏")
+// Messages.Count == 4, Messages[3] = { Role: "assistant", Content: "hey there gorgeous 😏" }
+```
+
+### Example 3: BuildRequest with accumulated state
+
+```
+Input:
+  model = "claude-sonnet-4-20250514"
+  maxTokens = 1024
+  temperature = 0.9
+  (session has 4 accumulated messages from Example 2)
+
+Output: MessagesRequest {
+  Model: "claude-sonnet-4-20250514",
+  MaxTokens: 1024,
+  Temperature: 0.9,
+  System: [ { Type: "text", Text: "You are Velvet...", CacheControl: { Type: "ephemeral" } } ],
+  Messages: [
+    { Role: "user",      Content: "[ENGINE — Turn 1: Option Generation]..." },
+    { Role: "assistant", Content: "OPTION_1\n[STAT: Charm]..." },
+    { Role: "user",      Content: "[ENGINE — Turn 1: Delivery]..." },
+    { Role: "assistant", Content: "hey there gorgeous 😏" }
+  ]
+}
+```
+
+### Example 4: Stateful adapter — GetDialogueOptionsAsync in stateful mode
+
+```
+Precondition: adapter.StartConversation("system prompt text") has been called.
+
+When: GetDialogueOptionsAsync(dialogueContext) is called
+
+Then:
+  1. Adapter builds user content from SessionDocumentBuilder (same as current)
+  2. Appends user message to ConversationSession
+  3. Calls _client.SendMessagesAsync() using session.BuildRequest(model, maxTokens, temperature)
+     — request includes ALL prior messages + the new user message
+  4. Parses response text into DialogueOption[]
+  5. Appends raw assistant response text to ConversationSession
+  6. Returns parsed DialogueOption[]
+```
+
+### Example 5: Stateless fallback (no session active)
+
+```
+Precondition: StartConversation() has NOT been called.
+
+When: GetDialogueOptionsAsync(dialogueContext) is called
+
+Then: Behavior is identical to current implementation:
+  1. Build system blocks from CacheBlockBuilder
+  2. Build user content from SessionDocumentBuilder
+  3. Build single-message MessagesRequest
+  4. Send, parse, return
+  (No ConversationSession involvement)
+```
+
+## Acceptance Criteria
+
+### AC1: ConversationSession class with AppendUser, AppendAssistant, Messages, SystemPrompt
+
+`ConversationSession` must be a `public sealed class` in the `Pinder.LlmAdapters` namespace. It must expose:
+
+- `SystemBlocks` (type: `ContentBlock[]`) — set at construction, read-only thereafter. Contains one `ContentBlock` with `Type = "text"`, the full system prompt as `Text`, and `CacheControl = { Type = "ephemeral" }`.
+- `Messages` (type: `IReadOnlyList<Message>`) — the ordered list of all appended messages.
+- `AppendUser(string content)` — adds a `Message` with `Role = "user"` and `Content = content`.
+- `AppendAssistant(string content)` — adds a `Message` with `Role = "assistant"` and `Content = content`.
+- `BuildRequest(string model, int maxTokens, double temperature)` — returns a `MessagesRequest` with `System = SystemBlocks`, `Messages` = snapshot of all accumulated messages as an array, and the provided model/maxTokens/temperature.
+
+Messages must be stored in append order. The `Messages` property must reflect all messages appended so far.
+
+### AC2: AnthropicLlmAdapter.StartConversation(systemPrompt) creates a session
+
+When `StartConversation(string systemPrompt)` is called on `AnthropicLlmAdapter`:
+
+- A new `ConversationSession` is constructed with the provided `systemPrompt`.
+- The internal `_session` field (type `ConversationSession?`) is set to the new instance.
+- `HasActiveConversation` returns `true` after the call.
+- If a session was already active, it is replaced (no error, no exception).
+
+### AC3: When a session is active, calls use accumulated messages[] not fresh context
+
+When `HasActiveConversation` is `true`, the four `ILlmAdapter` methods must:
+
+1. Build user content string the same way they currently do (via `SessionDocumentBuilder`).
+2. Append the user content to the active `ConversationSession` via `AppendUser()`.
+3. Build the `MessagesRequest` via `_session.BuildRequest()` (which includes system blocks + ALL accumulated messages).
+4. Send the request via `_client.SendMessagesAsync()`.
+5. Extract the response text.
+6. Append the raw response text to the session via `AppendAssistant()`.
+7. Parse the response text and return the result (same parsing logic as current).
+
+The system blocks come from the `ConversationSession` (set at construction), NOT from `CacheBlockBuilder` per-call methods.
+
+When `HasActiveConversation` is `false`, all four methods must behave identically to the current implementation (building fresh per-call `MessagesRequest` with `CacheBlockBuilder` system blocks and a single user message).
+
+### AC4: ILlmAdapter interface unchanged
+
+The `ILlmAdapter` interface in `Pinder.Core.Interfaces` must not be modified. No new methods, no signature changes. `StartConversation` and `HasActiveConversation` are concrete members on `AnthropicLlmAdapter` only (the interface extension `IStatefulLlmAdapter` is issue #542's responsibility).
+
+### AC5: All existing tests still pass
+
+All existing tests (currently 2979+) must continue to pass without modification. Since `NullLlmAdapter` does not gain `StartConversation`, and `AnthropicLlmAdapter` defaults to stateless mode (no session active), all existing test paths are unchanged.
+
+### AC6: Build clean
+
+The solution must compile without errors or warnings under `netstandard2.0` with `LangVersion 8.0` and nullable reference types enabled.
+
+## Edge Cases
+
+### Empty system prompt
+
+`ConversationSession(string systemPrompt)` must throw `ArgumentException` if `systemPrompt` is `null`, empty, or whitespace. A system prompt is required for every conversation session.
+
+### Null content in AppendUser/AppendAssistant
+
+Both methods must throw `ArgumentNullException` if `content` is `null`. Empty string (`""`) is allowed — the Anthropic API accepts empty content strings.
+
+### Calling StartConversation multiple times
+
+Each call to `StartConversation` replaces the previous session entirely. The old `ConversationSession` is discarded (garbage collected). No error is thrown. The new session starts with zero messages and the new system prompt.
+
+### Messages ordering: consecutive same-role messages
+
+The Anthropic Messages API requires user/assistant messages to alternate (user first). `ConversationSession` does NOT enforce alternation — it stores messages in whatever order they are appended. The caller (adapter) is responsible for correct alternation. If the caller appends two user messages in a row, the Anthropic API will return a 400 error at send time.
+
+### Unbounded message growth
+
+At prototype maturity, `ConversationSession` accumulates messages without limit. A 20-turn game session may produce ~40-60 messages. With Anthropic's 200k token context window, this is acceptable. No truncation or summarization is implemented.
+
+### BuildRequest returns a snapshot
+
+`BuildRequest()` must return a `MessagesRequest` containing a copy (array) of the current messages, not a reference to the live list. Subsequent `AppendUser`/`AppendAssistant` calls must not modify previously returned `MessagesRequest` instances.
+
+### ConversationSession is not thread-safe
+
+`ConversationSession` is designed for sequential use within one `GameSession`. No locking or synchronization is required. Concurrent access from multiple threads is undefined behavior.
+
+### Stateless path preserved with zero changes
+
+When `HasActiveConversation` is `false`, each `ILlmAdapter` method must execute the exact same code path as the current implementation. No conditional logic should be encountered in the stateless path — the if/else branch for stateful mode must not alter the stateless path in any way.
+
+## Error Conditions
+
+| Condition | Expected Behavior |
+|---|---|
+| `new ConversationSession(null)` | `ArgumentException` thrown |
+| `new ConversationSession("")` | `ArgumentException` thrown |
+| `new ConversationSession("  ")` | `ArgumentException` thrown |
+| `session.AppendUser(null)` | `ArgumentNullException` thrown |
+| `session.AppendAssistant(null)` | `ArgumentNullException` thrown |
+| `adapter.StartConversation(null)` | `ArgumentException` thrown |
+| `adapter.StartConversation("")` | `ArgumentException` thrown |
+| Two consecutive user messages sent to Anthropic API | `AnthropicApiException` (400) from `_client.SendMessagesAsync()` — not adapter's responsibility to prevent |
+| `_client.SendMessagesAsync()` throws during stateful call | Exception propagates to caller (same as stateless mode). The appended user message remains in the session. The assistant message is NOT appended (since no response was received). |
+| Response parsing fails in stateful mode | Raw response text is still appended to session via `AppendAssistant()` before parsing occurs. This ensures the session stays in sync even if parsing (e.g., `ParseDialogueOptions`) returns padded defaults. |
+
+## Dependencies
+
+### Internal (Pinder.LlmAdapters)
+
+- `ContentBlock` — system block DTO with `CacheControl` annotation.
+- `Message` — user/assistant message DTO with `Role` and `Content` string fields.
+- `MessagesRequest` — API request DTO: `System: ContentBlock[]`, `Messages: Message[]`, `Model`, `MaxTokens`, `Temperature`.
+- `MessagesResponse` — API response DTO with `GetText()` method.
+- `AnthropicClient` — HTTP transport. `SendMessagesAsync(MessagesRequest)` sends the request and returns `MessagesResponse`.
+- `CacheBlockBuilder` — used in stateless path only (builds per-call system blocks).
+- `SessionDocumentBuilder` — used in both paths to build user content strings.
+- `AnthropicOptions` — configuration (model, maxTokens, per-method temperatures).
+
+### Internal (Pinder.Core)
+
+- `ILlmAdapter` — interface that `AnthropicLlmAdapter` implements. NOT modified.
+- `DialogueContext`, `DeliveryContext`, `OpponentContext`, `InterestChangeContext` — context DTOs passed to each `ILlmAdapter` method.
+- `DialogueOption`, `OpponentResponse` — return types from adapter methods.
+
+### External
+
+- `Newtonsoft.Json` (13.0.3) — already a dependency of `Pinder.LlmAdapters`. Used for `MessagesRequest` serialization by `AnthropicClient`.
+- Anthropic Messages API (v1) — stateless HTTP API at `https://api.anthropic.com/v1/messages`. Full message history must be sent with each call. Prompt caching via `cache_control: ephemeral` on system blocks is GA.
+
+### Downstream (consumed by)
+
+- Issue #542 (`IStatefulLlmAdapter` interface + `GameSession` wiring) depends on this issue. `GameSession` will call `StartConversation()` at construction if the adapter supports it.
+- Issue #543 (`SessionSystemPromptBuilder`) provides the system prompt text that will be passed to `StartConversation()`.
+- Issue #544 (`EngineInjectionBuilder`) provides the `[ENGINE]` block content that will replace `SessionDocumentBuilder` content in stateful mode in a future enhancement.
+
+### Constraints
+
+- `Pinder.Core` must NOT reference `Pinder.LlmAdapters` — the dependency is strictly one-way.
+- `Pinder.Core` must remain zero NuGet dependencies.
+- Target framework: `netstandard2.0`, `LangVersion 8.0` — no `record` types, no pattern matching with `{}`, no generic `Enum.Parse<T>`.
+- `NullLlmAdapter` (in `Pinder.Core.Conversation`) is NOT modified and does NOT gain stateful capabilities.
+
+## Files to Create/Modify
+
+| File | Action | Notes |
+|---|---|---|
+| `src/Pinder.LlmAdapters/ConversationSession.cs` | Create | New class per spec |
+| `src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs` | Modify | Add `_session` field, `StartConversation()`, `HasActiveConversation`, dual code paths in all 4 ILlmAdapter methods |
+| `tests/Pinder.LlmAdapters.Tests/ConversationSessionTests.cs` | Create | Unit tests for ConversationSession |
+| `tests/Pinder.LlmAdapters.Tests/AnthropicLlmAdapterStatefulTests.cs` | Create | Tests for stateful adapter behavior |

--- a/docs/specs/issue-542-spec.md
+++ b/docs/specs/issue-542-spec.md
@@ -1,0 +1,314 @@
+# Spec: GameSession creates LLM conversation session at start
+
+**Issue**: #542  
+**Module**: docs/modules/conversation-game-session.md, docs/modules/llm-adapters.md
+
+---
+
+## Overview
+
+GameSession should automatically detect when its injected `ILlmAdapter` supports stateful conversation mode (via the new `IStatefulLlmAdapter` sub-interface) and, if so, start a persistent conversation session at construction time. This enables all LLM calls within a game session to share continuous context—messages accumulate across turns rather than being rebuilt from scratch each call. When the adapter does not support stateful mode (e.g., `NullLlmAdapter`), the existing stateless behavior is preserved with zero changes.
+
+This feature bridges three components: a new `IStatefulLlmAdapter` interface in `Pinder.Core.Interfaces`, an implementation of that interface in `AnthropicLlmAdapter` (which delegates to `ConversationSession` from #541), and wiring logic in `GameSession`'s constructor.
+
+---
+
+## Function Signatures
+
+### New Interface: `IStatefulLlmAdapter` (Pinder.Core.Interfaces)
+
+```csharp
+namespace Pinder.Core.Interfaces
+{
+    /// <summary>
+    /// Extends ILlmAdapter with stateful conversation support.
+    /// When implemented, GameSession creates a persistent conversation
+    /// at construction and routes all LLM calls through accumulated
+    /// message history.
+    /// </summary>
+    public interface IStatefulLlmAdapter : ILlmAdapter
+    {
+        /// <summary>
+        /// Start a new conversation session with the given system prompt.
+        /// The adapter internally tracks the active session.
+        /// Subsequent ILlmAdapter method calls use the accumulated
+        /// message history from this session.
+        /// Call once per GameSession lifetime.
+        /// </summary>
+        /// <param name="systemPrompt">
+        /// Full system prompt string (both character profiles + game context).
+        /// Must not be null or empty.
+        /// </param>
+        void StartConversation(string systemPrompt);
+
+        /// <summary>
+        /// Whether a conversation session is currently active.
+        /// Returns true after StartConversation has been called.
+        /// </summary>
+        bool HasActiveConversation { get; }
+    }
+}
+```
+
+**Key constraints:**
+- `IStatefulLlmAdapter` inherits all four methods from `ILlmAdapter` (`GetDialogueOptionsAsync`, `DeliverMessageAsync`, `GetOpponentResponseAsync`, `GetInterestChangeBeatAsync`).
+- `StartConversation(string)` returns `void` — the adapter internally owns the `ConversationSession` (#541). GameSession does not hold or pass a session reference.
+- Calling `StartConversation` when a session is already active replaces the existing session (no error thrown).
+- `HasActiveConversation` returns `false` before `StartConversation` is called, `true` after.
+
+### Modified: `AnthropicLlmAdapter` (Pinder.LlmAdapters.Anthropic)
+
+The class declaration changes from:
+
+```csharp
+public sealed class AnthropicLlmAdapter : ILlmAdapter, IDisposable
+```
+
+to:
+
+```csharp
+public sealed class AnthropicLlmAdapter : IStatefulLlmAdapter, IDisposable
+```
+
+New members added:
+
+```csharp
+// Internal field
+private ConversationSession? _session;
+
+// IStatefulLlmAdapter implementation
+public bool HasActiveConversation => _session != null;
+
+public void StartConversation(string systemPrompt)
+// Creates a new ConversationSession(systemPrompt), storing it in _session.
+// Replaces any existing session.
+```
+
+**Behavioral change when `_session` is active:**
+- Each `ILlmAdapter` method call appends a user message to `_session` (via `AppendUser`), sends the full accumulated `MessagesRequest` via `AnthropicClient`, appends the assistant response (via `AppendAssistant`), and returns the parsed result.
+- When `_session` is null, existing stateless behavior is unchanged (each call builds a fresh `MessagesRequest` from scratch using `SessionDocumentBuilder` and `CacheBlockBuilder`).
+
+### Modified: `GameSession` constructor (Pinder.Core.Conversation)
+
+No new public methods or properties. The change is inside the existing 6-parameter constructor body:
+
+```csharp
+public GameSession(
+    CharacterProfile player,
+    CharacterProfile opponent,
+    ILlmAdapter llm,
+    IDiceRoller dice,
+    ITrapRegistry trapRegistry,
+    GameSessionConfig? config)
+```
+
+**New logic added at the end of the constructor** (after all existing initialization):
+
+```
+if _llm is IStatefulLlmAdapter stateful:
+    build system prompt string from player and opponent profiles
+    call stateful.StartConversation(systemPrompt)
+```
+
+The system prompt assembly for this issue is a simple concatenation:
+
+```
+{player.AssembledSystemPrompt}
+
+---
+
+{opponent.AssembledSystemPrompt}
+```
+
+> **Note:** Issue #543 (`SessionSystemPromptBuilder`) replaces this simple concatenation with a structured prompt including game vision, world rules, and meta contract. The #542 implementer should use the simple concatenation above and expect #543 to replace it.
+
+### Unchanged: `NullLlmAdapter` (Pinder.Core.Conversation)
+
+`NullLlmAdapter` continues to implement only `ILlmAdapter`. It does **not** implement `IStatefulLlmAdapter`. This is the mechanism that guarantees all existing tests remain on the stateless path.
+
+### Unchanged: `GameSessionConfig` (Pinder.Core.Conversation)
+
+No new properties. The adapter type detection happens via interface check (`is IStatefulLlmAdapter`), not via config.
+
+---
+
+## Input/Output Examples
+
+### Example 1: Stateful adapter (AnthropicLlmAdapter)
+
+```
+// Setup
+var options = new AnthropicOptions("sk-ant-...", "claude-sonnet-4-20250514");
+var adapter = new AnthropicLlmAdapter(options);  // implements IStatefulLlmAdapter
+var session = new GameSession(velvet, sable, adapter, dice, trapReg, config);
+
+// At construction time:
+//   GameSession detects adapter is IStatefulLlmAdapter
+//   Builds system prompt: velvet.AssembledSystemPrompt + "\n\n---\n\n" + sable.AssembledSystemPrompt
+//   Calls adapter.StartConversation(systemPrompt)
+//   adapter.HasActiveConversation → true
+
+// Per turn:
+//   session.StartTurnAsync() → adapter.GetDialogueOptionsAsync(context)
+//     → adapter appends user message to internal ConversationSession
+//     → sends accumulated messages[] via AnthropicClient
+//     → appends assistant response to ConversationSession
+//     → returns parsed DialogueOption[]
+//
+//   session.ResolveTurnAsync(1) → adapter.DeliverMessageAsync(context)
+//     → adapter appends user message (delivery context)
+//     → sends accumulated messages[] (now includes option generation exchange)
+//     → appends assistant response
+//     → returns delivered text
+//   Then → adapter.GetOpponentResponseAsync(context)
+//     → adapter appends user message (opponent context)
+//     → sends accumulated messages[] (now includes delivery exchange)
+//     → appends assistant response
+//     → returns OpponentResponse
+```
+
+### Example 2: Stateless adapter (NullLlmAdapter)
+
+```
+// Setup
+var adapter = new NullLlmAdapter();  // implements ILlmAdapter only
+var session = new GameSession(velvet, sable, adapter, dice, trapReg, config);
+
+// At construction time:
+//   GameSession checks: adapter is IStatefulLlmAdapter? → false
+//   No conversation started
+//   Behavior is 100% identical to current code
+
+// Per turn:
+//   All ILlmAdapter calls use existing stateless behavior
+//   NullLlmAdapter returns hardcoded responses as before
+```
+
+### Example 3: System prompt content
+
+Given:
+- `player.AssembledSystemPrompt` = `"You are Velvet — lowercase-with-intent, precise, ironic..."`
+- `opponent.AssembledSystemPrompt` = `"You are Sable — omg, 😭, fast-talk energy..."`
+
+The system prompt passed to `StartConversation` is:
+
+```
+You are Velvet — lowercase-with-intent, precise, ironic...
+
+---
+
+You are Sable — omg, 😭, fast-talk energy...
+```
+
+---
+
+## Acceptance Criteria
+
+### AC1: `IStatefulLlmAdapter : ILlmAdapter` interface with `StartConversation(string)`
+
+A new file `src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs` defines `IStatefulLlmAdapter` extending `ILlmAdapter` with:
+- `void StartConversation(string systemPrompt)` — initializes internal conversation session
+- `bool HasActiveConversation { get; }` — returns whether a session is active
+
+The interface lives in namespace `Pinder.Core.Interfaces`, in the `Pinder.Core` project (zero external dependencies — this is an interface only).
+
+### AC2: `AnthropicLlmAdapter` implements `IStatefulLlmAdapter`
+
+`AnthropicLlmAdapter` changes its class declaration to implement `IStatefulLlmAdapter` (which extends `ILlmAdapter`, so all existing method implementations satisfy both interfaces).
+
+- `StartConversation(string)` creates a `ConversationSession` (#541 dependency) and stores it internally.
+- When a session is active, all four `ILlmAdapter` method calls route through the accumulated `ConversationSession` messages.
+- When no session is active, existing stateless behavior is preserved.
+
+### AC3: `GameSession` uses stateful session if adapter supports it
+
+In `GameSession`'s 6-parameter constructor, after all existing initialization:
+1. Check if `_llm is IStatefulLlmAdapter stateful`
+2. If true: build system prompt from `_player.AssembledSystemPrompt` and `_opponent.AssembledSystemPrompt`, call `stateful.StartConversation(systemPrompt)`
+3. If false: do nothing (stateless path)
+
+No changes to any `GameSession` method bodies (`StartTurnAsync`, `ResolveTurnAsync`, `ReadAsync`, `RecoverAsync`, `Wait`). The adapter itself handles routing through the session internally—GameSession continues calling `_llm.GetDialogueOptionsAsync(context)` etc. as before.
+
+### AC4: Session system prompt includes both character profiles
+
+The system prompt passed to `StartConversation` must contain:
+- The player character's full assembled system prompt (`_player.AssembledSystemPrompt`)
+- The opponent character's full assembled system prompt (`_opponent.AssembledSystemPrompt`)
+- Separated by `"\n\n---\n\n"`
+
+This is a temporary format. Issue #543 introduces `SessionSystemPromptBuilder` which produces a structured prompt with game vision, world rules, and meta contract.
+
+### AC5: All existing tests still pass (NullLlmAdapter is not IStatefulLlmAdapter → stateless path)
+
+Because `NullLlmAdapter` implements only `ILlmAdapter` (not `IStatefulLlmAdapter`), the `is IStatefulLlmAdapter` check in GameSession's constructor evaluates to `false` for all existing tests. No conversation session is started, and all existing behavior is preserved exactly as before. All 2979+ existing tests must compile and pass without modification.
+
+### AC6: Build clean
+
+The solution (`Pinder.Core`, `Pinder.LlmAdapters`, `Pinder.Rules`, all test projects, `session-runner`) must build with zero errors and zero warnings related to these changes.
+
+---
+
+## Edge Cases
+
+### Null or empty system prompt
+- If `_player.AssembledSystemPrompt` or `_opponent.AssembledSystemPrompt` is empty string (never null per `CharacterProfile` constructor validation), `StartConversation` receives a prompt with one empty section. The `ConversationSession` should accept any non-null string. GameSession does not guard against empty prompts—`CharacterProfile` guarantees non-null via its constructor.
+
+### Adapter is IStatefulLlmAdapter but StartConversation fails
+- `StartConversation` creates a `ConversationSession` object (no I/O, no network call). It should not throw under normal circumstances. If `systemPrompt` is null, `ConversationSession` constructor should throw `ArgumentNullException`. Since GameSession builds the prompt from non-null `AssembledSystemPrompt` values, this should never happen in practice.
+
+### Multiple GameSessions sharing one adapter instance
+- The architecture assumes one adapter instance per GameSession (1:1 relationship). If two `GameSession` instances share an `AnthropicLlmAdapter`, the second constructor call to `StartConversation` replaces the first session. This is documented as unsupported at prototype maturity. Do not throw; silently replace.
+
+### Adapter implements IStatefulLlmAdapter but StartConversation was already called
+- `StartConversation` replaces the existing session. No error. Previous message history is discarded.
+
+### Five-parameter GameSession constructor
+- The 5-parameter constructor delegates to the 6-parameter constructor with `config: null`. The `is IStatefulLlmAdapter` check still runs (it checks `_llm`, not config). If the adapter is stateful, the session is started even without config.
+
+### GameSession with IStatefulLlmAdapter but null config
+- The stateful detection is independent of `GameSessionConfig`. Config is not involved in the decision. A null config does not prevent stateful mode.
+
+---
+
+## Error Conditions
+
+| Condition | Expected Behavior |
+|-----------|-------------------|
+| `systemPrompt` argument to `StartConversation` is `null` | `ArgumentNullException` thrown by `ConversationSession` constructor |
+| `ILlmAdapter` methods called before `StartConversation` on `AnthropicLlmAdapter` | Existing stateless behavior (no session active) |
+| Network failure during a stateful LLM call | `AnthropicApiException` propagates up through `GameSession` (same as stateless mode) — the session's message history is NOT corrupted (failed response is not appended) |
+| `AnthropicLlmAdapter` disposed while session is active | Adapter disposal disposes `AnthropicClient`; subsequent calls throw `ObjectDisposedException` (existing behavior) |
+| Second `StartConversation` call on same adapter | Previous session is silently replaced — no error |
+
+---
+
+## Dependencies
+
+| Dependency | Type | Notes |
+|------------|------|-------|
+| #541 `ConversationSession` | Hard prerequisite | Must be merged first. `AnthropicLlmAdapter.StartConversation` creates a `ConversationSession` instance. |
+| `Pinder.Core` (netstandard2.0) | Project reference | `IStatefulLlmAdapter` interface lives here. Zero NuGet dependencies. |
+| `Pinder.LlmAdapters` (netstandard2.0) | Project reference | `AnthropicLlmAdapter` implementation lives here. References `Pinder.Core` + `Newtonsoft.Json`. |
+| `Pinder.Core.Characters.CharacterProfile` | Existing class | `AssembledSystemPrompt` property used to build system prompt. |
+| `Pinder.Core.Interfaces.ILlmAdapter` | Existing interface | Base interface extended by `IStatefulLlmAdapter`. |
+| `Pinder.LlmAdapters.Anthropic.Dto.Message` | Existing DTO | Used internally by `ConversationSession` for message accumulation. |
+| `Pinder.LlmAdapters.Anthropic.Dto.ContentBlock` | Existing DTO | Used by `ConversationSession` for system blocks. |
+| `Pinder.LlmAdapters.Anthropic.Dto.MessagesRequest` | Existing DTO | Built by `ConversationSession.BuildRequest()`. |
+
+### Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs` | **New** | Interface definition |
+| `src/Pinder.Core/Conversation/GameSession.cs` | **Modified** | Constructor body: `is IStatefulLlmAdapter` check + `StartConversation` call |
+| `src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs` | **Modified** | Implements `IStatefulLlmAdapter`; gains `_session` field and dual stateful/stateless code paths in all four `ILlmAdapter` methods |
+| `src/Pinder.Core/Conversation/NullLlmAdapter.cs` | **Unchanged** | Remains `ILlmAdapter` only |
+| `src/Pinder.Core/Conversation/GameSessionConfig.cs` | **Unchanged** | No new properties |
+
+### Constraints
+
+- **netstandard2.0 + LangVersion 8.0**: No `record` types. Use `sealed class`. No generic `Enum.Parse<T>`.
+- **Zero NuGet dependencies in Pinder.Core**: `IStatefulLlmAdapter` is a pure interface.
+- **Backward compatibility**: All 2979+ existing tests must pass unchanged.
+- **One-way dependency**: `Pinder.LlmAdapters → Pinder.Core`. Core must not reference LlmAdapters.
+- **ConversationSession type is internal to LlmAdapters**: GameSession never touches it directly. The adapter owns the session lifecycle.

--- a/docs/specs/issue-545-spec.md
+++ b/docs/specs/issue-545-spec.md
@@ -1,0 +1,270 @@
+# Issue #545 — Create game-definition.yaml with Pinder Game Vision, World Rules, and Meta Contract
+
+**Module**: `docs/modules/llm-adapters.md` (update existing)
+
+---
+
+## Overview
+
+Pinder's creative direction — game vision, world description, character role descriptions, meta contract, and writing rules — is currently either hardcoded in `GameDefinition.PinderDefaults` or does not exist as a standalone data artifact. This issue creates a YAML data file (`game-definition.yaml`) containing all five sections of Pinder's creative identity so that `GameDefinition.LoadFrom()` (from issue #543) can parse it and feed it into `SessionSystemPromptBuilder.Build()`. This makes creative direction data-driven: a game designer can edit the YAML without recompilation.
+
+---
+
+## File Location and Schema
+
+### File Path
+
+```
+/root/.openclaw/agents-extra/pinder/data/game-definition.yaml
+```
+
+### YAML Schema
+
+The file has exactly 7 top-level keys. All are required. All values are YAML block-scalar strings (using the `|` indicator for multi-line literal content).
+
+```yaml
+name: "Pinder"
+vision: |
+  <multi-line game vision text>
+world_description: |
+  <multi-line world rules text>
+player_role_description: |
+  <multi-line player role text>
+opponent_role_description: |
+  <multi-line opponent role text>
+meta_contract: |
+  <multi-line meta contract text>
+writing_rules: |
+  <multi-line writing rules text>
+```
+
+### Key Definitions
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | `string` | The game's display name. Value: `"Pinder"`. |
+| `vision` | `string` (multi-line) | The game's creative premise and tonal identity. Establishes what Pinder is, the comedy register, and the emotional core beneath the absurdity. |
+| `world_description` | `string` (multi-line) | The rules of Pinder's world. Describes the multiplayer structure, what characters are (sentient penises on a dating app), the stat/shadow system, and how conversations work mechanically. |
+| `player_role_description` | `string` (multi-line) | Instructions for how the LLM should generate content from the player's perspective. Covers: the player is the one initiating, their dialogue options should reflect their character build (stats, items, personality fragments), and their voice must match their texting style. |
+| `opponent_role_description` | `string` (multi-line) | Instructions for how the LLM should portray the opponent character. Covers: the opponent is another player's uploaded character being puppeted by the LLM, they maintain resistance below Interest 25, their personality comes from their own items/anatomy/fragments, and they react to game events (failures, traps, shadow taint). |
+| `meta_contract` | `string` (multi-line) | Rules the LLM must never break. Covers: never break character, never reference game mechanics explicitly in dialogue, never add content the player didn't choose, never resolve the date before Interest 25, maintain two distinct character voices throughout. |
+| `writing_rules` | `string` (multi-line) | Stylistic constraints for all LLM-generated text. Covers: texting register (not formal prose), message length limits, emoji usage conventions, no asterisk actions, comedy through character voice not narration, and the principle that strong rolls improve phrasing rather than adding ideas. |
+
+---
+
+## Content Requirements
+
+Each section must contain genuine Pinder creative direction derived from the game's design documents (primarily `design/systems/rules-v3.md` and `design/systems/character-construction.md`). The content must NOT be generic boilerplate — it must be specific to Pinder's identity as a comedy dating RPG where players are sentient penises.
+
+### `name`
+
+A single string: `"Pinder"`.
+
+### `vision`
+
+Must establish:
+- The core premise: sentient penises on a Tinder-like dating app
+- The tone: comedy first, but with genuine emotional stakes underneath the absurdity
+- The mechanical identity: RPG with dice rolls, stats, and shadows that corrupt your best qualities
+- The social contract: it's funny AND it matters — players should laugh but also feel tension when shadows grow or interest drops
+- That this is a multiplayer structure: every opponent is another real player's uploaded character, puppeted by the LLM
+
+### `world_description`
+
+Must establish:
+- Characters are sentient penises who dress up, build stats, and upload themselves to a dating server
+- The stat/shadow pair system (6 positive stats, 6 shadows that grow and penalize their paired stat)
+- The dating conversation structure: d20 rolls against opponent's defence DC, success/failure scale, interest meter (0–25)
+- The multiplayer async structure: your character exists on a server and other players encounter it independently
+- Shadows grow from in-conversation events (not player choice) and represent the character's psychological state
+- The interest meter is the conversation's health bar — Bored (1–4) risks ghosting, Date Secured (25) is victory
+
+### `player_role_description`
+
+Must establish:
+- The LLM generates 4 dialogue options per turn, each tied to one of the 6 stats
+- Options must reflect the player character's personality (assembled from items + anatomy fragments)
+- The player's texting style fragment is the voice authority — options must sound like THIS character, not generic
+- Horniness mechanics can force Rizz options (at shadow threshold ≥6, ≥12, ≥18)
+- Combo and callback opportunities should appear naturally in option content when available
+
+### `opponent_role_description`
+
+Must establish:
+- The opponent is another player's character being puppeted — their personality prompt is their bible
+- Below Interest 25, the opponent maintains resistance proportional to their current interest state
+- The opponent reacts to mechanical events: failure tiers affect their response tone, shadow taint affects their perception
+- The opponent has their own texting style that must remain distinct from the player's
+- At Date Secured (Interest 25), resistance dissolves genuinely — not abruptly, but as earned warmth
+
+### `meta_contract`
+
+Must establish:
+- Never break character — the LLM is always in-world
+- Never reference dice, DCs, stats, interest meters, or any game mechanic in dialogue text
+- Never add ideas the player didn't choose — success delivery improves phrasing, doesn't expand content
+- Never resolve the date early — Interest must reach 25 mechanically
+- Maintain two distinct character voices — the player and opponent should never sound alike
+- [ENGINE] blocks are out-of-character mechanical context — never quote or reference them in dialogue
+
+### `writing_rules`
+
+Must establish:
+- All dialogue is texting register — short messages, informal, platform-appropriate
+- Message length: typically 1–3 sentences for options, 1–4 for opponent responses
+- Emoji: use sparingly and only when it matches the character's texting style fragment
+- No asterisk actions (`*walks over*`) — this is a text-based dating app, not roleplay
+- Comedy comes from character voice, not narration or winking at the audience
+- Strong rolls sharpen phrasing; they do NOT add new ideas or topics
+- Failed deliveries corrupt the message — typos, awkward phrasing, wrong tone — proportional to failure tier
+
+---
+
+## Input/Output Examples
+
+### Input: Raw YAML file content (abbreviated)
+
+```yaml
+name: "Pinder"
+vision: |
+  Pinder is a comedy dating RPG where every character is a sentient penis
+  on a Tinder-like app. You dress up, build stats, and try to charm other
+  players' characters into going on a date — using dice rolls, real-time
+  stat checks, and an LLM that generates the actual conversation.
+  
+  The tone is absurdist comedy with genuine emotional stakes. You will laugh
+  at a mushroom-hat-wearing penis named Gerald trying to quote Dostoevsky,
+  but you will also feel the tension when his Dread shadow hits 18 and every
+  option starts sounding like a cry for help.
+world_description: |
+  Characters are sentient penises who exist on a dating server. Each has
+  6 positive stats (Charm, Rizz, Honesty, Chaos, Wit, Self-Awareness) and
+  6 shadow stats (Madness, Horniness, Denial, Fixation, Dread, Overthinking)
+  that grow during conversations and penalize their paired positive stat.
+  ...
+player_role_description: |
+  You generate dialogue options for the player character. Each turn produces
+  4 options, each tied to one of the 6 stats. Options must sound like the
+  player's character — use their texting style fragment as the voice bible.
+  ...
+opponent_role_description: |
+  You portray the opponent character — another player's uploaded creation
+  being puppeted by you. Their personality prompt is your character bible.
+  ...
+meta_contract: |
+  Never break character. Never reference dice, DCs, interest meters, or
+  any game mechanic in dialogue. Never add content the player didn't choose.
+  ...
+writing_rules: |
+  All dialogue uses texting register. Messages are short (1-3 sentences for
+  options, 1-4 for responses). No asterisk actions. Comedy through voice.
+  ...
+```
+
+### Output: Parsed by `GameDefinition.LoadFrom(yamlContent)`
+
+A `GameDefinition` instance with all 7 properties populated as non-null, non-empty strings. Each multi-line value preserves its line breaks (YAML `|` block scalar semantics: trailing newline, internal newlines preserved).
+
+```
+GameDefinition.Name           → "Pinder"
+GameDefinition.Vision         → "Pinder is a comedy dating RPG where every character is a sentient penis\non a Tinder-like app..."
+GameDefinition.WorldDescription → "Characters are sentient penises who exist on a dating server..."
+GameDefinition.PlayerRoleDescription → "You generate dialogue options for the player character..."
+GameDefinition.OpponentRoleDescription → "You portray the opponent character..."
+GameDefinition.MetaContract   → "Never break character. Never reference dice..."
+GameDefinition.WritingRules   → "All dialogue uses texting register..."
+```
+
+---
+
+## Acceptance Criteria
+
+### AC1: File exists at correct path
+
+The file MUST be created at `/root/.openclaw/agents-extra/pinder/data/game-definition.yaml`. This follows the existing data file pattern used by other Pinder data files (`traps/traps.json`, `items/starter-items.json`, `anatomy/anatomy-parameters.json`, `characters/*.json`).
+
+### AC2: All 5 sections present with Pinder-specific content
+
+All 7 YAML keys (`name`, `vision`, `world_description`, `player_role_description`, `opponent_role_description`, `meta_contract`, `writing_rules`) must be present. Note: while the issue AC says "5 sections", the contract specifies 7 keys — `name` and `writing_rules` are in addition to the 5 content sections (vision, world, player role, opponent role, meta contract). All values must contain substantive, Pinder-specific content — not placeholder text or generic game design boilerplate.
+
+### AC3: `GameDefinition.LoadFrom` can parse it successfully
+
+The YAML must be valid and parseable by `GameDefinition.LoadFrom(string yamlContent)` as defined in the #543 contract. Specifically:
+- Valid YAML syntax (no tabs, correct indentation)
+- All 7 top-level keys present as strings
+- Multi-line values use block scalar `|` syntax
+- No nested objects or arrays — all values are scalar strings
+- UTF-8 encoding, no BOM
+
+### AC4: Content reads as genuine creative direction, not boilerplate
+
+Each section must:
+- Reference Pinder-specific concepts (sentient penises, stat names, shadow names, interest states, dating app framing)
+- Use the game's tonal voice (comedy with emotional stakes)
+- Be actionable by an LLM reading it as system prompt context
+- Be internally consistent with `rules-v3.md` and `character-construction.md`
+
+### AC5: Build clean (file is data, not code)
+
+No C# code changes are required for this issue. The file is a pure data artifact. The build remains clean because no `.csproj` references this file.
+
+---
+
+## Edge Cases
+
+### Empty or whitespace-only values
+
+Not permitted. Every key must have at least one non-whitespace line of content. `GameDefinition.LoadFrom()` (implemented in #543) is expected to throw `FormatException` if any key is missing or empty.
+
+### YAML special characters in content
+
+Content may include colons (`:`), quotes, hyphens, and other characters common in English prose. Using block scalar `|` syntax avoids the need to escape these. Implementer must ensure no bare `:` on a line that could be misinterpreted as a YAML key — the `|` block scalar prevents this.
+
+### Trailing newlines
+
+YAML block scalar `|` includes a final trailing newline. This is expected behavior and `GameDefinition.LoadFrom()` should handle it (trim or preserve — that's #543's concern, not this issue's).
+
+### Line length
+
+No hard line-length limit, but lines should be wrapped at ~80–100 characters for readability in editors. This is a style guideline, not a parsing requirement.
+
+### Character encoding
+
+UTF-8 without BOM. No emoji in the YAML file itself (emoji usage is described in writing_rules but the rules text uses words, not emoji characters).
+
+---
+
+## Error Conditions
+
+Since this issue produces a data file (not code), error conditions relate to file validity:
+
+| Condition | Expected Outcome |
+|-----------|-----------------|
+| Missing key (e.g., no `meta_contract`) | `GameDefinition.LoadFrom()` throws `FormatException` — but this is a #543 concern. This issue must ensure all 7 keys are present. |
+| Invalid YAML syntax (tabs, bad indentation) | YAML parser throws. This issue must produce valid YAML. |
+| File not found at expected path | `GameDefinition.PinderDefaults` is used as fallback by #543. This issue must place the file at the correct path. |
+| Value is generic/placeholder text | Fails AC4 (content quality). Reviewer rejects. |
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status |
+|------------|------|--------|
+| Issue #543 (`GameDefinition.LoadFrom`) | Consumer — this file is parsed by #543's implementation | In this sprint (Wave 3) |
+| `rules-v3.md` (external design doc) | Content source — game rules and mechanics referenced in the YAML | Exists at `design/systems/rules-v3.md` |
+| `character-construction.md` (external design doc) | Content source — character assembly, prompts, texting style | Exists at `design/systems/character-construction.md` |
+| `risk-reward-and-hidden-depth.md` (external design doc) | Content source — combos, callbacks, tells, momentum | Exists at `design/systems/risk-reward-and-hidden-depth.md` |
+| `async-time.md` (external design doc) | Content source — multi-session, time-of-day, delay penalties | Exists at `design/systems/async-time.md` |
+
+No code dependencies. No build dependencies. This is Wave 1 (no dependencies on other sprint issues).
+
+---
+
+## Implementation Notes
+
+- This issue is **pure content authoring** — no C# code changes.
+- The implementer should read `design/systems/rules-v3.md`, `design/systems/character-construction.md`, and `design/systems/risk-reward-and-hidden-depth.md` thoroughly before writing content.
+- The file must be parseable by a standard YAML parser (YamlDotNet 16.3.0 as specified in the #543 contract).
+- The `GameDefinition.PinderDefaults` hardcoded fallback in #543 should contain equivalent content — but this YAML file is the canonical, editable source.
+- Validate the file with any YAML linter (e.g., `python3 -c "import yaml; yaml.safe_load(open('game-definition.yaml'))"`) before committing.

--- a/session-runner/ScoringPlayerAgent.cs
+++ b/session-runner/ScoringPlayerAgent.cs
@@ -13,8 +13,12 @@ namespace Pinder.SessionRunner
     /// </summary>
     public sealed class ScoringPlayerAgent : IPlayerAgent
     {
-        // Baseline fail cost approximation across failure tiers
-        private const float DefaultFailCost = 1.5f;
+        // Trap activation cost added to TropeTrap/Catastrophe/Legendary failure tiers
+        // Represents ~1.5 turns of reduced effectiveness from activated trap
+        private const float TrapActivationCost = 1.5f;
+
+        // Low success threshold below which combo bonus is further scaled down
+        private const float LowSuccessThreshold = 0.20f;
 
         // Strategic adjustment magnitudes
         private const float MomentumStreakBias = 1.0f;
@@ -122,11 +126,17 @@ namespace Pinder.SessionRunner
                     baseInterestGain = 0.0f;
                 }
 
-                float comboBonus = option.ComboName != null ? 1.0f : 0.0f;
+                // Scale combo bonus when success probability is low (<20%).
+                // A combo that fires 15% of the time is worth much less than full value.
+                float comboScale = successChance < LowSuccessThreshold
+                    ? successChance / LowSuccessThreshold
+                    : 1.0f;
+                float comboBonus = option.ComboName != null ? 1.0f * comboScale : 0.0f;
                 float expectedGainOnSuccess = baseInterestGain + riskInfo.Bonus + comboBonus;
 
-                // Step 5: Expected cost on failure
-                float failCost = DefaultFailCost;
+                // Step 5: Weighted failure cost based on miss margin distribution
+                // Accounts for trap activation on TropeTrap/Catastrophe/Legendary
+                float failCost = ComputeWeightedFailCost(need);
 
                 // Step 6: Raw EV
                 float expectedInterestGain = successChance * expectedGainOnSuccess
@@ -323,6 +333,57 @@ namespace Pinder.SessionRunner
                 case StatType.SelfAwareness: return "SA";
                 default: return s.ToString();
             }
+        }
+
+        /// <summary>
+        /// Computes weighted average failure cost based on the distribution of miss margins
+        /// across failure tiers. Includes trap activation cost for TropeTrap, Catastrophe,
+        /// and Legendary tiers. Replaces flat DefaultFailCost for more accurate EV.
+        /// </summary>
+        private static float ComputeWeightedFailCost(int need)
+        {
+            // If need <= 1, only nat1 can fail (handled by d20 min=1)
+            if (need <= 1) return 0f;
+
+            int maxFailRoll = Math.Min(need - 1, 20);
+            if (maxFailRoll <= 0) return 0f;
+
+            float totalCost = 0f;
+
+            for (int roll = 1; roll <= maxFailRoll; roll++)
+            {
+                if (roll == 1)
+                {
+                    // Nat1 → Legendary: -4 interest + trap activation
+                    totalCost += 4.0f + TrapActivationCost;
+                }
+                else
+                {
+                    int missMargin = need - roll;
+                    if (missMargin >= 10)
+                    {
+                        // Catastrophe: -3 interest + trap activation
+                        totalCost += 3.0f + TrapActivationCost;
+                    }
+                    else if (missMargin >= 6)
+                    {
+                        // TropeTrap: -2 interest + trap activation
+                        totalCost += 2.0f + TrapActivationCost;
+                    }
+                    else if (missMargin >= 3)
+                    {
+                        // Misfire: -1 interest
+                        totalCost += 1.0f;
+                    }
+                    else
+                    {
+                        // Fumble (miss 1-2): -1 interest
+                        totalCost += 1.0f;
+                    }
+                }
+            }
+
+            return totalCost / maxFailRoll;
         }
 
         private static RiskTierInfo ComputeRiskTier(int need)

--- a/tests/Pinder.Core.Tests/ScoringPlayerAgentEvTests.cs
+++ b/tests/Pinder.Core.Tests/ScoringPlayerAgentEvTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for ScoringPlayerAgent EV fix (issue #517).
+    /// Validates that combo/tell bonuses are scaled for low-success options,
+    /// and that trap cost is properly weighted by failure tier distribution.
+    /// </summary>
+    public class ScoringPlayerAgentEvTests
+    {
+        private readonly ScoringPlayerAgent _agent = new ScoringPlayerAgent();
+
+        #region Helpers
+
+        private static StatBlock MakeStats(
+            int charm = 0, int rizz = 0, int honesty = 0,
+            int chaos = 0, int wit = 0, int sa = 0,
+            int madness = 0, int horniness = 0, int denial = 0,
+            int fixation = 0, int dread = 0, int overthinking = 0)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm },
+                    { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty },
+                    { StatType.Chaos, chaos },
+                    { StatType.Wit, wit },
+                    { StatType.SelfAwareness, sa }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, madness },
+                    { ShadowStatType.Horniness, horniness },
+                    { ShadowStatType.Denial, denial },
+                    { ShadowStatType.Fixation, fixation },
+                    { ShadowStatType.Dread, dread },
+                    { ShadowStatType.Overthinking, overthinking }
+                });
+        }
+
+        private static DialogueOption MakeOption(
+            StatType stat,
+            int? callbackTurn = null,
+            string? comboName = null,
+            bool hasTellBonus = false)
+        {
+            return new DialogueOption(
+                stat, $"{stat} option",
+                callbackTurnNumber: callbackTurn,
+                comboName: comboName,
+                hasTellBonus: hasTellBonus);
+        }
+
+        private static TurnStart MakeTurn(params DialogueOption[] options)
+        {
+            return new TurnStart(
+                options,
+                new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 5));
+        }
+
+        private static PlayerAgentContext MakeContext(
+            StatBlock? player = null,
+            StatBlock? opponent = null,
+            int interest = 10,
+            InterestState state = InterestState.Interested,
+            int momentum = 0,
+            string[]? traps = null,
+            int turnNumber = 5)
+        {
+            return new PlayerAgentContext(
+                player ?? MakeStats(charm: 3, rizz: 2, honesty: 1, chaos: 2, wit: 2, sa: 1),
+                opponent ?? MakeStats(charm: 1, rizz: 1, honesty: 1, chaos: 1, wit: 1, sa: 1),
+                interest,
+                state,
+                momentum,
+                traps ?? Array.Empty<string>(),
+                0,
+                null,
+                turnNumber);
+        }
+
+        #endregion
+
+        #region AC: combo/tell scaled when success < 20%
+
+        /// <summary>
+        /// AC: option with 15% success and TropeTrap-range miss scores lower than
+        /// same option with 50% success, even when both have combo bonus.
+        /// </summary>
+        [Fact]
+        public async Task LowSuccess_WithCombo_ScoresLowerThanHighSuccess_WithCombo()
+        {
+            // Option A: high success (~55%). Player charm=3, opponent SA=0 → DC=13, need=10
+            // Option B: low success (~15%). Player rizz=0, opponent Wit=5 → DC=18, need=18
+            var player = MakeStats(charm: 3, rizz: 0);
+            var opponent = MakeStats(sa: 0, wit: 5);
+
+            var highSuccessCombo = MakeOption(StatType.Charm, comboName: "TheCombo");
+            var lowSuccessCombo = MakeOption(StatType.Rizz, comboName: "TheCombo");
+
+            var turn = MakeTurn(highSuccessCombo, lowSuccessCombo);
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // High-success option should have higher EV even with same combo
+            Assert.True(decision.Scores[0].ExpectedInterestGain > decision.Scores[1].ExpectedInterestGain,
+                $"High-success ({decision.Scores[0].SuccessChance:P0}) EV {decision.Scores[0].ExpectedInterestGain:F3} " +
+                $"should beat low-success ({decision.Scores[1].SuccessChance:P0}) EV {decision.Scores[1].ExpectedInterestGain:F3}");
+
+            // Low-success option should have NEGATIVE EV (failure cost dominates)
+            Assert.True(decision.Scores[1].ExpectedInterestGain < 0,
+                $"Low-success option EV should be negative, got {decision.Scores[1].ExpectedInterestGain:F3}");
+        }
+
+        /// <summary>
+        /// AC: combo bonus on low-success option (&lt;20%) is scaled down further,
+        /// not applied at full value.
+        /// </summary>
+        [Fact]
+        public async Task ComboBonus_ScaledDown_WhenSuccessBelow20Percent()
+        {
+            // Player SA=0, opponent Honesty=5 → DC=18, need=18 → success=15%
+            var player = MakeStats(sa: 0);
+            var opponent = MakeStats(honesty: 5);
+
+            var withCombo = MakeOption(StatType.SelfAwareness, comboName: "SomeCombo");
+            var withoutCombo = MakeOption(StatType.SelfAwareness);
+
+            var turnCombo = MakeTurn(withCombo);
+            var turnNoCombo = MakeTurn(withoutCombo);
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decisionCombo = await _agent.DecideAsync(turnCombo, context);
+            var decisionNoCombo = await _agent.DecideAsync(turnNoCombo, context);
+
+            float comboDelta = decisionCombo.Scores[0].ExpectedInterestGain
+                             - decisionNoCombo.Scores[0].ExpectedInterestGain;
+
+            // At ~15% success, combo is scaled by (0.15/0.20)=0.75, then multiplied by
+            // successChance=0.15 in the EV formula → contribution ~0.1125
+            // Without scaling, it would be 0.15 * 1.0 = 0.15
+            Assert.True(comboDelta >= 0,
+                $"Combo should still help (or be neutral), got delta={comboDelta:F4}");
+            Assert.True(comboDelta < 0.15f,
+                $"Combo delta at 15% success should be less than unscaled (0.15), got {comboDelta:F4}");
+        }
+
+        /// <summary>
+        /// AC: combo bonus at high success (&gt;=20%) is NOT scaled down.
+        /// </summary>
+        [Fact]
+        public async Task ComboBonus_NotScaled_WhenSuccessAbove20Percent()
+        {
+            // Player charm=3, opponent SA=0 → DC=13, need=10 → success=55%
+            var player = MakeStats(charm: 3);
+            var opponent = MakeStats(sa: 0);
+
+            var withCombo = MakeOption(StatType.Charm, comboName: "SomeCombo");
+            var withoutCombo = MakeOption(StatType.Charm);
+
+            var turnCombo = MakeTurn(withCombo);
+            var turnNoCombo = MakeTurn(withoutCombo);
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decisionCombo = await _agent.DecideAsync(turnCombo, context);
+            var decisionNoCombo = await _agent.DecideAsync(turnNoCombo, context);
+
+            float comboDelta = decisionCombo.Scores[0].ExpectedInterestGain
+                             - decisionNoCombo.Scores[0].ExpectedInterestGain;
+
+            // At 55% success, combo adds ~0.55 * 1.0 = ~0.55 to EV (unscaled)
+            Assert.True(comboDelta > 0.4f,
+                $"Combo at 55% success should add significant EV (~0.55), got {comboDelta:F4}");
+        }
+
+        #endregion
+
+        #region AC: TropeTrap range failure cost
+
+        /// <summary>
+        /// AC: When miss margin would land in TropeTrap range (6-9),
+        /// trap activation cost is included in the failure EV.
+        /// </summary>
+        [Fact]
+        public async Task TropeTrapRange_HigherFailCost_ThanFumbleRange()
+        {
+            // Option A: need=3 → failures are all Fumble (miss 1-2). Low fail cost.
+            // Option B: need=10 → failures span Fumble through TropeTrap. Higher fail cost.
+            // Both have same success chance area, but B's failures are more costly.
+            var playerA = MakeStats(charm: 10);
+            var playerB = MakeStats(rizz: 3);
+            var opponent = MakeStats(sa: 0, wit: 0); // DC=13 for both
+
+            // Charm: need=13-10=3, success=90%, failures are miss 1-2 (Fumble only)
+            // Rizz: need=13-3=10, success=55%, failures span all tiers up to TropeTrap
+            var turnA = MakeTurn(MakeOption(StatType.Charm));
+            var turnB = MakeTurn(MakeOption(StatType.Rizz));
+            var contextA = MakeContext(player: playerA, opponent: opponent);
+            var contextB = MakeContext(player: playerB, opponent: opponent);
+
+            var decisionA = await _agent.DecideAsync(turnA, contextA);
+            var decisionB = await _agent.DecideAsync(turnB, contextB);
+
+            // A has higher success and lower fail cost → much higher EV
+            Assert.True(decisionA.Scores[0].ExpectedInterestGain > decisionB.Scores[0].ExpectedInterestGain,
+                $"Low-need option EV ({decisionA.Scores[0].ExpectedInterestGain:F3}) " +
+                $"should beat high-need option EV ({decisionB.Scores[0].ExpectedInterestGain:F3})");
+        }
+
+        /// <summary>
+        /// AC: High-need option (need=18) has failures mostly in Catastrophe/TropeTrap range,
+        /// resulting in very high weighted failure cost.
+        /// </summary>
+        [Fact]
+        public async Task HighNeed_WeightedFailCost_MakesEvStronglyNegative()
+        {
+            // Player SA=0, opponent Honesty=5 → DC=18, need=18 → success=15%
+            // Most failures (rolls 2-17) miss by 1..17 → spans all tiers including Catastrophe
+            var player = MakeStats(sa: 0);
+            var opponent = MakeStats(honesty: 5);
+
+            var turn = MakeTurn(MakeOption(StatType.SelfAwareness));
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decision = await _agent.DecideAsync(turn, context);
+
+            // EV should be strongly negative: 85% chance of failure with high-tier costs
+            Assert.True(decision.Scores[0].ExpectedInterestGain < -1.0f,
+                $"High-need option should have strongly negative EV, got {decision.Scores[0].ExpectedInterestGain:F3}");
+        }
+
+        #endregion
+
+        #region AC: 15% success + TropeTrap < 50% success (integration)
+
+        /// <summary>
+        /// AC: Unit test with 15% success and TropeTrap-range miss scores
+        /// lower than same option with 50% success.
+        /// </summary>
+        [Fact]
+        public async Task Option15Pct_TropeTrapRange_ScoresLowerThan_Option50Pct()
+        {
+            // Option with ~15% success: need=18 (DC=18, mod=0)
+            // Failures at need=18 include TropeTrap range (miss 6-9 for rolls 9-12)
+            var playerLow = MakeStats(charm: 0);
+            var opponentHigh = MakeStats(sa: 5); // DC=18
+
+            // Option with ~50% success: need=11 (DC=13, mod=2)
+            var playerHigh = MakeStats(charm: 2);
+            var opponentLow = MakeStats(sa: 0); // DC=13
+
+            var turnLow = MakeTurn(MakeOption(StatType.Charm));
+            var turnHigh = MakeTurn(MakeOption(StatType.Charm));
+            var contextLow = MakeContext(player: playerLow, opponent: opponentHigh);
+            var contextHigh = MakeContext(player: playerHigh, opponent: opponentLow);
+
+            var decisionLow = await _agent.DecideAsync(turnLow, contextLow);
+            var decisionHigh = await _agent.DecideAsync(turnHigh, contextHigh);
+
+            // 15% success should score much lower than 50% success
+            Assert.True(decisionLow.Scores[0].Score < decisionHigh.Scores[0].Score,
+                $"15% success EV ({decisionLow.Scores[0].Score:F3}) should be lower than " +
+                $"50% success EV ({decisionHigh.Scores[0].Score:F3})");
+
+            // 15% option should have negative EV
+            Assert.True(decisionLow.Scores[0].ExpectedInterestGain < 0,
+                $"15% success option should have negative EV, got {decisionLow.Scores[0].ExpectedInterestGain:F3}");
+
+            // 50% option should have positive EV
+            Assert.True(decisionHigh.Scores[0].ExpectedInterestGain > 0,
+                $"50% success option should have positive EV, got {decisionHigh.Scores[0].ExpectedInterestGain:F3}");
+        }
+
+        /// <summary>
+        /// AC: Even with tell+combo bonuses, a near-zero success option should NOT
+        /// have positive EV that masks trap cost.
+        /// </summary>
+        [Fact]
+        public async Task LowSuccess_WithTellAndCombo_StillNegativeEv()
+        {
+            // Player SA=0, opponent Honesty=5 → DC=18
+            // With tell (+2): need=18-2=16 → success=25%
+            // Without tell: need=18 → success=15%
+            var player = MakeStats(sa: 0);
+            var opponent = MakeStats(honesty: 5);
+
+            var optionWithBonuses = MakeOption(StatType.SelfAwareness,
+                comboName: "RecoveryCombo", hasTellBonus: true);
+            var optionPlain = MakeOption(StatType.SelfAwareness);
+
+            var turnBonuses = MakeTurn(optionWithBonuses);
+            var turnPlain = MakeTurn(optionPlain);
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decisionBonuses = await _agent.DecideAsync(turnBonuses, context);
+            var decisionPlain = await _agent.DecideAsync(turnPlain, context);
+
+            // With tell, success raises to ~25% but failure cost is still heavy
+            // The tell+combo should improve EV but NOT make it positive at this difficulty
+            Assert.True(decisionBonuses.Scores[0].ExpectedInterestGain <
+                         decisionPlain.Scores[0].ExpectedInterestGain + 1.5f,
+                "Tell+combo should not inflate EV by more than 1.5 at this difficulty");
+
+            // Plain option (no bonuses) should have strongly negative EV
+            Assert.True(decisionPlain.Scores[0].ExpectedInterestGain < -1.0f,
+                $"Plain low-success option EV should be < -1.0, got {decisionPlain.Scores[0].ExpectedInterestGain:F3}");
+        }
+
+        #endregion
+
+        #region Regression: high-success options unaffected
+
+        /// <summary>
+        /// Combo bonus at high success is applied normally (no scaling).
+        /// </summary>
+        [Fact]
+        public async Task HighSuccess_ComboBonus_AppliedNormally()
+        {
+            // Player charm=8, opponent SA=0 → DC=13, need=5 → success=80%
+            var player = MakeStats(charm: 8);
+            var opponent = MakeStats(sa: 0);
+
+            var withCombo = MakeOption(StatType.Charm, comboName: "SomeCombo");
+            var withoutCombo = MakeOption(StatType.Charm);
+
+            var turnCombo = MakeTurn(withCombo);
+            var turnNoCombo = MakeTurn(withoutCombo);
+            var context = MakeContext(player: player, opponent: opponent);
+
+            var decisionCombo = await _agent.DecideAsync(turnCombo, context);
+            var decisionNoCombo = await _agent.DecideAsync(turnNoCombo, context);
+
+            // At 80% success, combo adds ~0.8 to EV
+            float comboDelta = decisionCombo.Scores[0].ExpectedInterestGain
+                             - decisionNoCombo.Scores[0].ExpectedInterestGain;
+            Assert.True(comboDelta > 0.7f,
+                $"Combo at 80% success should add ~0.8 to EV, got {comboDelta:F4}");
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Refs #545

## Summary

Specification document for issue #545 — creating the `game-definition.yaml` data file containing Pinder's creative direction (game vision, world description, character role descriptions, meta contract, and writing rules).

## Spec Location

`docs/specs/issue-545-spec.md`

## DoD Evidence
**Branch:** issue-545-write-spec-document-create-game-definiti
**Commit:** ddc2da4
**Spec file:** docs/specs/issue-545-spec.md — covers all 5 AC items, schema definition, content requirements per section, edge cases, error conditions, and dependencies.
