### PR TITLE
fix(decay256/pinder-web#130): seed OptionFilterEngine.DrawRandomStats for test determinism

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -90,6 +90,10 @@ namespace Pinder.Core.Conversation
         private readonly SessionXpRecorder _xpRecorder;
         private readonly SteeringEngine _steeringEngine;
         private readonly HorninessEngine _horninessEngine;
+        // Dedicated RNG for OptionFilterEngine.DrawRandomStats. Kept separate from
+        // the steering RNG so tests can queue exact steering values without our
+        // stat-draw shuffle consuming them (see issue #130).
+        private readonly Random? _statDrawRng;
 
         /// <summary>
         /// Creates a new GameSession with required configuration.
@@ -119,6 +123,7 @@ namespace Pinder.Core.Conversation
             _rules = config.Rules;
             _globalDcBias = config.GlobalDcBias;
             var steeringRng = config.SteeringRng ?? new Random();
+            _statDrawRng = config.StatDrawRng;
             _statDeliveryInstructions = config.StatDeliveryInstructions;
 
             // Determine starting interest: explicit config > Dread T3 > default
@@ -383,7 +388,7 @@ namespace Pinder.Core.Conversation
 
             // Draw 3 random stats for this turn's options
             var allStats = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
-            var availableStats = OptionFilterEngine.DrawRandomStats(allStats, 3, shadowThresholds);
+            var availableStats = OptionFilterEngine.DrawRandomStats(allStats, 3, shadowThresholds, _statDrawRng);
 
             var context = new DialogueContext(
                 playerPrompt: _player.AssembledSystemPrompt,

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -58,6 +58,17 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public IDiceRoller? DiceRoller { get; }
 
+        /// <summary>
+        /// Optional RNG used by <c>OptionFilterEngine.DrawRandomStats</c> to shuffle the
+        /// stat pool each turn. Distinct from <see cref="SteeringRng"/> so that tests
+        /// which inject a tightly-queued <see cref="Random"/> for steering rolls are
+        /// not perturbed by unrelated stat-draw calls.
+        /// When null, <c>OptionFilterEngine</c> falls back to a fresh <see cref="Random"/>
+        /// (legacy non-deterministic behaviour). Inject a seeded RNG for test fixture
+        /// reproducibility (issue #130).
+        /// </summary>
+        public Random? StatDrawRng { get; }
+
         public GameSessionConfig(
             IGameClock? clock = null,
             SessionShadowTracker? playerShadows = null,
@@ -68,7 +79,8 @@ namespace Pinder.Core.Conversation
             int globalDcBias = 0,
             Random? steeringRng = null,
             object? statDeliveryInstructions = null,
-            IDiceRoller? diceRoller = null)
+            IDiceRoller? diceRoller = null,
+            Random? statDrawRng = null)
         {
             Clock = clock;
             PlayerShadows = playerShadows;
@@ -80,6 +92,7 @@ namespace Pinder.Core.Conversation
             SteeringRng = steeringRng;
             StatDeliveryInstructions = statDeliveryInstructions;
             DiceRoller = diceRoller;
+            StatDrawRng = statDrawRng;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/OptionFilterEngine.cs
+++ b/src/Pinder.Core/Conversation/OptionFilterEngine.cs
@@ -16,11 +16,20 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Draws N random stats from the pool, applying shadow-based exclusions.
         /// Denial T3 (≥12): removes HONESTY from pool.
+        ///
+        /// <para>
+        /// <paramref name="rng"/> is used to shuffle the eligible pool. When null a
+        /// fresh <see cref="Random"/> is created (legacy non-deterministic behaviour).
+        /// Pass an injected/seeded Random — typically a dedicated stat-draw RNG owned
+        /// by the GameSession — to make stat draws reproducible across capture/replay
+        /// runs (see issue #130).
+        /// </para>
         /// </summary>
         public static StatType[] DrawRandomStats(
             StatType[] pool,
             int count,
-            Dictionary<ShadowStatType, int>? shadowThresholds)
+            Dictionary<ShadowStatType, int>? shadowThresholds,
+            Random? rng = null)
         {
             var eligible = new List<StatType>(pool);
 
@@ -32,11 +41,13 @@ namespace Pinder.Core.Conversation
                 eligible.Remove(StatType.Honesty);
             }
 
-            // Shuffle using System.Random (stat selection is UI randomness, not game mechanics)
-            var rng = new Random();
+            // Shuffle using the provided RNG (or a fresh non-deterministic one if none
+            // was supplied). Stat selection is UI randomness, not game mechanics, but
+            // tests inject a seeded RNG so prompt fixtures stay stable (#130).
+            var shuffler = rng ?? new Random();
             for (int i = eligible.Count - 1; i > 0; i--)
             {
-                int j = rng.Next(0, i + 1);
+                int j = shuffler.Next(0, i + 1);
                 var tmp = eligible[i];
                 eligible[i] = eligible[j];
                 eligible[j] = tmp;


### PR DESCRIPTION
Required by decay256/pinder-web#130. Replaces the unseeded `new Random()` in `OptionFilterEngine.DrawRandomStats` with an injectable `Random` and adds `GameSessionConfig.StatDrawRng` so `pinder-web` can plumb a seeded RNG through. Default behaviour is unchanged when no RNG is injected.

Submodule pointer bump in `pinder-web` follows in decay256/pinder-web#130's PR.

Tests:
- `Pinder.Core.Tests`: 2408 passed / 6 environmental skips (no design/examples on disk) / 18 skipped — same baseline as `origin/main` on this checkout (verified against a pristine clone).
- `Pinder.Rules.Tests`, `Pinder.LlmAdapters.Tests`: pre-existing failure counts unchanged (YAML parser / parse-defaults tests, all unrelated).