### PR TITLE
feat(SessionSetup): add LlmMatchupSummarizer for #332

### DIFF
--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -38,6 +38,14 @@ namespace Pinder.Core.Interfaces
         /// <summary>Session-setup matchup analysis.</summary>
         public const string MatchupAnalysis = "matchup_analysis";
 
+        /// <summary>
+        /// Session-setup short matchup summary (issue #332). A 1-2 paragraph
+        /// LLM-generated condensation of the long-form matchup analysis,
+        /// surfaced to the UI as a display-only affordance. NOT used as
+        /// input to any subsequent LLM prompt in the session.
+        /// </summary>
+        public const string MatchupSummary = "matchup_summary";
+
         /// <summary>Session-setup psychological-stake generation.</summary>
         public const string PsychologicalStake = "psychological_stake";
 

--- a/src/Pinder.SessionSetup/IMatchupSummarizer.cs
+++ b/src/Pinder.SessionSetup/IMatchupSummarizer.cs
@@ -1,0 +1,47 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Issue #332: produces a short (1-2 paragraph), human-readable summary
+    /// of a matchup. Display-only — the result is surfaced to the UI in the
+    /// Player Sheet "Background" tab alongside the full matchup analysis,
+    /// and is NOT used as input to any subsequent LLM prompt in the session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Output contract (mirrors <see cref="IMatchupAnalyzer"/> and
+    /// <see cref="IOutfitDescriber"/>): plain prose, paragraph breaks
+    /// only — no markdown, no bullets, no headings, no code formatting.
+    /// The web tier's <c>MarkdownSanitizer</c> runs as defence in depth.
+    /// </para>
+    /// <para>
+    /// One LLM call per session, run after / alongside the matchup-analysis
+    /// stage. Short — target ~120 tokens — so the round-trip is cheap.
+    /// </para>
+    /// <para>
+    /// Failure semantics: returns an empty string on any transport failure
+    /// (mirrors <see cref="IOutfitDescriber"/>). The summary is non-critical
+    /// to setup — when generation fails the UI simply hides the section, so
+    /// throwing here would be a needlessly heavy hammer.
+    /// </para>
+    /// </remarks>
+    public interface IMatchupSummarizer
+    {
+        /// <summary>
+        /// Generate a 1-2 paragraph plain-prose summary of the matchup
+        /// between <paramref name="player"/> and <paramref name="opponent"/>.
+        /// Returns the empty string on transport failure — never throws on
+        /// LLM errors.
+        /// </summary>
+        /// <param name="player">Player profile (display name, level, stats, shadows).</param>
+        /// <param name="opponent">Opponent profile.</param>
+        /// <param name="cancellationToken">Cancellation token tied to the session lifetime.</param>
+        Task<string> SummarizeAsync(
+            CharacterProfile player,
+            CharacterProfile opponent,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.SessionSetup/LlmMatchupSummarizer.cs
+++ b/src/Pinder.SessionSetup/LlmMatchupSummarizer.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Default <see cref="IMatchupSummarizer"/> built on
+    /// <see cref="ILlmTransport"/>. One LLM call per session.
+    /// Issue #332.
+    /// </summary>
+    /// <remarks>
+    /// Uses the canonical <see cref="LlmPhase.MatchupSummary"/> phase label
+    /// so snapshot recording and audit decorators tag the exchange without
+    /// re-deriving the phase from prompt text.
+    ///
+    /// The summary is intentionally produced by a SECOND LLM call rather
+    /// than extending the existing matchup-analysis prompt. The streaming
+    /// matchup-analysis path (see <see cref="LlmMatchupAnalyzer"/>) feeds
+    /// raw token deltas directly into the UI; appending a summary section
+    /// to that stream would leak the new affordance into the main matchup
+    /// display. A separate, short, non-streaming call keeps the two
+    /// concerns cleanly separated and runs in parallel with stake
+    /// generation in the web tier so it adds minimal end-to-end latency.
+    /// </remarks>
+    public sealed class LlmMatchupSummarizer : IMatchupSummarizer
+    {
+        private const string SystemPrompt =
+            "You are an expert game designer summarising a matchup in a dating RPG. " +
+            "Write a SHORT 1-2 paragraph summary (roughly 60-120 words total) of the " +
+            "matchup between the two characters. Capture the essential dynamic — who is " +
+            "trying what, and what is at stake — in plain prose. Do NOT use markdown " +
+            "formatting of any kind: no headings (#, ##), no bold or italics (**, __, *, _), " +
+            "no bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), and no " +
+            "inline or fenced code (`, ```). Use paragraph breaks for structure if you " +
+            "use two paragraphs.";
+
+        private readonly ILlmTransport _transport;
+        private readonly Options _options;
+
+        public LlmMatchupSummarizer(ILlmTransport transport, Options? options = null)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _options = options ?? new Options();
+        }
+
+        public async Task<string> SummarizeAsync(
+            CharacterProfile player,
+            CharacterProfile opponent,
+            CancellationToken cancellationToken = default)
+        {
+            if (player == null) throw new ArgumentNullException(nameof(player));
+            if (opponent == null) throw new ArgumentNullException(nameof(opponent));
+
+            string userMessage = BuildPrompt(player, opponent);
+
+            try
+            {
+                string response = await _transport
+                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.MatchupSummary)
+                    .ConfigureAwait(false);
+                return (response ?? string.Empty).Trim();
+            }
+            catch
+            {
+                // Parity with IOutfitDescriber: transport failure → empty string.
+                // The caller (web tier) tolerates an empty string by simply
+                // not surfacing the summary section in the UI.
+                return string.Empty;
+            }
+        }
+
+        private static string BuildPrompt(CharacterProfile player, CharacterProfile opponent)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Summarise the following matchup between two characters in a dating RPG.");
+            sb.AppendLine("Produce 1 to 2 short paragraphs in plain prose (no markdown).");
+            sb.AppendLine("Mention each character by name. Capture the essential dynamic and the");
+            sb.AppendLine("strongest lane of attack vs. defence — but keep it tight (60-120 words total).");
+            sb.AppendLine();
+            sb.AppendLine("Here is the data:");
+            sb.AppendLine();
+            AppendCharacterData(sb, "Player", player);
+            sb.AppendLine();
+            AppendCharacterData(sb, "Opponent", opponent);
+            return sb.ToString();
+        }
+
+        private static void AppendCharacterData(StringBuilder sb, string label, CharacterProfile character)
+        {
+            sb.AppendLine($"--- {label}: {character.DisplayName} ---");
+            sb.AppendLine($"Level: {character.Level}");
+            sb.AppendLine($"Bio: {character.Bio}");
+
+            sb.AppendLine("Stats:");
+            foreach (var stat in new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness })
+            {
+                sb.AppendLine($"- {stat}: {character.Stats.GetEffective(stat):+#;-#;0}");
+            }
+
+            sb.AppendLine("Shadows:");
+            foreach (var shadow in new[] { ShadowStatType.Dread, ShadowStatType.Fixation, ShadowStatType.Denial, ShadowStatType.Madness })
+            {
+                sb.AppendLine($"- {shadow}: {character.Stats.GetShadow(shadow)}");
+            }
+        }
+
+        /// <summary>Tunable knobs for <see cref="LlmMatchupSummarizer"/>.</summary>
+        public sealed class Options
+        {
+            /// <summary>Temperature. Default 0.7 — same as matchup analysis.</summary>
+            public double Temperature { get; set; } = 0.7;
+
+            /// <summary>
+            /// Max output tokens. Default 200 — enough for 1-2 short paragraphs
+            /// with headroom; the prompt aims for 60-120 words (~80-160 tokens).
+            /// </summary>
+            public int MaxTokens { get; set; } = 200;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `IMatchupSummarizer` + `LlmMatchupSummarizer` pair under `Pinder.SessionSetup` to produce a short 1-2 paragraph plain-prose summary of a matchup, intended as a display-only affordance alongside the existing long-form matchup analysis.

## Why a separate analyzer (and not extending `LlmMatchupAnalyzer`)?

The recommended approach in the issue was \"extend the matchup-analysis prompt to produce both outputs in one call\". Considered, rejected for these reasons:

1. The existing matchup-analysis path is **streaming-first**: `IMatchupAnalyzer.StreamMatchupAsync` feeds raw token deltas into the UI as they arrive (see `SetupStreamEvent.Delta` in pinder-web). Tacking a `Summary:` section onto the end of that stream would leak the new affordance into the main matchup-analysis display.
2. `ILlmTransport.SendAsync` returns plain `string`. Structured output (Anthropic `tool_use` / OpenAI structured outputs) would require an interface change with knock-on effects through every transport implementation.
3. A separate, short, non-streaming call is parallelisable with stake generation in the web tier, so the end-to-end latency cost is roughly free.

## What's here

- `Pinder.Core.Interfaces.LlmPhase.MatchupSummary` (`\"matchup_summary\"`) — new phase string for snapshot/audit decorators.
- `Pinder.SessionSetup.IMatchupSummarizer` — narrow interface, one method, returns a string.
- `Pinder.SessionSetup.LlmMatchupSummarizer` — default implementation built on `ILlmTransport` (non-streaming). 200-token cap, T=0.7. Failure semantics mirror `IOutfitDescriber`: empty string on transport failure (the summary is non-critical).

## Constraint

The summary is **display-only**. It is NOT used as input to any subsequent LLM prompt in the session — that is the explicit hard constraint from the issue's spec. Verifiable by grep: nothing reads `_matchupSummary` / `MatchupSummary` other than the API DTO and the persistence envelope.

## Companion PR

Wired into pinder-web in [decay256/pinder-web#332](https://github.com/decay256/pinder-web/issues/332) (`Closes #332`).

## DoD evidence

`dotnet build src/Pinder.SessionSetup/Pinder.SessionSetup.csproj` clean (84 unrelated warnings, 0 errors).