### PR TITLE
fix(#117): expose ComputeRiskTier as public static

### DIFF
--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -110,8 +110,9 @@ namespace Pinder.Core.Rolls
 
         /// <summary>
         /// Compute risk tier from the "need" value: dc - (statMod + levelBonus).
+        /// Canonical formula; DTOs/UI MUST call this rather than re-implement (#117).
         /// </summary>
-        private static RiskTier ComputeRiskTier(int dc, int statModifier, int levelBonus)
+        public static RiskTier ComputeRiskTier(int dc, int statModifier, int levelBonus)
         {
             int need = dc - (statModifier + levelBonus);
 


### PR DESCRIPTION
## Why

`DialogueOptionDto.From` in pinder-web (`src/Pinder.GameApi/Models/TurnDtos.cs`) re-implements the risk-tier threshold ladder (`need ≤7 Safe`, `≤11 Medium`, `≤15 Hard`, `≤19 Bold`, else `Reckless`) instead of calling the engine. Today the numbers agree, but if a future tweak changes the engine thresholds, the option-preview UI would silently lie.

This PR makes the canonical helper accessible so the parent repo can drop its duplicate.

## What

- `Pinder.Core.Rolls.RollResult.ComputeRiskTier(int dc, int statModifier, int levelBonus)`: `private static` → `public static`.
- XML doc note added: "canonical formula; DTOs/UI MUST call this rather than re-implement (#117)".
- No engine math change; signature & behaviour identical.

## Risk

Trivial. No call-site change inside this submodule. Build clean (0 errors).

## Pairs with

- decay256/pinder-web fix(#117): use engine's ComputeRiskTier in DialogueOptionDto (PR opened in parent)