### PR TITLE
feat: OpenAI-compatible LLM adapter (closes #703)

### DIFF
--- a/.matchup-cache/Sable_xo_vs_Zyx_444_7fd8f286.md
+++ b/.matchup-cache/Sable_xo_vs_Zyx_444_7fd8f286.md
@@ -1,0 +1,7 @@
+## Matchup Analysis
+
+**Sable_xo** (Level 3, Confident Flirt/Social Butterfly): Sable's strongest approach is through Chaos attacks, exploiting Zyx's complete lack of Charm defense for a solid 60% success rate. Her secondary Rizz lane offers 55% odds against Zyx's modest Wit defense, making her a formidable social aggressor. However, her Fixation shadow (5) poses serious risks of becoming obsessively attached, while her moderate Madness could lead to erratic behavior if the match drags on.
+
+**Zyx_444** (Level 1, Cryptic Truth-Seeker/Chaotic Sage): Zyx's fortress-like Honesty (+13) creates an impenetrable wall against Sable's self-awareness attempts, reducing her to 0% success in that lane. Their high Chaos (+8) also provides strong defense against honest approaches, while their elevated Madness shadow (6) suggests they're already operating from an altered reality that could either fascinate or completely unnerve opponents. Their main vulnerability lies in their non-existent Charm, leaving them completely exposed to chaotic social attacks.
+
+**Prediction:** This will likely be a brief but intense encounter where Sable's social aggression meets Zyx's mystical weirdness head-on. Sable's Chaos attacks will probably land early and often, but Zyx's reality-bending Madness may either create an unexpectedly deep connection or cause Sable's Fixation to spiral out of control as she tries to decode their cryptic nature.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -16,6 +16,7 @@ using Pinder.Core.Traps;
 using Pinder.Core.Data;
 using Pinder.LlmAdapters;
 using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.OpenAi;
 using Pinder.SessionRunner;
 
 class NullTrapRegistry : ITrapRegistry
@@ -353,11 +354,37 @@ class Program
             debugFile = Path.Combine(playtestDir, $"session-{sessionNumber:D3}-debug.md");
         }
 
-        var llm = new AnthropicLlmAdapter(new AnthropicOptions {
-            ApiKey = apiKey, Model = "claude-sonnet-4-20250514", MaxTokens = 1024, Temperature = 0.9,
-            GameDefinition = gameDef,
-            DebugDirectory = debugFile
-        });
+        string modelSpec = ParseArg(args, "--model") ?? "";
+        IStatefulLlmAdapter llm;
+        if (modelSpec.StartsWith("groq/") || modelSpec.StartsWith("together/") ||
+            modelSpec.StartsWith("openrouter/") || modelSpec.StartsWith("ollama/"))
+        {
+            string[] providerParts = modelSpec.Split(new[] { '/' }, 2);
+            string provider = providerParts[0];
+            string model = providerParts.Length > 1 ? providerParts[1] : modelSpec;
+            string baseUrl = GetProviderBaseUrl(provider);
+            string envKey = provider.ToUpperInvariant() + "_API_KEY";
+            string openAiKey = Environment.GetEnvironmentVariable(envKey) ?? apiKey;
+            llm = new OpenAiLlmAdapter(new OpenAiOptions
+            {
+                ApiKey = openAiKey,
+                BaseUrl = baseUrl,
+                Model = model,
+                MaxTokens = 1024,
+                Temperature = 0.9,
+                GameDefinition = gameDef,
+                DebugDirectory = debugFile
+            });
+        }
+        else
+        {
+            llm = new AnthropicLlmAdapter(new AnthropicOptions
+            {
+                ApiKey = apiKey, Model = "claude-sonnet-4-20250514", MaxTokens = 1024, Temperature = 0.9,
+                GameDefinition = gameDef,
+                DebugDirectory = debugFile
+            });
+        }
 
         // Load real trap definitions — fallback to NullTrapRegistry if file missing/corrupt
         ITrapRegistry trapRegistry = TrapRegistryLoader.Load(AppContext.BaseDirectory, Console.Error);
@@ -729,7 +756,7 @@ class Program
         }
         Console.WriteLine();
 
-        llm.Dispose();
+        (llm as IDisposable)?.Dispose();
 
         Console.SetOut(tee._console);
         WritePlaytestLog(buffer.ToString(), player1, player2, playtestDir, sessionNumber);
@@ -850,6 +877,18 @@ class Program
         ShadowStatType.Overthinking => "Self-Awareness",
         _ => shadow.ToString()
     };
+
+    static string GetProviderBaseUrl(string provider)
+    {
+        switch (provider.ToLowerInvariant())
+        {
+            case "groq": return "https://api.groq.com/openai";
+            case "together": return "https://api.together.xyz/v1";
+            case "openrouter": return "https://openrouter.ai/api/v1";
+            case "ollama": return "http://localhost:11434/v1";
+            default: return "https://api.openai.com";
+        }
+    }
 
     static void WritePlaytestLog(string content, string p1, string p2, string? dir, int sessionNumber)
     {

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiClient.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiClient.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Pinder.LlmAdapters.OpenAi
+{
+    /// <summary>
+    /// Raw HTTP client for OpenAI-compatible chat completions API.
+    /// Supports any provider that implements POST /v1/chat/completions
+    /// (OpenAI, Groq, Together, OpenRouter, Ollama, etc.).
+    /// </summary>
+    public sealed class OpenAiClient : IDisposable
+    {
+        private const int MaxRetries429 = 3;
+        private const int MaxRetries5xx = 2;
+        private const int DefaultRetryAfterSeconds = 5;
+
+        private readonly string _baseUrl;
+        private readonly HttpClient _httpClient;
+        private readonly bool _ownsHttpClient;
+        private bool _disposed;
+
+        /// <summary>Creates client with internally-owned HttpClient.</summary>
+        public OpenAiClient(string apiKey, string baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
+            _baseUrl = (baseUrl ?? "https://api.openai.com").TrimEnd('/');
+            _httpClient = new HttpClient();
+            ConfigureHeaders(_httpClient, apiKey);
+            _ownsHttpClient = true;
+        }
+
+        /// <summary>Creates client with externally-provided HttpClient (for testing).</summary>
+        public OpenAiClient(string apiKey, string baseUrl, HttpClient httpClient)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
+            _baseUrl = (baseUrl ?? "https://api.openai.com").TrimEnd('/');
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            ConfigureHeaders(_httpClient, apiKey);
+            _ownsHttpClient = false;
+        }
+
+        /// <summary>
+        /// Sends a chat completions request and returns the assistant message content.
+        /// </summary>
+        /// <param name="requestJson">Serialized JSON request body.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The text content of choices[0].message.content.</returns>
+        public async Task<string> SendChatCompletionAsync(string requestJson, CancellationToken ct = default)
+        {
+            if (requestJson == null) throw new ArgumentNullException(nameof(requestJson));
+
+            string url = _baseUrl + "/v1/chat/completions";
+            int retries429 = 0;
+            int retries5xx = 0;
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                using (var content = new StringContent(requestJson, Encoding.UTF8, "application/json"))
+                {
+                    var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
+                    int statusCode = (int)response.StatusCode;
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        try
+                        {
+                            var json = JObject.Parse(body);
+                            var text = json["choices"]?[0]?["message"]?["content"]?.ToString();
+                            return text ?? "";
+                        }
+                        catch (Exception)
+                        {
+                            var truncated = body.Length > 200 ? body.Substring(0, 200) : body;
+                            throw new InvalidOperationException(
+                                $"OpenAI-compatible API returned {statusCode} but response is malformed: {truncated}");
+                        }
+                    }
+
+                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                    if (statusCode == 429)
+                    {
+                        if (retries429 >= MaxRetries429)
+                            throw new HttpRequestException($"OpenAI-compatible API rate limited after {MaxRetries429} retries. Status: {statusCode}. Body: {errorBody}");
+                        retries429++;
+                        var delay = GetRetryAfterDelay(response);
+                        await Task.Delay(delay, ct).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    if (statusCode >= 500 && statusCode < 600)
+                    {
+                        if (retries5xx >= MaxRetries5xx)
+                            throw new HttpRequestException($"OpenAI-compatible API server error after {MaxRetries5xx} retries. Status: {statusCode}. Body: {errorBody}");
+                        retries5xx++;
+                        await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    throw new HttpRequestException($"OpenAI-compatible API error. Status: {statusCode}. Body: {errorBody}");
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed && _ownsHttpClient)
+            {
+                _httpClient.Dispose();
+            }
+            _disposed = true;
+        }
+
+        private static void ConfigureHeaders(HttpClient client, string apiKey)
+        {
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+        }
+
+        private static TimeSpan GetRetryAfterDelay(HttpResponseMessage response)
+        {
+            if (response.Headers.TryGetValues("Retry-After", out var values))
+            {
+                foreach (var value in values)
+                {
+                    if (int.TryParse(value, out var seconds) && seconds > 0)
+                        return TimeSpan.FromSeconds(seconds);
+                }
+            }
+            return TimeSpan.FromSeconds(DefaultRetryAfterSeconds);
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.Anthropic.Dto;
+
+namespace Pinder.LlmAdapters.OpenAi
+{
+    /// <summary>
+    /// ILlmAdapter + IStatefulLlmAdapter implementation for OpenAI-compatible APIs.
+    /// Supports OpenAI, Groq, Together, OpenRouter, Ollama, and any provider
+    /// that implements the /v1/chat/completions endpoint.
+    /// </summary>
+    public sealed class OpenAiLlmAdapter : IStatefulLlmAdapter, IDisposable
+    {
+        private const double DefaultDialogueOptionsTemperature = 0.9;
+        private const double DefaultDeliveryTemperature = 0.7;
+        private const double DefaultOpponentResponseTemperature = 0.85;
+
+        // Regex patterns — same as AnthropicLlmAdapter
+        private static readonly Regex OptionHeaderRegex = new Regex(
+            @"OPTION_\d+", RegexOptions.Compiled);
+        private static readonly Regex StatRegex = new Regex(
+            @"\[STAT:\s*(\w+)\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex CallbackRegex = new Regex(
+            @"\[CALLBACK:\s*([^\]]+)\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ComboRegex = new Regex(
+            @"\[COMBO:\s*([^\]]+)\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex TellBonusRegex = new Regex(
+            @"\[TELL_BONUS:\s*(\w+)\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex QuotedTextRegex = new Regex(
+            @"""([^""]+)""", RegexOptions.Compiled);
+        private static readonly Regex TellSignalRegex = new Regex(
+            @"TELL:\s*(\w+)\s*\(([^)]+)\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex WeaknessSignalRegex = new Regex(
+            @"WEAKNESS:\s*(\w+)\s*-(\d+)\s*\(([^)]+)\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly StatType[] DefaultPaddingStats = new[]
+        {
+            StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos
+        };
+
+        private readonly OpenAiClient _client;
+        private readonly OpenAiOptions _options;
+
+        // Stateful opponent session
+        private ConversationSession? _opponentSession;
+        private string? _opponentSystemPrompt;
+
+        /// <summary>Creates adapter with internally-owned OpenAiClient.</summary>
+        public OpenAiLlmAdapter(OpenAiOptions options)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _client = new OpenAiClient(options.ApiKey, options.BaseUrl);
+        }
+
+        /// <summary>Creates adapter with externally-provided HttpClient (for testing).</summary>
+        public OpenAiLlmAdapter(OpenAiOptions options, HttpClient httpClient)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
+            _client = new OpenAiClient(options.ApiKey, options.BaseUrl, httpClient);
+        }
+
+        /// <inheritdoc />
+        public void StartOpponentSession(string opponentSystemPrompt)
+        {
+            _opponentSystemPrompt = opponentSystemPrompt ?? throw new ArgumentNullException(nameof(opponentSystemPrompt));
+            _opponentSession = new ConversationSession();
+        }
+
+        /// <inheritdoc />
+        public bool HasOpponentSession => _opponentSession != null;
+
+        /// <inheritdoc />
+        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
+            var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
+
+            var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDialogueOptionsTemperature);
+            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+
+            return ParseDialogueOptions(responseText);
+        }
+
+        /// <inheritdoc />
+        public async Task<string> DeliverMessageAsync(DeliveryContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var deliveryRules = _options.GameDefinition?.DeliveryRules;
+            var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context, deliveryRules: deliveryRules);
+            var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
+
+            var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDeliveryTemperature);
+            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+
+            return responseText;
+        }
+
+        /// <inheritdoc />
+        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var userContent = SessionDocumentBuilder.BuildOpponentPrompt(context);
+            var systemPrompt = SessionSystemPromptBuilder.BuildOpponent(context.OpponentPrompt, _options.GameDefinition);
+
+            string requestJson;
+            if (_opponentSession != null)
+            {
+                // Stateful: accumulate messages
+                _opponentSession.AppendUser(userContent);
+                requestJson = BuildStatefulRequestJson(systemPrompt, _opponentSession, DefaultOpponentResponseTemperature);
+            }
+            else
+            {
+                requestJson = BuildRequestJson(systemPrompt, userContent, DefaultOpponentResponseTemperature);
+            }
+
+            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+
+            if (_opponentSession != null)
+            {
+                _opponentSession.AppendAssistant(responseText);
+            }
+
+            return ParseOpponentResponse(responseText);
+        }
+
+        /// <inheritdoc />
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            return Task.FromResult<string?>(null);
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+
+        // ── Request building ──────────────────────────────────────────────
+
+        private string BuildRequestJson(string systemPrompt, string userContent, double temperature)
+        {
+            var request = new
+            {
+                model = _options.Model,
+                max_tokens = _options.MaxTokens,
+                temperature = temperature,
+                messages = new[]
+                {
+                    new { role = "system", content = systemPrompt },
+                    new { role = "user", content = userContent }
+                }
+            };
+            return JsonConvert.SerializeObject(request);
+        }
+
+        private string BuildStatefulRequestJson(string systemPrompt, ConversationSession session, double temperature)
+        {
+            // Build messages array: system + all accumulated conversation messages
+            var messages = new List<object>();
+            messages.Add(new { role = "system", content = systemPrompt });
+
+            // Extract messages from the ConversationSession via its BuildRequest method
+            // We build an Anthropic request to get the messages, then translate
+            var anthropicRequest = session.BuildRequest(
+                _options.Model,
+                _options.MaxTokens,
+                temperature,
+                new ContentBlock[] { new ContentBlock { Type = "text", Text = systemPrompt } });
+
+            foreach (var msg in anthropicRequest.Messages)
+            {
+                messages.Add(new { role = msg.Role, content = msg.Content });
+            }
+
+            var request = new
+            {
+                model = _options.Model,
+                max_tokens = _options.MaxTokens,
+                temperature = temperature,
+                messages = messages
+            };
+            return JsonConvert.SerializeObject(request);
+        }
+
+        // ── Response parsing (duplicated from AnthropicLlmAdapter) ────────
+
+        /// <summary>
+        /// Parses structured LLM output into DialogueOption array.
+        /// Never throws — returns 4 options, padding with defaults if needed.
+        /// </summary>
+        internal static DialogueOption[] ParseDialogueOptions(string? llmResponse)
+        {
+            var parsed = new List<DialogueOption>();
+
+            if (!string.IsNullOrWhiteSpace(llmResponse))
+            {
+                try
+                {
+                    var sections = OptionHeaderRegex.Split(llmResponse);
+
+                    foreach (var section in sections)
+                    {
+                        if (string.IsNullOrWhiteSpace(section)) continue;
+                        if (parsed.Count >= 4) break;
+
+                        var statMatch = StatRegex.Match(section);
+                        if (!statMatch.Success) continue;
+
+                        var statStr = NormalizeStatName(statMatch.Groups[1].Value.Trim());
+                        StatType stat;
+                        try
+                        {
+                            stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
+                        }
+                        catch (ArgumentException)
+                        {
+                            continue;
+                        }
+
+                        var textMatch = QuotedTextRegex.Match(section);
+                        if (!textMatch.Success) continue;
+
+                        var text = textMatch.Groups[1].Value.Trim();
+                        if (string.IsNullOrEmpty(text)) continue;
+
+                        int? callbackTurn = null;
+                        var callbackMatch = CallbackRegex.Match(section);
+                        if (callbackMatch.Success)
+                        {
+                            var cbVal = callbackMatch.Groups[1].Value.Trim();
+                            if (!string.Equals(cbVal, "none", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (int.TryParse(cbVal, out int turnNum))
+                                    callbackTurn = turnNum;
+                                else if (cbVal.StartsWith("turn_", StringComparison.OrdinalIgnoreCase) &&
+                                         int.TryParse(cbVal.Substring(5), out int turnNum2))
+                                    callbackTurn = turnNum2;
+                            }
+                        }
+
+                        string? comboName = null;
+                        var comboMatch = ComboRegex.Match(section);
+                        if (comboMatch.Success)
+                        {
+                            var comboVal = comboMatch.Groups[1].Value.Trim();
+                            if (!string.Equals(comboVal, "none", StringComparison.OrdinalIgnoreCase))
+                                comboName = comboVal;
+                        }
+
+                        bool hasTellBonus = false;
+                        var tellMatch = TellBonusRegex.Match(section);
+                        if (tellMatch.Success)
+                        {
+                            hasTellBonus = string.Equals(
+                                tellMatch.Groups[1].Value.Trim(), "yes", StringComparison.OrdinalIgnoreCase);
+                        }
+
+                        parsed.Add(new DialogueOption(
+                            stat, text, callbackTurn, comboName, hasTellBonus, hasWeaknessWindow: false));
+                    }
+                }
+                catch
+                {
+                    // Swallow — pad below
+                }
+            }
+
+            return PadToFour(parsed);
+        }
+
+        /// <summary>
+        /// Parses structured LLM output with optional [SIGNALS] blocks.
+        /// Never throws — returns OpponentResponse with null signals on parse failure.
+        /// </summary>
+        internal static OpponentResponse ParseOpponentResponse(string? llmResponse)
+        {
+            if (string.IsNullOrWhiteSpace(llmResponse))
+                return new OpponentResponse("", null, null);
+
+            var response = llmResponse!;
+            string messageText;
+            Tell? tell = null;
+            WeaknessWindow? weakness = null;
+
+            try
+            {
+                var signalIdx = response.IndexOf("[SIGNALS]", StringComparison.OrdinalIgnoreCase);
+                messageText = signalIdx >= 0
+                    ? response.Substring(0, signalIdx).Trim()
+                    : response.Trim();
+
+                var responseTagIdx = messageText.IndexOf("[RESPONSE]", StringComparison.OrdinalIgnoreCase);
+                if (responseTagIdx >= 0)
+                    messageText = messageText.Substring(responseTagIdx + "[RESPONSE]".Length).Trim();
+
+                if (messageText.Length >= 2 && messageText[0] == '"' && messageText[messageText.Length - 1] == '"')
+                    messageText = messageText.Substring(1, messageText.Length - 2).Trim();
+
+                var signalsIndex = response.IndexOf("[SIGNALS]", StringComparison.OrdinalIgnoreCase);
+                if (signalsIndex >= 0)
+                {
+                    var signalsBlock = response.Substring(signalsIndex);
+
+                    var tellMatch = TellSignalRegex.Match(signalsBlock);
+                    if (tellMatch.Success)
+                    {
+                        var statStr = NormalizeStatName(tellMatch.Groups[1].Value.Trim());
+                        try
+                        {
+                            var stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
+                            var description = tellMatch.Groups[2].Value.Trim();
+                            tell = new Tell(stat, description);
+                        }
+                        catch (ArgumentException) { }
+                    }
+
+                    var weaknessMatch = WeaknessSignalRegex.Match(signalsBlock);
+                    if (weaknessMatch.Success)
+                    {
+                        var statStr = NormalizeStatName(weaknessMatch.Groups[1].Value.Trim());
+                        try
+                        {
+                            var stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
+                            var reduction = int.Parse(weaknessMatch.Groups[2].Value.Trim());
+                            if (reduction > 0)
+                                weakness = new WeaknessWindow(stat, reduction);
+                        }
+                        catch (Exception) { }
+                    }
+                }
+            }
+            catch
+            {
+                return new OpponentResponse(response.Trim(), null, null);
+            }
+
+            return new OpponentResponse(messageText, tell, weakness);
+        }
+
+        private static string NormalizeStatName(string raw)
+        {
+            if (string.Equals(raw, "SELF_AWARENESS", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(raw, "SELFAWARENESS", StringComparison.OrdinalIgnoreCase))
+                return "SelfAwareness";
+            return raw;
+        }
+
+        private static DialogueOption[] PadToFour(List<DialogueOption> parsed)
+        {
+            if (parsed.Count >= 4)
+                return parsed.GetRange(0, 4).ToArray();
+
+            var usedStats = new HashSet<StatType>();
+            foreach (var opt in parsed)
+                usedStats.Add(opt.Stat);
+
+            var result = new List<DialogueOption>(parsed);
+            foreach (var defaultStat in DefaultPaddingStats)
+            {
+                if (result.Count >= 4) break;
+                if (usedStats.Contains(defaultStat)) continue;
+                result.Add(new DialogueOption(defaultStat, "...",
+                    callbackTurnNumber: null, comboName: null,
+                    hasTellBonus: false, hasWeaknessWindow: false));
+            }
+
+            while (result.Count < 4)
+            {
+                result.Add(new DialogueOption(StatType.Charm, "...",
+                    callbackTurnNumber: null, comboName: null,
+                    hasTellBonus: false, hasWeaknessWindow: false));
+            }
+
+            return result.ToArray();
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiOptions.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiOptions.cs
@@ -1,0 +1,24 @@
+namespace Pinder.LlmAdapters.OpenAi
+{
+    /// <summary>
+    /// Configuration carrier for the OpenAI-compatible LLM adapter.
+    /// Supports any provider with an OpenAI-compatible chat completions API
+    /// (OpenAI, Groq, Together, OpenRouter, Ollama, etc.).
+    /// </summary>
+    public sealed class OpenAiOptions
+    {
+        public string ApiKey { get; set; } = "";
+        public string BaseUrl { get; set; } = "https://api.openai.com";
+        public string Model { get; set; } = "gpt-4o-mini";
+        public int MaxTokens { get; set; } = 1024;
+        public double Temperature { get; set; } = 0.9;
+
+        /// <summary>
+        /// Game definition used for building system prompts.
+        /// If null, GameDefinition.PinderDefaults is used.
+        /// </summary>
+        public GameDefinition? GameDefinition { get; set; }
+
+        public string? DebugDirectory { get; set; }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiLlmAdapterTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters.OpenAi;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.OpenAi
+{
+    public class OpenAiLlmAdapterParseTests
+    {
+        [Fact]
+        public void OpenAiLlmAdapter_ParsesDialogueOptions_FromChatResponse()
+        {
+            // Arrange: typical LLM output in the OPTION_N format
+            var llmOutput = @"OPTION_1
+[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+""Hey, I noticed your dog in that photo — what's their name?""
+
+OPTION_2
+[STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+""So your bio says you love hiking. Does that mean you're always up for an adventure?""
+
+OPTION_3
+[STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: yes]
+""I'll be real — your profile caught my eye and I had to say something.""
+
+OPTION_4
+[STAT: CHAOS] [CALLBACK: 3] [COMBO: The Setup] [TELL_BONUS: no]
+""Quick question: pineapple on pizza — deal-breaker or deal-maker?""";
+
+            // Act
+            var result = OpenAiLlmAdapter.ParseDialogueOptions(llmOutput);
+
+            // Assert
+            Assert.Equal(4, result.Length);
+            Assert.Equal(StatType.Charm, result[0].Stat);
+            Assert.Contains("dog", result[0].IntendedText);
+            Assert.Equal(StatType.Wit, result[1].Stat);
+            Assert.Equal(StatType.Honesty, result[2].Stat);
+            Assert.True(result[2].HasTellBonus);
+            Assert.Equal(StatType.Chaos, result[3].Stat);
+            Assert.Equal(3, result[3].CallbackTurnNumber);
+            Assert.Equal("The Setup", result[3].ComboName);
+        }
+
+        [Fact]
+        public void OpenAiLlmAdapter_ParsesOpponentResponse_FromChatResponse()
+        {
+            // Arrange: opponent response with signals
+            var llmOutput = @"Oh wow, you actually noticed Biscuit! Most people just swipe past. His name's Biscuit and he's basically my emotional support goblin.
+
+[SIGNALS]
+TELL: Charm (responds warmly to genuine interest in personal details)
+WEAKNESS: Honesty-2 (gets flustered when people are direct about attraction)";
+
+            // Act
+            var result = OpenAiLlmAdapter.ParseOpponentResponse(llmOutput);
+
+            // Assert
+            Assert.Contains("Biscuit", result.MessageText);
+            Assert.NotNull(result.DetectedTell);
+            Assert.Equal(StatType.Charm, result.DetectedTell!.Stat);
+            Assert.Contains("genuine interest", result.DetectedTell.Description);
+            Assert.NotNull(result.WeaknessWindow);
+            Assert.Equal(StatType.Honesty, result.WeaknessWindow!.DefendingStat);
+            Assert.Equal(2, result.WeaknessWindow.DcReduction);
+        }
+
+        [Fact]
+        public void ParseDialogueOptions_NullInput_Returns4Defaults()
+        {
+            var result = OpenAiLlmAdapter.ParseDialogueOptions(null);
+            Assert.Equal(4, result.Length);
+            foreach (var opt in result)
+                Assert.Equal("...", opt.IntendedText);
+        }
+
+        [Fact]
+        public void ParseOpponentResponse_EmptyInput_ReturnsEmptyMessage()
+        {
+            var result = OpenAiLlmAdapter.ParseOpponentResponse("");
+            Assert.Equal("", result.MessageText);
+            Assert.Null(result.DetectedTell);
+            Assert.Null(result.WeaknessWindow);
+        }
+    }
+}


### PR DESCRIPTION
Adds OpenAiLlmAdapter, OpenAiClient, OpenAiOptions. Enables Groq, Together, OpenRouter, and local Ollama via --model provider/model-name flag.

## Changes
- **OpenAiOptions** — config carrier (ApiKey, BaseUrl, Model, MaxTokens, Temperature, GameDefinition, DebugDirectory)
- **OpenAiClient** — HTTP client for POST /v1/chat/completions with retry logic (429, 5xx)
- **OpenAiLlmAdapter** — implements ILlmAdapter + IStatefulLlmAdapter with stateful opponent sessions via ConversationSession
- **session-runner/Program.cs** — wires --model prefix routing (groq/, together/, openrouter/, ollama/) with provider-specific base URLs and env var API keys
- **4 unit tests** for parse methods (dialogue options, opponent response, null/empty edge cases)

## Provider base URLs
| Provider | Base URL | API Key Env Var |
|----------|----------|-----------------|
| groq | https://api.groq.com/openai | GROQ_API_KEY |
| together | https://api.together.xyz/v1 | TOGETHER_API_KEY |
| openrouter | https://openrouter.ai/api/v1 | OPENROUTER_API_KEY |
| ollama | http://localhost:11434/v1 | OLLAMA_API_KEY |

## Test results
- Core: 2207 passed (unchanged)
- LlmAdapters: 872 passed (+4 new)
- Rules: 46 pre-existing failures (unchanged)