### PR TITLE
feat(setup): forbid markdown in matchup + stake prompts (pinder-web #136)

### DIFF
--- a/src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs
+++ b/src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs
@@ -18,6 +18,13 @@ namespace Pinder.SessionSetup
     /// Behaviour mirrors the previous static <c>MatchupAnalyzer</c> in
     /// <c>session-runner</c>: builds the same prompt, same 500-token budget,
     /// same 0.7 temperature. Caching is opt-in via <see cref="Options.CacheDirectory"/>.
+    ///
+    /// Output contract (issue pinder-web #136): the returned analysis is
+    /// plain prose with paragraph breaks only — no markdown headings, bold,
+    /// italics, bullet or numbered lists, blockquotes, or code fences. The
+    /// system + user prompts forbid markdown explicitly. <c>Pinder.GameApi</c>
+    /// additionally runs a <c>MarkdownSanitizer</c> as defence-in-depth before
+    /// storing the result.
     /// </remarks>
     public sealed class LlmMatchupAnalyzer : IMatchupAnalyzer
     {
@@ -63,7 +70,16 @@ namespace Pinder.SessionSetup
                 }
             }
 
-            string systemPrompt = "You are an expert game designer analyzing a matchup in a dating RPG.";
+            // Output is rendered as plain text by the frontend; markdown markers
+            // would leak through as literal characters. Forbid them at the
+            // system prompt level (pinder-web #136). MarkdownSanitizer in
+            // Pinder.GameApi.Services is the backstop.
+            string systemPrompt =
+                "You are an expert game designer analyzing a matchup in a dating RPG. " +
+                "Respond in plain prose only. Do NOT use markdown formatting of any " +
+                "kind: no headings (#, ##), no bold or italics (**, __, *, _), no " +
+                "bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), and " +
+                "no inline or fenced code (`, ```). Use paragraph breaks for structure.";
             string userPrompt = BuildPrompt(player, opponent);
 
             try
@@ -105,14 +121,15 @@ namespace Pinder.SessionSetup
         {
             var sb = new StringBuilder();
             sb.AppendLine("Analyze the following matchup between two characters in a dating RPG.");
-            sb.AppendLine("Produce a brief 3-paragraph output exactly matching this format:");
-            sb.AppendLine("## Matchup Analysis");
+            sb.AppendLine("Produce a brief 3-paragraph plain-prose output. The format must be:");
             sb.AppendLine();
-            sb.AppendLine("**[PlayerName]** (Level [X], [Archetypes]): [3-4 sentences on their strongest lane, % chance, and shadow risks.]");
+            sb.AppendLine("Paragraph 1 — begin with the player's name followed by their level and archetype list in parentheses, then 3-4 sentences on their strongest lane, percent chance, and shadow risks.");
             sb.AppendLine();
-            sb.AppendLine("**[OpponentName]** (Level [X], [Archetypes]): [3-4 sentences on their best defense, shadow effects, and vulnerabilities.]");
+            sb.AppendLine("Paragraph 2 — begin with the opponent's name followed by their level and archetype list in parentheses, then 3-4 sentences on their best defence, shadow effects, and vulnerabilities.");
             sb.AppendLine();
-            sb.AppendLine("**Prediction:** [2-3 sentences predicting how the match will play out based on stats and shadows.]");
+            sb.AppendLine("Paragraph 3 — begin with 'Prediction:' (followed by a space) and then 2-3 sentences predicting how the match will play out based on stats and shadows.");
+            sb.AppendLine();
+            sb.AppendLine("IMPORTANT: write plain prose only. Do not use markdown. Do not bold names with **. Do not use headings, bullets, numbered lists, blockquotes, or code formatting.");
             sb.AppendLine();
             sb.AppendLine("Here is the data:");
             sb.AppendLine();

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -9,6 +9,14 @@ namespace Pinder.SessionSetup
     /// Default <see cref="IStakeGenerator"/> built on <see cref="ILlmTransport"/>.
     /// Generates a novella-style "psychological stake" character bible.
     /// </summary>
+    /// <remarks>
+    /// Output contract (issue pinder-web #136): the returned stake is plain
+    /// prose, paragraph breaks only — no markdown headings, bold, italics,
+    /// bullet or numbered lists, blockquotes, or code fences. Both the system
+    /// and user prompts forbid markdown explicitly. <c>Pinder.GameApi</c>
+    /// runs a <c>MarkdownSanitizer</c> as defence-in-depth before storing
+    /// the result.
+    /// </remarks>
     public sealed class LlmStakeGenerator : IStakeGenerator
     {
         private readonly ILlmTransport _transport;
@@ -46,15 +54,23 @@ Cover six things, each in 2-3 paragraphs:
 5. What losing would mean emotionally — not 'getting unmatched' but the specific catastrophic conclusion they would draw about themselves.
 6. Their biographical backstory: 3-5 specific, concrete, slightly unhinged events from the last 2-3 years of their life. These should be specific enough to be revealed in conversation and funny enough to belong in a comedy — not themes but events. A named relationship and the specific absurd way it ended. A job decision and what they did the week after (something strange). A specific moment of realisation in an unlikely location. A place they went alone and what they did there. These are the facts the character can share when the conversation gets real. Write them as vivid, specific narrative fragments. The more specific and slightly absurd, the better.
 
-Write 2-3 paragraphs per point. This is a novelist's character bible for a comedy. Do not use headers or bullet points — write flowing prose. The character is real, their feelings are genuine, their reasons are ridiculous.
+Write 2-3 paragraphs per point. This is a novelist's character bible for a comedy. Write flowing prose only. Do NOT use markdown formatting of any kind: no headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), no inline or fenced code (`, ```). Separate paragraphs with blank lines. Do not number the six points; let the prose flow from one to the next. The character is real, their feelings are genuine, their reasons are ridiculous.
 
 CHARACTER PROFILE:
 {promptSlice}";
 
             try
             {
+                // Output is rendered as plain text by the frontend; markdown
+                // markers would leak through as literal characters. Forbid them
+                // at the system-prompt level (pinder-web #136).
+                // MarkdownSanitizer in Pinder.GameApi.Services is the backstop.
                 const string systemPrompt =
-                    "You are a novelist writing a character bible for a comedy about online dating.";
+                    "You are a novelist writing a character bible for a comedy about online dating. " +
+                    "Respond in plain prose only. Do NOT use markdown formatting of any kind: no " +
+                    "headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered " +
+                    "lists (-, *, +, 1., 2.), no blockquotes (>), and no inline or fenced code " +
+                    "(`, ```). Separate paragraphs with blank lines.";
                 string response = await _transport
                     .SendAsync(systemPrompt, userMessage, _options.Temperature, _options.MaxTokens)
                     .ConfigureAwait(false);


### PR DESCRIPTION
Companion to pinder-web #136 (issue: https://github.com/decay256/pinder-web/issues/136).

## Summary

The frontend renders matchup analysis and psychological stake outputs as plain text (`whitespace-pre-wrap`). Sonnet routinely emits markdown markers, which leak through as literal asterisks, hashes, and bullets.

This PR updates both prompts in `Pinder.SessionSetup` to explicitly forbid markdown formatting:

### `LlmMatchupAnalyzer`
- **System prompt** now states "plain prose only" with the full marker list (headings, bold, italics, list bullets, blockquotes, code).
- **User prompt** rephrased so the example format itself does not use `##` or `**` — paragraphs are described in prose. Closing reminder: "IMPORTANT: write plain prose only…".
- xmldoc updated to state the plain-text contract.

### `LlmStakeGenerator`
- **System prompt** now states "plain prose only" with the full marker list.
- **User prompt's** closing instruction now forbids all marker classes explicitly (was only "no headers or bullet points"). Added: "Do not number the six points; let the prose flow from one to the next."
- xmldoc updated to state the plain-text contract.

The pinder-web companion PR adds a `MarkdownSanitizer` defence-in-depth layer that strips any markers the model still emits.

## Companion PR (cross-link)

- **pinder-web**: https://github.com/decay256/pinder-web/pull/141 — adds `MarkdownSanitizer` + tests + wires it into `ActiveSession.SetupAsync`.
- The pinder-web submodule pointer should be bumped in a separate follow-up PR once this one merges.

## Files changed

- `src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs` — system prompt, user prompt, xmldoc.
- `src/Pinder.SessionSetup/LlmStakeGenerator.cs` — system prompt, user prompt, xmldoc.

## DoD Evidence

This PR is prompt-string + xmldoc only — no executable behaviour change in pinder-core itself. Verification happens in the pinder-web companion PR via the sanitizer unit tests and the full GameApi test suite (99 passing).

**Build** (built indirectly through pinder-web tests with the submodule pointing at this branch):
```
$ dotnet build src/Pinder.GameApi.Tests
84 Warning(s)
0 Error(s)
```

**Tests** (pinder-web full suite with this branch as submodule):
```
Passed!  - Failed:     0, Passed:    99, Skipped:     0, Total:    99, Duration: 9 s
```

**Commit**: `95ef9de feat(setup): forbid markdown in matchup + stake prompts (pinder-web #136)`.

**Push**: `3d92335..95ef9de  feat/136-strip-markdown-setup-output -> feat/136-strip-markdown-setup-output`.

**Docs**: xmldoc on both classes updated to state the plain-text contract.

**Deviations from contract**: none.

## Research Log

| Topic | Source | Key finding |
|---|---|---|
| Anthropic prompt-engineering guide on output formatting | https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/be-clear-direct | Negative instructions ("do NOT use X") are effective when paired with explicit examples of the forbidden markers — included in both prompts. |
| CommonMark spec for which characters constitute markdown markers | https://spec.commonmark.org/0.31.2/ | Used the canonical marker glyph set (#, **, __, *, _, -, +, 1., 2., >, `, ```) to enumerate the prohibited markers in both system prompts so the model gets a concrete list. |
