### PR TITLE
feat(#299): pass typed phase through ILlmTransport

### DIFF
--- a/src/Pinder.Core/Interfaces/ILlmTransport.cs
+++ b/src/Pinder.Core/Interfaces/ILlmTransport.cs
@@ -16,7 +16,14 @@ namespace Pinder.Core.Interfaces
         /// <param name="userMessage">The user-turn message content.</param>
         /// <param name="temperature">Sampling temperature (default 0.9).</param>
         /// <param name="maxTokens">Maximum tokens for the response (default 1024).</param>
+        /// <param name="phase">
+        /// Optional engine-phase label (see <see cref="LlmPhase"/>). Transports themselves
+        /// should ignore the value; decorators (snapshot recorders, telemetry) read it to
+        /// classify the exchange without inspecting prompt text. Defaults to <c>null</c>
+        /// for backwards compatibility — existing callers and ILlmTransport implementations
+        /// do not need to change.
+        /// </param>
         /// <returns>Raw text response from the LLM.</returns>
-        Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024);
+        Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null);
     }
 }

--- a/src/Pinder.Core/Interfaces/IStreamingLlmTransport.cs
+++ b/src/Pinder.Core/Interfaces/IStreamingLlmTransport.cs
@@ -34,6 +34,12 @@ namespace Pinder.Core.Interfaces
         /// <param name="temperature">Sampling temperature (default 0.9).</param>
         /// <param name="maxTokens">Maximum tokens for the response (default 1024).</param>
         /// <param name="cancellationToken">Cancellation token; cancelling stops the stream.</param>
+        /// <param name="phase">
+        /// Optional engine-phase label (see <see cref="LlmPhase"/>). Transports themselves
+        /// should ignore the value; decorators (snapshot recorders, telemetry) read it to
+        /// classify the exchange without inspecting prompt text. Defaults to <c>null</c>
+        /// for backwards compatibility.
+        /// </param>
         /// <returns>An async sequence of raw text fragments.</returns>
         /// <exception cref="LlmTransportException">Thrown from the enumerator on transport failure.</exception>
         IAsyncEnumerable<string> SendStreamAsync(
@@ -41,6 +47,7 @@ namespace Pinder.Core.Interfaces
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            string? phase = null);
     }
 }

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -1,0 +1,47 @@
+namespace Pinder.Core.Interfaces
+{
+    /// <summary>
+    /// Canonical phase identifiers passed through <see cref="ILlmTransport.SendAsync"/>
+    /// and <see cref="IStreamingLlmTransport.SendStreamAsync"/> so that decorators
+    /// (e.g. snapshot recorders, telemetry) can label exchanges without re-deriving
+    /// the phase from prompt text.
+    /// </summary>
+    /// <remarks>
+    /// Phase strings are part of the public contract: external decorators rely on
+    /// these exact values. Changes are breaking — add new constants instead of
+    /// renaming existing ones. Values are intentionally lower-snake-case to match
+    /// existing snapshot/telemetry conventions.
+    /// </remarks>
+    public static class LlmPhase
+    {
+        /// <summary>Player dialogue-options generation.</summary>
+        public const string DialogueOptions = "dialogue_options";
+
+        /// <summary>Player message delivery (final transformation of the chosen option).</summary>
+        public const string Delivery = "delivery";
+
+        /// <summary>Steering question for the player.</summary>
+        public const string Steering = "steering";
+
+        /// <summary>Opponent reply to the delivered player message.</summary>
+        public const string OpponentResponse = "opponent_response";
+
+        /// <summary>Optional narrative beat emitted when opponent interest changes.</summary>
+        public const string InterestChangeBeat = "interest_change_beat";
+
+        /// <summary>Horniness overlay rewrite of a delivered message.</summary>
+        public const string HorninessOverlay = "horniness_overlay";
+
+        /// <summary>Shadow-stat corruption rewrite of a delivered message.</summary>
+        public const string ShadowCorruption = "shadow_corruption";
+
+        /// <summary>Session-setup matchup analysis.</summary>
+        public const string MatchupAnalysis = "matchup_analysis";
+
+        /// <summary>Session-setup psychological-stake generation.</summary>
+        public const string PsychologicalStake = "psychological_stake";
+
+        /// <summary>Phase could not be determined (decorators may use this when no phase was supplied).</summary>
+        public const string Unknown = "unknown";
+    }
+}

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs
@@ -128,8 +128,11 @@ namespace Pinder.LlmAdapters.Anthropic
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            string? phase = null)
         {
+            // phase is metadata for decorators; the underlying provider has no use for it.
+            _ = phase;
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicTransport.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicTransport.cs
@@ -35,8 +35,10 @@ namespace Pinder.LlmAdapters.Anthropic
         }
 
         /// <inheritdoc />
-        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024)
+        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null)
         {
+            // phase is metadata for decorators; the underlying provider has no use for it.
+            _ = phase;
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
@@ -93,8 +93,11 @@ namespace Pinder.LlmAdapters.OpenAi
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            string? phase = null)
         {
+            // phase is metadata for decorators; the underlying provider has no use for it.
+            _ = phase;
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
@@ -37,8 +37,10 @@ namespace Pinder.LlmAdapters.OpenAi
         }
 
         /// <inheritdoc />
-        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024)
+        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null)
         {
+            // phase is metadata for decorators; the underlying provider has no use for it.
+            _ = phase;
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -62,7 +62,7 @@ namespace Pinder.LlmAdapters
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
             double temperature = _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature;
 
-            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions)
                 .ConfigureAwait(false);
 
             var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText);
@@ -87,7 +87,7 @@ namespace Pinder.LlmAdapters
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
             double temperature = _options.DeliveryTemperature ?? DefaultDeliveryTemperature;
 
-            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery)
                 .ConfigureAwait(false);
 
             return responseText ?? "";
@@ -114,7 +114,7 @@ namespace Pinder.LlmAdapters
             }
             else
             {
-                responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+                responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
                     .ConfigureAwait(false);
             }
 
@@ -144,7 +144,7 @@ namespace Pinder.LlmAdapters
 
             try
             {
-                var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+                var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.InterestChangeBeat)
                     .ConfigureAwait(false);
 
                 var trimmed = responseText?.Trim();
@@ -191,7 +191,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -229,7 +229,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens)
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -275,7 +275,7 @@ namespace Pinder.LlmAdapters
 
             string systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
 
-            var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens)
+            var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.Steering)
                 .ConfigureAwait(false);
 
             var question = responseText?.Trim();
@@ -299,14 +299,14 @@ namespace Pinder.LlmAdapters
         private async Task<string> SendStatefulOpponentAsync(string systemPrompt, double temperature)
         {
             if (_opponentHistory.Count == 0)
-                return await _transport.SendAsync(systemPrompt, "", temperature, _options.MaxTokens)
+                return await _transport.SendAsync(systemPrompt, "", temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
                     .ConfigureAwait(false);
 
             // The last message is the current user message (just appended)
             if (_opponentHistory.Count == 1)
             {
                 // Single user message — just send it directly
-                return await _transport.SendAsync(systemPrompt, _opponentHistory[0].Content, temperature, _options.MaxTokens)
+                return await _transport.SendAsync(systemPrompt, _opponentHistory[0].Content, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
                     .ConfigureAwait(false);
             }
 
@@ -326,7 +326,7 @@ namespace Pinder.LlmAdapters
             // Last message is the current user prompt
             contextBuilder.Append(_opponentHistory[_opponentHistory.Count - 1].Content);
 
-            return await _transport.SendAsync(systemPrompt, contextBuilder.ToString(), temperature, _options.MaxTokens)
+            return await _transport.SendAsync(systemPrompt, contextBuilder.ToString(), temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
                 .ConfigureAwait(false);
         }
 

--- a/src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs
+++ b/src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs
@@ -103,7 +103,7 @@ namespace Pinder.SessionSetup
             try
             {
                 string analysis = await _transport
-                    .SendAsync(SystemPrompt, userPrompt, _options.Temperature, _options.MaxTokens)
+                    .SendAsync(SystemPrompt, userPrompt, _options.Temperature, _options.MaxTokens, phase: LlmPhase.MatchupAnalysis)
                     .ConfigureAwait(false);
 
                 analysis = (analysis ?? string.Empty).Trim();
@@ -163,7 +163,8 @@ namespace Pinder.SessionSetup
                 enumerator = _streamingTransport.SendStreamAsync(
                         SystemPrompt, userPrompt,
                         _options.Temperature, _options.MaxTokens,
-                        cancellationToken)
+                        cancellationToken,
+                        phase: LlmPhase.MatchupAnalysis)
                     .GetAsyncEnumerator(cancellationToken);
             }
             catch (OperationCanceledException)

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -66,7 +66,7 @@ namespace Pinder.SessionSetup
             try
             {
                 string response = await _transport
-                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens)
+                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.PsychologicalStake)
                     .ConfigureAwait(false);
                 return (response ?? string.Empty).Trim();
             }
@@ -101,7 +101,8 @@ namespace Pinder.SessionSetup
                 enumerator = _streamingTransport.SendStreamAsync(
                         SystemPrompt, userMessage,
                         _options.Temperature, _options.MaxTokens,
-                        cancellationToken)
+                        cancellationToken,
+                        phase: LlmPhase.PsychologicalStake)
                     .GetAsyncEnumerator(cancellationToken);
             }
             catch (OperationCanceledException)

--- a/tests/Pinder.Core.Tests/SessionSetup/FakeStreamingTransport.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/FakeStreamingTransport.cs
@@ -23,6 +23,7 @@ namespace Pinder.Core.Tests.SessionSetup
         public string? LastUserMessage { get; private set; }
         public double? LastTemperature { get; private set; }
         public int? LastMaxTokens { get; private set; }
+        public string? LastPhase { get; private set; }
         public int FragmentsYielded { get; private set; }
 
         public FakeStreamingTransport(IEnumerable<string> fragments)
@@ -54,12 +55,14 @@ namespace Pinder.Core.Tests.SessionSetup
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            string? phase = null)
         {
             LastSystemPrompt = systemPrompt;
             LastUserMessage = userMessage;
             LastTemperature = temperature;
             LastMaxTokens = maxTokens;
+            LastPhase = phase;
 
             if (_throwOnOpen)
                 throw _throwException!;

--- a/tests/Pinder.Core.Tests/SessionSetup/StubLlmTransport.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/StubLlmTransport.cs
@@ -14,7 +14,8 @@ namespace Pinder.Core.Tests.SessionSetup
             string systemPrompt,
             string userMessage,
             double temperature = 0.9,
-            int maxTokens = 1024) =>
+            int maxTokens = 1024,
+            string? phase = null) =>
             Task.FromResult(string.Empty);
     }
 }


### PR DESCRIPTION
Adds an optional `phase` parameter to `ILlmTransport.SendAsync` and `IStreamingLlmTransport.SendStreamAsync` so decorators (snapshot recorders, telemetry) can label exchanges without re-deriving the phase from prompt text.

This is the pinder-core half of decay256/pinder-web#299.

## Changes

- New `LlmPhase` constants in `Pinder.Core.Interfaces` (canonical phase strings: `dialogue_options`, `delivery`, `steering`, `opponent_response`, `interest_change_beat`, `horniness_overlay`, `shadow_corruption`, `matchup_analysis`, `psychological_stake`, `unknown`).
- Optional `string? phase = null` parameter on `SendAsync` and `SendStreamAsync` — **backward compatible**, existing callers and implementations don't need to change.
- `AnthropicTransport` / `OpenAiTransport` / streaming counterparts accept and ignore the value (provider has no use for it).
- `PinderLlmAdapter` passes the canonical phase string at every call site.
- `LlmStakeGenerator` / `LlmMatchupAnalyzer` pass `psychological_stake` / `matchup_analysis` on both non-streaming and streaming paths.
- Test stubs (`StubLlmTransport`, `FakeStreamingTransport`) updated; `FakeStreamingTransport` now captures `LastPhase` for assertions.

## Backward compatibility

The interface change uses an optional default-null parameter, so existing implementations of `ILlmTransport` / `IStreamingLlmTransport` continue to compile and run without modification. Only test stubs that **explicitly** declare the full method signature needed updating (two of them).

## Pairs with

decay256/pinder-web PR `fix/299-typed-phase-param` — that PR bumps the submodule pointer here, swaps `SnapshotRecordingLlmTransport` to read the phase from the new param, and deletes `LlmExchangePhaseDetector`.

Merge this first.