### PR TITLE
feat: rule explanations, interest breakdown, position-aware scoring, test fixes (closes #481 #484 #470 #698 #699 #700)

### DIFF
--- a/.matchup-cache/Brick_haus_vs_Zyx_444_00d9aea6.md
+++ b/.matchup-cache/Brick_haus_vs_Zyx_444_00d9aea6.md
@@ -1,7 +1,0 @@
-## Matchup Analysis
-
-**Brick_haus** (Level 9, High Charm/Wit): Brick_haus dominates through wit-based attacks with an impressive 85% success rate, leveraging their superior experience and polished social skills. Their charm provides a solid secondary option at 65% success, creating multiple viable attack vectors. However, their high Denial shadow (5) creates significant blind spots that could be exploited, and their low self-awareness makes them vulnerable to honest, direct approaches.
-
-**Zyx_444** (Level 1, Honest Chaos): Despite their inexperience, Zyx_444 presents a surprisingly robust defense built on exceptional honesty (+13) that completely shuts down self-awareness attacks and strong chaos resistance. Their high Madness shadow (6) and Dread (4) suggest an unpredictable, potentially self-destructive fighting style that could create openings through sheer volatility. Their weakness lies in defending against wit and charm, where their low-level stats leave them exposed.
-
-**Prediction:** Brick_haus should secure victory through consistent wit-based pressure, but Zyx_444's chaotic nature and shadow instability could create unexpected complications. The level gap favors the experienced player, though Brick_haus's denial issues might prevent them from adapting quickly if Zyx_444's madness manifests in surprising ways.

--- a/.matchup-cache/Gerald_42_vs_Velvet_Void_224a1a12.md
+++ b/.matchup-cache/Gerald_42_vs_Velvet_Void_224a1a12.md
@@ -1,7 +1,0 @@
-## Matchup Analysis
-
-**Gerald_42** (Level 5, Gym Bro/Straightforward): Gerald's strongest approach is his impressive Charm (+10) against Velvet's SelfAwareness defense, giving him a solid 60% success rate to break through her mysterious facade. His high Rizz (+9) provides a backup option at 55% success, allowing him to lean into his natural charisma and genuine personality. However, his elevated Madness (5) and Fixation (4) shadows create serious risks of becoming obsessively attached or spiraling if Velvet's enigmatic nature triggers his insecurities.
-
-**Velvet_Void** (Level 7, Mysterious/Chaotic): Velvet's best defense lies in her maxed Chaos (+10), making her nearly impervious to honest, straightforward approaches with only a 5% vulnerability to Gerald's Honesty attacks. Her balanced Wit (+6) and SelfAwareness (+6) provide solid secondary defenses, while her high Dread (5) shadow can psychologically destabilize opponents who get too close. Her lower Fixation (2) suggests she won't get emotionally entangled easily, but her Denial (4) might blind her to genuine connections.
-
-**Prediction:** This matchup heavily favors Gerald's charm-based strategy, but the psychological warfare will be intense. Gerald's straightforward gym-bro energy clashes dramatically with Velvet's mysterious chaos, likely creating a push-pull dynamic where his Madness shadow feeds off her inscrutability while her Dread amplifies his growing obsession.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -551,12 +551,18 @@ class Program
 
             string arrowResult = string.IsNullOrEmpty(rollResult) ? "" : $" → {rollResult}";
             Console.WriteLine($"**🎲 Roll:** d20({roll.UsedDieRoll}) + {StatLabel(chosen.Stat)}({rollMod}) = **{roll.FinalTotal}** vs DC {roll.DC} → **{marginText}{arrowResult}**");
+
+            // #484/#698: Inline rule explanation after roll
+            string rollExplanation = GetRollExplanation(roll);
+            if (!string.IsNullOrEmpty(rollExplanation))
+                Console.WriteLine($"> 📋 *{rollExplanation}*");
             Console.WriteLine();
 
             if (result.ComboTriggered != null)
             {
                 Console.WriteLine($"> *⭐ {result.ComboTriggered} combo fires!*");
                 Console.WriteLine($"> *{PlaytestFormatter.GetComboSequenceDescription(result.ComboTriggered)}*");
+                Console.WriteLine($"> *{PlaytestFormatter.GetComboRewardSummary(result.ComboTriggered)}*");
             }
             if (result.TellReadBonus > 0)      Console.WriteLine($"> *📖 Tell read! +{result.TellReadBonus}*");
             Console.WriteLine();
@@ -603,15 +609,70 @@ class Program
             Console.WriteLine();
             Console.WriteLine("```");
             Console.WriteLine($"Interest: {InterestBar(newInterest)}  {newInterest}/25  ({deltaStr})");
+
+            // #699: Interest delta breakdown
+            if (delta != 0 && result.Roll != null)
+            {
+                var parts = new List<string>();
+                if (result.Roll.IsNatOne) parts.Add("Nat 1: -4");
+                else if (result.Roll.IsNatTwenty) parts.Add("Nat 20: +4 base");
+                else if (result.Roll.IsSuccess)
+                {
+                    int beat = result.Roll.FinalTotal - result.Roll.DC;
+                    if (beat >= 10) parts.Add("crit: +3 base");
+                    else if (beat >= 5) parts.Add("strong: +2 base");
+                    else parts.Add("clean: +1 base");
+                }
+                else parts.Add($"fail: {result.InterestDelta}");
+                if (result.ComboTriggered != null) parts.Add("combo bonus");
+                if (result.TellReadBonus > 0) parts.Add($"tell +{result.TellReadBonus}");
+                if (result.CallbackBonusApplied > 0) parts.Add($"callback +{result.CallbackBonusApplied}");
+                if (parts.Count > 0)
+                    Console.WriteLine($"  *({string.Join(", ", parts)})*");
+            }
             if (result.ShadowGrowthEvents?.Count > 0)
             {
                 foreach (var shadowEvent in result.ShadowGrowthEvents)
+                {
                     Console.WriteLine($"\u26a0\ufe0f SHADOW GROWTH: {shadowEvent}");
+                    // #484: Shadow threshold warnings
+                    foreach (ShadowStatType sType in Enum.GetValues(typeof(ShadowStatType)))
+                    {
+                        if (shadowEvent.Contains(sType.ToString()))
+                        {
+                            int sv = sableShadows.GetEffectiveShadow(sType);
+                            string paired = GetPairedStat(sType);
+                            if (sv == 6) Console.WriteLine($"> ⚠️ *Threshold 6: {sType} now taints {paired} dialogue.*");
+                            else if (sv == 12) Console.WriteLine($"> ⚠️ *Threshold 12: {sType} now penalizes {paired} rolls.*");
+                            else if (sv == 18) Console.WriteLine($"> ⚠️ *Threshold 18: {sType} may override your {paired} choices.*");
+                        }
+                    }
+                }
             }
             string trapLine = result.StateAfter.ActiveTrapNames.Length > 0
                 ? string.Join(", ", result.StateAfter.ActiveTrapNames) : "none";
             Console.WriteLine($"Active Traps: {trapLine}  |  Momentum: {result.StateAfter.MomentumStreak} win{(result.StateAfter.MomentumStreak!=1?"s":"")}");
             Console.WriteLine("```");
+
+            // #481/#700: Momentum tooltip
+            if (result.StateAfter.MomentumStreak >= 3)
+            {
+                int mBonus = result.StateAfter.MomentumStreak >= 5 ? 3 : 2;
+                Console.WriteLine($"> *Momentum: +{mBonus} added to your next roll total.*");
+            }
+
+            // #700: Interest state change explanation
+            {
+                InterestState stateBefore = snap.State;
+                InterestState stateAfter = result.StateAfter.State;
+                if (stateBefore != stateAfter)
+                {
+                    Console.WriteLine($"*** Interest state changed to {stateAfter} ***");
+                    string stateDesc = GetInterestStateDescription(stateAfter);
+                    if (!string.IsNullOrEmpty(stateDesc))
+                        Console.WriteLine($"> *{stateDesc}*");
+                }
+            }
 
             interest = newInterest;
             momentum = result.StateAfter.MomentumStreak;
@@ -742,6 +803,53 @@ class Program
         if (text.Length > 0) lines.Add(text);
         return lines.Count > 0 ? lines : new List<string> { "" };
     }
+
+    // #484/#698: Roll explanation helper
+    static string GetRollExplanation(RollResult roll)
+    {
+        if (roll.IsNatOne) return "Nat 1 — Legendary Fail: the die showing 1 overrides all bonuses. Maximum corruption tier.";
+        if (roll.IsNatTwenty) return "Nat 20 — Always succeeds regardless of DC. +4 Interest.";
+        if (!roll.IsSuccess)
+        {
+            int miss = roll.DC - roll.FinalTotal;
+            if (miss >= 10) return $"Catastrophe (miss by {miss}): −3 Interest + trap activates.";
+            if (miss >= 6)  return $"Trope Trap (miss by {miss}): −2 Interest + trap activates.";
+            if (miss >= 3)  return $"Misfire (miss by {miss}): −1 Interest.";
+            return $"Fumble (miss by {miss}): −1 Interest, slight stumble.";
+        }
+        else
+        {
+            int beat = roll.FinalTotal - roll.DC;
+            if (beat >= 15) return $"Exceptional (beat by {beat}): best possible delivery. +3 Interest base.";
+            if (beat >= 10) return $"Critical success (beat by {beat}): peak delivery. +3 Interest base.";
+            if (beat >= 5)  return $"Strong success (beat by {beat}): improved delivery. +2 Interest base.";
+            return $"Clean success (beat by {beat}): delivered as intended. +1 Interest base.";
+        }
+    }
+
+    // #700: Interest state description helper
+    static string GetInterestStateDescription(InterestState state) => state switch
+    {
+        InterestState.Bored => "Ghost risk: 25% per turn. Opponent may stop responding.",
+        InterestState.Lukewarm => "Opponent is present but unconvinced. No ghost risk.",
+        InterestState.Interested => "Conversation has traction. Opponent is engaged.",
+        InterestState.VeryIntoIt => "Opponent is genuinely interested. +advantage on rolls.",
+        InterestState.AlmostThere => "One step from the date. Opponent is deciding.",
+        InterestState.DateSecured => "Date secured. Opponent agreed to meet.",
+        _ => ""
+    };
+
+    // #484: Shadow-to-stat pairing helper
+    static string GetPairedStat(ShadowStatType shadow) => shadow switch
+    {
+        ShadowStatType.Madness => "Charm",
+        ShadowStatType.Horniness => "Rizz",
+        ShadowStatType.Denial => "Honesty",
+        ShadowStatType.Fixation => "Chaos",
+        ShadowStatType.Dread => "Wit",
+        ShadowStatType.Overthinking => "Self-Awareness",
+        _ => shadow.ToString()
+    };
 
     static void WritePlaytestLog(string content, string p1, string p2, string? dir, int sessionNumber)
     {

--- a/session-runner/ScoringPlayerAgent.cs
+++ b/session-runner/ScoringPlayerAgent.cs
@@ -25,6 +25,7 @@ namespace Pinder.SessionRunner
         private const float NearWinBias = 2.0f;
         private const float BoredBoldBias = 1.0f;
         private const float ActiveTrapPenalty = 2.0f;
+        private const float LukewarmBoldBias = 0.2f;
 
         // Shadow growth risk constants (§7)
         private const float ShadowAvoidanceBonus = 0.8f; // bonus to options that avoid shadow growth
@@ -172,6 +173,22 @@ namespace Pinder.SessionRunner
                 {
                     score += BoredBoldBias;
                     strategicReasons.Add("Bored — swinging for the fences");
+                }
+
+                // #481: High interest safety bias — penalize TropeTrap exposure when interest >= 20
+                // TropeTrap fires on miss by 6+, which requires need >= 7
+                if (context.CurrentInterest >= 20 && need >= 7)
+                {
+                    score -= 0.5f;
+                    strategicReasons.Add("High interest — penalizing TropeTrap exposure");
+                }
+
+                // #481: Low interest aggression bonus — favor higher-variance plays when Lukewarm
+                if (context.InterestState == InterestState.Lukewarm
+                    && (riskInfo.Tier == RiskTierCategory.Hard || riskInfo.Tier == RiskTierCategory.Bold))
+                {
+                    score += LukewarmBoldBias;
+                    strategicReasons.Add("Low interest — favoring higher-variance plays");
                 }
 
                 // Active trap penalty
@@ -369,8 +386,8 @@ namespace Pinder.SessionRunner
                     }
                     else if (missMargin >= 6)
                     {
-                        // TropeTrap: -2 interest + trap activation
-                        totalCost += 2.0f + TrapActivationCost;
+                        // TropeTrap: -2 interest + trap activation + duration penalty (#481)
+                        totalCost += 2.0f + TrapActivationCost + 0.5f;
                     }
                     else if (missMargin >= 3)
                     {

--- a/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
+++ b/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
@@ -125,11 +125,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            if (!result.Roll.IsSuccess)
-            {
-                Assert.True(resolver.FailureDeltaCalls.Count > 0,
-                    "Expected GetFailureInterestDelta to be called on a failed roll");
-            }
+            Assert.False(result.Roll.IsSuccess, "Expected failure roll — check FixedDice setup");
+            Assert.True(resolver.FailureDeltaCalls.Count > 0,
+                "Expected GetFailureInterestDelta to be called on a failed roll");
         }
 
         // Fails if: GameSession ignores the resolver's failure delta value
@@ -149,14 +147,12 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            if (!result.Roll.IsSuccess)
-            {
-                // With -10 delta from resolver, interest should drop significantly from 15
-                // Hardcoded max failure delta is -4 (Legendary), so if we see interest <= 5,
-                // the resolver value was used rather than hardcoded
-                Assert.True(result.StateAfter.Interest < 10,
-                    $"Expected interest < 10 with custom failure delta -10, got {result.StateAfter.Interest}");
-            }
+            Assert.False(result.Roll.IsSuccess, "Expected failure roll — check FixedDice setup");
+            // With -10 delta from resolver, interest should drop significantly from 15
+            // Hardcoded max failure delta is -4 (Legendary), so if we see interest <= 5,
+            // the resolver value was used rather than hardcoded
+            Assert.True(result.StateAfter.Interest < 10,
+                $"Expected interest < 10 with custom failure delta -10, got {result.StateAfter.Interest}");
         }
 
         // =====================================================================
@@ -357,11 +353,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            if (result.Roll.IsSuccess)
-            {
-                Assert.True(resolver.XpMultiplierCalls.Count > 0,
-                    "Expected GetRiskTierXpMultiplier to be called during ResolveTurnAsync on non-nat20 success");
-            }
+            Assert.True(result.Roll.IsSuccess, "Expected success roll — check FixedDice setup");
+            Assert.True(resolver.XpMultiplierCalls.Count > 0,
+                "Expected GetRiskTierXpMultiplier to be called during ResolveTurnAsync on non-nat20 success");
         }
 
         // Fails if: GameSession ignores the resolver's XP multiplier (uses hardcoded instead)
@@ -381,13 +375,11 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            if (result.Roll.IsSuccess)
-            {
-                // Base XP for a success is at least 5. With 10x = at least 50.
-                // Hardcoded Bold max is 3x = 15 from base 5.
-                Assert.True(result.XpEarned >= 50,
-                    $"Expected XP >= 50 with 10x multiplier, got {result.XpEarned}");
-            }
+            Assert.True(result.Roll.IsSuccess, "Expected success roll — check FixedDice setup");
+            // Base XP for a success is at least 5. With 10x = at least 50.
+            // Hardcoded Bold max is 3x = 15 from base 5.
+            Assert.True(result.XpEarned >= 50,
+                $"Expected XP >= 50 with 10x multiplier, got {result.XpEarned}");
         }
 
         // =====================================================================


### PR DESCRIPTION
Closes #481, #484, #470, #698, #699, #700

## Changes

### #470 — Test fix: replace conditional assertions
Replaced vacuous `if (result.Roll.IsSuccess)` guards in 4 tests with explicit `Assert.True`/`Assert.False` assertions before the core assertions. Tests now fail properly if dice/DC setup produces wrong outcomes.

### #481 — ScoringPlayerAgent: position-based risk appetite
- High interest (≥20) safety bias: penalizes options with TropeTrap exposure (need ≥ 7)
- Lukewarm aggression bonus: +0.2 to Hard/Bold options when interest is Lukewarm
- TropeTrap duration penalty: +0.5 added to TropeTrap failure cost in ComputeWeightedFailCost

### #484 — Inline rule explanations in playtest log
- Roll explanation after every roll line (success tiers, failure tiers, Nat 1/20)
- Combo fire explanations with reward summary
- Shadow growth threshold warnings at 6/12/18

### #698 — Nat 1/20 override explanation
Covered by #484's GetRollExplanation.

### #699 — Interest delta breakdown
Shows breakdown after interest bar: base tier, combo, tell, callback contributions.

### #700 — End-of-turn block explanations
- Interest state change announcements with descriptions
- Momentum tooltip when active