### PR TITLE
feat(GameSession): add typed MarkEnded(GameOutcome) API

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -213,6 +213,24 @@ namespace Pinder.Core.Conversation
         public GameOutcome? Outcome => _outcome;
 
         /// <summary>
+        /// Restore an already-ended session from persisted state. Sets the
+        /// terminal flags so subsequent <see cref="StartTurnAsync"/> throws
+        /// <see cref="GameEndedException"/> with the right outcome.
+        ///
+        /// Intended for post-game replay/rehydration paths (e.g. loading a
+        /// finished session back from storage). <see cref="RestoreState"/>
+        /// targets mid-game resimulation and deliberately does not touch the
+        /// terminal flags; callers reviving an ended session must call this
+        /// in addition.
+        /// </summary>
+        /// <param name="outcome">The terminal <see cref="GameOutcome"/> the session ended with.</param>
+        public void MarkEnded(GameOutcome outcome)
+        {
+            _ended = true;
+            _outcome = outcome;
+        }
+
+        /// <summary>
         /// Conversation history as (sender, text) tuples, in emission order.
         /// Read-only snapshot view; safe to enumerate concurrently with session mutation
         /// since the underlying list is only appended during ResolveTurnAsync.

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Traps;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Regression tests for the typed <see cref="GameSession.MarkEnded"/> API
+    /// added in pinder-web#293. Replaces the reflection-based wrapper used by
+    /// SessionStore.SetEngineEnded when rehydrating an already-finished
+    /// session from persistent storage.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue293_MarkEndedTests
+    {
+        private sealed class NullLlm : ILlmAdapter
+        {
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context) => Task.FromResult(new DialogueOption[0]);
+            public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => Task.FromResult(message);
+        }
+
+        private sealed class FixedDice : IDiceRoller
+        {
+            public int Roll(int sides) => 5;
+        }
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private static GameSession NewSession()
+        {
+            return new GameSession(
+                MakeProfile("P"),
+                MakeProfile("O"),
+                new NullLlm(),
+                new FixedDice(),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+        }
+
+        [Theory]
+        [InlineData(GameOutcome.DateSecured)]
+        [InlineData(GameOutcome.Unmatched)]
+        [InlineData(GameOutcome.Ghosted)]
+        public void MarkEnded_SetsTerminalFlags(GameOutcome outcome)
+        {
+            var session = NewSession();
+            Assert.False(session.IsEnded);
+            Assert.Null(session.Outcome);
+
+            session.MarkEnded(outcome);
+
+            Assert.True(session.IsEnded);
+            Assert.Equal(outcome, session.Outcome);
+        }
+
+        [Fact]
+        public async Task MarkEnded_StartTurnAsync_ThrowsGameEndedExceptionWithOutcome()
+        {
+            var session = NewSession();
+
+            session.MarkEnded(GameOutcome.DateSecured);
+
+            var ex = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
+            Assert.Equal(GameOutcome.DateSecured, ex.Outcome);
+        }
+
+        [Fact]
+        public async Task MarkEnded_OverridesUnmatched_ThrowsWithCorrectOutcome()
+        {
+            // Different outcome to prove the value flows through, not a default.
+            var session = NewSession();
+            session.MarkEnded(GameOutcome.Unmatched);
+
+            var ex = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
+            Assert.Equal(GameOutcome.Unmatched, ex.Outcome);
+        }
+    }
+}


### PR DESCRIPTION
Adds `GameSession.MarkEnded(GameOutcome outcome)` so post-game rehydration paths can mark a freshly-constructed session as ended without reflection.

```csharp
public void MarkEnded(GameOutcome outcome)
{
    _ended = true;
    _outcome = outcome;
}
```

## Why

`GameSession.RestoreState` is intentionally scoped to mid-game resimulation and does **not** touch the terminal `_ended` / `_outcome` flags. When pinder-web rehydrates an **already-finished** session from the DB, it needs to set those flags so:

1. `StartTurnAsync` throws `GameEndedException` with the correct outcome (defence-in-depth).
2. The fast-path in pinder-web's `SessionsController.GetTurnAsync` returns the persisted `EndStateDto`.

Today pinder-web (PR #292) does this via reflection on `_ended` / `_outcome`. Works, but brittle to internal renames. This PR adds the typed API; pinder-web's follow-up PR drops the reflection.

## Tests

New `Issue293_MarkEndedTests` in `tests/Pinder.Core.Tests/Conversation/`:

- `MarkEnded_SetsTerminalFlags` (theory over all three `GameOutcome` values) — asserts `IsEnded` flips and `Outcome` matches.
- `MarkEnded_StartTurnAsync_ThrowsGameEndedExceptionWithOutcome` — full integration of the contract (mark → next `StartTurnAsync` throws typed exception with the right outcome).
- `MarkEnded_OverridesUnmatched_ThrowsWithCorrectOutcome` — sanity check that a non-default outcome flows through.

```
Passed!  - Failed:     0, Passed:    68, Skipped:     0, Total:    68
```

Refs decay256/pinder-web#293.