### PR TITLE
[Issue #442] Write spec document: Rules DSL: bidirectional Markdown↔YAML converter with round-trip diff verification

### DIFF
--- a/docs/specs/issue-442-spec.md
+++ b/docs/specs/issue-442-spec.md
@@ -1,0 +1,126 @@
+**Module**: docs/modules/rules-dsl.md
+
+## Overview
+The Rules DSL pipeline establishes a bidirectional Markdown↔YAML conversion system for game design documents. It extracts authoritative Markdown rules into structured YAML format, enriches them with machine-readable conditions and outcomes, generates xUnit C# test stubs, and verifies the fidelity of the conversion by round-tripping YAML back to Markdown and comparing diffs. This enables game designers to author in Markdown while providing the game engine with validated, data-driven parameters.
+
+## Function Signatures
+
+**`rules/tools/extract.py`**
+* `def slugify(text: str) -> str:`
+* `def guess_type(title: str, blocks: list) -> str:`
+* `def parse_table(lines: list) -> dict:`
+* `def parse_archetype_blocks(title: str, blocks: list, current_tier: int) -> dict:`
+* `def extract_rules(filepath: str) -> list:`
+
+**`rules/tools/generate.py`**
+* `def generate_table(table_block: dict) -> str:`
+* `def render_blocks(blocks: list) -> str:`
+* `def generate_archetype_definition(rule: dict, heading_level: int = 4) -> str:`
+* `def rule_to_markdown(rule: dict, heading_level: int = 2) -> str:`
+* `def generate_markdown(rules: list) -> str:`
+
+**`rules/tools/enrich.py`**
+* `def load_yaml(path: str) -> list:`
+* `def save_yaml(path: str, data: list) -> None:`
+* `def enrich_rules_v3(entries: list) -> list:`
+* `def enrich_risk_reward(entries: list) -> list:`
+* `def enrich_async_time(entries: list) -> list:`
+* `def enrich_traps(entries: list) -> list:`
+* `def enrich_archetypes(entries: list) -> list:`
+* `def count_enriched(entries: list) -> tuple:`
+* `def validate_vocabulary(entries: list, filename: str) -> list:`
+
+**`rules/tools/accuracy_check.py`**
+* `def check_file(filepath: str) -> list:`
+
+*(Note: `coverage_check.py` and `generate_tests.py` contain standard CLI main entry points for pipeline execution as documented in the issue)*
+
+## Input/Output Examples
+
+**Extraction (Markdown to YAML)**
+*Input (`rules-v3.md`)*:
+```markdown
+## Fumble (Miss by 1-2)
+-1 Interest. You stumbled, but it's recoverable.
+```
+*Output (`extracted/rules-v3.yaml`)*:
+```yaml
+- id: fumble-miss-by-1-2
+  section: Fumble (Miss by 1-2)
+  type: interest_change
+  description: "-1 Interest. You stumbled, but it's recoverable."
+  blocks:
+    - kind: paragraph
+      text: "-1 Interest. You stumbled, but it's recoverable."
+```
+
+**Enrichment**
+*Input (`extracted/rules-v3.yaml`)*:
+(Same as above)
+*Output (`extracted/rules-v3-enriched.yaml`)*:
+```yaml
+- id: fumble-miss-by-1-2
+  section: Fumble (Miss by 1-2)
+  type: interest_change
+  description: "-1 Interest. You stumbled, but it's recoverable."
+  condition:
+    miss_margin_min: 1
+    miss_margin_max: 2
+  outcome:
+    interest_delta: -1
+```
+
+**Test Generation**
+*Input (`extracted/rules-v3-enriched.yaml`)*:
+(Same as above)
+*Output (`RulesSpecTests_Enriched.cs`)*:
+```csharp
+[Fact]
+public void FumbleMissBy12_AppliesEffect()
+{
+    // Arrange & Act
+    var delta = FailureScale.GetInterestDelta(FailureTier.Fumble);
+    
+    // Assert
+    Assert.Equal(-1, delta);
+}
+```
+
+## Acceptance Criteria
+
+1. **Bidirectional Extraction & Generation**
+   - The system must extract blocks (paragraphs, tables, code blocks, blockquotes) from Markdown files into an ordered list in YAML.
+   - The system must generate Markdown from YAML that maintains block ordering, table alignments, and column widths.
+2. **Round-Trip Fidelity**
+   - When extracting a document to YAML and regenerating it back to Markdown, the textual diff must not exceed 50 lines per document.
+   - No information loss (prose, structural depth) is permitted during the round-trip.
+3. **Coverage Enforcement**
+   - Every section heading in the source Markdown must have a corresponding extracted YAML entry (100% coverage, resulting in 0 orphaned entries).
+4. **Data Enrichment**
+   - The system must parse unstructured text into structured `condition` and `outcome` vocabularies for mechanical rules (e.g., `interest_change`, `roll_modifier`, `shadow_growth`).
+5. **Test Stub Generation**
+   - The system must generate C# xUnit test stubs (`RulesSpecTests.cs`) based on the YAML definitions.
+   - Qualitative/LLM rules must be mapped to `[Fact(Skip = "...")]` with `NotImplementedException`.
+6. **Accuracy Validation**
+   - Machine-readable enriched data must be validated against the source prose to ensure semantic equivalence without deviations.
+
+## Edge Cases
+
+* **Empty Cells / Padded Tables**: Tables with padded cells (e.g., `| ------------- |`) must be accurately represented and regenerated with identical padding.
+* **Heading Depth Flattening**: Headings `###` and `####` map to `##` upon regeneration. The hierarchical depth is safely maintained in the YAML `id` slug and `heading_level` properties.
+* **Unstructured Prose**: Rule blocks that are purely thematic or qualitative fallback to unstructured formatting or skipped test stubs if they represent cosmetic instructions.
+* **Open-ended Ranges**: Ranges like "Miss by 10+" map to `min: 10` without a `max` bound in the condition schema.
+
+## Error Conditions
+
+* **Extraction Failure**: Raised if a table in Markdown is malformed or lacks a separator row.
+* **CoverageMismatch**: Fails if a Markdown section has no corresponding YAML block.
+* **VocabularyValidationError**: Raised by `validate_vocabulary` if unrecognized keys are used in `condition` or `outcome`.
+* **Diff Threshold Exceeded**: The `roundtrip_test.sh` script fails with a non-zero exit code if any regenerated file exceeds the 50-line diff limit.
+
+## Dependencies
+
+* **Python 3.x**
+* **PyYAML**: Used for parsing and dumping YAML structures safely.
+* **Bash**: Required for executing `roundtrip_test.sh`.
+* **xUnit / C#**: Target framework for the output of `generate_tests.py`.

--- a/docs/specs/issue-484-spec.md
+++ b/docs/specs/issue-484-spec.md
@@ -1,0 +1,91 @@
+**Module**: docs/modules/session-runner.md
+
+## Overview
+
+The `session-runner` playtest log output will be enriched with inline rule explanations. Whenever a mechanical event occurs (a fail tier, trap activation, combo trigger, shadow growth, or Nat 1 / Nat 20), the log will insert a blockquote `> 📋 *Explanation*` line. This clarifies the game logic and consequences directly in the playtest transcript, pulling from the `RuleBook` (enriched YAML) where possible, with hard-coded fallbacks.
+
+## Function Signatures
+
+In `Pinder.SessionRunner` (e.g. within a new `RuleExplanationFormatter` class or as static methods added to `PlaytestFormatter`):
+
+```csharp
+namespace Pinder.SessionRunner
+{
+    public sealed class RuleExplanationFormatter
+    {
+        public RuleExplanationFormatter(Pinder.Rules.RuleBook? ruleBook);
+
+        /// <summary>Formats the rule explanation blockquote for a fail tier.</summary>
+        public string FormatFailTierExplanation(Pinder.Core.Rolls.FailureTier tier);
+
+        /// <summary>Formats the rule explanation blockquote for a combo.</summary>
+        public string FormatComboExplanation(string comboName);
+
+        /// <summary>Formats the rule explanation blockquote for a trap.</summary>
+        public string FormatTrapExplanation(Pinder.Core.Traps.TrapDefinition trap);
+
+        /// <summary>Formats the rule explanation blockquote for shadow growth.</summary>
+        public string FormatShadowGrowthExplanation(string shadowType);
+
+        /// <summary>Formats the rule explanation blockquote for a Natural 1.</summary>
+        public string FormatNat1Explanation();
+
+        /// <summary>Formats the rule explanation blockquote for a Natural 20.</summary>
+        public string FormatNat20Explanation();
+    }
+}
+```
+
+## Input/Output Examples
+
+**Fail Tier (Misfire)**
+- Input: `FailureTier.Misfire`
+- Output: `"> 📋 *Misfire: The message goes sideways. Interest −1. No trap.*"`
+
+**Combo (The Pivot)**
+- Input: `"The Pivot"`
+- Output: `"> 📋 *The Pivot (Honesty → Chaos): Emotional whiplash that lands. +1 bonus Interest on top of roll gain.*"`
+
+**Trap (The Spiral)**
+- Input: `new TrapDefinition { Id = "the_spiral", Stat = StatType.SelfAwareness }`
+- Output: `"> 📋 *The Spiral: Self-awareness collapses inward. All options carry meta-commentary. Clear: Read action (SA vs DC 12, uses your turn, −1 Interest on fail).*"`
+
+**Shadow Growth (Fixation)**
+- Input: `"Fixation"`
+- Output: `"> 📋 *Fixation penalizes Chaos. At 6: Chaos options feel calculated. At 12: Chaos disadvantage. At 18: forced to repeat last stat.*"`
+
+**Nat 1**
+- Input: *(none)*
+- Output: `"> 📋 *Legendary Fail: Automatic fail. −4 Interest. Trap fires. Shadow +1 on paired stat. Unique disaster — the character's worst impulse surfaces fully.*"`
+
+## Acceptance Criteria
+
+1. **Roll outcome**: Roll outcome line is followed by a 📋 explanation blockquote (including fail tier name, interest delta, trap note).
+2. **Combo fires**: Combo triggers are followed by a 📋 explanation blockquote (including the sequence, bonus, and meaning).
+3. **Trap activation**: Trap activations are followed by a 📋 explanation blockquote (including effect, duration, and how to clear).
+4. **Shadow growth**: Shadow growth events are followed by a 📋 explanation blockquote (detailing what the shadow does at current level and next thresholds).
+5. **Nat 1 and Nat 20**: These critical events are followed by a 📋 explanation blockquote.
+6. **Data Source**: Explanations load from `RuleBook` enriched YAML where possible:
+   - Fail tier descriptions: `§5.fail.{tier}` → `description` field
+   - Trap descriptions: `§14.trap.{trap_id}` or from `data/traps/traps.json`
+   - Combo descriptions: `§15.combo.{combo_name}` → `description` + `outcome.interest_bonus`
+   - Shadow growth: `§7.shadow.{shadow_type}` threshold descriptions
+   - Fallback: hard-coded short descriptions if rule book not loaded.
+7. **Build clean**: Solution compiles with zero warnings or errors.
+
+## Edge Cases
+
+- **Missing RuleBook**: If `RuleBook` is null (e.g. YAML file not loaded or found by runner), the formatter must degrade gracefully to hard-coded fallback strings.
+- **Missing Entry in RuleBook**: If the `RuleBook` exists but `ruleBook.GetById(id)` returns null for a specific key, the formatter must fall back to the hard-coded string.
+- **Unrecognized Combo/Shadow**: If an unknown `comboName` or `shadowType` is passed, the formatter should return a generic explanation or an empty string, rather than crashing.
+- **Missing Trap Data**: If `TrapDefinition` lacks a clear condition or description, default formatting should handle nulls gracefully.
+
+## Error Conditions
+
+- **No Exceptions Thrown**: The formatter methods must be pure and safe. Under no circumstances should formatting a log output throw an exception (e.g. `NullReferenceException`, `KeyNotFoundException`). All dictionary and object lookups must be null-conditional and safely defaulted.
+
+## Dependencies
+
+- **`Pinder.Rules.RuleBook`**: For querying YAML rule descriptions.
+- **`Pinder.Core.Traps.TrapDefinition`**: For trap details.
+- **`Pinder.Core.Rolls.FailureTier`**: For switch branching on roll failures.


### PR DESCRIPTION
Refs #442

## DoD Evidence
**Branch:** issue-442-write-spec-document-rules-dsl-bidirectio
**Commit:** 5aac81e
