### PR TITLE
[Issue #544] Add [ENGINE] injection blocks to LLM calls — dice results and game events as narrative

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -865,3 +865,4 @@
 {"ts":"2026-04-05T20:49:34.779Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
 {"ts":"2026-04-05T20:59:35.867Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
 {"ts":"2026-04-05T21:09:37.333Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
+{"ts":"2026-04-05T21:16:46+00:00","agent":"backend-engineer","issue":"544","component":"","action":"completed","correlationId":"sprint-sprint-decay256-pinder-core-8-1775410352776-issue-544-backend-engineer-a0","detail":"PR opened — correlationId: sprint-sprint-decay256-pinder-core-8-1775410352776-issue-544-backend-engineer-a0","commit":"535e144"}

--- a/agent.log
+++ b/agent.log
@@ -861,3 +861,7 @@
 {"ts":"2026-04-05T20:39:33.637Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
 {"ts":"2026-04-05T20:45:06+00:00","agent":"test-engineer","issue":"543","component":"","action":"started","detail":"Starting: Write tests: Build session system prompt","commit":null}
 {"ts":"2026-04-05T20:46:27+00:00","agent":"test-engineer","issue":"543","component":"","action":"completed","correlationId":"test-engineer-sprint-decay256-pinder-core-8-1775410352776-issue-543","detail":"PR #569 opened — 45 spec-driven tests for GameDefinition + SessionSystemPromptBuilder — correlationId: test-engineer-sprint-decay256-pinder-core-8-1775410352776-issue-543","commit":"ad9f9a1"}
+{"ts":"2026-04-05T20:49:25+00:00","agent":"doc-merge-agent","issue":"543","action":"completed","correlationId":"doc-merge-sprint-decay256-pinder-core-8-1775410352776-issue-543","detail":"Module doc updated — correlationId: doc-merge-sprint-decay256-pinder-core-8-1775410352776-issue-543"}
+{"ts":"2026-04-05T20:49:34.779Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
+{"ts":"2026-04-05T20:59:35.867Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}
+{"ts":"2026-04-05T21:09:37.333Z","agent":"progress-auditor","issue":"sprint","component":"orchestrator","action":"audit","detail":"All healthy","commit":null}

--- a/docs/modules/llm-adapters.md
+++ b/docs/modules/llm-adapters.md
@@ -25,6 +25,11 @@ The LLM Adapters module (`Pinder.LlmAdapters`) provides prompt templates and API
 | `Issue541_StatefulConversationTests.cs` (test) | Integration tests for stateful conversation mode — multi-turn accumulation, error recovery, stateless fallback |
 | `Issue541_AdditionalTests.cs` (test) | Additional coverage for snapshot isolation, role correctness, message ordering, system block caching, and API failure resilience |
 | `Issue542_StatefulSession_TestEngineerTests.cs` (test) | Spec-driven tests for `IStatefulLlmAdapter` interface shape, `GameSession` constructor stateful detection, system prompt format, and backward compatibility |
+| `GameDefinition.cs` | Sealed data carrier for game-level creative direction (7 string properties); includes `LoadFrom(yamlContent)` YAML parser and `PinderDefaults` hardcoded fallback |
+| `SessionSystemPromptBuilder.cs` | Static builder that assembles a 5-section session system prompt from character profiles and a `GameDefinition` |
+| `GameDefinitionTests.cs` (test) | Unit tests for `GameDefinition` constructor, `LoadFrom` YAML parsing (valid, invalid, missing keys, null values, extra keys), and `PinderDefaults` |
+| `SessionSystemPromptBuilderTests.cs` (test) | Unit tests for `SessionSystemPromptBuilder.Build` output structure, section ordering, null handling, and defaults fallback |
+| `Issue543_SessionSystemPromptSpecTests.cs` (test) | 45 spec-driven tests covering all acceptance criteria for `GameDefinition` and `SessionSystemPromptBuilder` |
 
 ## API / Public Interface
 
@@ -97,6 +102,42 @@ Accumulates user/assistant messages for stateful multi-turn conversations with t
 - **`HasActiveConversation`** (`bool`, read-only) — `true` when a `ConversationSession` is active; `false` otherwise. When `true`, all four `ILlmAdapter` methods route through the accumulated session.
 - **`StartConversation(string systemPrompt)`** — Creates a new `ConversationSession` and stores it in the internal `_session` field. Replaces any existing session (no error). Throws `ArgumentException` if `systemPrompt` is null or whitespace. Implements `IStatefulLlmAdapter.StartConversation`.
 
+### `GameDefinition` (public sealed class)
+
+Data carrier for game-level creative direction. Parsed from YAML or provided via hardcoded defaults. All properties are non-null strings set at construction.
+
+- **`Name`** (`string`) — Game name (e.g. "Pinder").
+- **`Vision`** (`string`) — Creative brief: what the game is, tone, goal.
+- **`WorldDescription`** (`string`) — World setting description.
+- **`PlayerRoleDescription`** (`string`) — Player character role description.
+- **`OpponentRoleDescription`** (`string`) — Opponent character role description.
+- **`MetaContract`** (`string`) — Immersion rules: never break character, [ENGINE] blocks as stage directions.
+- **`WritingRules`** (`string`) — Writing style rules: texting register, brevity, character voice fidelity.
+- **`GameDefinition(string name, string vision, string worldDescription, string playerRoleDescription, string opponentRoleDescription, string metaContract, string writingRules)`** — Constructor. Throws `ArgumentNullException` if any argument is null. Empty strings are allowed.
+- **`LoadFrom(string yamlContent)`** (`static`) — Parses a YAML string into a `GameDefinition`. Maps keys: `name`, `vision`, `world_description`, `player_role_description`, `opponent_role_description`, `meta_contract`, `writing_rules`. Extra YAML keys are ignored. Throws `ArgumentNullException` if `yamlContent` is null. Throws `FormatException` if YAML is unparseable, a required key is missing, or a key has a null value. Block scalar newlines are preserved as-is from the YAML parser (no trimming). Uses `YamlDotNet 16.3.0` with `UnderscoredNamingConvention`.
+- **`PinderDefaults`** (`static GameDefinition`) — Hardcoded fallback with all 7 fields populated with Pinder-specific creative direction: comedy dating RPG, sentient penises, absurdist world, d20 mechanics, shadow stats, texting register, immersion rules. Usable in production playtests.
+
+### `SessionSystemPromptBuilder` (public static class)
+
+Assembles a session-level system prompt from character profiles and game definition data.
+
+```csharp
+public static string Build(
+    string playerPrompt,
+    string opponentPrompt,
+    GameDefinition? gameDef = null);
+```
+
+- Returns a single string with 5 sections delimited by `== SECTION NAME ==` headers:
+  1. **== GAME VISION ==** — from `gameDef.Vision`
+  2. **== WORLD RULES ==** — from `gameDef.WorldDescription`
+  3. **== PLAYER CHARACTER ==** — `playerPrompt` verbatim
+  4. **== OPPONENT CHARACTER ==** — `opponentPrompt` verbatim
+  5. **== META CONTRACT ==** — `gameDef.MetaContract` + `gameDef.WritingRules` concatenated
+- Each section body is trimmed of trailing whitespace via `TrimEnd()`.
+- When `gameDef` is `null`, `GameDefinition.PinderDefaults` is used.
+- Throws `ArgumentNullException` if `playerPrompt` or `opponentPrompt` is null. Empty strings are allowed.
+
 ### Tell Category Mappings (in `OpponentResponseInstruction`)
 
 The prompt includes an explicit "ONLY" constraint with 10 behavior-to-stat mappings:
@@ -126,6 +167,7 @@ The prompt includes an explicit "ONLY" constraint with 10 behavior-to-stat mappi
 - **Success delivery: sharpen, not expand:** `SuccessDeliveryInstruction` (§3.3) uses margin-based tiers (1–4 clean, 5–9 strong, 10+ critical/Nat 20) aligned with `SuccessScale`. The strong tier allows sharpening word choice and adding at most ONE word or phrase to make the existing sentiment more precise, but explicitly prohibits adding new sentences or ideas not in the intended message. A counterpart rule enforces that every idea in the delivered message maps back to the intended message. This replaced an earlier version that used misaligned bands (1–5, 6–10) and a "small flourish" instruction that caused LLMs to inject new content.
 - **Failure degradation legibility:** When a player's roll fails, `OpponentContext.DeliveryTier` (set from `rollResult.Tier` in `GameSession.ResolveTurnAsync`) carries the `FailureTier` enum value into `BuildOpponentPrompt`. The method injects a "FAILURE CONTEXT" section with tier-specific guidance from `GetOpponentReactionGuidance()`, so the opponent LLM reacts proportionally to how badly the message was corrupted — from slight coolness (Fumble) to secondhand embarrassment (Legendary). Guidance text avoids fourth-wall-breaking language (no "failed", "rolled", etc.). On success (`FailureTier.None`), no failure section is injected. Note: the spec proposed a `PromptTemplates.GetOpponentFailureGuidance()` method and "DELIVERY NOTE" section name; the implementation places the method on `SessionDocumentBuilder.GetOpponentReactionGuidance()` and uses the section name "FAILURE CONTEXT".
 - **Stateful conversation mode:** `AnthropicLlmAdapter` supports an optional stateful mode activated by `StartConversation(systemPrompt)`. When active (`HasActiveConversation == true`), all four `ILlmAdapter` methods follow a shared pattern: (1) build user content via `SessionDocumentBuilder` (same as stateless), (2) append user message to `ConversationSession`, (3) build request via `_session.BuildRequest()` (includes system blocks + ALL accumulated messages), (4) send via `_client.SendMessagesAsync()`, (5) append raw assistant response to session, (6) parse and return. System blocks come from the `ConversationSession` (set at construction), not from `CacheBlockBuilder`. When no session is active, all methods execute the original stateless code path with no conditional logic overhead. The Anthropic Messages API is stateless (full history must be sent each call), so `ConversationSession` accumulates messages client-side. Messages grow unbounded within a session (acceptable for ~20-turn games within Anthropic's 200k token window). `ConversationSession` does not enforce user/assistant alternation — the caller is responsible. The class is not thread-safe; it is designed for sequential use within one `GameSession`.
+- **Session system prompt assembly:** `SessionSystemPromptBuilder.Build` produces a structured 5-section system prompt combining game-level creative direction (`GameDefinition`) with per-character profile prompts. This replaces the placeholder concatenation (player + `\n\n---\n\n` + opponent) used in the initial `GameSession` wiring (#542). The output is passed to `IStatefulLlmAdapter.StartConversation()` to initialize a stateful conversation session. `GameDefinition` can be loaded from a YAML file via `LoadFrom()` or use `PinderDefaults` as a hardcoded fallback. The YAML parsing uses `YamlDotNet 16.3.0` (same version as `Pinder.Rules`), added only to `Pinder.LlmAdapters.csproj` — `Pinder.Core` remains dependency-free.
 - **Provider abstraction:** The Anthropic-specific code is isolated in its own subdirectory. The adapter pattern allows swapping LLM providers without changing prompt templates or game logic.
 
 ## Change Log
@@ -141,3 +183,4 @@ The prompt includes an explicit "ONLY" constraint with 10 behavior-to-stat mappi
 | 2026-04-05 | #545 | Game definition YAML content validation — Added `GameDefinitionYamlContentTests.cs` (30 tests) in `Pinder.Rules.Tests`. Tests validate that `data/game-definition.yaml` exists, is valid YAML (no tabs, no BOM, all scalar strings, exactly 7 keys), and contains Pinder-specific creative content in all sections (vision, world_description, player_role_description, opponent_role_description, meta_contract, writing_rules). Each section is checked for required domain concepts (e.g. shadow growth, d20 rolls, 4 dialogue options, resistance, ENGINE blocks, asterisk prohibition). The YAML file itself lives outside the repo at `/root/.openclaw/agents-extra/pinder/data/game-definition.yaml` and is consumed by `GameDefinition.LoadFrom()` (#543). No C# production code changed. |
 | 2026-04-05 | #541 | Stateful conversation mode — Added `ConversationSession` class (`Pinder.LlmAdapters`) that accumulates user/assistant `Message` objects and builds `MessagesRequest` with cached system blocks (ephemeral `CacheControl`) + full message history snapshot. `AnthropicLlmAdapter` gains `StartConversation(string systemPrompt)` and `HasActiveConversation` property. When active, all four `ILlmAdapter` methods (`GetDialogueOptionsAsync`, `DeliverMessageAsync`, `GetOpponentResponseAsync`, `GetInterestChangeBeatAsync`) append to and read from the session instead of building fresh single-message requests. Stateless fallback is preserved when no session is active. `ILlmAdapter` interface unchanged. Tests: `ConversationSessionTests.cs` (16), `AnthropicLlmAdapterStatefulTests.cs` (12), `Issue541_StatefulConversationTests.cs`, `Issue541_AdditionalTests.cs`. |
 | 2026-04-05 | #542 | `IStatefulLlmAdapter` interface + GameSession wiring — New `IStatefulLlmAdapter` interface in `Pinder.Core.Interfaces` formalizes `StartConversation(string)` and `HasActiveConversation` as a sub-interface of `ILlmAdapter`. `AnthropicLlmAdapter` class declaration changed from `ILlmAdapter` to `IStatefulLlmAdapter`. `GameSession` 6-parameter constructor now checks `_llm is IStatefulLlmAdapter` and, if true, builds a system prompt from both character profiles (player + `\n\n---\n\n` + opponent) and calls `StartConversation`. `NullLlmAdapter` unchanged — stateless path preserved. Tests: `Issue542_StatefulSession_TestEngineerTests.cs`. |
+| 2026-04-05 | #543 | Session system prompt builder — Added `GameDefinition` sealed class (7 read-only string properties, `LoadFrom(yamlContent)` YAML parser, `PinderDefaults` hardcoded fallback) and `SessionSystemPromptBuilder` static class (`Build` method producing 5-section `== SECTION NAME ==` delimited prompt from character profiles + game definition). `YamlDotNet 16.3.0` added to `Pinder.LlmAdapters.csproj`. Tests: `GameDefinitionTests.cs`, `SessionSystemPromptBuilderTests.cs`, `Issue543_SessionSystemPromptSpecTests.cs` (45 spec-driven tests). |

--- a/src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj
+++ b/src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Pinder.Core\Pinder.Core.csproj" />
+    <ProjectReference Include="..\Pinder.Rules\Pinder.Rules.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -246,5 +246,69 @@ Rules:
         /// <summary>Legendary (Nat 1): maximum cringe response.</summary>
         internal const string OpponentReactionLegendary =
             "Their last message was spectacularly bad — the kind of message you screenshot and send to your friends. Your response reflects genuine shock, confusion, or secondhand embarrassment. The temperature in this conversation just dropped to freezing. Do NOT narrate your reaction. Just react.";
+
+        // ── Interest narrative bands for [ENGINE — OPPONENT] blocks ──
+
+        /// <summary>Interest 1-4: reconsidering.</summary>
+        internal const string InterestNarrative_1_4 =
+            "Reconsidering. Something went wrong.";
+
+        /// <summary>Interest 5-9: skeptical.</summary>
+        internal const string InterestNarrative_5_9 =
+            "Skeptical. Still testing.";
+
+        /// <summary>Interest 10-14: engaged but not sold.</summary>
+        internal const string InterestNarrative_10_14 =
+            "Engaged but not sold. Evaluating.";
+
+        /// <summary>Interest 15-20: interested but holding back.</summary>
+        internal const string InterestNarrative_15_20 =
+            "Interested but holding back. Close.";
+
+        /// <summary>Interest 21-24: basically sold.</summary>
+        internal const string InterestNarrative_21_24 =
+            "Basically sold. They can still blow it.";
+
+        /// <summary>Interest 25: resistance dissolved.</summary>
+        internal const string InterestNarrative_25 =
+            "The resistance dissolved.";
+
+        /// <summary>
+        /// Returns the interest narrative string for a given interest level.
+        /// Six configurable bands as specified in §544.
+        /// </summary>
+        internal static string GetInterestNarrative(int interest)
+        {
+            if (interest >= 25) return InterestNarrative_25;
+            if (interest >= 21) return InterestNarrative_21_24;
+            if (interest >= 15) return InterestNarrative_15_20;
+            if (interest >= 10) return InterestNarrative_10_14;
+            if (interest >= 5) return InterestNarrative_5_9;
+            if (interest >= 1) return InterestNarrative_1_4;
+            return "Unmatched. The conversation is over.";
+        }
+
+        // ── [ENGINE] block format templates ──
+
+        /// <summary>[ENGINE — Turn N] injection block for options generation.</summary>
+        internal const string EngineOptionsBlock =
+@"[ENGINE — Turn {turn}]
+{player_name} is deciding what to send next.
+{game_state}
+Generate 4 options for what {player_name} might send, given the conversation above.
+Format: OPTION_A: [message] OPTION_B: [message] etc.";
+
+        /// <summary>[ENGINE — DELIVERY] injection block for message delivery.</summary>
+        internal const string EngineDeliveryBlock =
+@"[ENGINE — DELIVERY]
+Player chose: '{chosen_option}'
+Dice result: {roll_context}
+Write the message {player_name} actually sends, given the above.";
+
+        /// <summary>[ENGINE — OPPONENT] injection block for opponent response.</summary>
+        internal const string EngineOpponentBlock =
+@"[ENGINE — OPPONENT]
+{opponent_name} is at Interest {interest}/25. {interest_narrative}
+Write {opponent_name}'s response.";
     }
 }

--- a/src/Pinder.LlmAdapters/RollContextBuilder.cs
+++ b/src/Pinder.LlmAdapters/RollContextBuilder.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Rolls;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Builds narrative roll context strings for [ENGINE — DELIVERY] blocks.
+    /// Reads flavor text from enriched YAML rule entries when available,
+    /// falling back to hardcoded defaults.
+    /// </summary>
+    public sealed class RollContextBuilder
+    {
+        private readonly Dictionary<string, string> _flavorById;
+
+        // ── Hardcoded fallback narratives ──
+
+        internal static readonly string FallbackCleanSuccess =
+            "The message landed. Deliver it as intended.";
+
+        internal static readonly string FallbackStrongSuccess =
+            "The message landed well. Sharpen the phrasing — it hits harder than intended.";
+
+        internal static readonly string FallbackCriticalSuccess =
+            "The best version of this message. It lands perfectly.";
+
+        internal static readonly string FallbackNat20 =
+            "Legendary success. The best thing anyone has ever said on this app.";
+
+        internal static readonly string FallbackFumble =
+            "Miss by 1-2. Slight fumble — right words, flat delivery.";
+
+        internal static readonly string FallbackMisfire =
+            "Miss by 3-5. The message went sideways — intent guessable but execution off.";
+
+        internal static readonly string FallbackTropeTrap =
+            "Miss by 6-9. Trope trap activated — the smoothness cracked, trying too hard showed.";
+
+        internal static readonly string FallbackCatastrophe =
+            "Miss by 10+. Spectacular disaster — the worst version of this message came out.";
+
+        internal static readonly string FallbackLegendary =
+            "Nat 1. Maximum humiliation. Something that has never happened on this app before.";
+
+        /// <summary>
+        /// Creates a RollContextBuilder with no YAML data (uses only hardcoded fallbacks).
+        /// </summary>
+        public RollContextBuilder()
+        {
+            _flavorById = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Creates a RollContextBuilder that extracts flavor text from enriched YAML entries.
+        /// Entries are expected to have table rows with "What Happens To Your Message" or "What Happens" columns.
+        /// Falls back to hardcoded defaults for any missing entries.
+        /// </summary>
+        /// <param name="yamlEntries">
+        /// Parsed rule entries indexed by id. Expects ids like "§7.fail-tier.fumble", "§7.success-scale.1-4", etc.
+        /// </param>
+        public RollContextBuilder(IReadOnlyDictionary<string, string> yamlEntries)
+        {
+            _flavorById = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (yamlEntries != null)
+            {
+                foreach (var kvp in yamlEntries)
+                {
+                    _flavorById[kvp.Key] = kvp.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a RollContextBuilder by extracting flavor text from a RuleBook.
+        /// Looks for table rows in §7 failure/success entries with descriptive text.
+        /// </summary>
+        /// <param name="ruleBook">A loaded RuleBook from rules-v3-enriched.yaml.</param>
+        /// <returns>A configured RollContextBuilder instance.</returns>
+        public static RollContextBuilder FromRuleBook(Pinder.Rules.RuleBook ruleBook)
+        {
+            if (ruleBook == null) throw new ArgumentNullException(nameof(ruleBook));
+
+            var flavors = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // Extract description text from enriched YAML entries
+            var failureIds = new[]
+            {
+                "§7.fail-tier.fumble",
+                "§7.fail-tier.misfire",
+                "§7.fail-tier.trope-trap",
+                "§7.fail-tier.catastrophe",
+                "§7.fail-tier.legendary-fail"
+            };
+
+            var successIds = new[]
+            {
+                "§7.success-scale.1-4",
+                "§7.success-scale.5-9",
+                "§7.success-scale.10plus",
+                "§7.success-scale.nat-20"
+            };
+
+            foreach (var id in failureIds)
+            {
+                var entry = ruleBook.GetById(id);
+                if (entry != null && !string.IsNullOrEmpty(entry.Description))
+                {
+                    flavors[id] = entry.Description;
+                }
+            }
+
+            foreach (var id in successIds)
+            {
+                var entry = ruleBook.GetById(id);
+                if (entry != null && !string.IsNullOrEmpty(entry.Description))
+                {
+                    flavors[id] = entry.Description;
+                }
+            }
+
+            return new RollContextBuilder(flavors);
+        }
+
+        /// <summary>
+        /// Gets the narrative roll context string for a successful roll.
+        /// </summary>
+        /// <param name="beatDcBy">How much the roll beat the DC by (positive).</param>
+        /// <param name="isNat20">Whether the roll was a natural 20.</param>
+        /// <returns>A narrative string describing how the message should land.</returns>
+        public string GetSuccessContext(int beatDcBy, bool isNat20)
+        {
+            if (isNat20)
+            {
+                return _flavorById.TryGetValue("§7.success-scale.nat-20", out var nat20)
+                    ? nat20 : FallbackNat20;
+            }
+
+            if (beatDcBy >= 10)
+            {
+                return _flavorById.TryGetValue("§7.success-scale.10plus", out var crit)
+                    ? crit : FallbackCriticalSuccess;
+            }
+
+            if (beatDcBy >= 5)
+            {
+                return _flavorById.TryGetValue("§7.success-scale.5-9", out var strong)
+                    ? strong : FallbackStrongSuccess;
+            }
+
+            return _flavorById.TryGetValue("§7.success-scale.1-4", out var clean)
+                ? clean : FallbackCleanSuccess;
+        }
+
+        /// <summary>
+        /// Gets the narrative roll context string for a failed roll.
+        /// </summary>
+        /// <param name="tier">The failure tier from the roll result.</param>
+        /// <returns>A narrative string describing what went wrong.</returns>
+        public string GetFailureContext(FailureTier tier)
+        {
+            switch (tier)
+            {
+                case FailureTier.Fumble:
+                    return _flavorById.TryGetValue("§7.fail-tier.fumble", out var fumble)
+                        ? fumble : FallbackFumble;
+                case FailureTier.Misfire:
+                    return _flavorById.TryGetValue("§7.fail-tier.misfire", out var misfire)
+                        ? misfire : FallbackMisfire;
+                case FailureTier.TropeTrap:
+                    return _flavorById.TryGetValue("§7.fail-tier.trope-trap", out var trap)
+                        ? trap : FallbackTropeTrap;
+                case FailureTier.Catastrophe:
+                    return _flavorById.TryGetValue("§7.fail-tier.catastrophe", out var cat)
+                        ? cat : FallbackCatastrophe;
+                case FailureTier.Legendary:
+                    return _flavorById.TryGetValue("§7.fail-tier.legendary-fail", out var leg)
+                        ? leg : FallbackLegendary;
+                default:
+                    return "A failure has occurred.";
+            }
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -10,11 +10,16 @@ namespace Pinder.LlmAdapters
     /// <summary>
     /// Builds the user-message content for each of the 4 ILlmAdapter method calls.
     /// Pure static utility — no I/O, no state, no async.
+    ///
+    /// Sprint 12+: Uses compact [ENGINE] injection blocks that translate game
+    /// mechanics into narrative for the LLM. Each block type provides exactly
+    /// the information the LLM needs for that call.
     /// </summary>
     public static class SessionDocumentBuilder
     {
         /// <summary>
-        /// Builds the user-message content for GetDialogueOptionsAsync (§3.2).
+        /// Builds the user-message content for GetDialogueOptionsAsync.
+        /// Uses [ENGINE — Turn N] injection block format.
         /// </summary>
         public static string BuildDialogueOptionsPrompt(DialogueContext context)
         {
@@ -26,7 +31,6 @@ namespace Pinder.LlmAdapters
             var sb = new StringBuilder();
 
             // Opponent profile as informational context (not system identity)
-            // so the LLM knows what kind of messages would land with this opponent
             if (!string.IsNullOrWhiteSpace(context.OpponentPrompt))
             {
                 sb.AppendLine($"OPPONENT PROFILE (for context — this is who you are talking to, NOT who you are):");
@@ -34,100 +38,97 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine();
             }
 
-            sb.AppendLine("CONVERSATION HISTORY");
+            // Conversation history
             AppendConversationHistory(sb, context.ConversationHistory, playerName);
-
             sb.AppendLine();
-            sb.AppendLine("OPPONENT'S LAST MESSAGE");
-            sb.AppendLine($"\"{context.OpponentLastMessage}\"");
 
-            sb.AppendLine();
-            sb.AppendLine("GAME STATE");
-            sb.AppendLine($"- Turn: {context.CurrentTurn}");
+            // Game state summary for the ENGINE block
+            var gameState = new StringBuilder();
+            gameState.AppendLine($"Interest: {context.CurrentInterest}/25 — {GetInterestLabel(context.CurrentInterest)}");
 
-            // Interest state label
-            string interestLabel = context.CurrentInterest >= 21 ? "Almost There \U0001f525"
-                : context.CurrentInterest >= 16 ? "Very Into It \U0001f60d (player has advantage)"
-                : context.CurrentInterest >= 10 ? "Interested \U0001f60a"
-                : context.CurrentInterest >= 5  ? "Lukewarm \U0001f914"
-                : context.CurrentInterest >= 1  ? "Bored \U0001f610 (player has disadvantage)"
-                : "Unmatched \U0001f480";
-            sb.AppendLine($"- Interest: {context.CurrentInterest}/25 — {interestLabel}");
-
-            if (context.ActiveTraps.Count == 0)
+            if (context.ActiveTraps.Count > 0)
             {
-                sb.AppendLine("- Active traps: none");
-            }
-            else
-            {
-                sb.AppendLine($"- Active traps: {string.Join(", ", context.ActiveTraps)}");
+                gameState.AppendLine($"Active traps: {string.Join(", ", context.ActiveTraps)}");
             }
 
             if (context.ActiveTrapInstructions != null && context.ActiveTrapInstructions.Length > 0)
             {
-                sb.AppendLine("ACTIVE TRAP INSTRUCTIONS (taint ALL generated options regardless of stat):");
+                gameState.AppendLine("ACTIVE TRAP INSTRUCTIONS (taint ALL generated options regardless of stat):");
                 foreach (var instruction in context.ActiveTrapInstructions)
-                    sb.AppendLine(instruction);
+                    gameState.AppendLine(instruction);
             }
 
             if (context.HorninessLevel >= 6)
             {
-                sb.AppendLine($"- Horniness level: {context.HorninessLevel}/10 (Rizz options are more prominent, slightly too forward)");
+                gameState.AppendLine($"Horniness: {context.HorninessLevel}/10 — Rizz options more prominent, slightly too forward.");
             }
             if (context.RequiresRizzOption)
             {
-                sb.AppendLine("- \U0001f525 REQUIRED: Include at least one Rizz option — Horniness is forcing it into the lineup.");
+                gameState.AppendLine("\U0001f525 REQUIRED: Include at least one Rizz option.");
             }
 
-            string dialogueTaint = BuildShadowTaintBlock(context.ShadowThresholds);
-            if (!string.IsNullOrEmpty(dialogueTaint))
+            string shadowTaint = BuildShadowTaintBlock(context.ShadowThresholds);
+            if (!string.IsNullOrEmpty(shadowTaint))
             {
-                sb.AppendLine();
-                sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
-                sb.AppendLine(dialogueTaint);
+                gameState.AppendLine($"Shadow state: {shadowTaint}");
             }
 
             if (context.CallbackOpportunities != null && context.CallbackOpportunities.Count > 0)
             {
-                sb.AppendLine();
-                sb.AppendLine("CALLBACK OPPORTUNITIES");
-                sb.AppendLine("Reference these topics naturally in 1-2 options to earn hidden roll bonuses:");
+                gameState.AppendLine("Callback opportunities:");
                 foreach (var cb in context.CallbackOpportunities)
                 {
                     int turnsAgo = context.CurrentTurn - cb.TurnIntroduced;
                     string bonus = turnsAgo >= 4 ? "+2 hidden" : turnsAgo >= 2 ? "+1 hidden" : "+3 hidden (opener)";
-                    sb.AppendLine($"- \"{cb.TopicKey}\" (introduced T{cb.TurnIntroduced}, {turnsAgo} turns ago, {bonus})");
+                    gameState.AppendLine($"  \"{cb.TopicKey}\" (T{cb.TurnIntroduced}, {turnsAgo} turns ago, {bonus})");
                 }
             }
 
-            // Inject texting style block immediately before task instruction (#489)
+            // Inject texting style immediately before the ENGINE block (#489)
             if (!string.IsNullOrEmpty(context.PlayerTextingStyle))
             {
-                sb.AppendLine();
                 sb.AppendLine("YOUR TEXTING STYLE — follow this exactly, no deviations:");
                 sb.AppendLine(context.PlayerTextingStyle);
+                sb.AppendLine();
             }
 
+            // [ENGINE — Turn N] injection block
+            sb.Append(PromptTemplates.EngineOptionsBlock
+                .Replace("{turn}", context.CurrentTurn.ToString())
+                .Replace("{player_name}", playerName)
+                .Replace("{game_state}", gameState.ToString().TrimEnd()));
+
             sb.AppendLine();
-            sb.AppendLine("YOUR TASK");
+            sb.AppendLine();
+
+            // Output format instructions
             sb.Append(PromptTemplates.DialogueOptionsInstruction.Replace("{player_name}", playerName));
 
             return sb.ToString();
         }
 
         /// <summary>
-        /// Builds the user-message content for DeliverMessageAsync (§3.3 success / §3.4 failure).
+        /// Builds the user-message content for DeliverMessageAsync.
+        /// Uses [ENGINE — DELIVERY] injection block format.
         /// </summary>
-        public static string BuildDeliveryPrompt(DeliveryContext context)
+        /// <param name="context">The delivery context.</param>
+        /// <param name="rollContextBuilder">
+        /// Optional RollContextBuilder for YAML-sourced flavor text.
+        /// When null, uses hardcoded roll context defaults.
+        /// </param>
+        public static string BuildDeliveryPrompt(
+            DeliveryContext context,
+            RollContextBuilder? rollContextBuilder = null)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var playerName = FallbackName(context.PlayerName, "Player");
             var opponentName = FallbackName(context.OpponentName, "Opponent");
+            var builder = rollContextBuilder ?? new RollContextBuilder();
 
             var sb = new StringBuilder();
 
-            sb.AppendLine("CONVERSATION HISTORY");
+            // Conversation history
             AppendConversationHistory(sb, context.ConversationHistory, playerName);
 
             string deliveryTaint = BuildShadowTaintBlock(context.ShadowThresholds);
@@ -140,28 +141,39 @@ namespace Pinder.LlmAdapters
 
             sb.AppendLine();
 
+            // Build roll context narrative from YAML or fallback
+            string rollContext;
             if (context.Outcome == FailureTier.None)
             {
-                // Success path (§3.3)
-                sb.AppendLine($"The player chose option: \"{context.ChosenOption.IntendedText}\"");
-                sb.AppendLine($"Stat used: {context.ChosenOption.Stat.ToString().ToUpperInvariant()}");
-                sb.AppendLine($"They rolled SUCCESS — beat DC by {context.BeatDcBy}.");
-                sb.AppendLine();
+                rollContext = builder.GetSuccessContext(context.BeatDcBy, false);
+            }
+            else
+            {
+                rollContext = builder.GetFailureContext(context.Outcome);
+            }
+
+            // [ENGINE — DELIVERY] injection block
+            sb.AppendLine(PromptTemplates.EngineDeliveryBlock
+                .Replace("{chosen_option}", context.ChosenOption.IntendedText)
+                .Replace("{roll_context}", rollContext)
+                .Replace("{player_name}", playerName));
+
+            sb.AppendLine();
+
+            // Additional context for the LLM based on outcome
+            if (context.Outcome == FailureTier.None)
+            {
+                sb.AppendLine($"Stat: {context.ChosenOption.Stat.ToString().ToUpperInvariant()} | Beat DC by {context.BeatDcBy}");
                 sb.Append(PromptTemplates.SuccessDeliveryInstruction
                     .Replace("{player_name}", playerName));
             }
             else
             {
-                // Failure path (§3.4)
                 int missMargin = Math.Abs(context.BeatDcBy);
                 string tierName = GetFailureTierName(context.Outcome);
                 string tierInstruction = GetTierInstruction(context.Outcome);
 
-                sb.AppendLine($"The player chose option: \"{context.ChosenOption.IntendedText}\"");
-                sb.AppendLine($"Stat used: {context.ChosenOption.Stat.ToString().ToUpperInvariant()}");
-                sb.AppendLine($"They rolled FAILED — missed DC by {missMargin}.");
-                sb.AppendLine($"Failure tier: {tierName}");
-                sb.AppendLine();
+                sb.AppendLine($"Stat: {context.ChosenOption.Stat.ToString().ToUpperInvariant()} | Missed DC by {missMargin} | Tier: {tierName}");
 
                 string failureText = PromptTemplates.FailureDeliveryInstruction
                     .Replace("{player_name}", playerName)
@@ -188,7 +200,8 @@ namespace Pinder.LlmAdapters
         }
 
         /// <summary>
-        /// Builds the user-message content for GetOpponentResponseAsync (§3.5).
+        /// Builds the user-message content for GetOpponentResponseAsync.
+        /// Uses [ENGINE — OPPONENT] injection block format.
         /// </summary>
         public static string BuildOpponentPrompt(OpponentContext context)
         {
@@ -199,11 +212,11 @@ namespace Pinder.LlmAdapters
 
             var sb = new StringBuilder();
 
-            sb.AppendLine("CONVERSATION HISTORY");
+            // Conversation history
             AppendConversationHistory(sb, context.ConversationHistory, playerName);
-
             sb.AppendLine();
 
+            // Player's last message with failure context if applicable
             if (context.DeliveryTier != FailureTier.None)
             {
                 string tierLabel = GetFailureTierName(context.DeliveryTier);
@@ -220,12 +233,22 @@ namespace Pinder.LlmAdapters
             }
 
             sb.AppendLine();
-            sb.AppendLine("INTEREST CHANGE");
+
+            // [ENGINE — OPPONENT] injection block with interest narrative
+            string interestNarrative = PromptTemplates.GetInterestNarrative(context.InterestAfter);
+            sb.AppendLine(PromptTemplates.EngineOpponentBlock
+                .Replace("{opponent_name}", opponentName)
+                .Replace("{interest}", context.InterestAfter.ToString())
+                .Replace("{interest_narrative}", interestNarrative));
+
+            sb.AppendLine();
+
+            // Interest change delta
             int delta = context.InterestAfter - context.InterestBefore;
             string deltaStr = delta >= 0 ? $"+{delta}" : delta.ToString();
             sb.AppendLine($"Interest moved from {context.InterestBefore} to {context.InterestAfter} ({deltaStr}).");
-            sb.AppendLine($"Current Interest: {context.InterestAfter}/25");
 
+            // Response timing
             sb.AppendLine();
             sb.AppendLine("RESPONSE TIMING");
             if (context.ResponseDelayMinutes < 1.0)
@@ -236,11 +259,6 @@ namespace Pinder.LlmAdapters
             {
                 sb.AppendLine($"Your reply arrives in approximately {context.ResponseDelayMinutes:F1} minutes.");
             }
-            sb.AppendLine("Write in a register consistent with that timing — a 3-minute reply feels different from a 3-hour reply.");
-
-            sb.AppendLine();
-            sb.AppendLine("CURRENT INTEREST STATE");
-            sb.AppendLine(GetInterestBehaviourBlock(context.InterestAfter));
 
             if (context.ActiveTrapInstructions != null && context.ActiveTrapInstructions.Length > 0)
             {
@@ -290,7 +308,6 @@ namespace Pinder.LlmAdapters
             if (conversationHistory != null && conversationHistory.Count > 0)
             {
                 sb.AppendLine("RECENT CONVERSATION (for context — reference specific details in your response):");
-                // Include last 6 messages (3 exchanges) to keep context focused
                 int start = Math.Max(0, conversationHistory.Count - 6);
                 for (int i = start; i < conversationHistory.Count; i++)
                 {
@@ -332,21 +349,17 @@ namespace Pinder.LlmAdapters
             sb.AppendLine("[CURRENT_TURN]");
         }
 
-        private static string GetInterestBehaviourBlock(int interest)
+        /// <summary>
+        /// Returns a compact interest state label for the game state summary.
+        /// </summary>
+        private static string GetInterestLabel(int interest)
         {
-            if (interest >= 21)
-                return "You are extremely interested. You're looking for excuses to keep talking. The date is basically happening.";
-            if (interest >= 17)
-                return "You are very interested. Replies come quickly. Tone is warmer, more playful. You might volunteer personal information.";
-            if (interest >= 13)
-                return "You are engaged. Normal pacing. Responsive but not eager. You're seeing where this goes.";
-            if (interest >= 9)
-                return "You are lukewarm. Taking your time. Replies are functional. You might test them a little.";
-            if (interest >= 5)
-                return "You are cooling. Short replies. A little dry. You're not sold. One or two good messages could change that.";
-            if (interest >= 1)
-                return "You are disengaged. Minimal effort. You might send a closing signal or go quiet.";
-            return "You have lost all interest. You are unmatching.";
+            if (interest >= 21) return "Almost There \U0001f525";
+            if (interest >= 16) return "Very Into It \U0001f60d (advantage)";
+            if (interest >= 10) return "Interested \U0001f60a";
+            if (interest >= 5) return "Lukewarm \U0001f914";
+            if (interest >= 1) return "Bored \U0001f610 (disadvantage)";
+            return "Unmatched \U0001f480";
         }
 
         private static string GetThresholdInstruction(int before, int after, InterestState newState, string opponentName)
@@ -360,7 +373,6 @@ namespace Pinder.LlmAdapters
             if (after < before && after < 8 && before >= 8)
                 return PromptTemplates.InterestBeatBelow8.Replace("{opponent_name}", opponentName);
 
-            // Generic fallback for other threshold crossings
             return PromptTemplates.InterestBeatGeneric.Replace("{opponent_name}", opponentName);
         }
 

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
@@ -1,0 +1,489 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Tests for [ENGINE] injection block format in SessionDocumentBuilder.
+    /// Verifies AC from Issue #544: options, delivery, and opponent injection formats.
+    /// </summary>
+    public class EngineInjectionBlockTests
+    {
+        // ── Helpers ──
+
+        private static DialogueContext MakeDialogueContext(
+            int currentTurn = 3,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            int currentInterest = 14,
+            IReadOnlyList<(string Sender, string Text)>? conversationHistory = null,
+            string opponentLastMessage = "hey",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            List<CallbackOpportunity>? callbackOpportunities = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false,
+            string[]? activeTrapInstructions = null,
+            string[]? activeTraps = null,
+            string playerTextingStyle = "")
+        {
+            return new DialogueContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!"),
+                    ("Velvet", "how's your night going"),
+                    ("Sable", "so good lol")
+                },
+                opponentLastMessage: opponentLastMessage,
+                activeTraps: activeTraps ?? Array.Empty<string>(),
+                currentInterest: currentInterest,
+                shadowThresholds: shadowThresholds,
+                callbackOpportunities: callbackOpportunities,
+                horninessLevel: horninessLevel,
+                requiresRizzOption: requiresRizzOption,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                currentTurn: currentTurn,
+                playerTextingStyle: playerTextingStyle);
+        }
+
+        private static DeliveryContext MakeDeliveryContext(
+            DialogueOption? chosenOption = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 5,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null)
+        {
+            return new DeliveryContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!")
+                },
+                opponentLastMessage: "omg hi!!",
+                chosenOption: chosenOption ?? new DialogueOption(StatType.Wit, "you remind me of a song I can't quite place"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
+        private static OpponentContext MakeOpponentContext(
+            int interestBefore = 12,
+            int interestAfter = 14,
+            string playerDeliveredMessage = "you remind me of a song I can't quite place",
+            double responseDelayMinutes = 2.5,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null,
+            FailureTier deliveryTier = FailureTier.None)
+        {
+            return new OpponentContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!")
+                },
+                opponentLastMessage: "omg hi!!",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: interestAfter,
+                playerDeliveredMessage: playerDeliveredMessage,
+                interestBefore: interestBefore,
+                interestAfter: interestAfter,
+                responseDelayMinutes: responseDelayMinutes,
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                deliveryTier: deliveryTier);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC1: Options injection format — [ENGINE — Turn N]
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OptionsPrompt_ContainsEngineBlock()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            Assert.Contains("[ENGINE — Turn 3]", result);
+        }
+
+        [Fact]
+        public void OptionsPrompt_EngineBlockContainsPlayerName()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            Assert.Contains("Velvet is deciding what to send next", result);
+        }
+
+        [Fact]
+        public void OptionsPrompt_EngineBlockContainsInterest()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext(currentInterest: 18));
+            Assert.Contains("Interest: 18/25", result);
+        }
+
+        [Fact]
+        public void OptionsPrompt_ContainsGenerateInstruction()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            Assert.Contains("Generate 4 options for what Velvet might send", result);
+        }
+
+        [Fact]
+        public void OptionsPrompt_ContainsFormatInstruction()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            Assert.Contains("Format: OPTION_A: [message] OPTION_B: [message] etc.", result);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(15)]
+        public void OptionsPrompt_TurnNumberMatches(int turn)
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext(currentTurn: turn));
+            Assert.Contains($"[ENGINE — Turn {turn}]", result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC2: Delivery injection format — [ENGINE — DELIVERY]
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void DeliveryPrompt_ContainsEngineDeliveryBlock()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(MakeDeliveryContext());
+            Assert.Contains("[ENGINE — DELIVERY]", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_ContainsChosenOption()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(MakeDeliveryContext());
+            Assert.Contains("Player chose: 'you remind me of a song I can't quite place'", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_Success_ContainsDiceResult()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(MakeDeliveryContext(beatDcBy: 7));
+            Assert.Contains("Dice result:", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_Success_ContainsWriteInstruction()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(MakeDeliveryContext());
+            Assert.Contains("Write the message Velvet actually sends", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_Failure_ContainsFailureContext()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MakeDeliveryContext(outcome: FailureTier.Misfire, beatDcBy: -4));
+            Assert.Contains("Dice result:", result);
+            Assert.Contains("MISFIRE", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_CleanSuccess_HasLandedNarrative()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MakeDeliveryContext(beatDcBy: 3));
+            Assert.Contains("landed", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_CriticalSuccess_HasBestVersionNarrative()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MakeDeliveryContext(beatDcBy: 12));
+            Assert.Contains("best version", result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC2: Roll context from YAML — RollContextBuilder
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void DeliveryPrompt_WithRollContextBuilder_UsesCustomContext()
+        {
+            var flavors = new Dictionary<string, string>
+            {
+                { "§7.success-scale.5-9", "Custom: strong success flavor text" }
+            };
+            var builder = new RollContextBuilder(flavors);
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MakeDeliveryContext(beatDcBy: 7), builder);
+
+            Assert.Contains("Custom: strong success flavor text", result);
+        }
+
+        [Fact]
+        public void DeliveryPrompt_WithRollContextBuilder_FallsBackForMissing()
+        {
+            var flavors = new Dictionary<string, string>();
+            var builder = new RollContextBuilder(flavors);
+
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(
+                MakeDeliveryContext(beatDcBy: 2), builder);
+
+            // Should use hardcoded fallback
+            Assert.Contains(RollContextBuilder.FallbackCleanSuccess, result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC3: Opponent injection format — [ENGINE — OPPONENT]
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OpponentPrompt_ContainsEngineOpponentBlock()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(MakeOpponentContext());
+            Assert.Contains("[ENGINE — OPPONENT]", result);
+        }
+
+        [Fact]
+        public void OpponentPrompt_ContainsOpponentNameAndInterest()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                MakeOpponentContext(interestAfter: 14));
+            Assert.Contains("Sable is at Interest 14/25", result);
+        }
+
+        [Fact]
+        public void OpponentPrompt_ContainsWriteInstruction()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(MakeOpponentContext());
+            Assert.Contains("Write Sable's response", result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC4: Interest narratives — 6 bands
+        // ═══════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(1, "Reconsidering")]
+        [InlineData(4, "Reconsidering")]
+        [InlineData(5, "Skeptical")]
+        [InlineData(9, "Skeptical")]
+        [InlineData(10, "Engaged but not sold")]
+        [InlineData(14, "Engaged but not sold")]
+        [InlineData(15, "Interested but holding back")]
+        [InlineData(20, "Interested but holding back")]
+        [InlineData(21, "Basically sold")]
+        [InlineData(24, "Basically sold")]
+        [InlineData(25, "resistance dissolved")]
+        public void OpponentPrompt_InterestNarrativeMatchesBand(int interest, string expectedFragment)
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                MakeOpponentContext(interestAfter: interest));
+            Assert.Contains(expectedFragment, result);
+        }
+
+        [Fact]
+        public void OpponentPrompt_Interest0_ShowsUnmatched()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                MakeOpponentContext(interestBefore: 2, interestAfter: 0));
+            Assert.Contains("Unmatched", result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC5: Roll context narratives — RollContextBuilder
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void RollContextBuilder_Fallback_CleanSuccess()
+        {
+            var builder = new RollContextBuilder();
+            var result = builder.GetSuccessContext(3, false);
+            Assert.Equal(RollContextBuilder.FallbackCleanSuccess, result);
+        }
+
+        [Fact]
+        public void RollContextBuilder_Fallback_StrongSuccess()
+        {
+            var builder = new RollContextBuilder();
+            var result = builder.GetSuccessContext(7, false);
+            Assert.Equal(RollContextBuilder.FallbackStrongSuccess, result);
+        }
+
+        [Fact]
+        public void RollContextBuilder_Fallback_CriticalSuccess()
+        {
+            var builder = new RollContextBuilder();
+            var result = builder.GetSuccessContext(12, false);
+            Assert.Equal(RollContextBuilder.FallbackCriticalSuccess, result);
+        }
+
+        [Fact]
+        public void RollContextBuilder_Fallback_Nat20()
+        {
+            var builder = new RollContextBuilder();
+            var result = builder.GetSuccessContext(15, true);
+            Assert.Equal(RollContextBuilder.FallbackNat20, result);
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        [InlineData(FailureTier.Legendary)]
+        public void RollContextBuilder_Fallback_AllFailureTiers(FailureTier tier)
+        {
+            var builder = new RollContextBuilder();
+            var result = builder.GetFailureContext(tier);
+            Assert.False(string.IsNullOrEmpty(result));
+        }
+
+        [Fact]
+        public void RollContextBuilder_WithYaml_OverridesFallback()
+        {
+            var flavors = new Dictionary<string, string>
+            {
+                { "§7.fail-tier.fumble", "Custom fumble text from YAML" }
+            };
+            var builder = new RollContextBuilder(flavors);
+            var result = builder.GetFailureContext(FailureTier.Fumble);
+            Assert.Equal("Custom fumble text from YAML", result);
+        }
+
+        [Fact]
+        public void RollContextBuilder_WithYaml_FallsBackForMissingEntries()
+        {
+            var flavors = new Dictionary<string, string>
+            {
+                { "§7.fail-tier.fumble", "Custom fumble" }
+            };
+            var builder = new RollContextBuilder(flavors);
+
+            // Misfire is not in the yaml dict, should use fallback
+            var result = builder.GetFailureContext(FailureTier.Misfire);
+            Assert.Equal(RollContextBuilder.FallbackMisfire, result);
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC5: RollContextBuilder.FromRuleBook integration
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void RollContextBuilder_FromRuleBook_LoadsRealYaml()
+        {
+            string yamlPath = FindYamlPath("rules/extracted/rules-v3-enriched.yaml");
+            if (yamlPath == null)
+            {
+                // Skip if YAML not available in test environment
+                return;
+            }
+
+            string yamlContent = System.IO.File.ReadAllText(yamlPath);
+            var ruleBook = Pinder.Rules.RuleBook.LoadFrom(yamlContent);
+            var builder = RollContextBuilder.FromRuleBook(ruleBook);
+
+            // Should get non-empty results for all tiers
+            Assert.False(string.IsNullOrEmpty(builder.GetSuccessContext(3, false)));
+            Assert.False(string.IsNullOrEmpty(builder.GetFailureContext(FailureTier.Fumble)));
+            Assert.False(string.IsNullOrEmpty(builder.GetFailureContext(FailureTier.Catastrophe)));
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC6: Interest narratives configurable via PromptTemplates
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void InterestNarrative_AllSixBandsDefined()
+        {
+            // Verify all 6 band constants exist and are non-empty
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_1_4));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_5_9));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_10_14));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_15_20));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_21_24));
+            Assert.False(string.IsNullOrEmpty(PromptTemplates.InterestNarrative_25));
+        }
+
+        [Fact]
+        public void GetInterestNarrative_CoversBoundaryValues()
+        {
+            Assert.NotEqual(PromptTemplates.GetInterestNarrative(4), PromptTemplates.GetInterestNarrative(5));
+            Assert.NotEqual(PromptTemplates.GetInterestNarrative(9), PromptTemplates.GetInterestNarrative(10));
+            Assert.NotEqual(PromptTemplates.GetInterestNarrative(14), PromptTemplates.GetInterestNarrative(15));
+            Assert.NotEqual(PromptTemplates.GetInterestNarrative(20), PromptTemplates.GetInterestNarrative(21));
+            Assert.NotEqual(PromptTemplates.GetInterestNarrative(24), PromptTemplates.GetInterestNarrative(25));
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // AC7: Build clean — format correctness
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OptionsPrompt_ConversationHistoryPrecedesEngineBlock()
+        {
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+
+            int historyIdx = result.IndexOf("[CONVERSATION_START]");
+            int engineIdx = result.IndexOf("[ENGINE — Turn");
+            Assert.True(historyIdx >= 0, "Conversation history must be present");
+            Assert.True(engineIdx >= 0, "ENGINE block must be present");
+            Assert.True(historyIdx < engineIdx, "Conversation history must precede ENGINE block");
+        }
+
+        [Fact]
+        public void DeliveryPrompt_ConversationHistoryPrecedesEngineBlock()
+        {
+            var result = SessionDocumentBuilder.BuildDeliveryPrompt(MakeDeliveryContext());
+
+            int historyIdx = result.IndexOf("[CONVERSATION_START]");
+            int engineIdx = result.IndexOf("[ENGINE — DELIVERY]");
+            Assert.True(historyIdx >= 0);
+            Assert.True(engineIdx >= 0);
+            Assert.True(historyIdx < engineIdx);
+        }
+
+        [Fact]
+        public void OpponentPrompt_EngineBlockPresentInOutput()
+        {
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(MakeOpponentContext());
+
+            int engineIdx = result.IndexOf("[ENGINE — OPPONENT]");
+            Assert.True(engineIdx >= 0, "[ENGINE — OPPONENT] block must be present");
+        }
+
+        // ── Helper ──
+
+        private static string? FindYamlPath(string relativePath)
+        {
+            string? dir = AppDomain.CurrentDomain.BaseDirectory;
+            while (dir != null)
+            {
+                string candidate = System.IO.Path.Combine(dir, relativePath);
+                if (System.IO.File.Exists(candidate)) return candidate;
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
@@ -30,7 +30,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.Contains("SHADOW STATE", result);
+            Assert.Contains("Shadow state:", result);
             Assert.Contains("Madness", result);
         }
 
@@ -48,7 +48,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.DoesNotContain("SHADOW STATE", result);
+            Assert.DoesNotContain("Shadow state:", result);
         }
 
         // ============== Edge: Boundary value Madness=5 → no taint (> 5 needed) ==============
@@ -65,7 +65,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.DoesNotContain("SHADOW STATE", result);
+            Assert.DoesNotContain("Shadow state:", result);
         }
 
         // ============== Edge: Boundary value Madness=6 → taint fires (> 5) ==============
@@ -82,7 +82,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.Contains("SHADOW STATE", result);
+            Assert.Contains("Shadow state:", result);
         }
 
         // ============== Edge: Horniness has different threshold (> 6) ==============
@@ -99,7 +99,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.DoesNotContain("SHADOW STATE", result);
+            Assert.DoesNotContain("Shadow state:", result);
         }
 
         // Mutation: would catch if Horniness threshold is > 7 instead of > 6
@@ -114,7 +114,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadows));
 
-            Assert.Contains("SHADOW STATE", result);
+            Assert.Contains("Shadow state:", result);
             Assert.Contains("Horniness", result);
         }
 

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
@@ -157,7 +157,7 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("lowercase-with-intent, precise, ironic", result);
         }
 
-        // Mutation: would catch if texting style is placed AFTER YOUR TASK instead of before
+        // Mutation: would catch if texting style is placed AFTER [ENGINE] block instead of before
         [Fact]
         public void BuildDialogueOptionsPrompt_TextingStyleAppearsBeforeYourTask()
         {
@@ -165,12 +165,12 @@ namespace Pinder.LlmAdapters.Tests
             string result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
 
             int styleIdx = result.IndexOf("YOUR TEXTING STYLE", StringComparison.Ordinal);
-            int taskIdx = result.IndexOf("YOUR TASK", StringComparison.Ordinal);
+            int engineIdx = result.IndexOf("[ENGINE — Turn", StringComparison.Ordinal);
 
             Assert.True(styleIdx >= 0, "TEXTING STYLE block must be present");
-            Assert.True(taskIdx >= 0, "YOUR TASK block must be present");
-            Assert.True(styleIdx < taskIdx,
-                $"TEXTING STYLE (at {styleIdx}) must appear before YOUR TASK (at {taskIdx})");
+            Assert.True(engineIdx >= 0, "[ENGINE] block must be present");
+            Assert.True(styleIdx < engineIdx,
+                $"TEXTING STYLE (at {styleIdx}) must appear before [ENGINE] block (at {engineIdx})");
         }
 
         // Mutation: would catch if texting style block is emitted even when style is empty
@@ -240,7 +240,7 @@ namespace Pinder.LlmAdapters.Tests
 
             Assert.DoesNotContain("YOUR TEXTING STYLE", result);
             // YOUR TASK should still appear
-            Assert.Contains("YOUR TASK", result);
+            Assert.Contains("Generate exactly 4 dialogue options", result);
         }
 
         // ══════════════════════════════════════════════════════════════
@@ -330,10 +330,10 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("YOUR TEXTING STYLE — follow this exactly, no deviations:", result);
             // Style text present
             Assert.Contains(velvetStyle, result);
-            // Style before task
+            // Style before ENGINE block
             int styleIdx = result.IndexOf("YOUR TEXTING STYLE", StringComparison.Ordinal);
-            int taskIdx = result.IndexOf("YOUR TASK", StringComparison.Ordinal);
-            Assert.True(styleIdx < taskIdx);
+            int engineIdx = result.IndexOf("[ENGINE — Turn", StringComparison.Ordinal);
+            Assert.True(styleIdx < engineIdx);
         }
 
         // ══════════════════════════════════════════════════════════════
@@ -349,7 +349,7 @@ namespace Pinder.LlmAdapters.Tests
 
             Assert.DoesNotContain("YOUR TEXTING STYLE", result);
             // YOUR TASK should still be present
-            Assert.Contains("YOUR TASK", result);
+            Assert.Contains("Generate exactly 4 dialogue options", result);
         }
 
         // ══════════════════════════════════════════════════════════════
@@ -385,7 +385,7 @@ namespace Pinder.LlmAdapters.Tests
             var ctx = MakeContext(playerTextingStyle: style);
             string result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
 
-            Assert.Contains("YOUR TASK", result);
+            Assert.Contains("Generate exactly 4 dialogue options", result);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
@@ -106,11 +106,11 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("YOUR TEXTING STYLE — follow this exactly, no deviations:", result);
             Assert.Contains("lowercase-with-intent, precise, ironic", result);
 
-            // TEXTING STYLE must appear before YOUR TASK
+            // TEXTING STYLE must appear before ENGINE block
             int styleIdx = result.IndexOf("YOUR TEXTING STYLE", StringComparison.Ordinal);
-            int taskIdx = result.IndexOf("YOUR TASK", StringComparison.Ordinal);
-            Assert.True(styleIdx < taskIdx,
-                "TEXTING STYLE block must appear before YOUR TASK");
+            int engineIdx = result.IndexOf("[ENGINE — Turn", StringComparison.Ordinal);
+            Assert.True(styleIdx < engineIdx,
+                "TEXTING STYLE block must appear before [ENGINE] block");
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
+++ b/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
+    <ProjectReference Include="..\..\src\Pinder.Rules\Pinder.Rules.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
@@ -71,7 +71,7 @@ namespace Pinder.LlmAdapters.Tests
 
             var result = BuildMinimal(callbackOpportunities: cbs, currentTurn: 5);
 
-            Assert.Contains("CALLBACK OPPORTUNITIES", result);
+            Assert.Contains("Callback opportunities:", result);
             Assert.Contains("\"cats\"", result);
             Assert.Contains("\"hiking\"", result);
             Assert.Contains("+2 hidden", result); // cats: 5-1=4 turns ago
@@ -125,7 +125,7 @@ namespace Pinder.LlmAdapters.Tests
         {
             var result = BuildMinimal(horninessLevel: 7);
 
-            Assert.Contains("Horniness level: 7/10", result);
+            Assert.Contains("Horniness: 7/10", result);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace Pinder.LlmAdapters.Tests
         {
             var result = BuildMinimal(horninessLevel: 5);
 
-            Assert.DoesNotContain("Horniness level", result);
+            Assert.DoesNotContain("Horniness:", result);
         }
 
         [Fact]
@@ -159,7 +159,7 @@ namespace Pinder.LlmAdapters.Tests
         {
             var result = BuildMinimal(currentTurn: 7);
 
-            Assert.Contains("Turn: 7", result);
+            Assert.Contains("[ENGINE — Turn 7]", result);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Pinder.LlmAdapters.Tests
 
             Assert.Contains("Interest: 2/25", result);
             Assert.Contains("Bored", result);
-            Assert.Contains("player has disadvantage", result);
+            Assert.Contains("disadvantage", result);
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = BuildMinimal(currentInterest: 18);
 
             Assert.Contains("Very Into It", result);
-            Assert.Contains("player has advantage", result);
+            Assert.Contains("advantage", result);
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
@@ -255,7 +255,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildDialogueOptionsPrompt_ContainsConversationHistoryHeader()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
-            Assert.Contains("CONVERSATION HISTORY", result);
+            Assert.Contains("[CONVERSATION_START]", result);
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(conversationHistory: history, opponentLastMessage: "Whatever", currentTurn: 2));
 
-            Assert.Contains("OPPONENT'S LAST MESSAGE", result);
+            // Opponent's last message is part of conversation history
             Assert.Contains("\"Whatever\"", result);
         }
 
@@ -278,7 +278,7 @@ namespace Pinder.LlmAdapters.Tests
         public void BuildDialogueOptionsPrompt_ContainsGameStateSection()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
-            Assert.Contains("GAME STATE", result);
+            Assert.Contains("[ENGINE — Turn", result);
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
                 MakeDeliveryContext(chosenOption: option, beatDcBy: 7));
 
-            Assert.Contains("Stat used: CHARM", result);
+            Assert.Contains("Stat: CHARM", result);
         }
 
         [Fact]
@@ -321,7 +321,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
                 MakeDeliveryContext(chosenOption: option, beatDcBy: 9));
 
-            Assert.Contains("beat DC by 9", result);
+            Assert.Contains("Beat DC by 9", result);
         }
 
         [Fact]
@@ -331,7 +331,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
                 MakeDeliveryContext(chosenOption: option, beatDcBy: 3));
 
-            Assert.Contains("SUCCESS", result);
+            Assert.Contains("[ENGINE — DELIVERY]", result);
             Assert.DoesNotContain("Failure tier:", result);
         }
 
@@ -445,7 +445,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 15));
 
-            Assert.Contains("Current Interest: 15/25", result);
+            Assert.Contains("Interest 15/25", result);
         }
 
         [Fact]
@@ -472,7 +472,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 20, interestAfter: 21));
 
-            Assert.Contains("extremely interested", result);
+            Assert.Contains("Basically sold", result);
         }
 
         [Fact]
@@ -481,7 +481,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 13));
 
-            Assert.Contains("engaged", result);
+            Assert.Contains("Engaged but not sold", result);
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 9));
 
-            Assert.Contains("lukewarm", result);
+            Assert.Contains("Skeptical", result);
         }
 
         [Fact]
@@ -499,7 +499,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 5));
 
-            Assert.Contains("cooling", result);
+            Assert.Contains("Skeptical", result);
         }
 
         [Fact]
@@ -508,7 +508,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 2, interestAfter: 0));
 
-            Assert.Contains("lost all interest", result);
+            Assert.Contains("Unmatched", result);
         }
 
         [Fact]
@@ -794,8 +794,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 16));
 
-            Assert.Contains("engaged", result);
-            Assert.DoesNotContain("very interested", result);
+            Assert.Contains("Interested but holding back", result);
         }
 
         [Fact]
@@ -804,7 +803,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 17));
 
-            Assert.Contains("very interested", result);
+            Assert.Contains("Interested but holding back", result);
         }
 
         [Fact]
@@ -813,7 +812,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 12));
 
-            Assert.Contains("lukewarm", result);
+            Assert.Contains("Engaged but not sold", result);
         }
 
         [Fact]
@@ -822,7 +821,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 8));
 
-            Assert.Contains("cooling", result);
+            Assert.Contains("Skeptical", result);
         }
 
         [Fact]
@@ -831,7 +830,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 4));
 
-            Assert.Contains("disengaged", result);
+            Assert.Contains("Reconsidering", result);
         }
 
         [Fact]
@@ -840,7 +839,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 25));
 
-            Assert.Contains("extremely interested", result);
+            Assert.Contains("resistance dissolved", result);
         }
 
         [Fact]
@@ -849,8 +848,8 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 2, interestAfter: 1));
 
-            Assert.Contains("disengaged", result);
-            Assert.DoesNotContain("lost all interest", result);
+            Assert.Contains("Reconsidering", result);
+            Assert.DoesNotContain("Unmatched", result);
         }
 
         // Issue #491 — success delivery tiers use margin-based language

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -137,7 +137,7 @@ namespace Pinder.LlmAdapters.Tests
                 MakeDialogueContext(playerName: "GERALD_42", opponentName: "VELVET"));
 
             int opponentIdx = result.IndexOf("OPPONENT PROFILE");
-            int historyIdx = result.IndexOf("CONVERSATION HISTORY");
+            int historyIdx = result.IndexOf("[CONVERSATION_START]");
             Assert.True(opponentIdx < historyIdx,
                 "Opponent profile should appear before conversation history");
         }
@@ -238,12 +238,13 @@ namespace Pinder.LlmAdapters.Tests
         }
 
         [Fact]
-        public void BuildDialogueOptionsPrompt_NoTraps_ShowsNone()
+        public void BuildDialogueOptionsPrompt_NoTraps_NoTrapsMentioned()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(playerName: "GERALD", opponentName: "VELVET"));
 
-            Assert.Contains("Active traps: none", result);
+            // With no active traps, the output should not mention any trap names
+            Assert.DoesNotContain("Active traps:", result);
         }
 
         [Fact]
@@ -252,7 +253,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(playerName: "GERALD", opponentName: "VELVET"));
 
-            Assert.Contains("YOUR TASK", result);
+            Assert.Contains("[ENGINE — Turn", result);
             Assert.Contains("Generate exactly 4 dialogue options for GERALD", result);
         }
 
@@ -265,9 +266,9 @@ namespace Pinder.LlmAdapters.Tests
                 MakeDeliveryContext(chosenOption: option, outcome: FailureTier.None, beatDcBy: 4,
                     playerName: "GERALD", opponentName: "VELVET"));
 
-            Assert.Contains("SUCCESS", result);
-            Assert.Contains("beat DC by 4", result);
-            Assert.Contains("Stat used: WIT", result);
+            Assert.Contains("[ENGINE — DELIVERY]", result);
+            Assert.Contains("Beat DC by 4", result);
+            Assert.Contains("Stat: WIT", result);
             Assert.Contains("Output only the message text", result);
         }
 
@@ -317,12 +318,12 @@ namespace Pinder.LlmAdapters.Tests
 
             Assert.Contains("PLAYER'S LAST MESSAGE", result);
             Assert.Contains("\"How are you?\"", result);
-            Assert.Contains("INTEREST CHANGE", result);
+            Assert.Contains("[ENGINE — OPPONENT]", result);
             Assert.Contains("Interest moved from 10 to 12 (+2)", result);
-            Assert.Contains("Current Interest: 12/25", result);
+            Assert.Contains("Interest 12/25", result);
             Assert.Contains("RESPONSE TIMING", result);
             Assert.Contains("3.5 minutes", result);
-            Assert.Contains("CURRENT INTEREST STATE", result);
+            Assert.Contains("Engaged but not sold", result);
             Assert.Contains("[RESPONSE]", result);
             Assert.Contains("[SIGNALS]", result);
         }
@@ -352,7 +353,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 10, interestAfter: 18));
 
-            Assert.Contains("very interested", result);
+            Assert.Contains("Interested but holding back", result);
         }
 
         [Fact]
@@ -361,7 +362,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(interestBefore: 5, interestAfter: 3));
 
-            Assert.Contains("disengaged", result);
+            Assert.Contains("Reconsidering", result);
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -73,7 +73,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadowThresholds: shadows));
 
-            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Shadow state:", result);
             Assert.Contains("Your Madness is elevated", result);
         }
 
@@ -135,7 +135,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext(shadowThresholds: shadows));
 
-            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("Shadow state:", result);
             Assert.Contains("Your Horniness is elevated", result);
         }
 
@@ -161,7 +161,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDeliveryPrompt(
                 MakeDeliveryContext(option, shadowThresholds: shadows));
 
-            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("SHADOW STATE", result);
             Assert.Contains("Your Overthinking is elevated", result);
         }
 
@@ -176,7 +176,7 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildOpponentPrompt(
                 MakeOpponentContext(shadowThresholds: shadows));
 
-            Assert.Contains("SHADOW STATE (corrupting forces on your communication)", result);
+            Assert.Contains("SHADOW STATE", result);
             Assert.Contains("Your Fixation is elevated", result);
         }
     }


### PR DESCRIPTION
Fixes #544

## What was done

Replaced the verbose user message format in SessionDocumentBuilder with compact `[ENGINE]` injection blocks that translate game mechanics into narrative for the LLM. Three injection types:

1. **`[ENGINE — Turn N]`** — Options generation: player name, interest, game state, generate instruction
2. **`[ENGINE — DELIVERY]`** — Message delivery: chosen option, dice result narrative (from YAML or fallback), write instruction  
3. **`[ENGINE — OPPONENT]`** — Opponent response: opponent name, interest level with narrative band, write instruction

### Key additions:
- **`RollContextBuilder`** — Sources roll context narratives from enriched YAML `flavor` fields (`§7.fail-tier.*`, `§7.success-scale.*`) with hardcoded fallbacks. Supports `FromRuleBook()` for YAML integration.
- **6 interest narrative bands** in `PromptTemplates` (1-4, 5-9, 10-14, 15-20, 21-24, 25) as specified in the issue
- **49 new tests** in `EngineInjectionBlockTests` covering all 3 injection types, interest narratives, roll context builder, and format correctness
- Updated existing tests to match new prompt format (41 assertions updated)

### How to test
```bash
dotnet test
```
All 3298 tests pass (2203 Core + 851 LlmAdapters + 244 Rules).

### Files changed
- `src/Pinder.LlmAdapters/SessionDocumentBuilder.cs` — New ENGINE block formats
- `src/Pinder.LlmAdapters/RollContextBuilder.cs` — New: YAML-sourced roll context
- `src/Pinder.LlmAdapters/PromptTemplates.cs` — Interest narratives + ENGINE templates
- `src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj` — Added Pinder.Rules reference
- `tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs` — New: 49 tests
- 7 existing test files updated for new prompt format

## Deviations from contract
- `BuildDeliveryPrompt` gained optional `RollContextBuilder?` parameter (backward-compatible default null → uses hardcoded fallbacks)
- Added `Pinder.Rules` project reference to `Pinder.LlmAdapters` for `RollContextBuilder.FromRuleBook()` — this is a new dependency (LlmAdapters → Rules → Core)

## DoD Evidence
**Branch:** issue-544-add-engine-injection-blocks-to-llm-calls
**Commit:** 535e144
