### PR TITLE
feat(#255): trap display_name + summary fields

### DIFF
--- a/data/traps/trap-schema.json
+++ b/data/traps/trap-schema.json
@@ -11,6 +11,16 @@
         "type": "string",
         "description": "Unique identifier for the trap (e.g. 'cringe', 'creep')."
       },
+      "display_name": {
+        "type": "string",
+        "description": "Player-facing Title-Case name of the trap (e.g. 'Cringe', 'Creep'). Used in the failure-tier label and the activated-trap line. Optional; falls back to id when absent. (#255)",
+        "default": ""
+      },
+      "summary": {
+        "type": "string",
+        "description": "Short one-sentence player-facing description of the trap's flavour. Distinct from llm_instruction (which is internal). Rendered under the activated-trap line. Optional; empty string omits the line. (#255)",
+        "default": ""
+      },
       "stat": {
         "type": "string",
         "enum": ["charm", "rizz", "honesty", "chaos", "wit", "self_awareness"],

--- a/data/traps/traps.json
+++ b/data/traps/traps.json
@@ -1,6 +1,8 @@
 [
   {
     "id": "cringe",
+    "display_name": "Cringe",
+    "summary": "You're aware of how you're coming across, which is making it worse.",
     "stat": "charm",
     "effect": "disadvantage",
     "effect_value": 0,
@@ -11,6 +13,8 @@
   },
   {
     "id": "creep",
+    "display_name": "Creep",
+    "summary": "An accidental 'agenda' quality is leaking into your messages.",
     "stat": "rizz",
     "effect": "stat_penalty",
     "effect_value": 2,
@@ -21,6 +25,8 @@
   },
   {
     "id": "overshare",
+    "display_name": "Overshare",
+    "summary": "Personal details keep leaking into your replies.",
     "stat": "honesty",
     "effect": "opponent_dc_increase",
     "effect_value": 2,
@@ -31,6 +37,8 @@
   },
   {
     "id": "unhinged",
+    "display_name": "Unhinged",
+    "summary": "Your messages keep accelerating beyond where you meant to land.",
     "stat": "chaos",
     "effect": "disadvantage",
     "effect_value": 0,
@@ -41,6 +49,8 @@
   },
   {
     "id": "pretentious",
+    "display_name": "Pretentious",
+    "summary": "You can't stop over-explaining things nobody asked you to clarify.",
     "stat": "wit",
     "effect": "opponent_dc_increase",
     "effect_value": 3,
@@ -51,6 +61,8 @@
   },
   {
     "id": "spiral",
+    "display_name": "Spiral",
+    "summary": "You keep narrating the conversation while you're inside it.",
     "stat": "self_awareness",
     "effect": "disadvantage",
     "effect_value": 0,

--- a/src/Pinder.Core/Data/JsonTrapRepository.cs
+++ b/src/Pinder.Core/Data/JsonTrapRepository.cs
@@ -103,9 +103,16 @@ namespace Pinder.Core.Data
             string clearMethod = obj.GetString("clear_method", "");
             string nat1Bonus = obj.GetString("nat1_bonus", "");
 
+            // #255: optional player-facing copy. Both default to safe values
+            // (display_name → id, summary → "") so legacy data files keep
+            // loading without changes.
+            string displayName = obj.GetString("display_name", "");
+            string summary = obj.GetString("summary", "");
+
             return new TrapDefinition(
                 id, stat, effect, effectValue, durationTurns,
-                llmInstruction, clearMethod, nat1Bonus);
+                llmInstruction, clearMethod, nat1Bonus,
+                displayName, summary);
         }
 
         private static bool TryParseStatType(string key, out StatType st)

--- a/src/Pinder.Core/Traps/TrapDefinition.cs
+++ b/src/Pinder.Core/Traps/TrapDefinition.cs
@@ -10,6 +10,15 @@ namespace Pinder.Core.Traps
         public string Id          { get; }
         public StatType Stat      { get; }
 
+        // Player-facing copy (#255)
+        // Title-Case display name (e.g. "Cringe"). Falls back to Id when the
+        // data file does not provide one, so legacy data continues to work.
+        public string DisplayName { get; }
+
+        // Short one-sentence player-facing flavour. Distinct from
+        // LlmInstruction (which is internal). Empty string when absent.
+        public string Summary     { get; }
+
         // Mechanical effect
         public TrapEffect Effect  { get; }
         public int EffectValue    { get; }   // magnitude of penalty / DC increase
@@ -32,7 +41,9 @@ namespace Pinder.Core.Traps
             int durationTurns,
             string llmInstruction,
             string clearMethod,
-            string nat1Bonus)
+            string nat1Bonus,
+            string? displayName = null,
+            string? summary = null)
         {
             Id             = id;
             Stat           = stat;
@@ -42,6 +53,8 @@ namespace Pinder.Core.Traps
             LlmInstruction = llmInstruction;
             ClearMethod    = clearMethod;
             Nat1Bonus      = nat1Bonus;
+            DisplayName    = string.IsNullOrEmpty(displayName) ? id : displayName!;
+            Summary        = summary ?? "";
         }
     }
 

--- a/tests/Pinder.Core.Tests/JsonTrapRepositoryDisplayNameSummaryTests.cs
+++ b/tests/Pinder.Core.Tests/JsonTrapRepositoryDisplayNameSummaryTests.cs
@@ -1,0 +1,135 @@
+using System.IO;
+using System.Linq;
+using Pinder.Core.Data;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #255 — display_name + summary fields on TrapDefinition.
+    /// Verifies (a) JsonTrapRepository parses both fields from data/traps/traps.json,
+    /// (b) all 6 canonical traps have non-empty values, (c) defaults are safe when
+    /// the fields are absent (display_name → id, summary → "").
+    /// </summary>
+    [Trait("Category", "Core")]
+    public sealed class JsonTrapRepositoryDisplayNameSummaryTests
+    {
+        private static string LoadTrapsJson()
+        {
+            var dir = Directory.GetCurrentDirectory();
+            while (dir != null && !File.Exists(Path.Combine(dir, "data", "traps", "traps.json")))
+            {
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            Assert.NotNull(dir);
+            return File.ReadAllText(Path.Combine(dir!, "data", "traps", "traps.json"));
+        }
+
+        // === Canonical data file: every trap has display_name + summary ===
+
+        [Fact]
+        public void AllCanonicalTraps_Have_NonEmpty_DisplayName()
+        {
+            var repo = new JsonTrapRepository(LoadTrapsJson());
+            foreach (var trap in repo.GetAll())
+            {
+                Assert.False(string.IsNullOrWhiteSpace(trap.DisplayName),
+                    $"Trap '{trap.Id}' must have a non-empty display_name.");
+            }
+        }
+
+        [Fact]
+        public void AllCanonicalTraps_Have_NonEmpty_Summary()
+        {
+            var repo = new JsonTrapRepository(LoadTrapsJson());
+            foreach (var trap in repo.GetAll())
+            {
+                Assert.False(string.IsNullOrWhiteSpace(trap.Summary),
+                    $"Trap '{trap.Id}' must have a non-empty summary.");
+            }
+        }
+
+        [Theory]
+        [InlineData(StatType.Charm,         "Cringe")]
+        [InlineData(StatType.Rizz,          "Creep")]
+        [InlineData(StatType.Honesty,       "Overshare")]
+        [InlineData(StatType.Chaos,         "Unhinged")]
+        [InlineData(StatType.Wit,           "Pretentious")]
+        [InlineData(StatType.SelfAwareness, "Spiral")]
+        public void DisplayName_MatchesSpec(StatType stat, string expected)
+        {
+            var repo = new JsonTrapRepository(LoadTrapsJson());
+            Assert.Equal(expected, repo.GetTrap(stat)!.DisplayName);
+        }
+
+        // Spot-check one summary so we'd catch silent drift in the canonical copy.
+        [Fact]
+        public void Cringe_Summary_Matches_Spec()
+        {
+            var repo = new JsonTrapRepository(LoadTrapsJson());
+            Assert.Equal(
+                "You're aware of how you're coming across, which is making it worse.",
+                repo.GetTrap(StatType.Charm)!.Summary);
+        }
+
+        // === Defaulting behaviour for legacy data without the new fields ===
+
+        private const string LegacyJsonNoDisplayName = @"
+        [
+          {
+            ""id"": ""legacy"",
+            ""stat"": ""charm"",
+            ""effect"": ""disadvantage"",
+            ""effect_value"": 0,
+            ""duration_turns"": 1,
+            ""llm_instruction"": ""legacy instruction"",
+            ""clear_method"": ""SA vs DC 12""
+          }
+        ]";
+
+        [Fact]
+        public void DisplayName_FallsBackToId_WhenAbsent()
+        {
+            var repo = new JsonTrapRepository(LegacyJsonNoDisplayName);
+            var trap = repo.GetTrap(StatType.Charm)!;
+            Assert.Equal("legacy", trap.Id);
+            Assert.Equal("legacy", trap.DisplayName);
+        }
+
+        [Fact]
+        public void Summary_DefaultsToEmptyString_WhenAbsent()
+        {
+            var repo = new JsonTrapRepository(LegacyJsonNoDisplayName);
+            var trap = repo.GetTrap(StatType.Charm)!;
+            Assert.Equal("", trap.Summary);
+        }
+
+        // === Explicit values when present ===
+
+        private const string ExplicitJson = @"
+        [
+          {
+            ""id"": ""custom"",
+            ""display_name"": ""Custom Trap"",
+            ""summary"": ""A bespoke flavour line."",
+            ""stat"": ""rizz"",
+            ""effect"": ""stat_penalty"",
+            ""effect_value"": 1,
+            ""duration_turns"": 2,
+            ""llm_instruction"": ""..."",
+            ""clear_method"": ""SA vs DC 10""
+          }
+        ]";
+
+        [Fact]
+        public void Explicit_DisplayName_AndSummary_AreParsed()
+        {
+            var repo = new JsonTrapRepository(ExplicitJson);
+            var trap = repo.GetTrap(StatType.Rizz)!;
+            Assert.Equal("Custom Trap", trap.DisplayName);
+            Assert.Equal("A bespoke flavour line.", trap.Summary);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add player-facing `display_name` (Title-Case) and `summary` (one-line flavour) to trap definitions so the web UI can show the specific trap name and description in the failure-tier label and activated-trap line — instead of a generic "Trope Trap" with a kebab-case id like `cringe`.

Tracks issue: decay256/pinder-web#255

This PR is the **submodule half** of that bundle. The parent repo PR (decay256/pinder-web) bumps the pinder-core pointer and wires the new fields through the C# DTO + frontend types + render.

## Changes

### Data
- `data/traps/traps.json`: `display_name` + `summary` on all 6 canonical traps (cringe / creep / overshare / unhinged / pretentious / spiral).
- `data/traps/trap-schema.json`: optional fields with safe defaults (so older data files without the fields still validate).

### Engine
- `src/Pinder.Core/Traps/TrapDefinition.cs`: new `DisplayName` and `Summary` properties.
  - Constructor takes both as **optional trailing parameters** so existing call sites keep compiling unchanged.
  - `DisplayName` falls back to `Id` when absent or empty.
  - `Summary` defaults to empty string.
- `src/Pinder.Core/Data/JsonTrapRepository.cs`: parses both fields via `obj.GetString(key, defaultValue)`.

### Tests
- `tests/Pinder.Core.Tests/JsonTrapRepositoryDisplayNameSummaryTests.cs`:
  - canonical data has non-empty `display_name` + `summary` on all 6 traps
  - per-stat spec values for `display_name` (Cringe / Creep / Overshare / Unhinged / Pretentious / Spiral)
  - one full-text `summary` spot-check (cringe)
  - legacy JSON without the fields still loads (`DisplayName → Id`, `Summary → ""`)
  - explicit JSON values parse correctly

## Wire-shape compatibility

Wire-shape change is **additive only**: no existing field renamed or removed. Backwards-compatible with all #117 / #196 consumers; the existing `id` field stays on the wire as the primary key, and the deprecated `activated_trap_name` alias keeps working.

## Test evidence

```
$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --no-build --filter "FullyQualifiedName~Trap|FullyQualifiedName~JsonTrapRepository"
Passed!  - Failed:     0, Passed:   176, Skipped:     0, Total:   176
```

Pre-existing test failures in `Pinder.Rules.Tests`, `Pinder.LlmAdapters.Tests`, and a handful of `CharacterLoaderSpecTests` are unrelated to this change (they fail identically on the unmodified base commit when run from this clone — environmental data-path issue, not something this PR touches).

## Acceptance against #255

- [x] All 6 traps in `traps.json` have `display_name` + `summary`.
- [x] Engine type carries the new fields.
- [x] Backwards-compatible default behaviour for legacy data.
- [ ] **DTO + frontend wiring + render** — handled in the parent repo PR.