### PR TITLE
fix(openai-stream): yield delta.reasoning for reasoning models (decay256/pinder-web#178)

### DIFF
--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
@@ -24,10 +24,24 @@ namespace Pinder.LlmAdapters.OpenAi
     /// stream terminates with <c>data: [DONE]</c>.
     /// </para>
     /// <para>
-    /// For each chunk, only <c>choices[0].delta.content</c> strings are yielded
-    /// (when present and non-empty). The role-only initial delta, tool/function
-    /// call deltas, and the <c>[DONE]</c> sentinel are ignored. <c>finish_reason</c>
-    /// is not surfaced — the stream simply ends when the response body is exhausted.
+    /// For each chunk, the transport yields, in this order:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description><c>choices[0].delta.content</c> if present and non-empty.</description></item>
+    ///   <item><description><c>choices[0].delta.reasoning</c> if present and non-empty
+    ///     (OpenAI/OpenRouter reasoning models — <c>gpt-5-nano</c>, <c>:thinking</c>
+    ///     variants, etc. — emit tokens here while <c>delta.content</c> stays empty).</description></item>
+    ///   <item><description>The concatenation of
+    ///     <c>choices[0].delta.reasoning_details[i].summary</c> strings if any are
+    ///     non-empty (OpenRouter v1 structured reasoning summaries).</description></item>
+    /// </list>
+    /// <para>
+    /// When both <c>content</c> and <c>reasoning</c> arrive in the same frame
+    /// (e.g. Anthropic-thinking on OpenRouter), content is yielded first and
+    /// reasoning second. Empty / whitespace fragments are suppressed. The
+    /// role-only initial delta, tool/function call deltas, and the
+    /// <c>[DONE]</c> sentinel are ignored. <c>finish_reason</c> is not surfaced —
+    /// the stream simply ends when the response body is exhausted.
     /// </para>
     /// <para>
     /// <b>Error mapping.</b> Any non-2xx HTTP response, malformed SSE frame, or
@@ -252,9 +266,13 @@ namespace Pinder.LlmAdapters.OpenAi
                         if (data == "[DONE]")
                             yield break;
 
-                        var fragment = ExtractContentFragmentOrThrow(data);
-                        if (!string.IsNullOrEmpty(fragment))
-                            yield return fragment!;
+                        foreach (var fragment in ExtractContentFragmentsOrThrow(data))
+                        {
+                            // Defensive: also suppress whitespace-only fragments so
+                            // consumers never see empty pushes.
+                            if (!string.IsNullOrWhiteSpace(fragment))
+                                yield return fragment;
+                        }
                     }
                     continue;
                 }
@@ -283,12 +301,16 @@ namespace Pinder.LlmAdapters.OpenAi
         }
 
         /// <summary>
-        /// Parse a single SSE <c>data:</c> JSON payload. Returns the
-        /// <c>choices[0].delta.content</c> string when present and non-empty,
-        /// otherwise <c>null</c>. Throws <see cref="LlmTransportException"/> on
-        /// a top-level <c>error</c> object or malformed JSON.
+        /// Parse a single SSE <c>data:</c> JSON payload. Returns an ordered
+        /// sequence of non-empty fragments to yield to the consumer:
+        /// <c>choices[0].delta.content</c> first (if non-empty), followed by
+        /// <c>choices[0].delta.reasoning</c> (if non-empty), followed by the
+        /// concatenation of <c>choices[0].delta.reasoning_details[i].summary</c>
+        /// strings (if any are non-empty). Whitespace-only candidates are
+        /// dropped. Throws <see cref="LlmTransportException"/> on a top-level
+        /// <c>error</c> object or malformed JSON.
         /// </summary>
-        private static string? ExtractContentFragmentOrThrow(string data)
+        private static IEnumerable<string> ExtractContentFragmentsOrThrow(string data)
         {
             JObject obj;
             try
@@ -315,8 +337,47 @@ namespace Pinder.LlmAdapters.OpenAi
                     "OpenAI-compatible streaming endpoint returned error frame: " + message);
             }
 
-            var content = obj["choices"]?[0]?["delta"]?["content"]?.Value<string?>();
-            return string.IsNullOrEmpty(content) ? null : content;
+            var delta = obj["choices"]?[0]?["delta"];
+            if (delta == null || delta.Type != JTokenType.Object)
+                yield break;
+
+            var results = new List<string>(3);
+
+            // 1) delta.content
+            var content = delta["content"]?.Value<string?>();
+            if (!string.IsNullOrWhiteSpace(content))
+                results.Add(content!);
+
+            // 2) delta.reasoning (OpenAI/OpenRouter reasoning models stream tokens here
+            //    while delta.content stays empty).
+            var reasoning = delta["reasoning"]?.Value<string?>();
+            if (!string.IsNullOrWhiteSpace(reasoning))
+                results.Add(reasoning!);
+
+            // 3) delta.reasoning_details[i].summary — concatenated as one fragment
+            //    so consumers see a single coherent reasoning-summary push per frame.
+            var details = delta["reasoning_details"] as JArray;
+            if (details != null && details.Count > 0)
+            {
+                StringBuilder? sb = null;
+                foreach (var d in details)
+                {
+                    if (d == null || d.Type != JTokenType.Object) continue;
+                    var summary = d["summary"]?.Value<string?>();
+                    if (string.IsNullOrEmpty(summary)) continue;
+                    if (sb == null) sb = new StringBuilder();
+                    sb.Append(summary);
+                }
+                if (sb != null)
+                {
+                    var joined = sb.ToString();
+                    if (!string.IsNullOrWhiteSpace(joined))
+                        results.Add(joined);
+                }
+            }
+
+            foreach (var r in results)
+                yield return r;
         }
 
         public void Dispose()

--- a/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiStreamingTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiStreamingTransportTests.cs
@@ -119,6 +119,61 @@ namespace Pinder.LlmAdapters.Tests.OpenAi
             Assert.Equal(new[] { "real" }, fragments);
         }
 
+        // ------------------------------------------------------------------
+        // Reasoning models (issue #178)
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public async Task SendStreamAsync_ReasoningOnlyStream_YieldsReasoningAndDetailSummaries()
+        {
+            // Reasoning model: every chunk has empty content but non-empty
+            // delta.reasoning, plus a structured reasoning_details[].summary
+            // on the final reasoning frame. No delta.content arrives at all.
+            var sse = BuildSse(new[]
+            {
+                ChunkRole(),
+                ChunkReasoning("I"),
+                ChunkReasoning(" need"),
+                ChunkReasoning(" to think."),
+                ChunkReasoningDetailsSummaries(new[] { "Summary part A.", " Summary part B." }),
+                "[DONE]",
+            });
+
+            using var transport = NewTransport(sse);
+            var fragments = await CollectAsync(transport.SendStreamAsync("sys", "user"));
+
+            Assert.Equal(
+                new[] { "I", " need", " to think.", "Summary part A. Summary part B." },
+                fragments);
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_MixedReasoningAndContentStream_YieldsContentFirstThenReasoning()
+        {
+            // Mixed stream:
+            //   1. role-only
+            //   2. reasoning-only frames (Anthropic-thinking style)
+            //   3. mixed frame with BOTH content and reasoning
+            //      (per yield order: content first, reasoning second)
+            //   4. final content-only frames
+            var sse = BuildSse(new[]
+            {
+                ChunkRole(),
+                ChunkReasoning("thinking..."),
+                ChunkContentAndReasoning("Hi", " still thinking"),
+                ChunkContent(", "),
+                ChunkContent("world!"),
+                "[DONE]",
+            });
+
+            using var transport = NewTransport(sse);
+            var fragments = await CollectAsync(transport.SendStreamAsync("sys", "user"));
+
+            Assert.Equal(
+                new[] { "thinking...", "Hi", " still thinking", ", ", "world!" },
+                fragments);
+        }
+
         [Fact]
         public async Task SendStreamAsync_TolleratesSseCommentsAndOtherFields()
         {
@@ -413,6 +468,39 @@ namespace Pinder.LlmAdapters.Tests.OpenAi
         private static string ChunkRole()
         {
             return "{\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}";
+        }
+
+        private static string ChunkReasoning(string reasoning)
+        {
+            var escaped = JsonEscape(reasoning);
+            return "{\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning\":\"" + escaped + "\"}}]}";
+        }
+
+        private static string ChunkContentAndReasoning(string content, string reasoning)
+        {
+            var ec = JsonEscape(content);
+            var er = JsonEscape(reasoning);
+            return "{\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"" + ec + "\",\"reasoning\":\"" + er + "\"}}]}";
+        }
+
+        private static string ChunkReasoningDetailsSummaries(string[] summaries)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning_details\":[");
+            for (int i = 0; i < summaries.Length; i++)
+            {
+                if (i > 0) sb.Append(',');
+                sb.Append("{\"type\":\"reasoning.summary\",\"summary\":\"")
+                  .Append(JsonEscape(summaries[i]))
+                  .Append("\"}");
+            }
+            sb.Append("]}}]}");
+            return sb.ToString();
+        }
+
+        private static string JsonEscape(string s)
+        {
+            return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
         }
 
         /// <summary>Handler that returns a fixed body (string) and optional status code.</summary>


### PR DESCRIPTION
Fixes decay256/pinder-web#178.

## Problem

OpenAI / OpenRouter reasoning models (`gpt-5-nano`, `:thinking` variants, OpenAI `gpt-5.5-pro`, etc.) stream tokens via `choices[0].delta.reasoning` (and structured `delta.reasoning_details[i].summary`) while `delta.content` stays empty until `[DONE]`. Sprint C UAT picked `openai/gpt-5-nano` and got an empty matchup analysis — the transport was dropping every frame.

## Change

`OpenAiStreamingTransport.SendStreamAsync` now yields, **per SSE chunk, in order**:

1. `delta.content` if non-empty (existing behaviour, kept first)
2. `delta.reasoning` if non-empty (new)
3. Concatenation of `delta.reasoning_details[i].summary` if any non-empty (new)

Empty / whitespace fragments are still suppressed. Role-only deltas, tool-call deltas, mid-stream `error` frames, and `[DONE]` are unchanged. xmldoc on the class updated to document the new yield order.

## Tests

Added two fixtures using the existing `CannedSseHandler` pattern:

- `SendStreamAsync_ReasoningOnlyStream_YieldsReasoningAndDetailSummaries` — every chunk has `content=""`, non-empty `reasoning`, plus a `reasoning_details` summary frame. Asserts all four reasoning fragments are yielded in order.
- `SendStreamAsync_MixedReasoningAndContentStream_YieldsContentFirstThenReasoning` — interleaved frames including one mixed frame with both fields. Verifies content-first / reasoning-second yield order.

`OpenAiStreamingTransport` test count: 18 → 20, all green.

## DoD Evidence

```
$ dotnet test tests/Pinder.LlmAdapters.Tests --filter "FullyQualifiedName~OpenAiStreamingTransport"
Passed!  - Failed:     0, Passed:    20, Skipped:     0, Total:    20
```

Full `Pinder.LlmAdapters.Tests`: 886 pass / 63 fail / 9 skipped — pre-existing 63 failures untouched.

## Out of Scope

- Frontend reasoning-UI affordance (per issue).
- Anthropic streaming transport (already produces text via `content_block_delta`).
- No `pinder-web` changes; no submodule pointer bump.