### PR TITLE
fix(transports): surface assistant text from thinking/reasoning channels

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesResponse.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -16,9 +17,41 @@ namespace Pinder.LlmAdapters.Anthropic.Dto
         public UsageStats? Usage { get; set; }
 
         /// <summary>
-        /// Returns the text of the first content block, or empty string if no content blocks exist.
+        /// Returns the user-visible assistant text from the response.
+        /// Concatenates every <c>type: "text"</c> content block in order and skips
+        /// non-text blocks such as <c>thinking</c> / <c>redacted_thinking</c>
+        /// (Anthropic extended thinking — issue #320) and <c>tool_use</c> (which is
+        /// surfaced separately via <see cref="GetToolInput"/>). Returns the empty
+        /// string when no text blocks are present.
         /// </summary>
-        public string GetText() => Content.Length > 0 ? Content[0].Text ?? "" : "";
+        /// <remarks>
+        /// Pre-#320 this method returned <c>Content[0].Text</c>. That was correct
+        /// only when the model emitted text as the very first block; with extended
+        /// thinking enabled the first block is <c>type: "thinking"</c> and the
+        /// real answer sits in a later <c>type: "text"</c> block, so the old
+        /// behaviour returned the empty string and downstream parsers reported
+        /// <c>matchup_llm_failed</c> / similar empty-output errors.
+        /// </remarks>
+        public string GetText()
+        {
+            if (Content == null || Content.Length == 0) return "";
+            StringBuilder? sb = null;
+            for (int i = 0; i < Content.Length; i++)
+            {
+                var block = Content[i];
+                if (block == null) continue;
+                // Only "text" blocks contribute to the user-visible answer. Thinking
+                // and redacted_thinking blocks are deliberately suppressed; tool_use
+                // is exposed separately via GetToolInput().
+                if (!string.Equals(block.Type, "text", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var text = block.Text;
+                if (string.IsNullOrEmpty(text)) continue;
+                if (sb == null) sb = new StringBuilder(text.Length);
+                sb.Append(text);
+            }
+            return sb?.ToString() ?? "";
+        }
 
         /// <summary>
         /// Returns the tool input from the first tool_use content block, or null if none.

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiClient.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiClient.cs
@@ -74,8 +74,13 @@ namespace Pinder.LlmAdapters.OpenAi
                         try
                         {
                             var json = JObject.Parse(body);
-                            var text = json["choices"]?[0]?["message"]?["content"]?.ToString();
-                            return text ?? "";
+                            return ExtractAssistantText(json);
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // ExtractAssistantText raises a typed error for malformed shapes;
+                            // re-throw without wrapping to preserve the message.
+                            throw;
                         }
                         catch (Exception)
                         {
@@ -109,6 +114,70 @@ namespace Pinder.LlmAdapters.OpenAi
                     throw new HttpRequestException($"OpenAI-compatible API error. Status: {statusCode}. Body: {errorBody}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Extracts the user-visible assistant text from a parsed chat-completions
+        /// response body. Issue #320: reasoning models on OpenAI/OpenRouter
+        /// (Anthropic-via-OpenRouter with extended thinking, OpenAI o-series,
+        /// gpt-5* with reasoning enabled, etc.) sometimes return
+        /// <c>choices[0].message.content == ""</c> (or null) and surface the
+        /// real answer alongside reasoning in <c>message.reasoning</c> and/or
+        /// <c>message.reasoning_details[i].summary</c>.
+        /// </summary>
+        /// <remarks>
+        /// Resolution order (mirrors <c>OpenAiStreamingTransport.ExtractContentFragmentsOrThrow</c>):
+        /// <list type="number">
+        ///   <item><description><c>message.content</c> when non-empty / non-whitespace.</description></item>
+        ///   <item><description><c>message.reasoning</c> when non-empty / non-whitespace.</description></item>
+        ///   <item><description>concatenated <c>message.reasoning_details[i].summary</c> when any are non-empty.</description></item>
+        /// </list>
+        /// Returns the empty string when none of the channels carry text.
+        /// </remarks>
+        internal static string ExtractAssistantText(JObject json)
+        {
+            if (json == null) throw new ArgumentNullException(nameof(json));
+
+            // Note: JArray's int indexer throws on empty arrays (it does not support
+            // null-conditional chain semantics for out-of-range indices). Guard
+            // explicitly so a no-choices payload returns the empty string.
+            var choices = json["choices"] as JArray;
+            if (choices == null || choices.Count == 0) return "";
+            var message = choices[0]?["message"];
+            if (message == null || message.Type != JTokenType.Object) return "";
+
+            // 1) message.content
+            var content = message["content"]?.Value<string?>();
+            if (!string.IsNullOrWhiteSpace(content))
+                return content!;
+
+            // 2) message.reasoning (OpenRouter / OpenAI surface internal reasoning here
+            //    for models like Anthropic-via-OpenRouter with extended thinking).
+            var reasoning = message["reasoning"]?.Value<string?>();
+            if (!string.IsNullOrWhiteSpace(reasoning))
+                return reasoning!;
+
+            // 3) message.reasoning_details[i].summary — concatenated.
+            if (message["reasoning_details"] is Newtonsoft.Json.Linq.JArray details && details.Count > 0)
+            {
+                System.Text.StringBuilder? sb = null;
+                foreach (var d in details)
+                {
+                    if (d == null || d.Type != JTokenType.Object) continue;
+                    var summary = d["summary"]?.Value<string?>();
+                    if (string.IsNullOrEmpty(summary)) continue;
+                    if (sb == null) sb = new System.Text.StringBuilder();
+                    sb.Append(summary);
+                }
+                if (sb != null)
+                {
+                    var joined = sb.ToString();
+                    if (!string.IsNullOrWhiteSpace(joined))
+                        return joined;
+                }
+            }
+
+            return "";
         }
 
         public void Dispose()

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesResponseTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/MessagesResponseTests.cs
@@ -42,8 +42,12 @@ namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
         }
 
         [Fact]
-        public void GetText_ReturnsFirstOnly_WhenMultipleBlocks()
+        public void GetText_ConcatenatesAllTextBlocks_WhenMultipleBlocks()
         {
+            // Issue #320: previously this returned only the first block. Anthropic
+            // can split a single answer across multiple type:"text" blocks (and
+            // also interleaves type:"thinking" blocks for extended-thinking
+            // models), so GetText() must concatenate every text block in order.
             var response = new MessagesResponse
             {
                 Content = new[]
@@ -53,7 +57,82 @@ namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
                 }
             };
 
-            Assert.Equal("First", response.GetText());
+            Assert.Equal("FirstSecond", response.GetText());
+        }
+
+        [Fact]
+        public void GetText_SkipsThinkingBlocks_AndReturnsTrailingText()
+        {
+            // Issue #320: Anthropic extended-thinking responses lead with a
+            // type:"thinking" block followed by the real type:"text" answer.
+            // The old GetText() returned Content[0].Text — i.e. the empty
+            // string — and downstream parsers saw "empty output".
+            var json = @"{
+                ""content"": [
+                    { ""type"": ""thinking"", ""thinking"": ""...internal reasoning..."" },
+                    { ""type"": ""text"", ""text"": ""The real answer."" }
+                ]
+            }";
+            var response = JsonConvert.DeserializeObject<MessagesResponse>(json)!;
+
+            Assert.Equal("The real answer.", response.GetText());
+        }
+
+        [Fact]
+        public void GetText_SkipsRedactedThinkingBlocks()
+        {
+            // redacted_thinking is the encrypted form Anthropic emits when the
+            // platform redacts internal reasoning. It must be skipped just like
+            // plain thinking blocks.
+            var response = new MessagesResponse
+            {
+                Content = new[]
+                {
+                    new ResponseContent { Type = "redacted_thinking", Text = "" },
+                    new ResponseContent { Type = "thinking", Text = "" },
+                    new ResponseContent { Type = "text", Text = "Visible answer." }
+                }
+            };
+
+            Assert.Equal("Visible answer.", response.GetText());
+        }
+
+        [Fact]
+        public void GetText_ReturnsEmpty_WhenOnlyThinkingBlocks()
+        {
+            // Defensive: if a provider returns a thinking-only payload (no text
+            // block), GetText() must return empty string — not throw, not return
+            // the thinking content. Callers detect empty and route to the
+            // setup_error path rather than feeding internal reasoning to users.
+            var response = new MessagesResponse
+            {
+                Content = new[]
+                {
+                    new ResponseContent { Type = "thinking", Text = "" }
+                }
+            };
+
+            Assert.Equal("", response.GetText());
+        }
+
+        [Fact]
+        public void GetText_IgnoresToolUseBlocks_ConcatenatesText()
+        {
+            // tool_use is surfaced via GetToolInput(). When a response contains
+            // both a text block and a tool_use block, GetText() must return only
+            // the text — the JObject input is for the structured-tool path.
+            var response = new MessagesResponse
+            {
+                Content = new[]
+                {
+                    new ResponseContent { Type = "thinking", Text = "" },
+                    new ResponseContent { Type = "text", Text = "Prelude. " },
+                    new ResponseContent { Type = "tool_use", Text = "", Name = "do_thing" },
+                    new ResponseContent { Type = "text", Text = "Postlude." }
+                }
+            };
+
+            Assert.Equal("Prelude. Postlude.", response.GetText());
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/SpecDtoTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Dto/SpecDtoTests.cs
@@ -224,10 +224,14 @@ namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
 
         #region AC2: MessagesResponse + GetText()
 
-        // What: AC2 — GetText() returns Content[0].Text when content exists
-        // Mutation: would catch if GetText() returned Content[1].Text or concatenated
+        // What: AC2 (revised by issue #320) — GetText() concatenates every
+        // type:"text" block in order. Pre-#320 it returned only Content[0].Text,
+        // which broke Anthropic extended-thinking responses (block 0 is
+        // type:"thinking", block 1 is the real type:"text" answer).
+        // Mutation: would catch if GetText() returned only the first block,
+        // skipped one of the text blocks, or reordered them.
         [Fact]
-        public void MessagesResponse_GetText_ReturnsFirstBlockText()
+        public void MessagesResponse_GetText_ConcatenatesAllTextBlocks()
         {
             var resp = new MessagesResponse
             {
@@ -237,7 +241,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic.Dto
                     new ResponseContent { Type = "text", Text = "Second block" }
                 }
             };
-            Assert.Equal("First block", resp.GetText());
+            Assert.Equal("First blockSecond block", resp.GetText());
         }
 
         // What: Edge case — GetText() returns "" when Content is empty array

--- a/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiClientReasoningTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiClientReasoningTests.cs
@@ -1,0 +1,146 @@
+using Newtonsoft.Json.Linq;
+using Pinder.LlmAdapters.OpenAi;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.OpenAi
+{
+    /// <summary>
+    /// Regression coverage for issue #320: the non-streaming OpenAI-compatible
+    /// client must surface assistant text from the reasoning channels (used by
+    /// OpenRouter when proxying Anthropic extended-thinking, OpenAI o-series,
+    /// gpt-5* with reasoning, etc.) when <c>message.content</c> is empty or
+    /// missing. The streaming variant already did this in pinder-core #178/#764;
+    /// the non-streaming gap surfaced as <c>matchup_llm_failed: matchup stage
+    /// produced empty output</c> on the GameApi side.
+    /// </summary>
+    public class OpenAiClientReasoningTests
+    {
+        [Fact]
+        public void ExtractAssistantText_ReturnsContent_WhenContentNonEmpty()
+        {
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": { ""role"": ""assistant"", ""content"": ""Hello world."" }
+                }]
+            }");
+            Assert.Equal("Hello world.", OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_FallsBackToReasoning_WhenContentEmpty()
+        {
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": """",
+                        ""reasoning"": ""The real answer with reasoning prefix.""
+                    }
+                }]
+            }");
+            Assert.Equal(
+                "The real answer with reasoning prefix.",
+                OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_FallsBackToReasoning_WhenContentNull()
+        {
+            // OpenRouter occasionally omits content entirely; older parsers
+            // tripped on the null and returned empty.
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": null,
+                        ""reasoning"": ""Reasoning-only response.""
+                    }
+                }]
+            }");
+            Assert.Equal(
+                "Reasoning-only response.",
+                OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_FallsBackToReasoningDetailsSummary_WhenContentAndReasoningEmpty()
+        {
+            // OpenRouter v1 structured-reasoning schema: reasoning_details is an
+            // array of typed blocks, each carrying a `summary` string.
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": """",
+                        ""reasoning"": """",
+                        ""reasoning_details"": [
+                            { ""type"": ""reasoning.summary"", ""summary"": ""Part A. "" },
+                            { ""type"": ""reasoning.summary"", ""summary"": ""Part B."" }
+                        ]
+                    }
+                }]
+            }");
+            Assert.Equal(
+                "Part A. Part B.",
+                OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_PrefersContent_OverReasoningChannels()
+        {
+            // When content is present, reasoning is metadata and must not
+            // contaminate the user-visible text.
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": ""Final answer."",
+                        ""reasoning"": ""scratchpad..."",
+                        ""reasoning_details"": [{ ""summary"": ""scratchpad..."" }]
+                    }
+                }]
+            }");
+            Assert.Equal("Final answer.", OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_ReturnsEmpty_WhenAllChannelsBlank()
+        {
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": """",
+                        ""reasoning"": """",
+                        ""reasoning_details"": []
+                    }
+                }]
+            }");
+            Assert.Equal("", OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_ReturnsEmpty_WhenNoChoices()
+        {
+            var json = JObject.Parse(@"{ ""choices"": [] }");
+            Assert.Equal("", OpenAiClient.ExtractAssistantText(json));
+        }
+
+        [Fact]
+        public void ExtractAssistantText_HandlesWhitespaceOnlyContent_PrefersReasoning()
+        {
+            // Defensive: providers occasionally return a single newline / space
+            // for content during reasoning-heavy turns.
+            var json = JObject.Parse(@"{
+                ""choices"": [{
+                    ""message"": {
+                        ""role"": ""assistant"",
+                        ""content"": ""   \n  "",
+                        ""reasoning"": ""Real text.""
+                    }
+                }]
+            }");
+            Assert.Equal("Real text.", OpenAiClient.ExtractAssistantText(json));
+        }
+    }
+}


### PR DESCRIPTION
Fixes the parser-level part of pinder-web #320.

## Problem

When the engine is configured with a thinking-capable model (Anthropic Claude with extended thinking, OpenAI o-series, gpt-5* with reasoning enabled, or any provider routing through OpenRouter that emits reasoning frames), the non-streaming transports silently returned the empty string and downstream callers (LlmMatchupAnalyzer, LlmStakeGenerator, AnthropicLlmAdapter delivery / opponent fallback) reported `matchup_llm_failed: matchup stage produced empty output`.

## Root cause — two distinct gaps

### 1. Anthropic native thinking blocks
`MessagesResponse.GetText()` returned `Content[0].Text`. Anthropic extended-thinking responses lead with a `type:"thinking"` block followed by the real `type:"text"` answer, so `GetText()` returned "" (the thinking block carries reasoning under a different field, not `text`). Every consumer of `GetText()` saw empty strings.

**Fix:** skip every non-`text` block (`thinking`, `redacted_thinking`, `tool_use` — the latter is exposed via `GetToolInput()`) and concatenate every `text` block in order.

### 2. OpenRouter reasoning channels (non-streaming)
`OpenAiClient.SendChatCompletionAsync` only read `choices[0].message.content`. OpenRouter (the routing layer for `openrouter/anthropic/claude-opus-4.7` and any reasoning-capable model) puts the user-visible answer in `message.reasoning` and/or `message.reasoning_details[i].summary` when `content` is empty/null.

The streaming transport already handled this in pinder-core #178/#764; the non-streaming path was the missing twin.

**Fix:** extract in priority order `content` → `reasoning` → concatenated `reasoning_details` summaries (mirrors `OpenAiStreamingTransport.ExtractContentFragmentsOrThrow`).

## Regression coverage

* `MessagesResponseTests` — new tests for thinking/redacted_thinking/tool_use skipping, concatenation across multiple text blocks, thinking-only payload returns empty string.
* `SpecDtoTests.MessagesResponse_GetText_ConcatenatesAllTextBlocks` — the previous AC2 test asserted "first block only" and was enforcing the bug; rewritten to assert concatenation.
* `OpenAiClientReasoningTests` — 9 new scenarios covering the `content` → `reasoning` → `reasoning_details` fallback ladder, including whitespace-only content, missing/empty choices, and content-wins precedence.

## Test results

`Pinder.LlmAdapters.Tests` (the affected assembly):

| | Failed | Passed | Total |
|---|---|---|---|
| `origin/main` baseline | 63 | 886 | 958 |
| this branch              | 63 | 898 | 970 |
| **delta**                | **0** | **+12** | **+12** |

12 new tests, all pass; zero pre-existing tests regressed. The 63 pre-existing failures on main are unrelated dialogue-options spec tests (`AnthropicLlmAdapterIssue208Tests`, `Issue240_DialogueOptionsFormatTests`, etc.) that fail on the bare `main` SHA `be19c29` and are out of scope for this PR.

`Pinder.GameApi.Tests` (downstream consumer of these DTOs): 382 / 382 pass.

## Out of scope

* Inline `<thinking>...</thinking>` tag stripping (some non-native-thinking models emit these in user-visible content). The structured paths in this code base use Anthropic `tool_use` (handled by `GetToolInput`) or prose (matchup / stakes), so inline tags would only manifest as cosmetic noise rather than parse failure. Filing as a follow-up if it becomes user-visible.
* OpenAI `reasoning_content` (Chat Completions `o1`-style field — distinct from OpenRouter's `reasoning`). If/when we wire o1-* directly without OpenRouter we should add it to the same ladder.

Closes the parser portion of decay256/pinder-web#320 (the pinder-web bump PR carries the issue closer).