### PR TITLE
feat: active archetype injection, shadow growth warnings, LlmPlayerAgent character voice (closes #649 #644 #492)

### DIFF
--- a/session-runner/CharacterDefinitionLoader.cs
+++ b/session-runner/CharacterDefinitionLoader.cs
@@ -86,7 +86,7 @@ namespace Pinder.SessionRunner
 
                 // Run assembly pipeline
                 var assembler = new CharacterAssembler(itemRepo, anatomyRepo);
-                var fragments = assembler.Assemble(items, anatomy, buildPoints, shadows);
+                var fragments = assembler.Assemble(items, anatomy, buildPoints, shadows, level);
 
                 // Build system prompt
                 string systemPrompt = PromptBuilder.BuildSystemPrompt(
@@ -101,7 +101,8 @@ namespace Pinder.SessionRunner
                 return new CharacterProfile(
                     fragments.Stats, systemPrompt, name, fragments.Timing, level,
                     bio: bio,
-                    textingStyleFragment: textingStyle);
+                    textingStyleFragment: textingStyle,
+                    activeArchetype: fragments.ActiveArchetype);
             }
         }
 

--- a/session-runner/LlmPlayerAgent.cs
+++ b/session-runner/LlmPlayerAgent.cs
@@ -17,10 +17,11 @@ namespace Pinder.SessionRunner
     /// </summary>
     public sealed class LlmPlayerAgent : IPlayerAgent, IDisposable
     {
-        private const string SystemMessage =
-            "You are a strategic player in Pinder, a comedy dating RPG. You analyze game mechanics " +
-            "and choose the optimal dialogue option each turn. Your goal is to reach Interest 25 " +
-            "(date secured) while avoiding Interest 0 (unmatched/ghosted).";
+        private const string DefaultSystemMessage =
+            "You are playing Pinder, a comedy dating RPG. You make choices as your character — " +
+            "genuine, in-voice decisions that reflect who they are. You want to reach Interest 25 " +
+            "(date secured) while avoiding Interest 0 (unmatched/ghosted), but you choose based on " +
+            "what your character would actually say, not just what maximizes expected value.";
 
         private const string RulesReminder =
             "## Rules Reminder\n" +
@@ -82,12 +83,14 @@ namespace Pinder.SessionRunner
             {
                 string userMessage = BuildPrompt(turn, context);
 
+                string systemMsg = BuildSystemMessage(context);
+
                 var request = new MessagesRequest
                 {
                     Model = _model,
                     MaxTokens = 512,
-                    Temperature = 0.3,
-                    System = new[] { new ContentBlock { Type = "text", Text = SystemMessage } },
+                    Temperature = 0.5,
+                    System = new[] { new ContentBlock { Type = "text", Text = systemMsg } },
                     Messages = new[] { new Message { Role = "user", Content = userMessage } }
                 };
 
@@ -126,15 +129,47 @@ namespace Pinder.SessionRunner
         }
 
         /// <summary>
+        /// Builds the system message, incorporating character personality if available.
+        /// </summary>
+        private string BuildSystemMessage(PlayerAgentContext context)
+        {
+            if (!string.IsNullOrEmpty(context.PlayerSystemPrompt))
+            {
+                string name = !string.IsNullOrEmpty(context.PlayerName) ? context.PlayerName : _playerName;
+                return $"You are {name}, making genuine character choices in Pinder (a comedy dating RPG). " +
+                       $"Stay in character. Your personality and voice:\n\n{context.PlayerSystemPrompt}\n\n" +
+                       "Your goal is Interest 25 (date secured) while avoiding Interest 0. " +
+                       "Choose based on what you would actually send, not just mechanical optimization.";
+            }
+            return DefaultSystemMessage;
+        }
+
+        /// <summary>
         /// Builds the full LLM prompt from turn data and agent context.
         /// </summary>
         internal string BuildPrompt(TurnStart turn, PlayerAgentContext context)
         {
             var sb = new System.Text.StringBuilder(2048);
 
-            sb.AppendLine($"You are playing as {_playerName}, a sentient penis on a dating app.");
-            sb.AppendLine($"You are talking to {_opponentName}. Choose one of the dialogue options below.");
+            string playerLabel = !string.IsNullOrEmpty(context.PlayerName) ? context.PlayerName : _playerName;
+            string opponentLabel = !string.IsNullOrEmpty(context.OpponentName) ? context.OpponentName : _opponentName;
+
+            sb.AppendLine($"You are {playerLabel}. Choose one of the dialogue options below.");
+            sb.AppendLine($"You are talking to {opponentLabel}.");
             sb.AppendLine();
+
+            // Recent conversation context (#492)
+            if (context.RecentHistory != null && context.RecentHistory.Count > 0)
+            {
+                sb.AppendLine("## Recent Conversation");
+                int start = Math.Max(0, context.RecentHistory.Count - 6);
+                for (int i = start; i < context.RecentHistory.Count; i++)
+                {
+                    var entry = context.RecentHistory[i];
+                    sb.AppendLine($"{entry.Sender}: \"{entry.Text}\"");
+                }
+                sb.AppendLine();
+            }
 
             // Current state
             sb.AppendLine("## Current State");
@@ -176,8 +211,13 @@ namespace Pinder.SessionRunner
             // Rules reminder
             sb.AppendLine(RulesReminder);
 
-            sb.AppendLine("Explain your reasoning step by step, weighing success probability, interest gain, risk,");
-            sb.AppendLine("and any active bonuses or traps. Then state your final choice as:");
+            sb.AppendLine($"Think as {playerLabel}. What would you actually send here? Consider:");
+            sb.AppendLine("- Which option sounds most like something you'd genuinely type?");
+            sb.AppendLine("- Success probability and risk (you still want to win)");
+            sb.AppendLine("- Any active bonuses, traps, or momentum");
+            sb.AppendLine();
+            sb.AppendLine("Explain your reasoning in your character's voice — why this feels right,");
+            sb.AppendLine("not just why it's optimal. Then state your final choice as:");
             sb.AppendLine("PICK: [A/B/C/D]");
 
             return sb.ToString();

--- a/session-runner/PlayerAgentContext.cs
+++ b/session-runner/PlayerAgentContext.cs
@@ -47,6 +47,18 @@ namespace Pinder.SessionRunner
         /// <summary>Whether Honesty was available as an option last turn. False on first turn or unknown.</summary>
         public bool HonestyAvailableLastTurn { get; }
 
+        /// <summary>The player character's assembled system prompt (personality, texting style). Empty if not available.</summary>
+        public string PlayerSystemPrompt { get; }
+
+        /// <summary>The player character's display name.</summary>
+        public string PlayerName { get; }
+
+        /// <summary>The opponent character's display name.</summary>
+        public string OpponentName { get; }
+
+        /// <summary>Recent conversation history as (sender, text) pairs. Null or empty on first turn.</summary>
+        public IReadOnlyList<(string Sender, string Text)> RecentHistory { get; }
+
         public PlayerAgentContext(
             StatBlock playerStats,
             StatBlock opponentStats,
@@ -59,7 +71,11 @@ namespace Pinder.SessionRunner
             int turnNumber,
             StatType? lastStatUsed = null,
             StatType? secondLastStatUsed = null,
-            bool honestyAvailableLastTurn = false)
+            bool honestyAvailableLastTurn = false,
+            string playerSystemPrompt = "",
+            string playerName = "",
+            string opponentName = "",
+            IReadOnlyList<(string Sender, string Text)> recentHistory = null)
         {
             PlayerStats = playerStats ?? throw new ArgumentNullException(nameof(playerStats));
             OpponentStats = opponentStats ?? throw new ArgumentNullException(nameof(opponentStats));
@@ -73,6 +89,10 @@ namespace Pinder.SessionRunner
             LastStatUsed = lastStatUsed;
             SecondLastStatUsed = secondLastStatUsed;
             HonestyAvailableLastTurn = honestyAvailableLastTurn;
+            PlayerSystemPrompt = playerSystemPrompt ?? "";
+            PlayerName = playerName ?? "";
+            OpponentName = opponentName ?? "";
+            RecentHistory = recentHistory;
         }
     }
 }

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -295,7 +295,9 @@ class Program
         Console.WriteLine($"# Playtest Session {sessionNumber:D3} — {player1} × {player2}");
         Console.WriteLine($"**Date:** {DateTime.UtcNow:yyyy-MM-dd}");
         Console.WriteLine($"**Engine:** `pinder-core GameSession` + `AnthropicLlmAdapter` → claude-sonnet-4-20250514");
-        Console.WriteLine($"**Player:** {player1} (Level {p1Level}, +{p1LevelBonus} level bonus) | **Opponent:** {player2} (Level {p2Level}, +{p2LevelBonus} level bonus, LLM puppet)");
+        string p1Archetype = sable.ActiveArchetype != null ? $" | Archetype: {sable.ActiveArchetype.Name} ({sable.ActiveArchetype.InterferenceLevel})" : "";
+        string p2Archetype = brick.ActiveArchetype != null ? $" | Archetype: {brick.ActiveArchetype.Name} ({brick.ActiveArchetype.InterferenceLevel})" : "";
+        Console.WriteLine($"**Player:** {player1} (Level {p1Level}, +{p1LevelBonus} level bonus{p1Archetype}) | **Opponent:** {player2} (Level {p2Level}, +{p2LevelBonus} level bonus, LLM puppet{p2Archetype})");
         Console.WriteLine();
 
         // ── character table ───────────────────────────────────────────────
@@ -410,6 +412,9 @@ class Program
         int turn = 0;
         GameOutcome? finalOutcome = null;
         string lastOpponentMsg = "";
+        StatType? lastStatUsed = null;
+        StatType? secondLastStatUsed = null;
+        var conversationHistory = new List<(string Sender, string Text)>();
 
         while (turn < maxTurns)
         {
@@ -458,6 +463,20 @@ class Program
                 if (opt.ComboName != null)           badges.Add($"⭐ Combo: {opt.ComboName} ({PlaytestFormatter.GetComboRewardSummary(opt.ComboName)})");
                 if (opt.CallbackTurnNumber.HasValue) badges.Add("Callback");
                 if (opt.HasWeaknessWindow)           badges.Add("Window");
+                // Shadow growth warnings (#644)
+                bool honestyAvailable = Array.Exists(turnStart.Options, o => o.Stat == StatType.Honesty);
+                if (opt.Stat != StatType.Honesty && honestyAvailable)
+                    badges.Add("⚠️ Denial +1");
+                if (opt.Stat == StatType.Honesty && honestyAvailable && interest >= 15)
+                    badges.Add("✨ Denial -1");
+                if (lastStatUsed.HasValue && secondLastStatUsed.HasValue
+                    && lastStatUsed.Value == secondLastStatUsed.Value
+                    && opt.Stat == lastStatUsed.Value)
+                    badges.Add("⚠️ Fixation +1");
+                if (lastStatUsed.HasValue && secondLastStatUsed.HasValue
+                    && lastStatUsed.Value == secondLastStatUsed.Value
+                    && opt.Stat != lastStatUsed.Value)
+                    badges.Add("✨ breaks streak");
                 string badgeStr = badges.Count > 0 ? " | " + string.Join(", ", badges) : "";
                 Console.WriteLine($"**{letters[i]})** {StatLabel(opt.Stat)} {mod:+#;-#;0} | {pct}% {riskColor}{badgeStr}");
                 
@@ -486,7 +505,11 @@ class Program
                 activeTrapNames: snap.ActiveTrapNames,
                 sessionHorniness: 0,
                 shadowValues: currentShadowValues,
-                turnNumber: snap.TurnNumber);
+                turnNumber: snap.TurnNumber,
+                playerSystemPrompt: sable.AssembledSystemPrompt,
+                playerName: player1,
+                opponentName: player2,
+                recentHistory: conversationHistory.Count > 0 ? conversationHistory.AsReadOnly() : null);
             var decision = await agent.DecideAsync(turnStart, agentContext);
             int pick = decision.OptionIndex;
             var chosen = turnStart.Options[pick];
@@ -563,7 +586,12 @@ class Program
             }
             Console.WriteLine();
 
+            // Track conversation history for LLM agent context (#492)
+            if (!string.IsNullOrEmpty(result.DeliveredMessage))
+                conversationHistory.Add((player1, result.DeliveredMessage));
             lastOpponentMsg = result.OpponentMessage ?? "";
+            if (!string.IsNullOrEmpty(lastOpponentMsg))
+                conversationHistory.Add((player2, lastOpponentMsg));
             Console.WriteLine($"**📩 {player2} replies:**");
             PrintQuoted(result.OpponentMessage);
             Console.WriteLine();
@@ -587,6 +615,10 @@ class Program
 
             interest = newInterest;
             momentum = result.StateAfter.MomentumStreak;
+
+            // Track stat usage for shadow warnings (#644)
+            secondLastStatUsed = lastStatUsed;
+            lastStatUsed = chosen.Stat;
 
             if (result.NarrativeBeat != null) { Console.WriteLine(); Console.WriteLine($"{result.NarrativeBeat}"); }
             if (result.IsGameOver) { finalOutcome = result.Outcome; break; }

--- a/src/Pinder.Core/Characters/ActiveArchetype.cs
+++ b/src/Pinder.Core/Characters/ActiveArchetype.cs
@@ -1,0 +1,50 @@
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Represents the currently active archetype for a character, including
+    /// its behavioral directive and interference level.
+    /// </summary>
+    public sealed class ActiveArchetype
+    {
+        /// <summary>Display name (e.g. "The Peacock").</summary>
+        public string Name { get; }
+
+        /// <summary>Behavioral instruction text from archetype definitions.</summary>
+        public string Behavior { get; }
+
+        /// <summary>How many times this archetype appeared in the character's fragments.</summary>
+        public int Count { get; }
+
+        /// <summary>
+        /// Interference level derived from count: 1-2 = "slight", 3-5 = "clear", 6+ = "dominant".
+        /// </summary>
+        public string InterferenceLevel
+        {
+            get
+            {
+                if (Count >= 6) return "dominant";
+                if (Count >= 3) return "clear";
+                return "slight";
+            }
+        }
+
+        /// <summary>
+        /// Full directive string suitable for injection into LLM prompts.
+        /// Format: "ACTIVE ARCHETYPE: {Name} ({interference})\n{behavior}"
+        /// </summary>
+        public string Directive
+        {
+            get
+            {
+                return $"ACTIVE ARCHETYPE: {Name} ({InterferenceLevel})\n{Behavior}";
+            }
+        }
+
+        public ActiveArchetype(string name, string behavior, int count)
+        {
+            Name = name ?? string.Empty;
+            Behavior = behavior ?? string.Empty;
+            Count = count;
+        }
+    }
+}

--- a/src/Pinder.Core/Characters/ArchetypeCatalog.cs
+++ b/src/Pinder.Core/Characters/ArchetypeCatalog.cs
@@ -67,5 +67,28 @@ namespace Pinder.Core.Characters
             if (def == null) return true; // unknown archetypes are not filtered
             return def.IsEligibleAtLevel(characterLevel);
         }
+
+        /// <summary>
+        /// Returns the behavioral instruction for the given archetype, or a
+        /// placeholder if no behavior text is registered.
+        /// </summary>
+        public static string GetBehavior(string archetypeName)
+        {
+            if (_behaviors.TryGetValue(archetypeName, out var behavior))
+                return behavior;
+            return $"Follow {archetypeName} behavioral pattern.";
+        }
+
+        /// <summary>
+        /// Register behavior text for an archetype (e.g. loaded from YAML).
+        /// </summary>
+        public static void RegisterBehavior(string archetypeName, string behavior)
+        {
+            if (!string.IsNullOrEmpty(archetypeName) && !string.IsNullOrEmpty(behavior))
+                _behaviors[archetypeName] = behavior;
+        }
+
+        private static readonly Dictionary<string, string> _behaviors
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Pinder.Core/Characters/CharacterAssembler.cs
+++ b/src/Pinder.Core/Characters/CharacterAssembler.cs
@@ -173,7 +173,11 @@ namespace Pinder.Core.Characters
                 .Select(kv => (kv.Key, kv.Value))
                 .ToList();
 
-            // --- 7. Return FragmentCollection -------------------------------------
+            // --- 7. Resolve active archetype ------------------------------------
+
+            ActiveArchetype activeArchetype = ResolveActiveArchetype(ranked, characterLevel);
+
+            // --- 8. Return FragmentCollection -------------------------------------
 
             return new FragmentCollection(
                 personality.AsReadOnly(),
@@ -181,7 +185,40 @@ namespace Pinder.Core.Characters
                 texting.AsReadOnly(),
                 ranked.AsReadOnly(),
                 timingProfile,
-                statBlock);
+                statBlock,
+                activeArchetype);
+        }
+
+        /// <summary>
+        /// Selects the active archetype from ranked archetypes based on character level.
+        /// If characterLevel > 0, prefers the highest-count archetype whose level range
+        /// includes the character's level. Falls back to highest-count overall.
+        /// </summary>
+        internal static ActiveArchetype ResolveActiveArchetype(
+            IReadOnlyList<(string Archetype, int Count)> ranked,
+            int characterLevel)
+        {
+            if (ranked == null || ranked.Count == 0)
+                return null;
+
+            // Try to find the highest-count archetype eligible at this level
+            if (characterLevel > 0)
+            {
+                foreach (var entry in ranked)
+                {
+                    var def = ArchetypeCatalog.GetByName(entry.Archetype);
+                    if (def != null && def.IsEligibleAtLevel(characterLevel))
+                    {
+                        string behavior = ArchetypeCatalog.GetBehavior(entry.Archetype);
+                        return new ActiveArchetype(entry.Archetype, behavior, entry.Count);
+                    }
+                }
+            }
+
+            // Fallback: use the highest-count archetype overall
+            var top = ranked[0];
+            string topBehavior = ArchetypeCatalog.GetBehavior(top.Archetype);
+            return new ActiveArchetype(top.Archetype, topBehavior, top.Count);
         }
     }
 }

--- a/src/Pinder.Core/Characters/CharacterProfile.cs
+++ b/src/Pinder.Core/Characters/CharacterProfile.cs
@@ -34,6 +34,12 @@ namespace Pinder.Core.Characters
         /// </summary>
         public string TextingStyleFragment { get; }
 
+        /// <summary>
+        /// The character's active archetype, or null if none resolved.
+        /// Carries name, behavior directive, and interference level.
+        /// </summary>
+        public ActiveArchetype ActiveArchetype { get; }
+
         public CharacterProfile(
             StatBlock stats,
             string assembledSystemPrompt,
@@ -41,7 +47,8 @@ namespace Pinder.Core.Characters
             TimingProfile timing,
             int level,
             string bio = "",
-            string textingStyleFragment = "")
+            string textingStyleFragment = "",
+            ActiveArchetype activeArchetype = null)
         {
             Stats = stats ?? throw new ArgumentNullException(nameof(stats));
             AssembledSystemPrompt = assembledSystemPrompt ?? throw new ArgumentNullException(nameof(assembledSystemPrompt));
@@ -50,6 +57,7 @@ namespace Pinder.Core.Characters
             Level = level;
             Bio = bio ?? string.Empty;
             TextingStyleFragment = textingStyleFragment ?? string.Empty;
+            ActiveArchetype = activeArchetype;
         }
     }
 }

--- a/src/Pinder.Core/Characters/FragmentCollection.cs
+++ b/src/Pinder.Core/Characters/FragmentCollection.cs
@@ -31,13 +31,20 @@ namespace Pinder.Core.Characters
         /// <summary>Effective stat block (base + item + anatomy modifiers, shadow applied).</summary>
         public StatBlock Stats { get; }
 
+        /// <summary>
+        /// The resolved active archetype for this character, or null if none could be determined.
+        /// Selected based on character level and archetype frequency.
+        /// </summary>
+        public ActiveArchetype ActiveArchetype { get; }
+
         public FragmentCollection(
             IReadOnlyList<string> personalityFragments,
             IReadOnlyList<string> backstoryFragments,
             IReadOnlyList<string> textingStyleFragments,
             IReadOnlyList<(string Archetype, int Count)> rankedArchetypes,
             TimingProfile timing,
-            StatBlock stats)
+            StatBlock stats,
+            ActiveArchetype activeArchetype = null)
         {
             PersonalityFragments  = personalityFragments;
             BackstoryFragments    = backstoryFragments;
@@ -45,6 +52,7 @@ namespace Pinder.Core.Characters
             RankedArchetypes      = rankedArchetypes;
             Timing                = timing;
             Stats                 = stats;
+            ActiveArchetype       = activeArchetype;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/DialogueContext.cs
+++ b/src/Pinder.Core/Conversation/DialogueContext.cs
@@ -60,6 +60,9 @@ namespace Pinder.Core.Conversation
         /// <summary>The stats available for options this turn (randomly drawn). Null means all 6 stats available.</summary>
         public StatType[]? AvailableStats { get; }
 
+        /// <summary>Active archetype directive for the player character, or null if none.</summary>
+        public string ActiveArchetypeDirective { get; }
+
         public DialogueContext(
             string playerPrompt,
             string opponentPrompt,
@@ -77,7 +80,8 @@ namespace Pinder.Core.Conversation
             int currentTurn = 0,
             string playerTextingStyle = "",
             Tell? activeTell = null,
-            StatType[]? availableStats = null)
+            StatType[]? availableStats = null,
+            string activeArchetypeDirective = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -96,6 +100,7 @@ namespace Pinder.Core.Conversation
             PlayerTextingStyle = playerTextingStyle ?? "";
             ActiveTell = activeTell;
             AvailableStats = availableStats;
+            ActiveArchetypeDirective = activeArchetypeDirective;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -297,6 +297,9 @@ namespace Pinder.Core.Conversation
             var activeTrapInstructions = GetActiveTrapInstructions();
 
             // Build dialogue context — pass callback topics (#47) and shadow thresholds (#45)
+            // Resolve active archetype directive for player
+            string playerArchetypeDirective = _player.ActiveArchetype?.Directive;
+
             var context = new DialogueContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -311,7 +314,8 @@ namespace Pinder.Core.Conversation
                 requiresRizzOption: _sessionHorniness >= 12,
                 currentTurn: _turnNumber,
                 playerTextingStyle: _player.TextingStyleFragment,
-                activeTell: _activeTell);
+                activeTell: _activeTell,
+                activeArchetypeDirective: playerArchetypeDirective);
 
             // Get dialogue options from LLM
             var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
@@ -649,6 +653,9 @@ namespace Pinder.Core.Conversation
                 }
             }
 
+            // Resolve active archetype directive for opponent
+            string opponentArchetypeDirective = _opponent.ActiveArchetype?.Directive;
+
             var opponentContext = new OpponentContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -665,7 +672,8 @@ namespace Pinder.Core.Conversation
                 opponentName: _opponent.DisplayName,
                 currentTurn: _turnNumber,
                 shadowThresholds: opponentShadowThresholds,
-                deliveryTier: rollResult.Tier);
+                deliveryTier: rollResult.Tier,
+                activeArchetypeDirective: opponentArchetypeDirective);
 
             var opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
             if (opponentResponse == null)

--- a/src/Pinder.Core/Conversation/OpponentContext.cs
+++ b/src/Pinder.Core/Conversation/OpponentContext.cs
@@ -57,6 +57,9 @@ namespace Pinder.Core.Conversation
         /// <summary>Failure tier of the player's last roll. None means success. Default None for backward compatibility.</summary>
         public FailureTier DeliveryTier { get; }
 
+        /// <summary>Active archetype directive for the opponent character, or null if none.</summary>
+        public string ActiveArchetypeDirective { get; }
+
         public OpponentContext(
             string playerPrompt,
             string opponentPrompt,
@@ -73,7 +76,8 @@ namespace Pinder.Core.Conversation
             string playerName = "",
             string opponentName = "",
             int currentTurn = 0,
-            FailureTier deliveryTier = FailureTier.None)
+            FailureTier deliveryTier = FailureTier.None,
+            string activeArchetypeDirective = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -91,6 +95,7 @@ namespace Pinder.Core.Conversation
             OpponentName = opponentName ?? "";
             CurrentTurn = currentTurn;
             DeliveryTier = deliveryTier;
+            ActiveArchetypeDirective = activeArchetypeDirective;
         }
     }
 }

--- a/src/Pinder.Core/Pinder.Core.csproj
+++ b/src/Pinder.Core/Pinder.Core.csproj
@@ -8,4 +8,10 @@
     <AssemblyName>Pinder.Core</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Pinder.Core.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -91,6 +91,13 @@ namespace Pinder.LlmAdapters
                 gameState.AppendLine("it landed differently than intended. The player read the room.");
             }
 
+            // Inject active archetype directive (#649)
+            if (!string.IsNullOrEmpty(context.ActiveArchetypeDirective))
+            {
+                sb.AppendLine(context.ActiveArchetypeDirective);
+                sb.AppendLine();
+            }
+
             // Inject texting style immediately before the ENGINE block (#489)
             if (!string.IsNullOrEmpty(context.PlayerTextingStyle))
             {
@@ -299,6 +306,13 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine();
                 sb.AppendLine("SHADOW STATE (corrupting forces on your communication)");
                 sb.AppendLine(opponentTaint);
+            }
+
+            // Inject active archetype directive for opponent (#649)
+            if (!string.IsNullOrEmpty(context.ActiveArchetypeDirective))
+            {
+                sb.AppendLine();
+                sb.AppendLine(context.ActiveArchetypeDirective);
             }
 
             sb.AppendLine();

--- a/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
+++ b/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using Pinder.Core.Characters;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for ActiveArchetype resolution in CharacterAssembler (#649).
+    /// </summary>
+    public class ActiveArchetypeTests
+    {
+        [Fact]
+        public void ResolveActiveArchetype_SelectsHighestCountEligibleAtLevel()
+        {
+            // Arrange: "The Peacock" (3-8) count=5, "The Sniper" (5-11) count=3
+            var ranked = new List<(string Archetype, int Count)>
+            {
+                ("The Peacock", 5),
+                ("The Sniper", 3),
+                ("The Hey Opener", 2)
+            };
+
+            // Act: level 4 — Peacock eligible (3-8), Sniper not (5-11)
+            var result = CharacterAssembler.ResolveActiveArchetype(ranked, 4);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("The Peacock", result.Name);
+            Assert.Equal(5, result.Count);
+            Assert.Equal("clear", result.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ResolveActiveArchetype_FallsBackToHighestCountWhenNoneEligible()
+        {
+            // Arrange: all archetypes have high min levels
+            var ranked = new List<(string Archetype, int Count)>
+            {
+                ("The Sniper", 5),   // 5-11
+                ("The Player", 3),   // 5-10
+            };
+
+            // Act: level 2 — neither eligible
+            var result = CharacterAssembler.ResolveActiveArchetype(ranked, 2);
+
+            // Assert: falls back to highest count overall
+            Assert.NotNull(result);
+            Assert.Equal("The Sniper", result.Name);
+            Assert.Equal(5, result.Count);
+        }
+
+        [Fact]
+        public void ResolveActiveArchetype_ReturnsNullForEmptyList()
+        {
+            var ranked = new List<(string Archetype, int Count)>();
+            var result = CharacterAssembler.ResolveActiveArchetype(ranked, 5);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ResolveActiveArchetype_NoLevelFiltering_WhenLevelIsZero()
+        {
+            var ranked = new List<(string Archetype, int Count)>
+            {
+                ("The Sniper", 5),
+                ("The Peacock", 3),
+            };
+
+            // Act: level 0 — no filtering, just pick highest count
+            var result = CharacterAssembler.ResolveActiveArchetype(ranked, 0);
+
+            Assert.NotNull(result);
+            Assert.Equal("The Sniper", result.Name);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_Slight()
+        {
+            var arch = new ActiveArchetype("Test", "behavior", 1);
+            Assert.Equal("slight", arch.InterferenceLevel);
+
+            arch = new ActiveArchetype("Test", "behavior", 2);
+            Assert.Equal("slight", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_Clear()
+        {
+            var arch = new ActiveArchetype("Test", "behavior", 3);
+            Assert.Equal("clear", arch.InterferenceLevel);
+
+            arch = new ActiveArchetype("Test", "behavior", 5);
+            Assert.Equal("clear", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_Dominant()
+        {
+            var arch = new ActiveArchetype("Test", "behavior", 6);
+            Assert.Equal("dominant", arch.InterferenceLevel);
+
+            arch = new ActiveArchetype("Test", "behavior", 10);
+            Assert.Equal("dominant", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_Directive_ContainsNameAndBehavior()
+        {
+            var arch = new ActiveArchetype("The Peacock", "Shows off constantly.", 4);
+            var directive = arch.Directive;
+
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", directive);
+            Assert.Contains("Shows off constantly.", directive);
+        }
+
+        [Fact]
+        public void ArchetypeCatalog_GetBehavior_ReturnsPlaceholderForUnknown()
+        {
+            var behavior = ArchetypeCatalog.GetBehavior("Unknown Archetype XYZ");
+            Assert.Contains("Unknown Archetype XYZ", behavior);
+            Assert.Contains("behavioral pattern", behavior);
+        }
+
+        [Fact]
+        public void ArchetypeCatalog_RegisterAndGetBehavior()
+        {
+            ArchetypeCatalog.RegisterBehavior("Test Archetype 12345", "Test behavior text");
+            var behavior = ArchetypeCatalog.GetBehavior("Test Archetype 12345");
+            Assert.Equal("Test behavior text", behavior);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/LlmPlayerAgentCharacterVoiceTests.cs
+++ b/tests/Pinder.Core.Tests/LlmPlayerAgentCharacterVoiceTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for LlmPlayerAgent character-driven improvements (#492).
+    /// </summary>
+    public class LlmPlayerAgentCharacterVoiceTests
+    {
+        private static StatBlock MakeStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 4 }, { StatType.Rizz, 1 }, { StatType.Honesty, 3 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 3 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Horniness, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static TurnStart MakeTurnStart()
+        {
+            var opts = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hey gorgeous"),
+                new DialogueOption(StatType.Honesty, "I'm actually nervous")
+            };
+            var state = new GameStateSnapshot(12, InterestState.Interested, 0, Array.Empty<string>(), 3);
+            return new TurnStart(opts, state);
+        }
+
+        [Fact]
+        public void BuildPrompt_WithPlayerSystemPrompt_IncludesCharacterContext()
+        {
+            var apiOpts = new Pinder.LlmAdapters.Anthropic.AnthropicOptions { ApiKey = "test-key" };
+            using var agent = new LlmPlayerAgent(apiOpts, new ScoringPlayerAgent(), "Gerald", "Velvet");
+            var turn = MakeTurnStart();
+            var context = new PlayerAgentContext(
+                MakeStats(), MakeStats(), 12, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, null, 3,
+                playerSystemPrompt: "You are Gerald, a nervous overachiever.",
+                playerName: "Gerald",
+                opponentName: "Velvet");
+
+            string prompt = agent.BuildPrompt(turn, context);
+
+            // Should use player name from context
+            Assert.Contains("Gerald", prompt);
+            Assert.Contains("Velvet", prompt);
+        }
+
+        [Fact]
+        public void BuildPrompt_WithRecentHistory_IncludesConversation()
+        {
+            var apiOpts = new Pinder.LlmAdapters.Anthropic.AnthropicOptions { ApiKey = "test-key" };
+            using var agent = new LlmPlayerAgent(apiOpts, new ScoringPlayerAgent(), "Gerald", "Velvet");
+            var turn = MakeTurnStart();
+            var history = new List<(string Sender, string Text)>
+            {
+                ("Gerald", "Hey there!"),
+                ("Velvet", "Oh hey, what's up?"),
+                ("Gerald", "Just thinking about you."),
+                ("Velvet", "That's sweet.")
+            };
+            var context = new PlayerAgentContext(
+                MakeStats(), MakeStats(), 12, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, null, 3,
+                playerName: "Gerald",
+                opponentName: "Velvet",
+                recentHistory: history.AsReadOnly());
+
+            string prompt = agent.BuildPrompt(turn, context);
+
+            Assert.Contains("Recent Conversation", prompt);
+            Assert.Contains("Hey there!", prompt);
+            Assert.Contains("That's sweet.", prompt);
+        }
+
+        [Fact]
+        public void BuildPrompt_WithoutHistory_NoConversationSection()
+        {
+            var apiOpts = new Pinder.LlmAdapters.Anthropic.AnthropicOptions { ApiKey = "test-key" };
+            using var agent = new LlmPlayerAgent(apiOpts, new ScoringPlayerAgent(), "Gerald", "Velvet");
+            var turn = MakeTurnStart();
+            var context = new PlayerAgentContext(
+                MakeStats(), MakeStats(), 12, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, null, 3);
+
+            string prompt = agent.BuildPrompt(turn, context);
+
+            Assert.DoesNotContain("Recent Conversation", prompt);
+        }
+
+        [Fact]
+        public void BuildPrompt_CharacterVoice_AsksForGenuineChoice()
+        {
+            var apiOpts = new Pinder.LlmAdapters.Anthropic.AnthropicOptions { ApiKey = "test-key" };
+            using var agent = new LlmPlayerAgent(apiOpts, new ScoringPlayerAgent(), "Gerald", "Velvet");
+            var turn = MakeTurnStart();
+            var context = new PlayerAgentContext(
+                MakeStats(), MakeStats(), 12, InterestState.Interested, 0,
+                Array.Empty<string>(), 0, null, 3,
+                playerName: "Gerald");
+
+            string prompt = agent.BuildPrompt(turn, context);
+
+            // Should ask for character-driven reasoning, not just strategic
+            Assert.Contains("genuinely type", prompt);
+            Assert.Contains("character's voice", prompt);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Tests that active archetype directives are injected into LLM prompts (#649).
+    /// </summary>
+    public class ArchetypeInjectionTests
+    {
+        private static DialogueContext MakeDialogueContext(string activeArchetypeDirective = null)
+        {
+            return new DialogueContext(
+                playerPrompt: "You are a test player.",
+                opponentPrompt: "You are a test opponent.",
+                conversationHistory: Array.Empty<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 12,
+                playerName: "TestPlayer",
+                opponentName: "TestOpponent",
+                currentTurn: 1,
+                activeArchetypeDirective: activeArchetypeDirective);
+        }
+
+        private static OpponentContext MakeOpponentContext(string activeArchetypeDirective = null)
+        {
+            return new OpponentContext(
+                playerPrompt: "You are a test player.",
+                opponentPrompt: "You are a test opponent.",
+                conversationHistory: Array.Empty<(string, string)>(),
+                opponentLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 12,
+                playerDeliveredMessage: "hey",
+                interestBefore: 10,
+                interestAfter: 12,
+                responseDelayMinutes: 2.0,
+                playerName: "TestPlayer",
+                opponentName: "TestOpponent",
+                currentTurn: 1,
+                activeArchetypeDirective: activeArchetypeDirective);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_WithArchetypeDirective_InjectsIt()
+        {
+            var ctx = MakeDialogueContext("ACTIVE ARCHETYPE: The Peacock (clear)\nShows off constantly.");
+            string prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", prompt);
+            Assert.Contains("Shows off constantly.", prompt);
+        }
+
+        [Fact]
+        public void BuildDialogueOptionsPrompt_WithoutArchetypeDirective_DoesNotInject()
+        {
+            var ctx = MakeDialogueContext(null);
+            string prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE:", prompt);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_WithArchetypeDirective_InjectsIt()
+        {
+            var ctx = MakeOpponentContext("ACTIVE ARCHETYPE: The Love Bomber (dominant)\nOverwhelming affection.");
+            string prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+            Assert.Contains("ACTIVE ARCHETYPE: The Love Bomber (dominant)", prompt);
+            Assert.Contains("Overwhelming affection.", prompt);
+        }
+
+        [Fact]
+        public void BuildOpponentPrompt_WithoutArchetypeDirective_DoesNotInject()
+        {
+            var ctx = MakeOpponentContext(null);
+            string prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE:", prompt);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements three issues in a single branch:

### Issue #649 — Active archetype selection and injection
- **ActiveArchetype model**: Carries name, behavioral instruction, count, and interference level (slight/clear/dominant)
- **Selection logic**: CharacterAssembler resolves the highest-count archetype eligible at the character's level; falls back to highest-count overall
- **Wiring**: FragmentCollection → CharacterProfile → DialogueContext/OpponentContext → GameSession → SessionDocumentBuilder
- **LLM injection**: Archetype directive injected into both option-generation and opponent-response prompts
- **Session runner**: Header displays active archetype for both characters
- **ArchetypeCatalog**: Extended with behavior text lookup/registration (placeholder for YAML-loaded behaviors)

### Issue #644 — Shadow growth warnings in option blocks
- Tracks `lastStatUsed` and `secondLastStatUsed` across turns in session runner
- Each option displays shadow growth warning badges:
  - ⚠️ Denial +1 (choosing non-Honesty when Honesty available)
  - ✨ Denial -1 (choosing Honesty at interest ≥15)
  - ⚠️ Fixation +1 (same stat 3x in a row)
  - ✨ breaks streak (different stat breaks a 2-turn streak)

### Issue #492 — LlmPlayerAgent character-driven improvements
- System message now character-driven: "you are {name}, making genuine character choices" instead of "strategic player maximizing EV"
- Includes player's assembled system prompt (personality, texting style) in LLM call
- Includes conversation history context (last 6 exchanges) in decision prompt
- Reasoning instructions ask for character-voice decisions
- Temperature raised from 0.3 to 0.5 for more authentic responses
- PlayerAgentContext extended with PlayerSystemPrompt, PlayerName, OpponentName, RecentHistory

## Test Results
- **Core**: 2207 passed (was 2193, +14 new tests), 18 skipped
- **LlmAdapters**: 868 passed (was 864, +4 new tests), 9 skipped
- **Rules**: 46 pre-existing failures (unchanged)
- **Zero new failures**

## Constraints
- netstandard2.0 / C# 8.0 compatible (no `is not`, no records, no init-only)
- No new third-party dependencies
- All existing tests pass unchanged
