### PR TITLE
[Issue #536] Write spec document: Architecture: switch to one persistent LLM session per conversation (options generated in context)

### DIFF
--- a/docs/specs/issue-536-spec.md
+++ b/docs/specs/issue-536-spec.md
@@ -1,0 +1,75 @@
+# Specification: Architecture: switch to one persistent LLM session per conversation (Reverted)
+
+**Module**: docs/modules/llm-adapters.md
+
+## Overview
+Issue #536 was originally conceived to switch the LLM adapter to a stateful conversation accumulation pattern. However, per CPO Vision Concern #583, this approach has been explicitly rejected and reverted. Mixing meta-engine option generation, player dialogue, and opponent responses into a single Anthropic `messages[]` array causes catastrophic voice bleed, fundamentally breaking the LLM's understanding of its role. This specification mandates the complete removal of the `IStatefulLlmAdapter` interface and associated stateful logic, restoring a strictly stateless, zero-dependency pattern for `GameSession` and `AnthropicLlmAdapter`.
+
+## Function Signatures
+
+### Removed Interface
+The following interface is **deleted** entirely:
+- `Pinder.Core.Interfaces.IStatefulLlmAdapter`
+
+### Modified Class: `AnthropicLlmAdapter`
+Removed from implemented interfaces: `IStatefulLlmAdapter`
+
+Removed fields/properties:
+- `private ConversationSession? _session;`
+- `public bool HasActiveConversation { get; }`
+
+Removed methods:
+- `public void StartConversation(string systemPrompt)`
+
+All internal branching based on `if (_session != null)` in `GetDialogueOptionsAsync`, `DeliverMessageAsync`, `GetOpponentResponseAsync`, and `GetInterestChangeBeatAsync` is removed, leaving only the stateless request path.
+
+### Modified Class: `GameSession`
+In the constructor:
+`public GameSession(...)`
+The block initializing stateful sessions via `if (_llm is IStatefulLlmAdapter stateful)` is removed.
+
+## Input/Output Examples
+
+**GameSession Constructor Execution**
+```csharp
+// Before:
+var session = new GameSession(player, opponent, llm, dice, trapRegistry, rules);
+// Would check if llm is IStatefulLlmAdapter and call StartConversation()
+
+// After:
+var session = new GameSession(player, opponent, llm, dice, trapRegistry, rules);
+// Standard initialization completes. No LLM state initialization occurs.
+```
+
+**Stateless LLM Adapter Flow**
+```csharp
+// Turn 1
+await llm.GetDialogueOptionsAsync(context1);
+// Adapter builds an isolated MessagesRequest, sends it, returns options.
+
+// Turn 2
+await llm.GetDialogueOptionsAsync(context2);
+// Adapter builds a fresh MessagesRequest using context2. No hidden session state persists.
+```
+
+## Acceptance Criteria
+
+1. **Delete Interface**: The file `src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs` is deleted.
+2. **Remove Adapter Implementation**: `AnthropicLlmAdapter` implements only `ILlmAdapter` and `IDisposable`.
+3. **Remove Adapter Methods**: `StartConversation` method and `HasActiveConversation` property are deleted from `AnthropicLlmAdapter`.
+4. **Remove Internal State**: The `_session` field and all `if (_session != null)` logic branches are removed from all four adapter action methods in `AnthropicLlmAdapter`.
+5. **Revert GameSession Wiring**: The `GameSession` constructor has the `if (_llm is IStatefulLlmAdapter stateful)` type check and associated `StartConversation()` call removed.
+
+## Edge Cases
+
+- **Existing Tests**: Obsolete tests verifying stateful adapter capabilities (e.g., `AnthropicLlmAdapterStatefulTests.cs` or `Issue541_StatefulConversationTests.cs`) must be removed or ignored.
+- **Context Integrity**: The removal of session arrays ensures that all context relies strictly on the current turn's parameters passed via `DialogueContext`, `DeliveryContext`, etc., thereby isolating persona prompts and avoiding character voice bleed.
+
+## Error Conditions
+
+- With `IStatefulLlmAdapter` removed, any consuming code attempting to cast `ILlmAdapter` to `IStatefulLlmAdapter` or call `StartConversation` will fail at compile-time. The adapter now behaves completely statelessly, relying on `AnthropicClient` request-level validations.
+
+## Dependencies
+
+- **Pinder.Core**: Must remain completely zero-dependency. Returning strictly to the stateless approach natively respects this invariant.
+- **Anthropic API**: The underlying API calls remain unchanged, utilizing the standard `SendMessagesAsync` method over HTTP.


### PR DESCRIPTION
Refs #536

## DoD Evidence
**Branch:** issue-536-write-spec-document-architecture-switch-
**Commit:** efc497f
