### PR TITLE
[Issue #381] Write spec document: Test cleanup: delete 3 trivial InterestMeter tests from CharacterSystemTests.cs

### DIFF
--- a/docs/specs/issue-380-spec.md
+++ b/docs/specs/issue-380-spec.md
@@ -1,0 +1,37 @@
+**Module**: docs/modules/llm-adapters.md
+
+## Overview
+This specification addresses the cleanup of redundant test coverage for Tell Categories (from Issue #311). The `Issue311_TellCategoriesSpecTests.cs` file contains 14 tests that duplicate the coverage provided by a `Theory` in `Issue311_TellCategoriesTests.cs`. Deleting the duplicate file reduces the net test count by 14 and lowers the test maintenance burden without sacrificing coverage.
+
+## Function Signatures
+No production functions or methods are changed. The scope is purely the deletion of a single test file.
+- **Target File**: `tests/Pinder.LlmAdapters.Tests/Issue311_TellCategoriesSpecTests.cs` (to be deleted)
+
+## Input/Output Examples
+**Input:** Test suite execution before deletion.
+**Output:** Test suite passes.
+
+**Input:** Test suite execution after deletion.
+**Output:** Test suite passes with the total number of executed tests reduced by exactly 14.
+
+## Acceptance Criteria
+
+### `Issue311_TellCategoriesSpecTests.cs` deleted
+The file `tests/Pinder.LlmAdapters.Tests/Issue311_TellCategoriesSpecTests.cs` must be completely removed from the repository. No logic, helpers, or test cases from this file need to be merged into any other file.
+
+### All remaining tests pass
+The entire test suite must compile and execute cleanly after the deletion. There should be no compilation errors, missing references, or test failures resulting from this removal.
+
+### Net test count reduced by 14
+The test runner output must reflect that the total number of tests executed is exactly 14 less than the count prior to the deletion.
+
+## Edge Cases
+- **Shared Helpers:** Ensure no other test classes or files depend on constants, fixtures, or helper methods defined exclusively inside `Issue311_TellCategoriesSpecTests.cs`.
+- **Dangling References:** Verify the project file (`Pinder.LlmAdapters.Tests.csproj`) does not hardcode an inclusion of the deleted file (though SDK-style projects typically use auto-globbing).
+
+## Error Conditions
+- **Build Failure:** If deleting the file causes a compiler error, another file incorrectly references a symbol inside `Issue311_TellCategoriesSpecTests.cs`. That reference must be removed or properly isolated.
+- **Test Count Mismatch:** If the test count drops by a number other than 14, investigate whether the file being deleted contained a different number of tests than expected, or if another file was inadvertently modified or deleted.
+
+## Dependencies
+- **Component:** `Pinder.LlmAdapters.Tests`

--- a/docs/specs/issue-381-spec.md
+++ b/docs/specs/issue-381-spec.md
@@ -1,0 +1,36 @@
+# Specification: Test cleanup: delete 3 trivial InterestMeter tests
+
+**Module**: docs/modules/conversation.md
+
+## Overview
+This issue involves cleaning up the test suite by deleting three trivial `InterestMeter` tests from `CharacterSystemTests.cs`. These tests simply assert that constants equal literals or duplicate existing tests in other files, providing no real value and causing brittle failures if constants change.
+
+## Function Signatures
+*N/A - This issue only involves deleting test code.*
+
+## Input/Output Examples
+*N/A*
+
+## Acceptance Criteria
+
+### 1. Remove 3 trivial tests from `CharacterSystemTests.cs`
+The following three test methods must be completely deleted from `tests/Pinder.Core.Tests/CharacterSystemTests.cs`:
+- `InterestMeter_MaxIs25()`
+- `InterestMeter_StartingValueIs10()`
+- `InterestMeter_StartsAt10()`
+
+### 2. All remaining tests pass
+The deletion of these tests must not impact the build or the execution of any other tests in the suite. All remaining tests must pass successfully.
+
+### 3. Net count reduced by 3
+The total number of tests in the test suite should decrease by exactly 3 after these deletions.
+
+## Edge Cases
+- **Constant Usage**: Ensure that no other tests are relying on these specific test methods (which is impossible in xUnit/NUnit anyway, but guarantees no indirect breakages).
+
+## Error Conditions
+- If the tests are not correctly removed, the net count of tests will not decrease by 3.
+- If extra code is accidentally deleted, the project might fail to compile.
+
+## Dependencies
+- `tests/Pinder.Core.Tests/CharacterSystemTests.cs`

--- a/docs/specs/issue-382-spec.md
+++ b/docs/specs/issue-382-spec.md
@@ -1,0 +1,83 @@
+# Specification: Test Coverage for SuccessScale
+
+**Module**: docs/modules/rolls.md
+
+## Overview
+This issue adds comprehensive unit test coverage for the `SuccessScale` static class, ensuring that the rules for determining interest deltas on successful rolls are explicitly verified. This creates a more robust testing suite by decoupling the verification of success tiers from `GameSession` integration tests and guaranteeing correct behavior at tier boundaries.
+
+## Function Signatures
+
+This issue introduces a new unit test class. It does not modify any existing production code.
+
+```csharp
+namespace Pinder.Core.Tests.Rolls
+{
+    public class SuccessScaleTests
+    {
+        [Theory]
+        [InlineData(1, true, false, 1)]
+        [InlineData(4, true, false, 1)]
+        [InlineData(5, true, false, 2)]
+        [InlineData(9, true, false, 2)]
+        [InlineData(10, true, false, 3)]
+        [InlineData(50, true, false, 3)]
+        [InlineData(1, true, true, 4)]
+        [InlineData(-5, false, false, 0)]
+        public void GetInterestDelta_ReturnsExpectedValue(int margin, bool isSuccess, bool isNat20, int expectedDelta);
+    }
+}
+```
+
+*Note: The exact method signature or data provision strategy (`InlineData`, `MemberData`, etc.) is determined by the implementation as long as all boundaries described below are tested.*
+
+## Input/Output Examples
+
+The tests must invoke `SuccessScale.GetInterestDelta(RollResult result)` with `RollResult` instances configured as follows:
+
+| Margin | IsSuccess | IsNat20 | Expected Delta | Reason |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | `true` | `false` | `1` | Lower boundary for Tier 1 |
+| 4 | `true` | `false` | `1` | Upper boundary for Tier 1 |
+| 5 | `true` | `false` | `2` | Lower boundary for Tier 2 |
+| 9 | `true` | `false` | `2` | Upper boundary for Tier 2 |
+| 10 | `true` | `false` | `3` | Lower boundary for Tier 3 |
+| 50 | `true` | `false` | `3` | Large margin for Tier 3 |
+| (Any) | `true` | `true` | `4` | Natural 20 |
+| (Any) | `false` | `false` | `0` | Failure (margin <= 0) |
+
+## Acceptance Criteria
+
+### 1. Create `SuccessScaleTests.cs`
+- The file `tests/Pinder.Core.Tests/Rolls/SuccessScaleTests.cs` (or `tests/Pinder.Core.Tests/SuccessScaleTests.cs`) must be created.
+- The tests must use `[Theory]` and provide `[InlineData]` or `MemberData` to verify all specific boundaries.
+
+### 2. Verify all tier boundaries
+- margin=1 → +1
+- margin=4 → +1
+- margin=5 → +2
+- margin=9 → +2
+- margin=10 → +3
+- margin=50 → +3
+- Nat 20 → +4 (regardless of the margin)
+- margin=0 or below (failure) → 0
+
+### 3. Direct unit tests
+- The assertions must directly target `SuccessScale.GetInterestDelta()`.
+- The tests must NOT use or instantiate `GameSession` or other external system integration components.
+
+### 4. Build clean, all tests pass
+- The overall solution must compile without warnings.
+- The new tests and all existing tests in the suite must pass successfully.
+
+## Edge Cases
+- **Natural 20 with small margin:** Even if the margin is low (e.g., 1 or even negative) but `IsNat20` is true, the delta returned must be exactly 4.
+- **Failures:** `IsSuccess` evaluates to false, which must always result in 0 regardless of other properties.
+- **Extreme Margins:** Unusually high margins (e.g., 50 or 100) must consistently return the tier 3 bonus of +3.
+
+## Error Conditions
+- Since `SuccessScale.GetInterestDelta()` handles logic based on its parameter properties securely, no explicit error throws are expected based on game values. 
+- A null `RollResult` will trigger a standard `NullReferenceException`, which is typical and out of scope for boundary logic testing.
+
+## Dependencies
+- **Pinder.Core**: Target of testing.
+- **xUnit**: The testing framework utilized to execute `[Theory]` tests.


### PR DESCRIPTION
Refs #381

## DoD Evidence
**Branch:** issue-381-write-spec-document-test-cleanup-delete-
**Commit:** 2c0b82f
