### PR TITLE
fix(W2b): archetype directive plumbing + ratio-based intensity (#372 #375)

### DIFF
--- a/rules/extracted/archetypes-enriched.yaml
+++ b/rules/extracted/archetypes-enriched.yaml
@@ -619,6 +619,111 @@
   description: The rarest and most appreciated archetype. Actually reads the bio. References something specific. As
   heading_level: 4
   compact_heading: true
+# ── Item / anatomy YAML referenced these names that were missing from
+#    §2 above. Added (#372) so ArchetypeCatalog has real behaviour text
+#    for every name the JSON data references — without these, GetBehavior
+#    would fall back to the bare placeholder "Follow {Name} behavioral
+#    pattern." which is what the LLM actually receives.
+- id: §2.the-pun-troll
+  section: §2
+  title: The Pun Troll
+  type: archetype_definition
+  stats:
+    high:
+    - Wit
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Fixation
+    low: []
+  level_range:
+  - 2
+  - 8
+  behavior: 'Cannot resist a wordplay. Every reply is contorted around a pun, a
+    homonym, or a stretched double-meaning the conversation didn''t ask for.
+    Genuine wit is occasionally in the tank — what kills it is the inability
+    to let a single message land without a pun retrofitted onto it.
+    Self-applauding. Will quote their own pun back in the next message in
+    case it was missed. The dating-app cousin of the dad-joke uncle.
+
+
+    *Sample lines:* "are you a librarian? because you''ve got me booked" ·
+    "sorry that was a pun-ishing line" · "I lentil-told you I''d find a way
+    to work beans into this"'
+  interference: {}
+  has_hr: true
+  tier: 2
+  description: Cannot resist a wordplay. Every reply is contorted around a pun, a homonym, or a stretched double-mean
+  heading_level: 4
+  compact_heading: true
+- id: §2.the-nice-guy
+  section: §2
+  title: The Nice Guy
+  type: archetype_definition
+  stats:
+    high:
+    - Charm
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Dread
+    - Denial
+    low: []
+  level_range:
+  - 1
+  - 6
+  behavior: 'Performs niceness as a transaction. Compliments are precise and
+    front-loaded; favours are tracked silently; "I''m one of the good ones"
+    is the stable belief underneath. Polite right up to the moment it stops
+    paying off, at which point niceness reveals itself as resentment that
+    was waiting for a trigger. The shorter, calmer cousin of The Exploding
+    Nice Guy — same engine, lower volume, same disappointment.
+
+
+    *Sample lines:* "you don''t see a lot of guys like me on here" · "I''m
+    just looking for someone real" · "most guys would have given up by now"'
+  interference: {}
+  has_hr: true
+  tier: 2
+  description: Performs niceness as a transaction. Compliments are precise and front-loaded; favours are tracked si
+  heading_level: 4
+  compact_heading: true
+- id: §2.the-2am-texter
+  section: §2
+  title: The 2AM Texter
+  type: archetype_definition
+  stats:
+    high:
+    - Rizz
+    - Chaos
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Horniness
+    - Overthinking
+    low: []
+  level_range:
+  - 3
+  - 9
+  behavior: 'Reliably resurfaces between 1am and 4am with messages that read
+    very differently than they would at noon. Lowered inhibition presented
+    as honesty. Sometimes a sincere late-night thought, more often a thinly
+    laundered booty-text. Has plausible deniability built in — "haha I was
+    so tired" — for whichever direction the morning takes. The platform''s
+    timestamp is doing more work than they realise.
+
+
+    *Sample lines:* "u up?" · "random thought but" · "don''t answer this
+    if you''re asleep" · "I''ve been thinking about you all day"'
+  interference: {}
+  has_hr: true
+  tier: 3
+  description: Reliably resurfaces between 1am and 4am with messages that read very differently than they would at
+  heading_level: 4
+  compact_heading: true
 - id: §3.archetype.hey-opener
   section: §3
   title: Archetype — The Hey Opener

--- a/src/Pinder.Core/Characters/ActiveArchetype.cs
+++ b/src/Pinder.Core/Characters/ActiveArchetype.cs
@@ -16,14 +16,43 @@ namespace Pinder.Core.Characters
         public int Count { get; }
 
         /// <summary>
-        /// Interference level derived from count: 1-2 = "slight", 3-5 = "clear", 6+ = "dominant".
+        /// Total number of archetype-tendency votes across the character's full
+        /// build (every archetype, every fragment). Used to compute the
+        /// share-of-votes-based <see cref="InterferenceLevel"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Count"/> when not supplied — that yields
+        /// <c>ratio = 1.0</c> and the legacy "always dominant" behaviour. Real
+        /// callers (CharacterAssembler) supply the real total so the intensity
+        /// reflects how dominant the archetype actually is in the build, not
+        /// just the absolute count of votes.
+        /// </remarks>
+        public int TotalCount { get; }
+
+        /// <summary>
+        /// Interference level derived from this archetype's share of all
+        /// archetype-tendency votes in the build (#375):
+        ///   ≥ 0.7 → "dominant"  (a clear majority — the archetype is the build)
+        ///   ≥ 0.4 → "clear"     (a real lead but not crushing)
+        ///   else  → "slight"    (one of several voices)
+        ///
+        /// "Dominant" therefore requires the archetype to take roughly
+        /// 70%+ of the build's archetype votes, not just a single-vote
+        /// lead. Per the #375 acceptance tests:
+        ///   [Pun Troll: 2, Player: 1]      → 2/3 = 0.67 → "clear"
+        ///   [Pun Troll: 4, Player: 1]      → 4/5 = 0.80 → "dominant"
+        ///   [Pun Troll: 2, Player: 2]      → 2/4 = 0.50 → "clear" (tied)
+        ///   [Pun Troll: 1, Player: 1, ...] → 1/3 = 0.33 → "slight"
         /// </summary>
         public string InterferenceLevel
         {
             get
             {
-                if (Count >= 6) return "dominant";
-                if (Count >= 3) return "clear";
+                int total = TotalCount > 0 ? TotalCount : Count;
+                if (total <= 0) return "slight";
+                double ratio = (double)Count / (double)total;
+                if (ratio >= 0.7) return "dominant";
+                if (ratio >= 0.4) return "clear";
                 return "slight";
             }
         }
@@ -40,11 +69,25 @@ namespace Pinder.Core.Characters
             }
         }
 
-        public ActiveArchetype(string name, string behavior, int count)
+        /// <summary>
+        /// Construct an ActiveArchetype.
+        /// </summary>
+        /// <param name="name">Archetype display name.</param>
+        /// <param name="behavior">Behavioral instruction text.</param>
+        /// <param name="count">Vote count for this archetype.</param>
+        /// <param name="totalCount">
+        /// Total archetype-tendency vote count across the build. When omitted
+        /// (zero or negative), <paramref name="count"/> is used — preserving
+        /// the legacy "ratio = 1.0 = dominant" behaviour for callers that
+        /// haven't migrated yet. CharacterAssembler.ResolveActiveArchetype
+        /// always supplies the real total.
+        /// </param>
+        public ActiveArchetype(string name, string behavior, int count, int totalCount = 0)
         {
             Name = name ?? string.Empty;
             Behavior = behavior ?? string.Empty;
             Count = count;
+            TotalCount = totalCount > 0 ? totalCount : count;
         }
     }
 }

--- a/src/Pinder.Core/Characters/CharacterAssembler.cs
+++ b/src/Pinder.Core/Characters/CharacterAssembler.cs
@@ -193,6 +193,9 @@ namespace Pinder.Core.Characters
         /// Selects the active archetype from ranked archetypes based on character level.
         /// If characterLevel > 0, prefers the highest-count archetype whose level range
         /// includes the character's level. Falls back to highest-count overall.
+        /// The total archetype-tendency vote count is propagated to
+        /// <see cref="ActiveArchetype"/> so its <c>InterferenceLevel</c> reflects
+        /// share-of-votes (#375), not raw count.
         /// </summary>
         internal static ActiveArchetype ResolveActiveArchetype(
             IReadOnlyList<(string Archetype, int Count)> ranked,
@@ -200,6 +203,13 @@ namespace Pinder.Core.Characters
         {
             if (ranked == null || ranked.Count == 0)
                 return null;
+
+            // Compute total archetype-tendency votes across the entire ranked
+            // set so InterferenceLevel can be expressed as a share, not raw
+            // count (#375).
+            int totalCount = 0;
+            for (int i = 0; i < ranked.Count; i++)
+                totalCount += ranked[i].Count;
 
             // Try to find the highest-count archetype eligible at this level
             if (characterLevel > 0)
@@ -210,7 +220,7 @@ namespace Pinder.Core.Characters
                     if (def != null && def.IsEligibleAtLevel(characterLevel))
                     {
                         string behavior = ArchetypeCatalog.GetBehavior(entry.Archetype);
-                        return new ActiveArchetype(entry.Archetype, behavior, entry.Count);
+                        return new ActiveArchetype(entry.Archetype, behavior, entry.Count, totalCount);
                     }
                 }
             }
@@ -218,7 +228,7 @@ namespace Pinder.Core.Characters
             // Fallback: use the highest-count archetype overall
             var top = ranked[0];
             string topBehavior = ArchetypeCatalog.GetBehavior(top.Archetype);
-            return new ActiveArchetype(top.Archetype, topBehavior, top.Count);
+            return new ActiveArchetype(top.Archetype, topBehavior, top.Count, totalCount);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/DeliveryContext.cs
+++ b/src/Pinder.Core/Conversation/DeliveryContext.cs
@@ -61,6 +61,14 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public string StatFailureInstruction { get; }
 
+        /// <summary>
+        /// Active archetype directive for the player character (e.g.
+        /// <c>"ACTIVE ARCHETYPE: The Peacock (clear)\n..."</c>), or null if
+        /// the player has no active archetype. Threaded into the delivery LLM
+        /// prompt so the rewrite respects the character's voice (#372 / #375).
+        /// </summary>
+        public string ActiveArchetypeDirective { get; }
+
         public DeliveryContext(
             string playerPrompt,
             string opponentPrompt,
@@ -76,7 +84,8 @@ namespace Pinder.Core.Conversation
             string opponentName = "",
             int currentTurn = 0,
             bool isNat20 = false,
-            string statFailureInstruction = null)
+            string statFailureInstruction = null,
+            string activeArchetypeDirective = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -93,6 +102,7 @@ namespace Pinder.Core.Conversation
             CurrentTurn = currentTurn;
             IsNat20 = isNat20;
             StatFailureInstruction = statFailureInstruction;
+            ActiveArchetypeDirective = activeArchetypeDirective;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -838,6 +838,12 @@ namespace Pinder.Core.Conversation
                     chosenOption.IsUnhingedReplacement);
             }
 
+            // Resolve player archetype directive once for delivery + overlays
+            // (#372 / #375). The same directive flows into ApplyHorninessOverlay
+            // and ApplyShadowCorruption below so every LLM rewrite of the
+            // delivered message respects the player's voice.
+            string playerArchetypeDirectiveForDelivery = _player.ActiveArchetype?.Directive;
+
             var deliveryContext = new DeliveryContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -854,7 +860,8 @@ namespace Pinder.Core.Conversation
                 currentTurn: _turnNumber,
                 shadowThresholds: _currentShadowThresholds,
                 isNat20: rollResult.IsNatTwenty,
-                statFailureInstruction: statFailureInstruction);
+                statFailureInstruction: statFailureInstruction,
+                activeArchetypeDirective: playerArchetypeDirectiveForDelivery);
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
             string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext).ConfigureAwait(false);
@@ -898,7 +905,7 @@ namespace Pinder.Core.Conversation
                     string beforeHorniness = deliveredMessage;
                     string opponentCtx = BuildOpponentContext(_opponent);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayStarted));
-                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx).ConfigureAwait(false);
+                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, deliveredMessage));
                     if (deliveredMessage != beforeHorniness)
                     {
@@ -958,7 +965,7 @@ namespace Pinder.Core.Conversation
                             string beforeShadow = deliveredMessage;
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionStarted));
                             deliveredMessage = await _llm.ApplyShadowCorruptionAsync(
-                                deliveredMessage, corruptionInstruction, pairedShadow.Value).ConfigureAwait(false);
+                                deliveredMessage, corruptionInstruction, pairedShadow.Value, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionCompleted, deliveredMessage));
                             if (deliveredMessage != beforeShadow)
                             {

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -75,7 +75,7 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Returns the message unchanged (no LLM overlay in test mode).
         /// </summary>
-        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }
@@ -83,7 +83,7 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Returns the message unchanged (no shadow corruption in test mode).
         /// </summary>
-        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -39,7 +39,12 @@ namespace Pinder.Core.Interfaces
         /// Returns the modified message text.
         /// </summary>
         /// <param name="opponentContext">Optional compact opponent context (name, bio, items) to ground the overlay.</param>
-        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null);
+        /// <param name="archetypeDirective">
+        /// Optional active archetype directive for the speaking character
+        /// (e.g. <c>"ACTIVE ARCHETYPE: The Peacock (clear)\n..."</c>) so the
+        /// overlay rewrite respects the character's voice (#372).
+        /// </param>
+        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null);
 
         /// <summary>
         /// Apply a shadow corruption instruction to a delivered message.
@@ -47,6 +52,10 @@ namespace Pinder.Core.Interfaces
         /// the message is rewritten to show the corruption bleeding through.
         /// Returns the corrupted message text.
         /// </summary>
-        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow);
+        /// <param name="archetypeDirective">
+        /// Optional active archetype directive for the speaking character so
+        /// the corrupted rewrite still sounds like the character (#372).
+        /// </param>
+        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null);
     }
 }

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -267,20 +267,20 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Apply a horniness overlay to a delivered message by calling the LLM.
         /// Routes to Groq when OverlayGroqModel and OverlayGroqApiKey are configured.
         /// </summary>
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
                     .ConfigureAwait(false);
             }
             return await AnthropicOverlayApplier.ApplyHorninessOverlayAsync(
-                _client, _options, message, instruction, opponentContext).ConfigureAwait(false);
+                _client, _options, message, instruction, opponentContext, archetypeDirective).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -291,7 +291,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 "Now the character's shadow stat is corrupting it further. " +
                 "Return ONLY the corrupted message text. No commentary, no preamble, no refusals.";
 
-            string userContent = $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // shadow-corrupted rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nSHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above) and return the modified message."
+                : $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
 
             try
             {

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
@@ -18,7 +18,8 @@ namespace Pinder.LlmAdapters.Anthropic
             AnthropicOptions options,
             string message,
             string instruction,
-            string? opponentContext = null)
+            string? opponentContext = null,
+            string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -35,7 +36,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 new ContentBlock { Type = "text", Text = systemPrompt }
             };
 
-            string userContent = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
 
             var request = AnthropicRequestBuilders.BuildMessagesRequest(
                 options.Model,

--- a/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
+++ b/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Characters;
+using YamlDotNet.RepresentationModel;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Loads <c>archetypes-enriched.yaml</c> at startup and registers each
+    /// archetype's <c>behavior</c> string with <see cref="ArchetypeCatalog"/>
+    /// so the LLM directive ("ACTIVE ARCHETYPE: ...") is sourced from the
+    /// canonical YAML rather than from hand-copied literals in
+    /// <see cref="ArchetypeCatalog"/>'s static initialiser (#372).
+    ///
+    /// <para>
+    /// The YAML structure is a flat list of section blocks; each archetype is
+    /// a block with <c>type: archetype_definition</c>, a <c>title</c> field
+    /// (e.g. <c>"The Peacock"</c>), and a <c>behavior</c> field (the multi-line
+    /// behavioural-instruction text).
+    /// </para>
+    ///
+    /// <para>
+    /// The hardcoded behaviour strings in <see cref="ArchetypeCatalog"/>'s
+    /// static initialiser remain as a degraded-mode fallback. If the YAML file
+    /// is missing, fails to parse, or lacks an entry for a given archetype,
+    /// the catalog falls back to the hand-copied literal (still better than
+    /// the bare placeholder <c>"Follow {Name} behavioral pattern."</c>).
+    /// </para>
+    /// </summary>
+    public static class ArchetypeYamlLoader
+    {
+        /// <summary>
+        /// Result of a load operation. Useful for logging at startup.
+        /// </summary>
+        public sealed class LoadResult
+        {
+            /// <summary>Number of (title, behavior) pairs registered with the catalog.</summary>
+            public int Registered { get; }
+
+            /// <summary>Names of archetype blocks skipped because they had no <c>behavior</c> text.</summary>
+            public IReadOnlyList<string> SkippedMissingBehavior { get; }
+
+            /// <summary>Error message when the YAML failed to parse, or null on success.</summary>
+            public string? Error { get; }
+
+            public LoadResult(int registered, IReadOnlyList<string> skippedMissingBehavior, string? error)
+            {
+                Registered = registered;
+                SkippedMissingBehavior = skippedMissingBehavior ?? Array.Empty<string>();
+                Error = error;
+            }
+        }
+
+        /// <summary>
+        /// Parse the supplied YAML text and register every archetype's
+        /// behaviour with <see cref="ArchetypeCatalog.RegisterBehavior"/>.
+        /// On any parse failure returns a <see cref="LoadResult"/> with
+        /// <c>Error</c> populated and <c>Registered = 0</c>; the catalog is
+        /// not modified in that case (callers should log the error so the
+        /// degraded fallback is visible).
+        /// </summary>
+        /// <param name="yamlContent">Full text of <c>archetypes-enriched.yaml</c>.</param>
+        /// <returns>Load summary.</returns>
+        public static LoadResult LoadFromYaml(string yamlContent)
+        {
+            if (string.IsNullOrWhiteSpace(yamlContent))
+                return new LoadResult(0, Array.Empty<string>(), "yaml content was empty");
+
+            int registered = 0;
+            var skipped = new List<string>();
+
+            try
+            {
+                var stream = new YamlStream();
+                using (var reader = new System.IO.StringReader(yamlContent))
+                    stream.Load(reader);
+
+                if (stream.Documents.Count == 0)
+                    return new LoadResult(0, skipped, "yaml had no documents");
+
+                if (!(stream.Documents[0].RootNode is YamlSequenceNode root))
+                    return new LoadResult(0, skipped, "yaml root was not a sequence");
+
+                foreach (var node in root.Children)
+                {
+                    if (!(node is YamlMappingNode block)) continue;
+
+                    string? type = GetScalar(block, "type");
+                    if (!string.Equals(type, "archetype_definition", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string? title = GetScalar(block, "title");
+                    string? behavior = GetScalar(block, "behavior");
+
+                    if (string.IsNullOrWhiteSpace(title))
+                        continue;
+
+                    if (string.IsNullOrWhiteSpace(behavior))
+                    {
+                        skipped.Add(title!);
+                        continue;
+                    }
+
+                    ArchetypeCatalog.RegisterBehavior(title!, behavior!);
+                    registered++;
+                }
+
+                return new LoadResult(registered, skipped, null);
+            }
+            catch (Exception ex)
+            {
+                return new LoadResult(0, skipped, ex.Message);
+            }
+        }
+
+        private static string? GetScalar(YamlMappingNode mapping, string key)
+        {
+            if (mapping.Children.TryGetValue(new YamlScalarNode(key), out var v) && v is YamlScalarNode scalar)
+                return scalar.Value;
+            return null;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -16,7 +16,8 @@ namespace Pinder.LlmAdapters.Groq
             string model,
             string message,
             string instruction,
-            string? opponentContext = null)
+            string? opponentContext = null,
+            string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -29,6 +30,12 @@ namespace Pinder.LlmAdapters.Groq
             if (!string.IsNullOrWhiteSpace(opponentContext))
                 systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
 
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+
             var payload = new
             {
                 model = model,
@@ -36,7 +43,7 @@ namespace Pinder.LlmAdapters.Groq
                 messages = new[]
                 {
                     new { role = "system", content = systemPrompt },
-                    new { role = "user", content = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message." }
+                    new { role = "user", content = userContent }
                 }
             };
 

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -431,13 +431,13 @@ namespace Pinder.LlmAdapters.OpenAi
         /// <summary>
         /// Apply a horniness overlay — returns input unchanged (OpenAI overlay not yet implemented).
         /// </summary>
-        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }
 
         /// <inheritdoc />
-        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             // Shadow corruption via OpenAI transport — returns input unchanged (not yet implemented).
             return Task.FromResult(message);

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -164,7 +164,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -173,7 +173,7 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
                     .ConfigureAwait(false);
             }
 
@@ -186,7 +186,12 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(opponentContext))
                 systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
 
-            string userContent = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice instead of
+            // collapsing to a generic horny rewrite.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
 
             try
             {
@@ -213,7 +218,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -224,7 +229,11 @@ namespace Pinder.LlmAdapters
                 "Now the character's shadow stat is corrupting it further. " +
                 "Return ONLY the corrupted message text. No commentary, no preamble, no refusals.";
 
-            string userContent = $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // shadow-corrupted rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nSHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above) and return the modified message."
+                : $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
 
             try
             {

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -179,6 +179,16 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine(deliveryTaint);
             }
 
+            // Inject active archetype directive (#372 / #375). Without this
+            // the delivery rewrite scrubs the archetype voice that the
+            // dialogue-options call already chose, leaving the actually-sent
+            // message generic.
+            if (!string.IsNullOrEmpty(context.ActiveArchetypeDirective))
+            {
+                sb.AppendLine();
+                sb.AppendLine(context.ActiveArchetypeDirective);
+            }
+
             sb.AppendLine();
 
             // Build roll context narrative from YAML or fallback

--- a/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
+++ b/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
@@ -24,10 +24,11 @@ namespace Pinder.Core.Tests
             // Act: level 4 — Peacock eligible (3-8), Sniper not (5-11)
             var result = CharacterAssembler.ResolveActiveArchetype(ranked, 4);
 
-            // Assert
+            // Assert: 5 / (5+3+2) = 0.50 → "clear" (#375 ratio rule).
             Assert.NotNull(result);
             Assert.Equal("The Peacock", result.Name);
             Assert.Equal(5, result.Count);
+            Assert.Equal(10, result.TotalCount);
             Assert.Equal("clear", result.InterferenceLevel);
         }
 
@@ -74,43 +75,75 @@ namespace Pinder.Core.Tests
             Assert.Equal("The Sniper", result.Name);
         }
 
+        // ── #375 ratio-based intensity tests ─────────────────────────────────────
+        // Intensity is now share-of-archetype-votes, not raw count, so a
+        // single-vote lead no longer gets "clear" or "dominant". The legacy
+        // single-arg ctor defaults TotalCount to Count, which gives ratio=1.0
+        // and therefore "dominant" — preserved for backward compatibility for
+        // callers that have not yet been migrated to pass totalCount.
+
         [Fact]
-        public void ActiveArchetype_InterferenceLevel_Slight()
+        public void ActiveArchetype_InterferenceLevel_LegacyCtor_DefaultsToDominant()
         {
+            // No total supplied → ratio = Count/Count = 1.0 → dominant.
+            // This preserves "always dominant" for callers that haven't
+            // migrated to pass totalCount, and keeps the public API
+            // source-compatible.
             var arch = new ActiveArchetype("Test", "behavior", 1);
-            Assert.Equal("slight", arch.InterferenceLevel);
-
-            arch = new ActiveArchetype("Test", "behavior", 2);
-            Assert.Equal("slight", arch.InterferenceLevel);
-        }
-
-        [Fact]
-        public void ActiveArchetype_InterferenceLevel_Clear()
-        {
-            var arch = new ActiveArchetype("Test", "behavior", 3);
-            Assert.Equal("clear", arch.InterferenceLevel);
-
-            arch = new ActiveArchetype("Test", "behavior", 5);
-            Assert.Equal("clear", arch.InterferenceLevel);
-        }
-
-        [Fact]
-        public void ActiveArchetype_InterferenceLevel_Dominant()
-        {
-            var arch = new ActiveArchetype("Test", "behavior", 6);
             Assert.Equal("dominant", arch.InterferenceLevel);
+            Assert.Equal(1, arch.TotalCount);
+        }
 
-            arch = new ActiveArchetype("Test", "behavior", 10);
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PunTroll2_Player1_IsClear()
+        {
+            // The #375 acceptance test: a 2-over-1 lead must NOT be "dominant".
+            // 2/3 = 0.67 → < 0.7 → "clear".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 2, totalCount: 3);
+            Assert.Equal("clear", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PunTroll4_Player1_IsDominant()
+        {
+            // The #375 acceptance test: a 4-over-1 lead IS "dominant".
+            // 4/5 = 0.80 → ≥ 0.7 → "dominant".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 4, totalCount: 5);
+            Assert.Equal("dominant", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_TiedBuild_IsClear()
+        {
+            // [Pun Troll: 2, Player: 2] → 2/4 = 0.50 → "clear" (tied lead).
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 2, totalCount: 4);
+            Assert.Equal("clear", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_OneVoiceAmongMany_IsSlight()
+        {
+            // 1/4 = 0.25 → < 0.4 → "slight".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 1, totalCount: 4);
+            Assert.Equal("slight", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PureBuild_IsDominant()
+        {
+            // 4/4 = 1.0 → "dominant" (a build that votes one archetype only).
+            var arch = new ActiveArchetype("The Peacock", "behavior", count: 4, totalCount: 4);
             Assert.Equal("dominant", arch.InterferenceLevel);
         }
 
         [Fact]
         public void ActiveArchetype_Directive_ContainsNameAndBehavior()
         {
-            var arch = new ActiveArchetype("The Peacock", "Shows off constantly.", 4);
+            // Build of 4 votes total, this archetype gets 4 → dominant.
+            var arch = new ActiveArchetype("The Peacock", "Shows off constantly.", count: 4, totalCount: 4);
             var directive = arch.Directive;
 
-            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", directive);
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (dominant)", directive);
             Assert.Contains("Shows off constantly.", directive);
         }
 

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -184,8 +184,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -56,8 +56,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 [Fact]

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -51,8 +51,8 @@ namespace Pinder.Core.Tests
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     [Trait("Category", "Core")]

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -22,8 +22,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => Task.FromResult(message);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -18,8 +18,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
@@ -40,8 +40,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -238,8 +238,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
@@ -315,8 +315,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -217,8 +217,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -208,8 +208,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -229,8 +229,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -173,8 +173,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -280,8 +280,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class ThrowingLlmAdapter : ILlmAdapter
@@ -297,8 +297,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StubTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -162,8 +162,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class TestClock : IGameClock

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -247,10 +247,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
     }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -751,8 +751,8 @@ namespace Pinder.Core.Tests.Integration
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -117,8 +117,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -278,8 +278,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -301,8 +301,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -254,8 +254,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -438,8 +438,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -170,9 +170,9 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
     }

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -271,10 +271,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -254,10 +254,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
             {
                 ShadowCorruptionCalled = true;
                 // Rewrite the message so a textDiff is emitted.

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -61,8 +61,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -191,10 +191,10 @@ namespace Pinder.Core.Tests
             public Task<string> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
 

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -433,8 +433,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>Null trap registry for tests.</summary>

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -650,8 +650,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1257,8 +1257,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that returns a Tell on the opponent's response for a specific stat.</summary>
@@ -1285,8 +1285,8 @@ namespace Pinder.Core.Tests
                     detectedTell: new Tell(_tellStat, $"Tell on {_tellStat}")));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
@@ -1308,8 +1308,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -640,8 +640,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -641,8 +641,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -716,8 +716,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
@@ -741,8 +741,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -787,8 +787,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -811,8 +811,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -333,8 +333,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -511,8 +511,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -55,8 +55,8 @@ namespace Pinder.Core.Tests
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     // ---------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -75,8 +75,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("reply"));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -422,8 +422,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -442,8 +442,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #372 / #375 \u2014 the active archetype directive must be injected into
+    /// the <c>delivery</c> LLM user prompt for any character with a non-null
+    /// ActiveArchetype. Before this fix, the directive only reached
+    /// <c>dialogue_options</c> + <c>opponent_response</c>, so the rewrite that
+    /// produces the actually-sent message scrubbed the archetype voice.
+    /// </summary>
+    [Trait("Category", "LlmAdapters")]
+    public class Issue372_ArchetypeDirectiveDeliveryTests
+    {
+        private const string SampleDirective =
+            "ACTIVE ARCHETYPE: The Peacock (clear)\nUses the opening message to establish status.";
+
+        private static DeliveryContext MakeDeliveryContext(
+            string activeArchetypeDirective = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 0)
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string Sender, string Text)>(),
+                opponentLastMessage: "",
+                chosenOption: new DialogueOption(StatType.Charm, "ok cool"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                playerName: "P",
+                opponentName: "O",
+                activeArchetypeDirective: activeArchetypeDirective);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_Success_ContainsActiveArchetypeDirective()
+        {
+            // Arrange
+            var ctx = MakeDeliveryContext(
+                activeArchetypeDirective: SampleDirective,
+                outcome: FailureTier.None,
+                beatDcBy: 7);
+
+            // Act
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+
+            // Assert
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", prompt);
+            Assert.Contains("Uses the opening message to establish status.", prompt);
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        [InlineData(FailureTier.Legendary)]
+        public void BuildDeliveryPrompt_Failure_ContainsActiveArchetypeDirective(FailureTier tier)
+        {
+            // Arrange
+            var ctx = MakeDeliveryContext(
+                activeArchetypeDirective: SampleDirective,
+                outcome: tier,
+                beatDcBy: -5);
+
+            // Act
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+
+            // Assert: directive must reach BOTH success and failure branches.
+            // Otherwise a Fumble/Catastrophe rewrite scrubs the archetype voice.
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", prompt);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_NullDirective_DoesNotInjectAnything()
+        {
+            var ctx = MakeDeliveryContext(activeArchetypeDirective: null, beatDcBy: 4);
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", prompt);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_EmptyDirective_DoesNotInjectAnything()
+        {
+            var ctx = MakeDeliveryContext(activeArchetypeDirective: "", beatDcBy: 4);
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", prompt);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeYamlLoaderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeYamlLoaderTests.cs
@@ -1,0 +1,69 @@
+using Pinder.Core.Characters;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #372 \u2014 ArchetypeYamlLoader must parse the canonical
+    /// <c>archetypes-enriched.yaml</c> structure and register every block of
+    /// <c>type: archetype_definition</c> into <see cref="ArchetypeCatalog"/>.
+    /// </summary>
+    [Trait("Category", "LlmAdapters")]
+    public class Issue372_ArchetypeYamlLoaderTests
+    {
+        private const string SampleYaml = @"- id: header
+  type: definition
+  title: Header
+- id: archetype.fake-troll-9999
+  type: archetype_definition
+  title: The Fake Troll 9999
+  behavior: |
+    Loves wordplay. Cannot let a sentence land without a pun retrofitted.
+    Self-applauding.
+- id: archetype.empty-9999
+  type: archetype_definition
+  title: The Empty 9999
+  behavior: ''
+- id: not-an-archetype-9999
+  type: definition
+  title: Other
+";
+
+        [Fact]
+        public void LoadFromYaml_RegistersBehaviorForEachArchetypeDefinition()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml(SampleYaml);
+
+            // Sanity: parsed without error
+            Assert.Null(result.Error);
+            Assert.Equal(1, result.Registered);
+            Assert.Single(result.SkippedMissingBehavior);
+            Assert.Equal("The Empty 9999", result.SkippedMissingBehavior[0]);
+
+            // The behaviour must now be retrievable from the catalog.
+            string behavior = ArchetypeCatalog.GetBehavior("The Fake Troll 9999");
+            Assert.Contains("Loves wordplay", behavior);
+
+            // The non-archetype block must NOT have been registered.
+            string headerBehavior = ArchetypeCatalog.GetBehavior("Header");
+            Assert.Contains("behavioral pattern", headerBehavior); // bare placeholder
+        }
+
+        [Fact]
+        public void LoadFromYaml_EmptyInput_ReturnsErrorAndDoesNotMutateCatalog()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml("");
+            Assert.NotNull(result.Error);
+            Assert.Equal(0, result.Registered);
+        }
+
+        [Fact]
+        public void LoadFromYaml_MalformedYaml_ReturnsErrorWithoutThrowing()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml("- id: incomplete\n  type: archetype_definition\n  title: [this is wrong\n  behavior: x");
+            Assert.NotNull(result.Error);
+            Assert.Equal(0, result.Registered);
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Companion to pinder-web W2b. This PR delivers the engine-side changes for two issues:

- **#372** — Archetype directive only reaches 2 of 7 LLM calls per turn; catalog hardcoded and incomplete
- **#375** — Inject archetype directive into the delivery LLM call + tighten intensity-tier computation

The pinder-web PR (TBD) bumps this submodule and wires the YAML loader into `Pinder.GameApi/Program.cs`. Merge order: this PR first, then the web PR.

## What's in this PR

### 1. Plumb the directive into more LLM calls (#372)

Before:
- ✅ `dialogue_options` — `BuildDialogueOptionsPrompt` injected directive
- ✅ `opponent_response` — `BuildOpponentPrompt` injected directive
- ❌ `delivery` — directive missing
- ❌ `horniness_overlay` — no archetype awareness
- ❌ `shadow_corruption` — no archetype awareness

After:
- `DeliveryContext` gains `ActiveArchetypeDirective` field. `GameSession.ResolveTurnAsync` populates from `_player.ActiveArchetype?.Directive`.
- `SessionDocumentBuilder.BuildDeliveryPrompt` injects it for **both** success and failure branches.
- `ILlmAdapter.ApplyHorninessOverlayAsync` and `ApplyShadowCorruptionAsync` gain a trailing optional `string? archetypeDirective = null` param. `GameSession` threads the same directive through both, so every LLM rewrite of the delivered message stays in the character's voice.
- All five overlay applier implementations (PinderLlmAdapter, AnthropicLlmAdapter, AnthropicOverlayApplier, GroqOverlayApplier, OpenAiLlmAdapter passthrough) lead with `ACTIVE ARCHETYPE: <Name> (<intensity>)\n<behavior>` in the user prompt with explicit "preserving the archetype voice above" framing.

`matchup_analysis` and `psychological_stake` are deliberately **out of scope** per the #372 issue body.

### 2. Tighten intensity-tier computation (#375)

Before: `InterferenceLevel` from raw count: 1-2 = slight, 3-5 = clear, 6+ = dominant. So `[Pun Troll: 2, Player: 1]` got "clear Pun Troll" even though Pun Troll only narrowly leads.

After: ratio-based.
| ratio | intensity |
|-------|-----------|
| ≥ 0.7 | dominant |
| ≥ 0.4 | clear |
| < 0.4 | slight |

`ActiveArchetype` gains an optional `totalCount` ctor param. The legacy single-arg ctor defaults `total = count` so source-compat is preserved (ratio = 1.0 → dominant). `CharacterAssembler.ResolveActiveArchetype` always passes the real total now.

Acceptance per #375:
- `[Pun Troll: 2, Player: 1]` → 2/3 = 0.67 → **clear** (no longer dominant)
- `[Pun Troll: 4, Player: 1]` → 4/5 = 0.80 → **dominant**

Threshold is 0.7, not the issue body's 0.6, because 0.6 makes `[Pun Troll: 2, Player: 1]` register as dominant — directly contradicting the AC the issue calls out. 0.7 satisfies both AC bullets.

### 3. YAML-driven catalog + missing-archetype audit (#372)

`ArchetypeCatalog` hardcoded behaviour text for 20 archetypes, and `rules/extracted/archetypes-enriched.yaml` was never loaded at runtime. New archetypes added to the YAML never reached the LLM directive.

- New `ArchetypeYamlLoader` (in `Pinder.LlmAdapters` — already has YamlDotNet): parses `archetype_definition` blocks and registers `(title → behavior)` via `ArchetypeCatalog.RegisterBehavior(...)`. Hardcoded fallback in `ArchetypeCatalog`'s static initialiser is preserved for degraded mode (missing/broken YAML).

- The actual `Program.cs` loader call lives in pinder-web (companion PR), wired to startup with `DataFileLocator` (#366 W1a pattern).

#### Catalog gap audit

Inventoried every archetype name referenced by `pinder-core/data/items/*.json` and `pinder-core/data/anatomy/*.json` (the ones the engine actually loads — `rules/extracted/*-enriched.yaml` is documentation only).

| Name | Action |
|------|--------|
| The 2AM Texter | **Added** to archetypes-enriched.yaml (Tier 3, level 3-9) |
| The Nice Guy | **Added** to archetypes-enriched.yaml (Tier 2, level 1-6) — distinct from "The Exploding Nice Guy" already in the catalog |
| The Pun Troll | **Added** to archetypes-enriched.yaml (Tier 2, level 2-8) |

Behaviour strings written in the existing archetype tone (sample lines + voice description, ~150 words each).

Three names now have real LLM-prompt behaviour text instead of the bare placeholder `"Follow {Name} behavioral pattern."`

## DoD Evidence

```
$ dotnet build
Build succeeded.
    87 Warning(s)    (all pre-existing nullability)
    0 Error(s)

$ dotnet test pinder-core/tests/Pinder.Core.Tests/ --filter ActiveArchetype
Passed!  - Failed:     0, Passed:    15, Skipped:     0, Total:    15

$ dotnet test pinder-core/tests/Pinder.LlmAdapters.Tests/ --filter "Issue372|ActiveArchetype"
Passed!  - Failed:     0, Passed:    11, Skipped:     0, Total:    11

$ dotnet test src/Pinder.GameApi.Tests/
Passed!  - Failed:     0, Passed:   411, Skipped:     0, Total:   411
```

(Pinder.Core.Tests has 7 pre-existing baseline failures unrelated to W2b — `CharacterLoaderSpecTests` self-skipping for missing `design/examples/` dir + `Issue527_SessionRunnerBioFormatTests`. Confirmed identical on baseline `main` via stash + replay.)

### Verifying the directive injection (#372 acceptance)

Inspect any `turn0-happy-005.json` fixture in pinder-web post-bump:

```
$ python3 -c "import json; d=json.load(open('turn0-happy-005.json')); print(d['request']['user_message'])" | grep -A3 'ACTIVE ARCHETYPE'
ACTIVE ARCHETYPE: The Philosopher (slight)
Opens with \"what do you think the meaning of life is?\" or a would-you-rather...
```

The delivery prompt now contains the directive — confirming AC #1.

## Research Log

| Topic | Source | Key finding |
|-------|--------|-------------|
| YamlDotNet 16.3 RepresentationModel | https://github.com/aaubry/YamlDotNet/wiki | `YamlStream.Load(reader)` + `YamlMappingNode` / `YamlSequenceNode` is the right shape for traversing a list-of-mappings YAML doc; tried this rather than typed deserialization because the YAML has many block types and we only care about `type: archetype_definition`. |
| Lessons §13 (cross-repo commit ordering) | LESSONS_LEARNED.md | Commit + push pinder-core first; THEN `git add pinder-core && git commit` in pinder-web; never `git submodule update` between. Followed exactly. |
| Lessons §5/§9 (worktree isolation) | LESSONS_LEARNED.md | Worked entirely in `/tmp/work-W2b` worktree, never touched `/root/projects/pinder-web`. |
| W1a DataFileLocator pattern | `Pinder.GameApi/Services/DataFileLocator.cs` (#366) | Reused verbatim for archetype YAML lookup so dev (walks up to repo root) and prod (Data/ next to binary) both resolve. |
| #375 issue body's threshold prose vs. AC | https://github.com/decay256/pinder-web/issues/375 | Issue body says `≥ 0.6 → dominant` but the AC says `[Pun Troll: 2, Player: 1] → clear` (which is 2/3 = 0.67, ≥ 0.6 → dominant under the issue's own rule). Honoured the AC over the prose: threshold is 0.7. Documented in code + commit message. |
