### PR TITLE
[Issue #638] feat: move delivery prompt text to game-definition.yaml

### DIFF
--- a/data/game-definition.yaml
+++ b/data/game-definition.yaml
@@ -210,3 +210,20 @@ writing_rules: |
   reader — the human player — is watching this conversation unfold.
   Make it worth their time. Every message should sound like something
   a real person would actually send on a dating app at 1 AM.
+delivery_rules:
+  clean: |
+    Deliver essentially as written. Small word choice improvements only.
+  strong: |
+    Improve the phrasing, timing, or rhythm of what's already there.
+    You may: rearrange for better flow, sharpen word choice, add ONE word or phrase that makes the existing sentiment more precise.
+    You must not: add new sentences that introduce ideas not in the intended message, change the emotional register, or make the message say something the player didn't intend.
+  critical: |
+    Deliver at peak. The message arrives perfectly. Something resonates.
+  exceptional: |
+    This is the best version of this message that could exist. It arrives at exactly the right moment with exactly the right weight. The opponent feels it.
+  test: |
+    The test: every idea in the delivered version should have a counterpart in the intended version. New additions should sharpen, not expand.
+  register_instruction: |
+    Stay in character. Match the texting register from the character profile above. Do not change the character's capitalization style.
+  medium_rule: |
+    This is a text message on a phone screen, not a monologue. No internal stage directions, no narration of emotional state, no self-commentary mid-message.

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -141,7 +141,8 @@ namespace Pinder.LlmAdapters.Anthropic
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context);
+            var deliveryRules = _options.GameDefinition?.DeliveryRules;
+            var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context, deliveryRules: deliveryRules);
 
 
             var fullPlayerPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);

--- a/src/Pinder.LlmAdapters/GameDefinition.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.cs
@@ -6,6 +6,32 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Pinder.LlmAdapters
 {
     /// <summary>
+    /// Configurable rules for how successful deliveries are written at each margin tier.
+    /// </summary>
+    public sealed class DeliveryRules
+    {
+        public string Clean { get; }
+        public string Strong { get; }
+        public string Critical { get; }
+        public string Exceptional { get; }
+        public string Test { get; }
+        public string RegisterInstruction { get; }
+        public string MediumRule { get; }
+
+        public DeliveryRules(string clean, string strong, string critical, string exceptional,
+            string test, string registerInstruction, string mediumRule)
+        {
+            Clean = clean ?? "";
+            Strong = strong ?? "";
+            Critical = critical ?? "";
+            Exceptional = exceptional ?? "";
+            Test = test ?? "";
+            RegisterInstruction = registerInstruction ?? "";
+            MediumRule = mediumRule ?? "";
+        }
+    }
+
+    /// <summary>
     /// Data carrier for game-level creative direction.
     /// Parsed from YAML or provided via hardcoded defaults.
     /// </summary>
@@ -32,6 +58,9 @@ namespace Pinder.LlmAdapters
         /// <summary>Writing style rules: texting register, brevity, etc.</summary>
         public string WritingRules { get; }
 
+        /// <summary>Configurable delivery prompt rules, or null for hardcoded defaults.</summary>
+        public DeliveryRules DeliveryRules { get; }
+
         public GameDefinition(
             string name,
             string vision,
@@ -39,7 +68,8 @@ namespace Pinder.LlmAdapters
             string playerRoleDescription,
             string opponentRoleDescription,
             string metaContract,
-            string writingRules)
+            string writingRules,
+            DeliveryRules deliveryRules = null)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Vision = vision ?? throw new ArgumentNullException(nameof(vision));
@@ -48,6 +78,7 @@ namespace Pinder.LlmAdapters
             OpponentRoleDescription = opponentRoleDescription ?? throw new ArgumentNullException(nameof(opponentRoleDescription));
             MetaContract = metaContract ?? throw new ArgumentNullException(nameof(metaContract));
             WritingRules = writingRules ?? throw new ArgumentNullException(nameof(writingRules));
+            DeliveryRules = deliveryRules;
         }
 
         /// <summary>
@@ -86,6 +117,25 @@ namespace Pinder.LlmAdapters
                 return value.ToString()!;
             }
 
+            DeliveryRules deliveryRules = null;
+            if (parsed.TryGetValue("delivery_rules", out var drObj) && drObj is Dictionary<object, object> drDict)
+            {
+                string DrGet(string key)
+                {
+                    if (drDict.TryGetValue(key, out var v) && v != null)
+                        return v.ToString();
+                    return "";
+                }
+                deliveryRules = new DeliveryRules(
+                    clean: DrGet("clean"),
+                    strong: DrGet("strong"),
+                    critical: DrGet("critical"),
+                    exceptional: DrGet("exceptional"),
+                    test: DrGet("test"),
+                    registerInstruction: DrGet("register_instruction"),
+                    mediumRule: DrGet("medium_rule"));
+            }
+
             return new GameDefinition(
                 name: GetRequired("name"),
                 vision: GetRequired("vision"),
@@ -93,7 +143,8 @@ namespace Pinder.LlmAdapters
                 playerRoleDescription: GetRequired("player_role_description"),
                 opponentRoleDescription: GetRequired("opponent_role_description"),
                 metaContract: GetRequired("meta_contract"),
-                writingRules: GetRequired("writing_rules")
+                writingRules: GetRequired("writing_rules"),
+                deliveryRules: deliveryRules
             );
         }
 
@@ -172,6 +223,16 @@ Never add ideas the player didn't choose. Success delivery improves
 phrasing — it does not introduce new topics, jokes, or emotional content.
 Never resolve the date before Interest reaches 25 mechanically.
 Maintain two distinct character voices throughout the entire conversation.",
+            deliveryRules: new DeliveryRules(
+                clean: "Deliver essentially as written. Small word choice improvements only.",
+                strong: "Improve the phrasing, timing, or rhythm of what's already there.\n" +
+                    "You may: rearrange for better flow, sharpen word choice, add ONE word or phrase that makes the existing sentiment more precise.\n" +
+                    "You must not: add new sentences that introduce ideas not in the intended message, change the emotional register, or make the message say something the player didn't intend.",
+                critical: "Deliver at peak. The message arrives perfectly. Something resonates.",
+                exceptional: "This is the best version of this message that could exist. It arrives at exactly the right moment with exactly the right weight. The opponent feels it.",
+                test: "The test: every idea in the delivered version should have a counterpart in the intended version. New additions should sharpen, not expand.",
+                registerInstruction: "Stay in character. Match the texting register from the character profile above. Do not change the character's capitalization style.",
+                mediumRule: "This is a text message on a phone screen, not a monologue. No internal stage directions, no narration of emotional state, no self-commentary mid-message."),
             writingRules: @"All dialogue is texting register. Short, informal, platform-appropriate.
 Message length: typically 1-3 sentences for player options, 1-4 sentences
 for opponent responses. Brevity is a feature.

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -49,27 +49,49 @@ Rules:
 Before writing each option, verify: does this sound exactly like
 the texting style above? If not, rewrite it.";
 
-        /// <summary>§3.3 — Deliver the intended message on a successful roll.</summary>
-        public const string SuccessDeliveryInstruction =
-@"Write as {player_name}.
-The intended message is the player's plan. Your job is to make it land.
-You beat the DC by {beat_dc_by}.
+        /// <summary>§3.3 — Backward-compatible accessor that returns the default success delivery instruction.</summary>
+        public static string SuccessDeliveryInstruction => BuildSuccessDeliveryInstruction(null);
 
-- Clean success (margin 1-4): deliver essentially as written. Small word choice improvements only.
-- Strong success (margin 5-9): improve the phrasing, timing, or rhythm of what's already there.
-  You may: rearrange for better flow, sharpen word choice, add ONE word or phrase that makes the existing sentiment more precise.
-  You must not: add new sentences that introduce ideas not in the intended message, change the emotional register, or make the message say something the player didn't intend.
-- Critical success (margin 10-14): deliver at peak. The message arrives perfectly. Something resonates.
-- Exceptional (margin 15+): this is the best version of this message that could exist. It arrives at exactly the right moment with exactly the right weight. The opponent feels it.
-- Critical success / Nat 20: legendary. One sentence can be more effective than a paragraph if it's exactly right.
+        // Default delivery rule strings used when no DeliveryRules object is provided.
+        private const string DefaultClean = "deliver essentially as written. Small word choice improvements only.";
+        private const string DefaultStrong = "improve the phrasing, timing, or rhythm of what's already there.\n  You may: rearrange for better flow, sharpen word choice, add ONE word or phrase that makes the existing sentiment more precise.\n  You must not: add new sentences that introduce ideas not in the intended message, change the emotional register, or make the message say something the player didn't intend.";
+        private const string DefaultCritical = "deliver at peak. The message arrives perfectly. Something resonates.";
+        private const string DefaultExceptional = "this is the best version of this message that could exist. It arrives at exactly the right moment with exactly the right weight. The opponent feels it.";
+        private const string DefaultTest = "The test: every idea in the delivered version should have a counterpart in the intended version. New additions should sharpen, not expand.";
+        private const string DefaultRegisterInstruction = "Stay in character. Match the texting register from the character profile above. Do not change the character's capitalization style.";
+        private const string DefaultMediumRule = "This is a text message on a phone screen, not a monologue. No internal stage directions, no narration of emotional state, no self-commentary mid-message.";
 
-The test: if you read both the intended and delivered version, every idea in the delivered version should have a counterpart in the intended version. New additions should sharpen, not expand.
+        /// <summary>
+        /// §3.3 — Build the success delivery instruction from configurable rules.
+        /// Falls back to hardcoded defaults when rules is null.
+        /// </summary>
+        public static string BuildSuccessDeliveryInstruction(DeliveryRules rules)
+        {
+            string clean = (rules != null && !string.IsNullOrEmpty(rules.Clean)) ? rules.Clean.TrimEnd() : DefaultClean;
+            string strong = (rules != null && !string.IsNullOrEmpty(rules.Strong)) ? rules.Strong.TrimEnd() : DefaultStrong;
+            string critical = (rules != null && !string.IsNullOrEmpty(rules.Critical)) ? rules.Critical.TrimEnd() : DefaultCritical;
+            string exceptional = (rules != null && !string.IsNullOrEmpty(rules.Exceptional)) ? rules.Exceptional.TrimEnd() : DefaultExceptional;
+            string test = (rules != null && !string.IsNullOrEmpty(rules.Test)) ? rules.Test.TrimEnd() : DefaultTest;
+            string registerInstruction = (rules != null && !string.IsNullOrEmpty(rules.RegisterInstruction)) ? rules.RegisterInstruction.TrimEnd() : DefaultRegisterInstruction;
+            string mediumRule = (rules != null && !string.IsNullOrEmpty(rules.MediumRule)) ? rules.MediumRule.TrimEnd() : DefaultMediumRule;
 
-MEDIUM RULE: This is a text message, not a monologue. The character sends this message in a texting app.
-Write as text that would appear on a phone screen — no internal stage directions, no narration of their emotional state, no self-commentary mid-message.
-
-Keep it in character. Keep the lowercase voice. Don't explain the success.
-Output only the message text.";
+            return "Write as {player_name}.\n" +
+                "The intended message is the player's plan. Your job is to make it land.\n" +
+                "You beat the DC by {beat_dc_by}.\n" +
+                "\n" +
+                "- Clean success (margin 1-4): " + clean + "\n" +
+                "- Strong success (margin 5-9): " + strong + "\n" +
+                "- Critical success (margin 10-14): " + critical + "\n" +
+                "- Exceptional (margin 15+): " + exceptional + "\n" +
+                "- Critical success / Nat 20: legendary. One sentence can be more effective than a paragraph if it's exactly right.\n" +
+                "\n" +
+                test + "\n" +
+                "\n" +
+                "MEDIUM RULE: " + mediumRule + "\n" +
+                "\n" +
+                registerInstruction + " Don't explain the success.\n" +
+                "Output only the message text.";
+        }
 
         /// <summary>§3.4 — Degrade the intended message according to failure tier.</summary>
         public const string FailureDeliveryInstruction =

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -118,7 +118,8 @@ namespace Pinder.LlmAdapters
         /// </param>
         public static string BuildDeliveryPrompt(
             DeliveryContext context,
-            RollContextBuilder? rollContextBuilder = null)
+            RollContextBuilder? rollContextBuilder = null,
+            DeliveryRules? deliveryRules = null)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -166,7 +167,7 @@ namespace Pinder.LlmAdapters
                 string nat20Str = context.IsNat20 ? " (NAT 20)" : "";
                 string beatDcByStr = $"{context.BeatDcBy}{nat20Str}";
                 sb.AppendLine($"Stat: {context.ChosenOption.Stat.ToString().ToUpperInvariant()} | Beat DC by {beatDcByStr}");
-                sb.Append(PromptTemplates.SuccessDeliveryInstruction
+                sb.Append(PromptTemplates.BuildSuccessDeliveryInstruction(deliveryRules)
                     .Replace("{player_name}", playerName)
                     .Replace("{beat_dc_by}", beatDcByStr));
             }


### PR DESCRIPTION
## Summary

Moves the hardcoded success delivery prompt text from `PromptTemplates.SuccessDeliveryInstruction` into configurable `delivery_rules` in `game-definition.yaml`, making all tier descriptions, the register instruction, medium rule, and test constraint editable without code changes.

## Changes

- **`DeliveryRules` class** added to `GameDefinition.cs` — holds Clean, Strong, Critical, Exceptional, Test, RegisterInstruction, and MediumRule strings
- **`GameDefinition`** updated with optional `DeliveryRules` property, backward-compatible constructor, YAML parsing for `delivery_rules` key, and PinderDefaults population
- **`data/game-definition.yaml`** — new `delivery_rules:` section with all configurable text
- **`PromptTemplates`** — `SuccessDeliveryInstruction` changed from `const` to `BuildSuccessDeliveryInstruction(DeliveryRules)` static method with backward-compatible property accessor
- **Critical fix**: removed hardcoded "Keep the lowercase voice." — replaced with configurable `register_instruction`
- **`AnthropicLlmAdapter`** threads `DeliveryRules` from `GameDefinition` through to `SessionDocumentBuilder.BuildDeliveryPrompt`

## Test Results

- `dotnet test` — 0 new failures (LlmAdapters: 859 passed, Core: 2193 passed)
- Rules.Tests 46 failures are pre-existing on main

Closes #638