### PR TITLE
feat: post-LLM text-processing layer (#340 em-dash, #339 callback strip, #333 turn-0 scene)

### DIFF
--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -63,7 +63,15 @@ namespace Pinder.SessionRunner.Snapshot
     ///   <item><description><c>CharmUsageCount</c>, <c>CharmMadnessTriggered</c></description></item>
     ///   <item><description><c>SaUsageCount</c>, <c>SaOverthinkingTriggered</c></description></item>
     ///   <item><description><c>RizzCumulativeFailureCount</c></description></item>
-    ///   <item><description><c>ConversationHistory</c> (per-entry sender + text + per-layer text_diffs[] — issue #305)</description></item>
+    ///   <item><description>
+    ///     <c>ConversationHistory</c> (per-entry sender + text + per-layer text_diffs[]
+    ///     — issue #305). Includes the turn-0 scene-setting entries seeded by
+    ///     <c>GameSession.SeedSceneEntries</c> (issue #333): three entries with
+    ///     sender == <c>"[scene]"</c> for player bio, opponent bio, and the
+    ///     LLM-generated outfit description. The <c>callback_strip</c> layer
+    ///     (issue #339) appears as one more entry in <c>TextDiffs</c> when
+    ///     same-turn callback phrases were stripped from the delivered message.
+    ///   </description></item>
     /// </list>
     /// </summary>
     public sealed class TurnSnapshot

--- a/src/Pinder.Core/Conversation/ConversationIndexing.cs
+++ b/src/Pinder.Core/Conversation/ConversationIndexing.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Helpers for mapping a physical <c>ConversationHistory</c> index
+    /// to a logical (turn-number, role) pair while transparently skipping
+    /// non-conversational <see cref="Senders.Scene"/> entries seeded at
+    /// the front of the history (issue #333).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Pre-#333 the conversation log was strict alternating
+    /// <c>(player, opponent, player, opponent, ...)</c> pairs, so consumers
+    /// could derive the turn number with <c>(i / 2) + 1</c> and the role
+    /// with <c>i % 2 == 0</c>. Once the engine started seeding
+    /// <c>[scene]</c> entries (player bio, opponent bio, outfit
+    /// description) at indices 0..N before the first turn, that pair-math
+    /// shifts by N and silently misattributes turn numbers / text-diffs.
+    /// </para>
+    /// <para>
+    /// This class encapsulates the "skip scenes, then pair-math the
+    /// remaining entries" rule so every consumer agrees on the same
+    /// mapping. Two patterns are exposed:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <see cref="TurnNumberAt"/> / <see cref="IsPlayerEntryAt"/> for
+    ///     point queries (random access — O(N) per call, fine when
+    ///     called at most once per entry).
+    ///   </description></item>
+    ///   <item><description>
+    ///     <see cref="EnumerateConversation(IReadOnlyList{ValueTuple{string, string}})"/>
+    ///     for streaming iteration through the whole history — emits
+    ///     <c>(physicalIndex, sender, text, isScene, turnNumber, isPlayerEntry)</c>
+    ///     in O(N) total. Use this in batch loops (persistence, log
+    ///     rendering).
+    ///   </description></item>
+    /// </list>
+    /// </remarks>
+    public static class ConversationIndexing
+    {
+        /// <summary>
+        /// True when the entry at <paramref name="index"/> is a synthetic
+        /// scene-setting entry rather than a real conversational turn.
+        /// </summary>
+        public static bool IsSceneAt(
+            IReadOnlyList<(string Sender, string Text)> history, int index)
+        {
+            return Senders.IsScene(history[index].Sender);
+        }
+
+        /// <summary>
+        /// 1-based turn number for the conversational entry at
+        /// <paramref name="index"/>. Returns <c>0</c> when the entry is a
+        /// <c>[scene]</c> entry (scene entries do not belong to any turn).
+        /// </summary>
+        /// <remarks>
+        /// Turn 1 starts at the first non-scene entry. The first non-scene
+        /// entry (the player's turn-1 message) and the second non-scene
+        /// entry (the opponent's turn-1 reply) both return <c>1</c>; the
+        /// third and fourth return <c>2</c>; and so on.
+        /// </remarks>
+        public static int TurnNumberAt(
+            IReadOnlyList<(string Sender, string Text)> history, int index)
+        {
+            if (Senders.IsScene(history[index].Sender)) return 0;
+            int nonSceneCount = 0;
+            for (int i = 0; i <= index; i++)
+            {
+                if (!Senders.IsScene(history[i].Sender)) nonSceneCount++;
+            }
+            // nonSceneCount is 1-based count of conversational entries up
+            // to and including the current one. Pairs are (player, opp)
+            // so entries 1+2 → turn 1, 3+4 → turn 2, etc.
+            return ((nonSceneCount - 1) / 2) + 1;
+        }
+
+        /// <summary>
+        /// True when the entry at <paramref name="index"/> is the player
+        /// half of a (player, opponent) turn pair. False for opponent
+        /// entries and for <c>[scene]</c> entries.
+        /// </summary>
+        public static bool IsPlayerEntryAt(
+            IReadOnlyList<(string Sender, string Text)> history, int index)
+        {
+            if (Senders.IsScene(history[index].Sender)) return false;
+            int nonSceneCount = 0;
+            for (int i = 0; i <= index; i++)
+            {
+                if (!Senders.IsScene(history[i].Sender)) nonSceneCount++;
+            }
+            // 1st, 3rd, 5th, ... non-scene entry is a player entry.
+            return (nonSceneCount - 1) % 2 == 0;
+        }
+
+        /// <summary>
+        /// Walks <paramref name="history"/> once and yields a tagged view
+        /// of every entry — physical index, sender, text, whether it's a
+        /// scene entry, the 1-based turn number it belongs to (0 for
+        /// scenes), and whether it's the player half of its turn.
+        /// </summary>
+        /// <remarks>
+        /// Single-pass O(N) — use this in batch loops where every entry
+        /// needs to be classified (e.g. building a persisted history row
+        /// array, rendering the public log endpoint).
+        /// </remarks>
+        public static IEnumerable<ConversationEntryView> EnumerateConversation(
+            IReadOnlyList<(string Sender, string Text)> history)
+        {
+            int nonSceneCount = 0;
+            for (int i = 0; i < history.Count; i++)
+            {
+                var (sender, text) = history[i];
+                bool isScene = Senders.IsScene(sender);
+                int turnNumber;
+                bool isPlayerEntry;
+                if (isScene)
+                {
+                    turnNumber = 0;
+                    isPlayerEntry = false;
+                }
+                else
+                {
+                    nonSceneCount++;
+                    turnNumber = ((nonSceneCount - 1) / 2) + 1;
+                    isPlayerEntry = (nonSceneCount - 1) % 2 == 0;
+                }
+                yield return new ConversationEntryView(
+                    physicalIndex: i,
+                    sender: sender,
+                    text: text,
+                    isScene: isScene,
+                    turnNumber: turnNumber,
+                    isPlayerEntry: isPlayerEntry);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tagged view of a single <c>ConversationHistory</c> entry — the
+    /// physical (sender, text) plus its derived classification
+    /// (<see cref="IsScene"/>, <see cref="TurnNumber"/>, <see cref="IsPlayerEntry"/>).
+    /// Returned by <see cref="ConversationIndexing.EnumerateConversation(IReadOnlyList{ValueTuple{string, string}})"/>.
+    /// </summary>
+    /// <remarks>
+    /// Implemented as a plain immutable struct (no <c>record struct</c>)
+    /// because Pinder.Core targets <c>netstandard2.0</c> with
+    /// <c>LangVersion=8.0</c>.
+    /// </remarks>
+    public readonly struct ConversationEntryView
+    {
+        public ConversationEntryView(
+            int physicalIndex,
+            string sender,
+            string text,
+            bool isScene,
+            int turnNumber,
+            bool isPlayerEntry)
+        {
+            PhysicalIndex = physicalIndex;
+            Sender = sender;
+            Text = text;
+            IsScene = isScene;
+            TurnNumber = turnNumber;
+            IsPlayerEntry = isPlayerEntry;
+        }
+
+        public int PhysicalIndex { get; }
+        public string Sender { get; }
+        public string Text { get; }
+        public bool IsScene { get; }
+        public int TurnNumber { get; }
+        public bool IsPlayerEntry { get; }
+    }
+}

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -235,8 +235,68 @@ namespace Pinder.Core.Conversation
         /// Read-only snapshot view; safe to enumerate concurrently with session mutation
         /// since the underlying list is only appended during ResolveTurnAsync.
         /// </summary>
+        /// <remarks>
+        /// Includes any turn-0 scene-setting entries (issue #333) tagged with
+        /// <see cref="Senders.Scene"/>. Callers that feed the history back
+        /// into an LLM should use <see cref="BuildHistoryForLlmContext"/>
+        /// instead so the analyzer/delivery LLM does not see the scene
+        /// entries.
+        /// </remarks>
         public System.Collections.Generic.IReadOnlyList<(string Sender, string Text)> ConversationHistory
             => _history;
+
+        /// <summary>
+        /// Build the conversation history view fed to subsequent LLM calls.
+        /// Excludes synthetic scene-setting entries (issue #333) so the
+        /// matchup analyser / delivery LLM / opponent-response LLM never
+        /// sees its own scene-description output as prior conversation.
+        /// </summary>
+        private System.Collections.Generic.IReadOnlyList<(string Sender, string Text)> BuildHistoryForLlmContext()
+        {
+            // Hot path: when there are no scene entries, return the full
+            // list as-is so we don’t allocate a copy on every turn.
+            bool anyScene = false;
+            for (int i = 0; i < _history.Count; i++)
+            {
+                if (Senders.IsScene(_history[i].Sender)) { anyScene = true; break; }
+            }
+            if (!anyScene) return _history.AsReadOnly();
+
+            var view = new List<(string Sender, string Text)>(_history.Count);
+            for (int i = 0; i < _history.Count; i++)
+            {
+                var entry = _history[i];
+                if (Senders.IsScene(entry.Sender)) continue;
+                view.Add(entry);
+            }
+            return view.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Issue #333: append the three turn-0 scene-setting entries
+        /// (player bio, opponent bio, LLM-generated outfit description) to
+        /// the conversation log BEFORE the first player turn. Sender for
+        /// each entry is <see cref="Senders.Scene"/>; the frontend renders
+        /// these distinctly from player/opponent dialogue.
+        /// </summary>
+        /// <param name="playerBio">Player bio text. Empty entries are skipped.</param>
+        /// <param name="opponentBio">Opponent bio text. Empty entries are skipped.</param>
+        /// <param name="outfitDescription">LLM-generated outfit description. Empty entries are skipped.</param>
+        /// <exception cref="InvalidOperationException">If any turn has already been resolved.</exception>
+        public void SeedSceneEntries(string? playerBio, string? opponentBio, string? outfitDescription)
+        {
+            if (_turnNumber > 0)
+            {
+                throw new InvalidOperationException(
+                    "SeedSceneEntries must be called before the first turn is resolved.");
+            }
+            if (!string.IsNullOrWhiteSpace(playerBio))
+                _history.Add((Senders.Scene, playerBio!.Trim()));
+            if (!string.IsNullOrWhiteSpace(opponentBio))
+                _history.Add((Senders.Scene, opponentBio!.Trim()));
+            if (!string.IsNullOrWhiteSpace(outfitDescription))
+                _history.Add((Senders.Scene, outfitDescription!.Trim()));
+        }
 
         /// <summary>Session horniness value (d10 + clock modifier). Used for display.</summary>
         public int SessionHorniness => _sessionHorniness;
@@ -411,7 +471,8 @@ namespace Pinder.Core.Conversation
             var context = new DialogueContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: GameSessionHelpers.BuildOpponentVisibleProfile(_opponent),
-                conversationHistory: _history.AsReadOnly(),
+                // #333: scene entries are excluded from the LLM context view.
+                conversationHistory: BuildHistoryForLlmContext(),
                 opponentLastMessage: GameSessionHelpers.GetLastOpponentMessage(_history, _opponent.DisplayName),
                 activeTraps: activeTrapNames,
                 currentInterest: _interest.Current,
@@ -724,7 +785,8 @@ namespace Pinder.Core.Conversation
             var deliveryContext = new DeliveryContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
-                conversationHistory: _history.AsReadOnly(),
+                // #333: scene entries are excluded from the LLM context view.
+                conversationHistory: BuildHistoryForLlmContext(),
                 opponentLastMessage: GameSessionHelpers.GetLastOpponentMessage(_history, _opponent.DisplayName),
                 chosenOption: chosenOption,
                 outcome: rollResult.Tier,
@@ -769,8 +831,9 @@ namespace Pinder.Core.Conversation
 
             // 10b. Steering roll — attempt to append a date-steering question
             progress?.Report(new TurnProgressEvent(TurnProgressStage.SteeringStarted));
+            // #333: scene entries are excluded from the LLM context view.
             SteeringRollResult steeringResult = await _steeringEngine.AttemptSteeringRollAsync(
-                deliveredMessage, _player, _opponent, _llm, _history.AsReadOnly()).ConfigureAwait(false);
+                deliveredMessage, _player, _opponent, _llm, BuildHistoryForLlmContext()).ConfigureAwait(false);
             progress?.Report(new TurnProgressEvent(
                 TurnProgressStage.SteeringCompleted,
                 steeringResult.SteeringSucceeded ? steeringResult.SteeringQuestion : null));
@@ -877,6 +940,25 @@ namespace Pinder.Core.Conversation
                 }
             }
 
+            // Issue #339: same-turn callback-phrase strip. Runs after all
+            // LLM-driven transforms so it operates on the final delivered
+            // text. Emits a TextDiff layer when it actually changes the
+            // message so the audit log / replay tool / UI can render the
+            // before/after just like Steering / Horniness / Shadow.
+            {
+                string beforeCallbackStrip = deliveredMessage;
+                string strippedMessage = CallbackStripper.Strip(beforeCallbackStrip);
+                if (!ReferenceEquals(strippedMessage, beforeCallbackStrip)
+                    && strippedMessage != beforeCallbackStrip)
+                {
+                    deliveredMessage = strippedMessage;
+                    var stripSpans = WordDiff.Compute(beforeCallbackStrip, deliveredMessage);
+                    textDiffs.Add(new TextDiff(
+                        CallbackStripper.LayerName, stripSpans,
+                        beforeCallbackStrip, deliveredMessage));
+                }
+            }
+
             _history.Add((_player.DisplayName, deliveredMessage));
 
             // 11. Generate opponent response
@@ -899,7 +981,8 @@ namespace Pinder.Core.Conversation
             var opponentContext = new OpponentContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
-                conversationHistory: _history.AsReadOnly(),
+                // #333: scene entries are excluded from the LLM context view.
+                conversationHistory: BuildHistoryForLlmContext(),
                 opponentLastMessage: GameSessionHelpers.GetLastOpponentMessage(_history, _opponent.DisplayName),
                 activeTraps: GameSessionHelpers.GetActiveTrapNames(_traps),
                 currentInterest: _interest.Current,

--- a/src/Pinder.Core/Conversation/Senders.cs
+++ b/src/Pinder.Core/Conversation/Senders.cs
@@ -1,0 +1,40 @@
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Conventional sender tags used in <c>GameSession.ConversationHistory</c>
+    /// for non-conversational entries. Player and opponent senders are
+    /// the characters' display names (free strings) — these constants
+    /// cover the synthetic, scene-setting tags that have no character
+    /// behind them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #333: turn-0 scene entries (player bio, opponent bio,
+    /// LLM-generated outfit description) are appended to the conversation
+    /// log with <see cref="Scene"/> as their sender. The frontend renders
+    /// these distinctly (italics / indented / different tint) — that's
+    /// frontend-side polish, separate from the engine work — and the
+    /// engine deliberately filters them out of the conversation history
+    /// fed to subsequent LLM calls so the analyzer does not see itself.
+    /// </para>
+    /// </remarks>
+    public static class Senders
+    {
+        /// <summary>
+        /// Synthetic sender tag for non-conversational scene-setting
+        /// entries (issue #333). Stable wire string — snapshot tooling,
+        /// the wire DTO layer, and the frontend renderer all match
+        /// against this exact value.
+        /// </summary>
+        public const string Scene = "[scene]";
+
+        /// <summary>
+        /// True when <paramref name="sender"/> is a synthetic
+        /// scene-setting tag rather than a character speaking.
+        /// </summary>
+        public static bool IsScene(string? sender)
+        {
+            return sender == Scene;
+        }
+    }
+}

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -41,6 +41,23 @@ namespace Pinder.Core.Interfaces
         /// <summary>Session-setup psychological-stake generation.</summary>
         public const string PsychologicalStake = "psychological_stake";
 
+        /// <summary>
+        /// Same-turn callback-phrase strip pass (issue #339). No LLM call —
+        /// purely a regex post-process that runs alongside the other text
+        /// transform layers — but the constant is reserved here so any
+        /// future LLM-driven variant lands under the same phase id and
+        /// snapshot tooling has a stable label.
+        /// </summary>
+        public const string CallbackStrip = "callback_strip";
+
+        /// <summary>
+        /// Session-setup outfit description generation (issue #333).
+        /// One LLM call per session that produces the brief paragraph
+        /// describing what each character is wearing for the turn-0
+        /// scene-setting entry.
+        /// </summary>
+        public const string OutfitDescription = "outfit_description";
+
         /// <summary>Phase could not be determined (decorators may use this when no phase was supplied).</summary>
         public const string Unknown = "unknown";
     }

--- a/src/Pinder.Core/Text/CallbackStripper.cs
+++ b/src/Pinder.Core/Text/CallbackStripper.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Pinder.Core.Text
+{
+    /// <summary>
+    /// Issue #339: post-process pass that strips same-turn "callback"
+    /// phrases — short references the LLM emits to a previous turn or
+    /// thought within the same conversation, e.g. "As you just said,",
+    /// "Like we mentioned,", "As we discussed,". These read as filler at
+    /// the rendering layer; the engine strips them after the LLM call so
+    /// the player never sees them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The pattern set is intentionally conservative — only phrases with
+    /// strong same-turn-callback semantics, not legitimate cross-turn
+    /// references. In particular, anything that names a turn explicitly
+    /// (<c>"Earlier, on turn 2..."</c>) or references a specific named
+    /// topic (<c>"As we said about the IKEA..."</c>) is left alone.
+    /// </para>
+    /// <para>
+    /// Output contract: returns the stripped text. If at least one
+    /// pattern matched, the returned text differs from the input;
+    /// otherwise the input is returned unchanged. Whitespace adjacent to
+    /// the stripped span is normalised so we don't leave double spaces
+    /// or a leading lowercase letter after a stripped sentence opener.
+    /// </para>
+    /// </remarks>
+    public static class CallbackStripper
+    {
+        /// <summary>
+        /// Layer name emitted on the <see cref="TextDiff"/> when the
+        /// strip pass actually changed the message. Stable string —
+        /// snapshot/replay tooling can match against it.
+        /// </summary>
+        public const string LayerName = "Callback Strip";
+
+        // Patterns target the typical opening-phrase shape: optional
+        // "and"/"so" lead-in, the callback verb, optional "just", and a
+        // trailing comma. Anchored to start-of-line OR start-of-sentence
+        // (after `. `, `! `, `? `) so we only strip callback OPENERS, not
+        // mid-sentence references.
+        //
+        // Each pattern matches the trailing comma + any following
+        // whitespace so what's stripped is "<phrase>, " in one move; the
+        // remaining text is then capitalised at its new opener if needed.
+        //
+        // RegexOptions.IgnoreCase covers the surface forms the LLM emits.
+        // Compiled once at class init — these are hot-path on every
+        // delivered turn.
+        private static readonly Regex[] Patterns =
+        {
+            // "As you said,"  /  "As you just said,"
+            new Regex(@"(?<=^|[\.\!\?]\s)As you (?:just )?said,?\s*",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // "Like we said," / "Like you just said," / "Like we mentioned," etc.
+            new Regex(@"(?<=^|[\.\!\?]\s)Like (?:we|you) (?:just )?(?:said|mentioned),?\s*",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // "As we discussed," / "As I just discussed,"
+            new Regex(@"(?<=^|[\.\!\?]\s)As (?:we|I) (?:just )?discussed,?\s*",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // "Like I said,"
+            new Regex(@"(?<=^|[\.\!\?]\s)Like I (?:just )?said,?\s*",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // "As I mentioned,"
+            new Regex(@"(?<=^|[\.\!\?]\s)As I (?:just )?mentioned,?\s*",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        };
+
+        // Patterns that look callback-shaped but contain an explicit
+        // turn-number reference are kept as legitimate cross-turn
+        // references and NEVER stripped. Checked before any pattern runs;
+        // if any preserve-pattern matches we short-circuit out.
+        private static readonly Regex[] PreservePatterns =
+        {
+            // "earlier, on turn 2..." / "back on turn 5..."
+            new Regex(@"\bturn\s+\d+\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        };
+
+        /// <summary>
+        /// Run the strip pass on <paramref name="input"/>. Returns the
+        /// stripped text (possibly equal to the input if no pattern
+        /// matched). Never null.
+        /// </summary>
+        public static string Strip(string? input)
+        {
+            if (string.IsNullOrEmpty(input)) return input ?? string.Empty;
+
+            // Preserve legitimate cross-turn references: if the message
+            // contains an explicit "turn N" reference, treat the whole
+            // message as legitimate and skip the strip pass.
+            foreach (var preserve in PreservePatterns)
+                if (preserve.IsMatch(input!)) return input!;
+
+            string result = input!;
+            foreach (var p in Patterns)
+            {
+                result = p.Replace(result, string.Empty);
+            }
+
+            if (ReferenceEquals(result, input)) return input!;
+
+            // Cosmetic cleanup pass 1: collapse double spaces produced
+            // when a stripped span sat between two existing spaces.
+            while (result.Contains("  "))
+                result = result.Replace("  ", " ");
+
+            // Cosmetic cleanup pass 2: stripped openers leave a leading
+            // lowercase letter (start-of-message OR after a sentence
+            // boundary). Re-capitalise the first alpha after the start of
+            // the message and after each `". "` / `"! "` / `"? "` pair.
+            result = result.TrimStart();
+            result = ReCapitaliseSentenceStarts(result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Walk the string, lower-casing the first alpha char of each
+        /// sentence (start of string + immediately after a `". "`, `"! "`,
+        /// or `"? "`). Used post-strip so a callback removed from the
+        /// middle of a multi-sentence message doesn’t leave the next
+        /// sentence starting in lower case.
+        /// </summary>
+        private static string ReCapitaliseSentenceStarts(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            var chars = s.ToCharArray();
+            bool atSentenceStart = true;
+            for (int i = 0; i < chars.Length; i++)
+            {
+                char c = chars[i];
+                if (atSentenceStart && char.IsLetter(c))
+                {
+                    chars[i] = char.ToUpperInvariant(c);
+                    atSentenceStart = false;
+                    continue;
+                }
+                if ((c == '.' || c == '!' || c == '?')
+                    && i + 1 < chars.Length && chars[i + 1] == ' ')
+                {
+                    atSentenceStart = true; // capitalise next alpha
+                }
+                else if (!char.IsWhiteSpace(c))
+                {
+                    atSentenceStart = false;
+                }
+            }
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Convenience: returns whether <see cref="Strip"/> would actually
+        /// change <paramref name="input"/>. Same logic, exposed for
+        /// callers that want to skip building a <see cref="TextDiff"/>
+        /// when there's nothing to record.
+        /// </summary>
+        public static bool WouldStrip(string? input)
+        {
+            if (string.IsNullOrEmpty(input)) return false;
+            string stripped = Strip(input);
+            return !ReferenceEquals(stripped, input) && stripped != input;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
+++ b/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Issue #340: cosmetic post-processing decorator that normalises
+    /// space-em-dash-space (` — `) into semicolon-space (`; `) on every
+    /// LLM response. Wraps an underlying <see cref="ILlmTransport"/> (and
+    /// optionally <see cref="IStreamingLlmTransport"/>) so all engine
+    /// consumers — delivery, opponent reply, steering, horniness overlay,
+    /// shadow corruption, matchup analysis, psychological stake, etc. —
+    /// pick up the cleanup automatically without each call site having to
+    /// remember.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Replaces three variants:
+    /// <list type="bullet">
+    ///   <item><description>ASCII space + em-dash (U+2014) + ASCII space</description></item>
+    ///   <item><description>Thin-space (U+2009) + em-dash (U+2014) + thin-space</description></item>
+    ///   <item><description>Mixed thin/ascii whitespace + em-dash + thin/ascii whitespace</description></item>
+    /// </list>
+    /// All three become the canonical <c>"; "</c> (ASCII semicolon + ASCII
+    /// space). The no-space form (<c>word—word</c>) is intentionally
+    /// preserved — only the surround-with-spaces stylistic variant is
+    /// converted, per the issue spec.
+    /// </para>
+    /// <para>
+    /// En-dashes (U+2013) are left untouched: en-dashes carry semantic
+    /// meaning (number ranges, "Mon–Fri") and converting them would be
+    /// incorrect.
+    /// </para>
+    /// <para>
+    /// The streaming overload normalises each emitted fragment
+    /// independently. This is sufficient for the surround-with-spaces
+    /// pattern since both spaces and the em-dash are typically tokenised
+    /// together by upstream providers; if a future provider splits the
+    /// pattern across fragments the worst case is "no normalisation
+    /// happened for that one fragment", which matches today's behaviour
+    /// without this decorator. We keep it simple — no cross-fragment
+    /// buffering — to avoid changing streaming latency characteristics.
+    /// </para>
+    /// </remarks>
+    public sealed class PunctuationNormalizingTransport : ILlmTransport, IStreamingLlmTransport
+    {
+        // U+2014 = em-dash, U+2009 = thin-space.
+        private const char EmDash    = '\u2014';
+        private const char ThinSpace = '\u2009';
+
+        private readonly ILlmTransport _inner;
+        private readonly IStreamingLlmTransport? _innerStreaming;
+
+        public PunctuationNormalizingTransport(ILlmTransport inner)
+            : this(inner, innerStreaming: null) { }
+
+        public PunctuationNormalizingTransport(ILlmTransport inner, IStreamingLlmTransport? innerStreaming)
+        {
+            _inner = inner ?? throw new System.ArgumentNullException(nameof(inner));
+            _innerStreaming = innerStreaming;
+        }
+
+        /// <summary>
+        /// The wrapped non-streaming transport. Exposed so tests — and any
+        /// future reflective tooling — can walk the decorator chain to
+        /// inspect the underlying provider transport.
+        /// </summary>
+        public ILlmTransport Inner => _inner;
+
+        /// <summary>
+        /// The wrapped streaming transport, or null when this instance was
+        /// constructed without one. Same purpose as <see cref="Inner"/>.
+        /// </summary>
+        public IStreamingLlmTransport? InnerStreaming => _innerStreaming;
+
+        public async Task<string> SendAsync(
+            string systemPrompt, string userMessage,
+            double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+        {
+            string raw = await _inner
+                .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase)
+                .ConfigureAwait(false);
+            return Normalize(raw);
+        }
+
+        public async IAsyncEnumerable<string> SendStreamAsync(
+            string systemPrompt, string userMessage,
+            double temperature = 0.9, int maxTokens = 1024,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default,
+            string? phase = null)
+        {
+            if (_innerStreaming == null)
+            {
+                throw new System.InvalidOperationException(
+                    "PunctuationNormalizingTransport was constructed without a streaming inner transport. " +
+                    "Use the (ILlmTransport, IStreamingLlmTransport) overload to enable streaming.");
+            }
+
+            await foreach (var chunk in _innerStreaming
+                .SendStreamAsync(systemPrompt, userMessage, temperature, maxTokens, cancellationToken, phase)
+                .ConfigureAwait(false))
+            {
+                yield return Normalize(chunk);
+            }
+        }
+
+        /// <summary>
+        /// Replace ` — ` (any whitespace + em-dash + whitespace, where each
+        /// side is an ASCII space or U+2009 thin-space) with `; `. Leaves
+        /// no-space em-dashes (<c>word—word</c>) and en-dashes (U+2013) alone.
+        /// </summary>
+        public static string Normalize(string? input)
+        {
+            if (string.IsNullOrEmpty(input)) return input ?? string.Empty;
+
+            // Fast bail: no em-dash anywhere → nothing to do.
+            if (input!.IndexOf(EmDash) < 0) return input;
+
+            var sb = new System.Text.StringBuilder(input.Length);
+            for (int i = 0; i < input.Length; i++)
+            {
+                char c = input[i];
+                if (c == EmDash
+                    && i > 0 && IsConvertibleSpace(input[i - 1])
+                    && i + 1 < input.Length && IsConvertibleSpace(input[i + 1]))
+                {
+                    // Drop the prior space we already wrote, write '; '
+                    if (sb.Length > 0 && IsConvertibleSpace(sb[sb.Length - 1]))
+                        sb.Length -= 1;
+                    sb.Append("; ");
+                    i += 1; // skip the trailing space
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+
+        private static bool IsConvertibleSpace(char c) => c == ' ' || c == ThinSpace;
+    }
+}

--- a/src/Pinder.SessionSetup/IOutfitDescriber.cs
+++ b/src/Pinder.SessionSetup/IOutfitDescriber.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Issue #333: produces a brief, human-readable paragraph describing
+    /// what each character is wearing for the turn-0 scene-setting entry.
+    /// One LLM call per session, run in parallel with matchup analysis.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Output contract (mirroring <see cref="IMatchupAnalyzer"/> and
+    /// <see cref="IStakeGenerator"/>): plain prose, paragraph breaks
+    /// only \u2014 no markdown, no bullets, no headings. The web tier's
+    /// <c>MarkdownSanitizer</c> runs as defence in depth.
+    /// </para>
+    /// <para>
+    /// The shape is deliberately item-list-based rather than
+    /// <see cref="Pinder.Core.Characters.CharacterProfile"/>-based:
+    /// callers pass display strings for each character's equipped
+    /// items so the implementation has no dependency on the wider
+    /// character-assembly pipeline. Each item description string is
+    /// of the form <c>"&lt;display name&gt;: &lt;description&gt;"</c>.
+    /// </para>
+    /// </remarks>
+    public interface IOutfitDescriber
+    {
+        /// <summary>
+        /// Generate a brief outfit-description paragraph covering both
+        /// characters' equipped items. Returns an empty string on any
+        /// transport failure (mirrors <see cref="IStakeGenerator"/>) \u2014
+        /// never throws on LLM errors. The caller must therefore tolerate
+        /// an empty string and decide whether to short-circuit setup or
+        /// continue without the scene entry.
+        /// </summary>
+        /// <param name="playerName">Player display name.</param>
+        /// <param name="playerItems">
+        /// One entry per equipped item on the player; each entry combines
+        /// the item display name and its description, e.g.
+        /// <c>"Battered jeans: faded indigo, knee-blown, smells of pine."</c>.
+        /// </param>
+        /// <param name="opponentName">Opponent display name.</param>
+        /// <param name="opponentItems">Same shape as <paramref name="playerItems"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<string> GenerateAsync(
+            string playerName,
+            IReadOnlyList<string> playerItems,
+            string opponentName,
+            IReadOnlyList<string> opponentItems,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.SessionSetup/LlmOutfitDescriber.cs
+++ b/src/Pinder.SessionSetup/LlmOutfitDescriber.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Default <see cref="IOutfitDescriber"/> built on
+    /// <see cref="ILlmTransport"/>. One LLM call per session.
+    /// Issue #333.
+    /// </summary>
+    /// <remarks>
+    /// Uses the canonical <see cref="LlmPhase.OutfitDescription"/> phase
+    /// label so snapshot recording and audit decorators tag the exchange
+    /// without re-deriving the phase from prompt text.
+    /// </remarks>
+    public sealed class LlmOutfitDescriber : IOutfitDescriber
+    {
+        private const string SystemPrompt =
+            "You are setting the visual scene for a comedy dating-RPG conversation. " +
+            "Given the items both characters are wearing, write a single brief paragraph " +
+            "describing what each is wearing and the visual / aesthetic vibe of the encounter. " +
+            "Keep it grounded and concrete. " +
+            "Respond in plain prose only. Do NOT use markdown formatting of any kind: no " +
+            "headings, no bold or italics, no bullet or numbered lists, no blockquotes, no " +
+            "inline or fenced code. Two to four sentences total \u2014 not a list, not a fashion review.";
+
+        private readonly ILlmTransport _transport;
+        private readonly Options _options;
+
+        public LlmOutfitDescriber(ILlmTransport transport, Options? options = null)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _options = options ?? new Options();
+        }
+
+        public async Task<string> GenerateAsync(
+            string playerName,
+            IReadOnlyList<string> playerItems,
+            string opponentName,
+            IReadOnlyList<string> opponentItems,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(playerName))
+                throw new ArgumentException("playerName must not be null or whitespace.", nameof(playerName));
+            if (string.IsNullOrWhiteSpace(opponentName))
+                throw new ArgumentException("opponentName must not be null or whitespace.", nameof(opponentName));
+            if (playerItems == null) throw new ArgumentNullException(nameof(playerItems));
+            if (opponentItems == null) throw new ArgumentNullException(nameof(opponentItems));
+
+            string userMessage = BuildUserMessage(playerName, playerItems, opponentName, opponentItems);
+
+            try
+            {
+                string response = await _transport
+                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.OutfitDescription)
+                    .ConfigureAwait(false);
+                return (response ?? string.Empty).Trim();
+            }
+            catch
+            {
+                // Parity with IStakeGenerator: transport failure \u2192 empty string.
+                // The caller decides what to do (skip scene entry, or fail setup).
+                return string.Empty;
+            }
+        }
+
+        private static string BuildUserMessage(
+            string playerName, IReadOnlyList<string> playerItems,
+            string opponentName, IReadOnlyList<string> opponentItems)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Player ({playerName}) is wearing:");
+            if (playerItems.Count == 0) sb.AppendLine("- (no items recorded)");
+            else
+                foreach (var i in playerItems)
+                    sb.AppendLine($"- {i}");
+            sb.AppendLine();
+            sb.AppendLine($"Opponent ({opponentName}) is wearing:");
+            if (opponentItems.Count == 0) sb.AppendLine("- (no items recorded)");
+            else
+                foreach (var i in opponentItems)
+                    sb.AppendLine($"- {i}");
+            sb.AppendLine();
+            sb.AppendLine(
+                "Write 2\u20134 sentences in plain prose: what each is wearing and the overall vibe of the encounter. " +
+                "Do not list items \u2014 weave them into the description. Mention both characters by name.");
+            return sb.ToString();
+        }
+
+        /// <summary>Tunable knobs for <see cref="LlmOutfitDescriber"/>.</summary>
+        public sealed class Options
+        {
+            /// <summary>Temperature. Default 0.8 \u2014 a touch warmer than matchup analysis.</summary>
+            public double Temperature { get; set; } = 0.8;
+
+            /// <summary>Max output tokens. Default 250 (paragraph-sized).</summary>
+            public int MaxTokens { get; set; } = 250;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/ConversationIndexingTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/ConversationIndexingTests.cs
@@ -1,0 +1,273 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Conversation;
+using Xunit;
+
+namespace Pinder.Core.Tests.Conversation;
+
+/// <summary>
+/// Pin tests for <see cref="ConversationIndexing"/> — the helper that
+/// reconciles physical <c>ConversationHistory</c> indices with logical
+/// (turn, role) pairs in the presence of leading <c>[scene]</c> entries
+/// (issue #333). These tests exist because two pinder-web consumers
+/// shipped pair-math (<c>i / 2</c>, <c>i % 2 == 0</c>) that silently
+/// misattributed turn numbers and text-diffs once scene entries were
+/// seeded at the front of the history (review feedback on PR #350).
+/// </summary>
+public sealed class ConversationIndexingTests
+{
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static (string Sender, string Text) Scene(string text)
+        => (Senders.Scene, text);
+
+    private static (string Sender, string Text) Player(string text)
+        => ("Reuben", text);
+
+    private static (string Sender, string Text) Opp(string text)
+        => ("Sable", text);
+
+    // ── 0 scene entries (legacy / pre-#333 layout) ──────────────────────
+
+    [Fact]
+    public void NoScene_TurnNumberAt_MatchesLegacyPairMath()
+    {
+        // Legacy: (player, opp, player, opp, ...) → turns 1, 1, 2, 2, ...
+        var history = new[]
+        {
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+            Player("p3"), Opp("o3"),
+        };
+
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 0));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 1));
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 2));
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 3));
+        Assert.Equal(3, ConversationIndexing.TurnNumberAt(history, 4));
+        Assert.Equal(3, ConversationIndexing.TurnNumberAt(history, 5));
+    }
+
+    [Fact]
+    public void NoScene_IsPlayerEntryAt_MatchesLegacyPairMath()
+    {
+        var history = new[]
+        {
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+        };
+
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 0));
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 1));
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 2));
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 3));
+    }
+
+    // ── 1 scene entry ───────────────────────────────────────────────────
+
+    [Fact]
+    public void OneScene_TurnNumberAt_Skips()
+    {
+        // 1 scene + (player, opp, player, opp, ...).
+        var history = new[]
+        {
+            Scene("player bio"),
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+        };
+
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 0));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 1));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 2));
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 3));
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 4));
+    }
+
+    [Fact]
+    public void OneScene_IsPlayerEntryAt_Skips()
+    {
+        var history = new[]
+        {
+            Scene("player bio"),
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+        };
+
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 0));   // scene
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 1));    // p1
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 2));   // o1
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 3));    // p2
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 4));   // o2
+    }
+
+    // ── 3 scene entries (full #333: bio + bio + outfit) ─────────────────
+
+    [Fact]
+    public void ThreeScene_TurnNumberAt_AllScenesReturnZero_PairMathRebasedOnFirstNonScene()
+    {
+        // 3 scene + 3 turns of (player, opp).
+        var history = new[]
+        {
+            Scene("player bio"),
+            Scene("opponent bio"),
+            Scene("outfit description"),
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+            Player("p3"), Opp("o3"),
+        };
+
+        // Scene entries → turn 0
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 0));
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 1));
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 2));
+
+        // Turn 1: indices 3+4
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 3));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 4));
+
+        // Turn 2: indices 5+6
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 5));
+        Assert.Equal(2, ConversationIndexing.TurnNumberAt(history, 6));
+
+        // Turn 3: indices 7+8
+        Assert.Equal(3, ConversationIndexing.TurnNumberAt(history, 7));
+        Assert.Equal(3, ConversationIndexing.TurnNumberAt(history, 8));
+    }
+
+    [Fact]
+    public void ThreeScene_IsPlayerEntryAt_ScenesNeverPlayer_PairMathRebased()
+    {
+        var history = new[]
+        {
+            Scene("player bio"),
+            Scene("opponent bio"),
+            Scene("outfit description"),
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+        };
+
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 0));  // scene
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 1));  // scene
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 2));  // scene
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 3));   // p1
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 4));  // o1
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 5));   // p2
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 6));  // o2
+    }
+
+    // ── 2 scene entries (test-override path: bio + bio, outfit skipped) ─
+
+    [Fact]
+    public void TwoScene_MatchesProductionTestOverridePath()
+    {
+        // The PlaybackLlmTransport / test-override path skips the outfit
+        // describer, so a real test session has 2 scene entries up front.
+        var history = new[]
+        {
+            Scene("player bio"),
+            Scene("opponent bio"),
+            Player("p1"), Opp("o1"),
+        };
+
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 0));
+        Assert.Equal(0, ConversationIndexing.TurnNumberAt(history, 1));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 2));
+        Assert.Equal(1, ConversationIndexing.TurnNumberAt(history, 3));
+
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 0));
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 1));
+        Assert.True(ConversationIndexing.IsPlayerEntryAt(history, 2));
+        Assert.False(ConversationIndexing.IsPlayerEntryAt(history, 3));
+    }
+
+    // ── EnumerateConversation streaming variant ─────────────────────────
+
+    [Fact]
+    public void EnumerateConversation_TagsEveryEntryWithItsLogicalRole()
+    {
+        var history = new[]
+        {
+            Scene("player bio"),
+            Scene("opponent bio"),
+            Player("p1"), Opp("o1"),
+            Player("p2"), Opp("o2"),
+        };
+
+        var views = ConversationIndexing.EnumerateConversation(history).ToArray();
+
+        Assert.Equal(6, views.Length);
+
+        // Scene entries
+        Assert.True(views[0].IsScene);
+        Assert.Equal(0, views[0].TurnNumber);
+        Assert.False(views[0].IsPlayerEntry);
+        Assert.Equal(0, views[0].PhysicalIndex);
+
+        Assert.True(views[1].IsScene);
+        Assert.Equal(0, views[1].TurnNumber);
+        Assert.False(views[1].IsPlayerEntry);
+
+        // Turn 1 player
+        Assert.False(views[2].IsScene);
+        Assert.Equal(1, views[2].TurnNumber);
+        Assert.True(views[2].IsPlayerEntry);
+        Assert.Equal(2, views[2].PhysicalIndex);
+        Assert.Equal("p1", views[2].Text);
+
+        // Turn 1 opponent
+        Assert.False(views[3].IsScene);
+        Assert.Equal(1, views[3].TurnNumber);
+        Assert.False(views[3].IsPlayerEntry);
+
+        // Turn 2 player + opponent
+        Assert.Equal(2, views[4].TurnNumber);
+        Assert.True(views[4].IsPlayerEntry);
+        Assert.Equal(2, views[5].TurnNumber);
+        Assert.False(views[5].IsPlayerEntry);
+    }
+
+    [Fact]
+    public void EnumerateConversation_EmptyHistory_ReturnsNoViews()
+    {
+        var history = System.Array.Empty<(string Sender, string Text)>();
+        var views = ConversationIndexing.EnumerateConversation(history).ToArray();
+        Assert.Empty(views);
+    }
+
+    [Fact]
+    public void EnumerateConversation_ScenesOnly_AllZero()
+    {
+        var history = new[]
+        {
+            Scene("player bio"),
+            Scene("opponent bio"),
+            Scene("outfit description"),
+        };
+
+        var views = ConversationIndexing.EnumerateConversation(history).ToArray();
+        Assert.Equal(3, views.Length);
+        foreach (var v in views)
+        {
+            Assert.True(v.IsScene);
+            Assert.Equal(0, v.TurnNumber);
+            Assert.False(v.IsPlayerEntry);
+        }
+    }
+
+    // ── IsSceneAt sanity ────────────────────────────────────────────────
+
+    [Fact]
+    public void IsSceneAt_DistinguishesSceneFromCharacterSenders()
+    {
+        var history = new[]
+        {
+            Scene("bio"),
+            Player("hi"),
+            Opp("hello"),
+        };
+
+        Assert.True(ConversationIndexing.IsSceneAt(history, 0));
+        Assert.False(ConversationIndexing.IsSceneAt(history, 1));
+        Assert.False(ConversationIndexing.IsSceneAt(history, 2));
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #333: regression tests for the turn-0 scene-setting entries
+    /// (player bio, opponent bio, LLM-generated outfit description) seeded
+    /// onto <see cref="GameSession.ConversationHistory"/> via
+    /// <see cref="GameSession.SeedSceneEntries"/>.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue333_TurnZeroSceneEntriesTests
+    {
+        [Fact]
+        public void SeedSceneEntries_appends_three_scene_entries_to_history()
+        {
+            var session = MakeSession(out _);
+
+            session.SeedSceneEntries(
+                "Player bio text.",
+                "Opponent bio text.",
+                "Both wear something quietly out of fashion.");
+
+            var history = session.ConversationHistory;
+            Assert.Equal(3, history.Count);
+            Assert.All(history, e => Assert.Equal(Senders.Scene, e.Sender));
+            Assert.Equal("Player bio text.",                                history[0].Text);
+            Assert.Equal("Opponent bio text.",                              history[1].Text);
+            Assert.Equal("Both wear something quietly out of fashion.",    history[2].Text);
+        }
+
+        [Theory]
+        [InlineData(null,    "B", "C", new[] { "B", "C" })]
+        [InlineData("",      "B", "C", new[] { "B", "C" })]
+        [InlineData("   ",   "B", "C", new[] { "B", "C" })]
+        [InlineData("A",     null, "C", new[] { "A", "C" })]
+        [InlineData("A",     "B", "",   new[] { "A", "B" })]
+        public void SeedSceneEntries_skips_empty_entries(string a, string b, string c, string[] expected)
+        {
+            var session = MakeSession(out _);
+            session.SeedSceneEntries(a, b, c);
+
+            Assert.Equal(expected.Length, session.ConversationHistory.Count);
+            Assert.Equal(
+                expected,
+                session.ConversationHistory.Select(e => e.Text).ToArray());
+        }
+
+        [Fact]
+        public async Task SeedSceneEntries_throws_after_first_turn_resolved()
+        {
+            var session = MakeSession(out _);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.Throws<System.InvalidOperationException>(() =>
+                session.SeedSceneEntries("a", "b", "c"));
+        }
+
+        [Fact]
+        public async Task Scene_entries_are_excluded_from_LLM_context_history()
+        {
+            var session = MakeSession(out var llm);
+            session.SeedSceneEntries("Player bio.", "Opponent bio.", "Outfit prose.");
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // The DeliveryContext capture is the proof: scene entries
+            // must NOT appear in the conversation history fed to the LLM.
+            Assert.NotNull(llm.CapturedDeliveryContext);
+            Assert.DoesNotContain(
+                llm.CapturedDeliveryContext!.ConversationHistory,
+                e => e.Sender == Senders.Scene);
+
+            // BUT the public ConversationHistory still includes them.
+            Assert.Contains(session.ConversationHistory, e => e.Sender == Senders.Scene);
+        }
+
+        [Fact]
+        public void Scene_entries_round_trip_through_ResimulateData()
+        {
+            var session = MakeSession(out _);
+            session.SeedSceneEntries("a", "b", "c");
+
+            // Snapshot the history into a ResimulateData and rebuild.
+            var snapshotHistory = session.ConversationHistory
+                .Select(e => (e.Sender, e.Text))
+                .ToList();
+            var resim = new ResimulateData
+            {
+                ConversationHistory = snapshotHistory,
+                ShadowValues = new Dictionary<string, int>(),
+            };
+
+            var freshSession = MakeSession(out _);
+            freshSession.RestoreState(resim, new NullTrapRegistry());
+
+            Assert.Equal(3, freshSession.ConversationHistory.Count);
+            Assert.All(freshSession.ConversationHistory,
+                e => Assert.Equal(Senders.Scene, e.Sender));
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────
+
+        private static GameSession MakeSession(out CapturingLlm llm)
+        {
+            llm = new CapturingLlm();
+            var dice = new FixedDice(15, 5);
+            return new GameSession(
+                MakeProfile("Sable"), MakeProfile("Brick"),
+                llm, dice, new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+        }
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private sealed class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _rolls;
+            public FixedDice(params int[] rolls) { _rolls = new Queue<int>(rolls); }
+            public int Roll(int sides) => _rolls.Count > 0 ? _rolls.Dequeue() : 1;
+            public int RollWithAdvantage(int sides) => Roll(sides);
+            public int RollWithDisadvantage(int sides) => Roll(sides);
+        }
+
+        private sealed class CapturingLlm : ILlmAdapter
+        {
+            public DeliveryContext? CapturedDeliveryContext { get; private set; }
+            public OpponentContext? CapturedOpponentContext { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+                => Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, "Hey there"),
+                    new DialogueOption(StatType.Rizz, "Nice"),
+                    new DialogueOption(StatType.Honesty, "Real talk"),
+                    new DialogueOption(StatType.Wit, "Clever")
+                });
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            {
+                CapturedDeliveryContext = context;
+                return Task.FromResult(context.ChosenOption.IntendedText);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            {
+                CapturedOpponentContext = context;
+                return Task.FromResult(new OpponentResponse("Reply"));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+                => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+                => Task.FromResult(message);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue339_CallbackStripperTests.cs
+++ b/tests/Pinder.Core.Tests/Issue339_CallbackStripperTests.cs
@@ -1,0 +1,97 @@
+using Pinder.Core.Text;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #339: regression tests for the same-turn callback strip.
+    /// </summary>
+    public class Issue339_CallbackStripperTests
+    {
+        // ── Stripped openers ─────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("As you said, that was wild.",       "That was wild.")]
+        [InlineData("As you just said, that was wild.",   "That was wild.")]
+        [InlineData("As we discussed, no thanks.",        "No thanks.")]
+        [InlineData("As I just discussed, that's fine.",   "That's fine.")]
+        [InlineData("Like we said, fine.",                 "Fine.")]
+        [InlineData("Like you mentioned, sure.",           "Sure.")]
+        [InlineData("Like you just said, ok.",             "Ok.")]
+        [InlineData("As I mentioned, ok.",                 "Ok.")]
+        [InlineData("Like I said, fine.",                  "Fine.")]
+        public void Strip_removes_known_callback_openers(string input, string expected)
+        {
+            Assert.Equal(expected, CallbackStripper.Strip(input));
+        }
+
+        [Theory]
+        [InlineData("It was great. As you said, that was wild.",
+                    "It was great. That was wild.")]
+        public void Strip_removes_callbacks_after_sentence_boundary(string input, string expected)
+        {
+            Assert.Equal(expected, CallbackStripper.Strip(input));
+        }
+
+        // ── Cross-turn references preserved ──────────────────────────────
+
+        [Theory]
+        [InlineData("Earlier, on turn 2, you said something funny.")]
+        [InlineData("As you said back on turn 5, the pasta was a sign.")]
+        [InlineData("On turn 3 we talked about it.")]
+        public void Strip_preserves_explicit_cross_turn_references(string input)
+        {
+            // Even if the message LOOKS like it has a callback shape,
+            // any explicit "turn N" reference flips the whole message
+            // into "legitimate cross-turn" mode and nothing is stripped.
+            Assert.Equal(input, CallbackStripper.Strip(input));
+        }
+
+        // ── Non-matches unchanged ────────────────────────────────────────
+
+        [Theory]
+        [InlineData("Hello, how are you?")]
+        [InlineData("As a kid I loved that show.")]              // "As" + non-callback continuation
+        [InlineData("Like coffee, I prefer dark beans.")]        // "Like" + non-callback continuation
+        [InlineData("")]
+        public void Strip_leaves_non_matches_alone(string input)
+        {
+            Assert.Equal(input, CallbackStripper.Strip(input));
+        }
+
+        [Fact]
+        public void Strip_handles_null_as_empty()
+        {
+            Assert.Equal(string.Empty, CallbackStripper.Strip(null));
+        }
+
+        // ── WouldStrip flag ──────────────────────────────────────────────
+
+        [Fact]
+        public void WouldStrip_returns_true_only_when_strip_changes_text()
+        {
+            Assert.True(CallbackStripper.WouldStrip("As you said, hi."));
+            Assert.False(CallbackStripper.WouldStrip("Hi there."));
+            Assert.False(CallbackStripper.WouldStrip(""));
+            Assert.False(CallbackStripper.WouldStrip(null));
+        }
+
+        // ── Cosmetic cleanup ─────────────────────────────────────────────
+
+        [Fact]
+        public void Strip_collapses_double_spaces_left_by_removal()
+        {
+            // After stripping "As you said, " from the middle, we don't
+            // want "It happened.  And it stuck." with two spaces.
+            string got = CallbackStripper.Strip("It happened. As you said, and it stuck.");
+            Assert.Equal("It happened. And it stuck.", got);
+        }
+
+        [Fact]
+        public void Strip_capitalises_new_opener_after_stripping()
+        {
+            string got = CallbackStripper.Strip("As you just said, that was a lot.");
+            Assert.Equal("That was a lot.", got);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue340_PunctuationNormalizingTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue340_PunctuationNormalizingTransportTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #340: regression tests for the punctuation-normalising
+    /// decorator transport that maps space-em-dash-space patterns into
+    /// "; " on every LLM response.
+    /// </summary>
+    public class Issue340_PunctuationNormalizingTransportTests
+    {
+        // ── Pure-function tests ──────────────────────────────────────────
+
+        [Theory]
+        [InlineData("hello \u2014 world",                "hello; world")] // ASCII space + em + ASCII space
+        [InlineData("hello\u2009\u2014\u2009world",       "hello; world")] // thin-space + em + thin-space
+        [InlineData("hello \u2014\u2009world",             "hello; world")] // mixed: ASCII left, thin right
+        [InlineData("hello\u2009\u2014 world",             "hello; world")] // mixed: thin left, ASCII right
+        [InlineData("a \u2014 b \u2014 c",                "a; b; c")]      // multiple occurrences
+        public void Normalize_replaces_space_em_space(string input, string expected)
+        {
+            Assert.Equal(expected, PunctuationNormalizingTransport.Normalize(input));
+        }
+
+        [Theory]
+        [InlineData("word\u2014word",        "word\u2014word")]   // no surrounding spaces \u2192 unchanged
+        [InlineData("foo\u2014bar baz",       "foo\u2014bar baz")] // bare em-dash inside compound \u2192 unchanged
+        [InlineData("Mon\u2013Fri",           "Mon\u2013Fri")]    // en-dash range \u2192 unchanged
+        [InlineData("nothing to do",          "nothing to do")]   // no em-dash at all
+        [InlineData("",                       "")]               // empty
+        public void Normalize_leaves_unsurrounded_dashes_alone(string input, string expected)
+        {
+            Assert.Equal(expected, PunctuationNormalizingTransport.Normalize(input));
+        }
+
+        [Fact]
+        public void Normalize_handles_null_as_empty()
+        {
+            Assert.Equal(string.Empty, PunctuationNormalizingTransport.Normalize(null));
+        }
+
+        // ── Decorator behaviour tests ────────────────────────────────────
+
+        [Fact]
+        public async Task SendAsync_wraps_inner_response()
+        {
+            var inner = new RecordingTransport("hello \u2014 world");
+            var sut = new PunctuationNormalizingTransport(inner);
+
+            var result = await sut.SendAsync("sys", "user", phase: LlmPhase.Delivery);
+
+            Assert.Equal("hello; world", result);
+            Assert.Equal("sys", inner.LastSystem);
+            Assert.Equal("user", inner.LastUser);
+            Assert.Equal(LlmPhase.Delivery, inner.LastPhase);
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_normalises_each_fragment()
+        {
+            var fragments = new[] { "hello \u2014 ", "world\u2009\u2014\u2009ok" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new PunctuationNormalizingTransport(inner, inner);
+
+            var got = new List<string>();
+            await foreach (var chunk in sut.SendStreamAsync("sys", "user"))
+                got.Add(chunk);
+
+            Assert.Equal(new[] { "hello; ", "world; ok" }, got);
+        }
+
+        // ── Test transport ───────────────────────────────────────────────
+
+        private sealed class RecordingTransport : ILlmTransport, IStreamingLlmTransport
+        {
+            private readonly string _response;
+            private readonly string[]? _fragments;
+
+            public string? LastSystem { get; private set; }
+            public string? LastUser { get; private set; }
+            public string? LastPhase { get; private set; }
+
+            public RecordingTransport(string response, string[]? streamingFragments = null)
+            {
+                _response = response;
+                _fragments = streamingFragments;
+            }
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+            {
+                LastSystem = systemPrompt;
+                LastUser = userMessage;
+                LastPhase = phase;
+                return Task.FromResult(_response);
+            }
+
+#pragma warning disable CS1998 // async without await — yield-based async iterator
+            public async IAsyncEnumerable<string> SendStreamAsync(
+                string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024,
+                [EnumeratorCancellation] CancellationToken cancellationToken = default,
+                string? phase = null)
+            {
+                LastSystem = systemPrompt;
+                LastUser = userMessage;
+                LastPhase = phase;
+                if (_fragments == null) yield break;
+                foreach (var f in _fragments) yield return f;
+            }
+#pragma warning restore CS1998
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three engine-side text-processing changes, packaged together because they all touch the post-LLM text-handling layer in pinder-core.

### #340 — em-dash → semicolon post-process
`PunctuationNormalizingTransport` decorator wraps any `ILlmTransport` (and optionally `IStreamingLlmTransport`). On every response it rewrites ` — ` → `; ` (covers ASCII space + U+2014, U+2009 thin-space, and mixed variants). `word—word` and en-dashes (U+2013) are intentionally preserved.

The web tier wraps the provider transport in this decorator BEFORE the snapshot recorder so audit logs capture the post-normalised text.

### #339 — same-turn callback strip
`CallbackStripper` regex pass that runs in `GameSession.ResolveTurnAsync` after the existing Steering / Horniness / Shadow layers. Strips conservative same-turn callback patterns ("As you (just) said,", "Like we mentioned,", "As we discussed,", etc.) and emits a `Callback Strip` `TextDiff` layer when it changes the message — same diff plumbing as the other text-transform layers.

Adds `LlmPhase.CallbackStrip` and `LlmPhase.OutfitDescription` (latter consumed by #333).

Explicit cross-turn references ("earlier on turn 2…") short-circuit the strip and are returned unchanged.

### #333 — turn-0 bios + outfit description
- New `IOutfitDescriber` + default `LlmOutfitDescriber` (sibling to `IMatchupAnalyzer` / `IStakeGenerator`). Single non-streaming call, returns empty string on transport failure.
- New `Senders.Scene` constant (`"[scene]"`) for synthetic scene-entry sender tag.
- `GameSession.SeedSceneEntries(playerBio, opponentBio, outfitDescription)` appends up to three `[scene]` entries to the conversation log; throws if any turn has resolved.
- New private `BuildHistoryForLlmContext()` filter excludes `[scene]` entries from the history view fed to subsequent LLM calls so the analyzer never sees its own scene-description output.
- `TurnSnapshot.ConversationEntry` comment block updated per AGENTS.md schema discipline.

The pinder-web tier wires this up in `ActiveSession.SetupAsync`, running the outfit call in parallel with matchup analysis (`Task.Run` + join after stakes).

## Tests

| Layer | Added | Notes |
|---|---|---|
| #340 | 13 | Pure normalisation + decorator behaviour, both streaming and non-streaming |
| #339 | 13 | Stripped openers, mid-sentence cleanup, capitalisation, cross-turn preservation |
| #333 | 5 | Seeded entries, empty-skip, post-turn guard, LLM-context filter, ResimulateData round-trip |

```
Passed!  - Pinder.Core.Tests   — 30/30 new tests pass
Passed!  - Pinder.LlmAdapters.Tests — 13/13 new tests pass
```

Pre-existing baseline failures (`CharacterLoaderSpecTests` — design/examples directory missing, YamlDotNet test infrastructure bug) confirmed unchanged on baseline by stash + re-test.

## Companion PR
pinder-web: https://github.com/decay256/pinder-web/pull/new/fix/A1-engine-text-and-turn0 — bumps the submodule pointer + wires up the LlmOutfitDescriber + ICharacterRepository.Items.

**Merge order: this PR first, then the pinder-web PR.**