### PR TITLE
feat(#305): TurnSnapshot.ConversationEntry carries per-layer text_diffs[]

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -753,6 +753,17 @@ class Program
             ? resimTurnSnap.ConversationHistory.Select(e => (e.Sender, e.Text)).ToList()
             : new List<(string Sender, string Text)>();
 
+        // #305: parallel list of per-turn text_diffs[] for the player's
+        // delivered message. Index = turn_number - 1. When resuming from a
+        // resim snapshot we lift the diffs from the player entries (the
+        // opponent entries always carry an empty list).
+        var perTurnTextDiffs = isResimulation && resimTurnSnap != null
+            ? resimTurnSnap.ConversationHistory
+                .Where((_, idx) => idx % 2 == 0)
+                .Select(e => e.TextDiffs ?? new List<TextDiffSnapshot>())
+                .ToList()
+            : new List<List<TextDiffSnapshot>>();
+
         string lastOpponentMsg = isResimulation && resimTurnSnap != null
             ? (resimTurnSnap.ConversationHistory.LastOrDefault(e => e.Sender == player2)?.Text ?? "")
             : "";
@@ -1081,6 +1092,24 @@ class Program
             // Track conversation history for LLM agent context (#492)
             if (!string.IsNullOrEmpty(result.DeliveredMessage))
                 conversationHistory.Add((player1, result.DeliveredMessage));
+                // #305: stash this turn's TextDiffs (snapshot shape) so we can
+                // attach them to the player's history entry when building
+                // the turn snapshot below. Empty list when no layer
+                // transformed the text.
+                perTurnTextDiffs.Add(
+                    (result.TextDiffs ?? Array.Empty<Pinder.Core.Text.TextDiff>())
+                        .Select(d => new TextDiffSnapshot
+                        {
+                            Layer = d.LayerName,
+                            Before = d.Before,
+                            After = d.After,
+                            Spans = d.Spans.Select(s => new TextDiffSpanSnapshot
+                            {
+                                Type = s.Type.ToString(),
+                                Text = s.Text,
+                            }).ToList(),
+                        })
+                        .ToList());
             lastOpponentMsg = result.OpponentMessage ?? "";
             if (!string.IsNullOrEmpty(lastOpponentMsg))
                 conversationHistory.Add((player2, lastOpponentMsg));
@@ -1267,7 +1296,8 @@ class Program
                     rizzCumulativeFailureCount,
                     conversationHistory,
                     comboHistoryForSnapshot,
-                    tellSnap);
+                    tellSnap,
+                    perTurnTextDiffs);
 
                 string turnSnapPath = Path.Combine(playtestDir, $"{sessionSlug}.turn-{turn:D2}.snap.json");
                 File.WriteAllText(turnSnapPath, JsonSerializer.Serialize(turnSnap, new JsonSerializerOptions { WriteIndented = true }));
@@ -1563,7 +1593,8 @@ class Program
         int rizzCumulativeFailureCount,
         List<(string Sender, string Text)> conversationHistory,
         List<(StatType Stat, bool Succeeded)> comboHistory,
-        TellSnapshot? activeTell)
+        TellSnapshot? activeTell,
+        List<List<TextDiffSnapshot>>? perTurnTextDiffs = null)
     {
         var state = result.StateAfter;
 
@@ -1583,10 +1614,26 @@ class Program
             .Select(e => new TurnHistoryEntry { Stat = e.Stat.ToString(), Succeeded = e.Succeeded })
             .ToList();
 
-        // Conversation history
-        var convEntries = conversationHistory
-            .Select(e => new ConversationEntry { Sender = e.Sender, Text = e.Text })
-            .ToList();
+        // Conversation history (#305: attach per-turn text_diffs[] to the
+        // player's entry on each turn so the snapshot can be deserialised
+        // straight into a renderer / replay tool. Each resolved turn
+        // appends two entries — player then opponent — so player entries
+        // live at even indices and turn-N maps to history index 2*(N-1).)
+        var convEntries = new List<ConversationEntry>(conversationHistory.Count);
+        for (int i = 0; i < conversationHistory.Count; i++)
+        {
+            var (sender, text) = conversationHistory[i];
+            var entry = new ConversationEntry { Sender = sender, Text = text };
+            bool isPlayerEntry = (i % 2) == 0;
+            int turnIdx = i / 2;
+            if (isPlayerEntry
+                && perTurnTextDiffs != null
+                && turnIdx < perTurnTextDiffs.Count)
+            {
+                entry.TextDiffs = perTurnTextDiffs[turnIdx] ?? new List<TextDiffSnapshot>();
+            }
+            convEntries.Add(entry);
+        }
 
         return new TurnSnapshot
         {

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1091,11 +1091,16 @@ class Program
 
             // Track conversation history for LLM agent context (#492)
             if (!string.IsNullOrEmpty(result.DeliveredMessage))
+            {
                 conversationHistory.Add((player1, result.DeliveredMessage));
                 // #305: stash this turn's TextDiffs (snapshot shape) so we can
                 // attach them to the player's history entry when building
                 // the turn snapshot below. Empty list when no layer
-                // transformed the text.
+                // transformed the text. MUST stay in lock-step with
+                // conversationHistory — BuildTurnSnapshot indexes
+                // perTurnTextDiffs[i/2] against the player entry at index i,
+                // so skipping a player entry without skipping the diffs entry
+                // (or vice versa) desyncs every subsequent turn's diffs.
                 perTurnTextDiffs.Add(
                     (result.TextDiffs ?? Array.Empty<Pinder.Core.Text.TextDiff>())
                         .Select(d => new TextDiffSnapshot
@@ -1110,6 +1115,7 @@ class Program
                             }).ToList(),
                         })
                         .ToList());
+            }
             lastOpponentMsg = result.OpponentMessage ?? "";
             if (!string.IsNullOrEmpty(lastOpponentMsg))
                 conversationHistory.Add((player2, lastOpponentMsg));
@@ -1580,7 +1586,9 @@ class Program
         };
     }
 
-    static TurnSnapshot BuildTurnSnapshot(
+    // internal so Pinder.Core.Tests can verify the conversationHistory ↔ perTurnTextDiffs
+    // indexing contract (see Issue767BraceScopeTests).
+    internal static TurnSnapshot BuildTurnSnapshot(
         int turnNumber,
         TurnResult result,
         SessionShadowTracker shadows,

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -48,6 +48,23 @@ namespace Pinder.SessionRunner.Snapshot
     /// <summary>
     /// Snapshot of tracking state written after each ResolveTurnAsync call.
     /// Contains everything needed to reconstruct mid-session state.
+    ///
+    /// <para>
+    /// Fields covered (per AGENTS.md schema-discipline rule — every
+    /// player-visible <c>GameSession</c> field MUST appear here):
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>TurnNumber</c>, <c>Interest</c></description></item>
+    ///   <item><description><c>ShadowValues</c> (per <c>ShadowStatType</c>)</description></item>
+    ///   <item><description><c>MomentumStreak</c>, <c>PendingTripleBonus</c></description></item>
+    ///   <item><description><c>ActiveTraps</c>, <c>ActiveTell</c></description></item>
+    ///   <item><description><c>ComboHistory</c> (last 3 turns of stat + success)</description></item>
+    ///   <item><description><c>StatsUsedHistory</c>, <c>HighestPctHistory</c></description></item>
+    ///   <item><description><c>CharmUsageCount</c>, <c>CharmMadnessTriggered</c></description></item>
+    ///   <item><description><c>SaUsageCount</c>, <c>SaOverthinkingTriggered</c></description></item>
+    ///   <item><description><c>RizzCumulativeFailureCount</c></description></item>
+    ///   <item><description><c>ConversationHistory</c> (per-entry sender + text + per-layer text_diffs[] — issue #305)</description></item>
+    /// </list>
     /// </summary>
     public sealed class TurnSnapshot
     {
@@ -78,7 +95,12 @@ namespace Pinder.SessionRunner.Snapshot
         public bool SaOverthinkingTriggered { get; set; }
         public int RizzCumulativeFailureCount { get; set; }
 
-        /// <summary>Full conversation history up to and including this turn.</summary>
+        /// <summary>
+        /// Full conversation history up to and including this turn.
+        /// Per #305 each entry now carries optional <see cref="ConversationEntry.TextDiffs"/>
+        /// for the player's delivered message (Misfire / Steering /
+        /// Horniness / Shadow layers); opponent entries leave it empty.
+        /// </summary>
         public List<ConversationEntry> ConversationHistory { get; set; } = new List<ConversationEntry>();
     }
 
@@ -108,6 +130,41 @@ namespace Pinder.SessionRunner.Snapshot
     public sealed class ConversationEntry
     {
         public string Sender { get; set; } = string.Empty;
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Issue #305: per-layer word-level diffs for the player's
+        /// delivered message on this turn (Misfire / Steering / Horniness
+        /// / Shadow). Empty list for opponent entries and for player
+        /// entries with no recorded transformations. Mirrors the wire
+        /// <c>TextDiffDto</c> shape so the snapshot can be deserialised
+        /// straight into a renderer / replay tool.
+        /// </summary>
+        public List<TextDiffSnapshot> TextDiffs { get; set; } = new List<TextDiffSnapshot>();
+    }
+
+    /// <summary>
+    /// Issue #305: snapshot shape for one text-transform layer's
+    /// word-level diff. Layer name + before/after strings + per-token
+    /// spans (Keep / Remove / Add).
+    /// </summary>
+    public sealed class TextDiffSnapshot
+    {
+        public string Layer { get; set; } = string.Empty;
+        public string Before { get; set; } = string.Empty;
+        public string After { get; set; } = string.Empty;
+        public List<TextDiffSpanSnapshot> Spans { get; set; } = new List<TextDiffSpanSnapshot>();
+    }
+
+    /// <summary>
+    /// Issue #305: one word-level token span inside a
+    /// <see cref="TextDiffSnapshot"/>. <see cref="Type"/> is one of
+    /// <c>Keep</c> / <c>Remove</c> / <c>Add</c> (mirrors
+    /// <c>Pinder.Core.Text.DiffSpanType</c>).
+    /// </summary>
+    public sealed class TextDiffSpanSnapshot
+    {
+        public string Type { get; set; } = string.Empty;
         public string Text { get; set; } = string.Empty;
     }
 }

--- a/tests/Pinder.Core.Tests/Issue767BraceScopeTests.cs
+++ b/tests/Pinder.Core.Tests/Issue767BraceScopeTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner.Snapshot;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Regression tests for the brace-scope bug on PR
+    /// <c>decay256/pinder-core#767</c> (issue #305).
+    ///
+    /// <para>
+    /// Original bug: in <c>session-runner/Program.cs</c> the per-turn
+    /// loop did
+    /// <code>
+    /// if (!string.IsNullOrEmpty(result.DeliveredMessage))
+    ///     conversationHistory.Add((player1, result.DeliveredMessage));
+    ///     perTurnTextDiffs.Add(...);   // visually nested, actually unconditional
+    /// </code>
+    /// because the <c>if</c> had no braces. When <c>DeliveredMessage</c>
+    /// was empty the player entry was skipped from
+    /// <c>conversationHistory</c> but the diffs entry was still appended,
+    /// which desynced the two lists. <c>BuildTurnSnapshot</c> walks
+    /// <c>conversationHistory</c> with <c>turnIdx = i / 2</c> and uses
+    /// that index into <c>perTurnTextDiffs</c>, so every turn after the
+    /// skip would attach diffs to the wrong entry.
+    /// </para>
+    ///
+    /// <para>
+    /// The fix added braces so both <c>Add</c> calls are gated by the
+    /// same <c>if</c>. These tests pin the contract:
+    /// 1. The two lists are co-indexed by player-entry, so the diffs of
+    ///    turn N are <c>perTurnTextDiffs[N-1]</c>.
+    /// 2. Skipping a turn (empty <c>DeliveredMessage</c>) MUST skip both
+    ///    lists in lock-step or downstream snapshots desync.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "SessionRunner")]
+    public class Issue767BraceScopeTests
+    {
+        // ── Helpers ────────────────────────────────────────────────────────
+
+        private static StatBlock MakeStats() => new StatBlock(
+            new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 3 }, { StatType.Rizz, 2 },
+                { StatType.Honesty, 1 }, { StatType.Chaos, 0 },
+                { StatType.Wit, 4 }, { StatType.SelfAwareness, 2 },
+            },
+            new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            });
+
+        private static RollResult MakeRoll() =>
+            new RollResult(10, null, 10, StatType.Charm, 2, 0, 13, FailureTier.None);
+
+        private static GameStateSnapshot MakeState() =>
+            new GameStateSnapshot(10, InterestState.Interested, 0, Array.Empty<string>(), 1);
+
+        private static TurnResult MakeResult() =>
+            new TurnResult(MakeRoll(), "delivered", "reply", null, 1, MakeState(), false, null);
+
+        private static List<TextDiffSnapshot> Diffs(string layer) =>
+            new List<TextDiffSnapshot>
+            {
+                new TextDiffSnapshot
+                {
+                    Layer = layer,
+                    Before = "before",
+                    After = "after",
+                    Spans = new List<TextDiffSpanSnapshot>
+                    {
+                        new TextDiffSpanSnapshot { Type = "Keep", Text = layer },
+                    },
+                },
+            };
+
+        // ── Tests ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void BuildTurnSnapshot_AttachesPerTurnDiffsToCorrectPlayerEntry()
+        {
+            // 3 turns, all with non-empty DeliveredMessage and OpponentMessage
+            // → conversationHistory has 6 entries (alternating P1/P2),
+            // → perTurnTextDiffs has 3 entries.
+            var conversationHistory = new List<(string Sender, string Text)>
+            {
+                ("P1", "p1 turn 1"), ("P2", "p2 turn 1"),
+                ("P1", "p1 turn 2"), ("P2", "p2 turn 2"),
+                ("P1", "p1 turn 3"), ("P2", "p2 turn 3"),
+            };
+            var perTurnTextDiffs = new List<List<TextDiffSnapshot>>
+            {
+                Diffs("turn1"), Diffs("turn2"), Diffs("turn3"),
+            };
+
+            var snap = global::Program.BuildTurnSnapshot(
+                turnNumber: 3,
+                result: MakeResult(),
+                shadows: new SessionShadowTracker(MakeStats()),
+                statsUsedHistory: new List<StatType>(),
+                highestPctHistory: new List<bool>(),
+                charmUsageCount: 0,
+                charmMadnessTriggered: false,
+                saUsageCount: 0,
+                saOverthinkingTriggered: false,
+                rizzCumulativeFailureCount: 0,
+                conversationHistory: conversationHistory,
+                comboHistory: new List<(StatType Stat, bool Succeeded)>(),
+                activeTell: null,
+                perTurnTextDiffs: perTurnTextDiffs);
+
+            Assert.Equal(6, snap.ConversationHistory.Count);
+
+            // Player entries (even indices) carry their turn's diffs.
+            Assert.Equal("turn1", Assert.Single(snap.ConversationHistory[0].TextDiffs).Layer);
+            Assert.Equal("turn2", Assert.Single(snap.ConversationHistory[2].TextDiffs).Layer);
+            Assert.Equal("turn3", Assert.Single(snap.ConversationHistory[4].TextDiffs).Layer);
+
+            // Opponent entries (odd indices) carry no diffs.
+            Assert.Empty(snap.ConversationHistory[1].TextDiffs);
+            Assert.Empty(snap.ConversationHistory[3].TextDiffs);
+            Assert.Empty(snap.ConversationHistory[5].TextDiffs);
+        }
+
+        [Fact]
+        public void EmptyDeliveredMessage_LoopBody_KeepsListsLockstepOnPlayerAxis()
+        {
+            // Mirrors the (now-fixed) loop body of Program.Main across 3
+            // turns. Turn 2 has empty DeliveredMessage — the exact bug
+            // scenario. The fix requires that BOTH conversationHistory.Add
+            // AND perTurnTextDiffs.Add are gated by the same `if`. So
+            // after the loop, the count of player-sender entries in
+            // conversationHistory MUST equal the length of
+            // perTurnTextDiffs — otherwise downstream code that pairs
+            // them by index will desync.
+            //
+            // Under the buggy (brace-less) code, perTurnTextDiffs would
+            // have grown on every turn including turn 2, ending up
+            // longer than the player-entry count.
+            var conversationHistory = new List<(string Sender, string Text)>();
+            var perTurnTextDiffs = new List<List<TextDiffSnapshot>>();
+
+            // Turn 1 — both adds happen.
+            ApplyTurn(conversationHistory, perTurnTextDiffs,
+                deliveredMessage: "p1 turn 1",
+                opponentMessage: "p2 turn 1",
+                turnDiffs: Diffs("turn1"));
+
+            // Turn 2 — empty DeliveredMessage; player entry skipped.
+            ApplyTurn(conversationHistory, perTurnTextDiffs,
+                deliveredMessage: "",
+                opponentMessage: "p2 turn 2",
+                turnDiffs: Diffs("turn2-should-not-appear"));
+
+            // Turn 3 — both adds happen.
+            ApplyTurn(conversationHistory, perTurnTextDiffs,
+                deliveredMessage: "p1 turn 3",
+                opponentMessage: "p2 turn 3",
+                turnDiffs: Diffs("turn3"));
+
+            // Core invariant the fix guarantees.
+            int playerEntries = conversationHistory.Count(e => e.Sender == "P1");
+            Assert.Equal(2, playerEntries);
+            Assert.Equal(playerEntries, perTurnTextDiffs.Count);
+
+            // Diffs that survived correspond to turn 1 and turn 3 (in
+            // order). The "turn2-should-not-appear" diff was correctly
+            // skipped together with its player entry.
+            Assert.Equal("turn1", perTurnTextDiffs[0][0].Layer);
+            Assert.Equal("turn3", perTurnTextDiffs[1][0].Layer);
+            Assert.DoesNotContain(perTurnTextDiffs,
+                d => d.Count > 0 && d[0].Layer == "turn2-should-not-appear");
+        }
+
+        [Fact]
+        public void EmptyDeliveredMessage_BuggyLoopBody_DesyncsLists()
+        {
+            // Sanity check: the OLD (brace-less) loop body would have
+            // grown perTurnTextDiffs even when DeliveredMessage was
+            // empty. We replay that exact buggy logic here so the
+            // regression test above clearly distinguishes "fix in place"
+            // from "fix reverted".
+            var conversationHistory = new List<(string Sender, string Text)>();
+            var perTurnTextDiffs = new List<List<TextDiffSnapshot>>();
+
+            BuggyApplyTurn(conversationHistory, perTurnTextDiffs,
+                "p1 turn 1", "p2 turn 1", Diffs("turn1"));
+            BuggyApplyTurn(conversationHistory, perTurnTextDiffs,
+                "", "p2 turn 2", Diffs("turn2-should-not-appear"));
+            BuggyApplyTurn(conversationHistory, perTurnTextDiffs,
+                "p1 turn 3", "p2 turn 3", Diffs("turn3"));
+
+            int playerEntries = conversationHistory.Count(e => e.Sender == "P1");
+            Assert.Equal(2, playerEntries);
+            // Buggy behaviour: perTurnTextDiffs has 3 entries, off by one.
+            Assert.Equal(3, perTurnTextDiffs.Count);
+            Assert.NotEqual(playerEntries, perTurnTextDiffs.Count);
+        }
+
+        /// <summary>
+        /// Mirrors the (now-fixed) loop body in
+        /// <c>session-runner/Program.cs</c>: when
+        /// <c>DeliveredMessage</c> is empty, neither
+        /// <c>conversationHistory</c> NOR <c>perTurnTextDiffs</c> grows on
+        /// the player axis.
+        /// </summary>
+        private static void ApplyTurn(
+            List<(string Sender, string Text)> conversationHistory,
+            List<List<TextDiffSnapshot>> perTurnTextDiffs,
+            string deliveredMessage,
+            string opponentMessage,
+            List<TextDiffSnapshot> turnDiffs)
+        {
+            if (!string.IsNullOrEmpty(deliveredMessage))
+            {
+                conversationHistory.Add(("P1", deliveredMessage));
+                perTurnTextDiffs.Add(turnDiffs);
+            }
+            if (!string.IsNullOrEmpty(opponentMessage))
+            {
+                conversationHistory.Add(("P2", opponentMessage));
+            }
+        }
+
+        /// <summary>
+        /// Mirrors the ORIGINAL (brace-less) loop body where
+        /// <c>perTurnTextDiffs.Add</c> was visually nested inside the
+        /// <c>if</c> but actually unconditional. Used as a counter-example
+        /// so the regression test cleanly distinguishes correct vs broken
+        /// behaviour.
+        /// </summary>
+        private static void BuggyApplyTurn(
+            List<(string Sender, string Text)> conversationHistory,
+            List<List<TextDiffSnapshot>> perTurnTextDiffs,
+            string deliveredMessage,
+            string opponentMessage,
+            List<TextDiffSnapshot> turnDiffs)
+        {
+            if (!string.IsNullOrEmpty(deliveredMessage))
+                conversationHistory.Add(("P1", deliveredMessage));
+            // Indented as if nested but actually outside the `if` —
+            // exactly the bug.
+                perTurnTextDiffs.Add(turnDiffs);
+            if (!string.IsNullOrEmpty(opponentMessage))
+            {
+                conversationHistory.Add(("P2", opponentMessage));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Per AGENTS.md schema-discipline rule (every player-visible `GameSession` field MUST be reflected in `TurnSnapshot`), `TextDiffs[]` — produced by `GameSession.ResolveTurnAsync` on `TurnResult.TextDiffs` — now flows into `ConversationEntry` on each turn snapshot.

Companion to **decay256/pinder-web#310** (which addresses the same issue from the GameApi side: audit row + state envelope persistence). This submodule PR is the schema-discipline counterpart.

## Changes

- `ConversationEntry` gains `TextDiffs` (`List<TextDiffSnapshot>`), defaulting to empty so legacy snapshots round-trip cleanly.
- `TextDiffSnapshot` / `TextDiffSpanSnapshot` mirror the wire `TextDiffDto` shape.
- `BuildTurnSnapshot` accepts an optional `perTurnTextDiffs` list and attaches each turn's diffs to the player entry (history index `2*(N-1)`). Opponent entries leave `TextDiffs` empty.
- `Program.cs` accumulates per-turn `TextDiffs` alongside `conversationHistory` and threads them through.
- Top-of-class "fields covered" comment block updated to list `ConversationLog + per-layer text_diffs[]`.

## Verification

End-to-end JSON round-trip verified: serialize a populated `TurnSnapshot` → `textDiffs` array present on the player entry with all three layers + spans → deserialize → all values intact.

Refs decay256/pinder-web#305.