### PR TITLE
fix(W2a): trap mechanic redesign — single slot, 3-turn duration, SA-disarm-on-selection (#371)

### DIFF
--- a/data/traps/traps.json
+++ b/data/traps/traps.json
@@ -6,9 +6,9 @@
     "stat": "charm",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "You are aware of how you're coming across, which is making it worse. Every message is slightly over-explained or self-undermined. The more you try to be charming, the harder you try.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -18,9 +18,9 @@
     "stat": "rizz",
     "effect": "stat_penalty",
     "effect_value": 2,
-    "duration_turns": 2,
+    "duration_turns": 3,
     "llm_instruction": "Inject a subtle 'agenda' quality into ALL generated messages. On success: one line that could be read two ways. On failure: the entire message feels like it's leading somewhere uncomfortable.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -30,9 +30,9 @@
     "stat": "honesty",
     "effect": "opponent_dc_increase",
     "effect_value": 2,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject an accidental personal detail into ALL generated messages regardless of stat. On success: one parenthetical or aside that reveals something private. On failure: multiple personal details intrude and derail the message.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -42,9 +42,9 @@
     "stat": "chaos",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject momentum/acceleration into ALL generated messages. On success: one extra clause or tangent at the end that wasn't planned. On failure: the message progressively derails, starting controlled and ending somewhere completely different.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -54,9 +54,9 @@
     "stat": "wit",
     "effect": "opponent_dc_increase",
     "effect_value": 3,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject a condescending or over-explanatory quality into ALL generated messages. On success: one unnecessary clarification or reference. On failure: the message becomes pedagogical — explaining things the opponent didn't ask about.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -66,9 +66,9 @@
     "stat": "self_awareness",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 2,
+    "duration_turns": 3,
     "llm_instruction": "While this trap is active, inject meta-commentary into ALL generated messages. On success: one aside that acknowledges the conversation dynamic. On failure: the character narrates their own failure, creating a recursive self-awareness loop.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   }
 ]

--- a/rules/extracted/traps-enriched.yaml
+++ b/rules/extracted/traps-enriched.yaml
@@ -20,18 +20,19 @@
   type: interest_change
   blocks:
   - kind: paragraph
-    text: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 1–2 turns (defined per trap).  \n**Effect:** Two layers:\n1. **Mechanical**\
+    text: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 3 turns (fixed for all traps; activation turn counts as turn 1 of 3).  \n**Effect:** Two layers:\n1. **Mechanical**\
       \ — disadvantage on the triggering stat, or opponent's defense stat boosted\n2. **Prompt taint** — `llm_instruction` injected into the character system prompt for the duration; taints all generated\
       \ messages regardless of what stat is being rolled"
   - kind: paragraph
-    text: '**Clearing a trap:** Spend a turn on a Self-Awareness recovery roll (DC 12). Costs −1 Interest and the turn. The trap remains active until either the roll succeeds or duration expires.'
+    text: '**Disarm:** selecting any SA-stat option disarms the active trap immediately, before the SA roll resolves. Disarm fires regardless of whether the SA roll succeeds. A failed SA roll then triggers Spiral as the new active trap (this turn is Spiral''s turn 1 of 3, taint via roll-modification, no separate trap LLM call this turn).'
   - kind: paragraph
-    text: '**Stacking:** Multiple active traps stack. Each injects its `llm_instruction` independently. A character with The Cringe and The Spiral active is simultaneously try-hard and narrating their own
-      try-hardness.'
+    text: '**Single slot:** a newly activated trap replaces the currently active trap. Old trap''s remaining turns are discarded. The new trap''s first corruption turn IS the activation turn (taint via roll-modification, no separate trap LLM call).'
+  - kind: paragraph
+    text: '**Stacking:** single slot only; new activation replaces. Traps do not stack.'
   - kind: paragraph
     text: '**Nat 1 bonus:** Rolling a natural 1 on any roll while a trap is active escalates the trap''s DC modifier and adds a shadow stat bonus.'
   - kind: hr
-  description: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 1–2 turns (defined per trap).  \n**Effect:** Two layers:\n1. **Mechanical**\
+  description: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 3 turns (fixed for all traps; activation turn counts as turn 1 of 3).  \n**Effect:** Two layers:\n1. **Mechanical**\
     \ — disadvantage on the triggering stat, or opponent's defense stat boosted\n2. **Prompt taint** — `llm_instruction` injected into the character system prompt for the duration; taints all generated\
     \ messages regardless of what stat is being rolled"
   heading_level: 2
@@ -41,7 +42,7 @@
     - 9
   outcome:
     trap: true
-    duration_turns: 1
+    duration_turns: 3
 - id: §2.trap-reference
   section: §2
   title: Trap Reference
@@ -54,7 +55,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Charm miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Charm miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Everything sounds slightly try-hard. Compliments feel rehearsed. Humor has a "please laugh" energy. Even a successful Wit line has an aftertaste of desperation.'
   - kind: table
@@ -72,7 +73,7 @@
   - kind: blockquote
     text: "*\"Your smooth line landed like a pickup artist at a poetry reading. The emoji made it worse.\"*  \n*Expiry: \"The cringe fades. You can look at your own messages again without wincing.\"*"
   - kind: hr
-  description: "**Triggered by:** Charm miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Charm miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -80,7 +81,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-cringe
-    duration_turns: 1
+    duration_turns: 3
     effect: disadvantage
     stat: Charm
 - id: §2.the-creep
@@ -89,7 +90,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Bold statements read as loaded. Innocent questions sound like they have an agenda. Even a kind Charm message feels like it''s building toward something uncomfortable.'
   - kind: table
@@ -108,7 +109,7 @@
     text: "*\"Your bold move didn't read as confident. It read as desperate. They visibly recoiled.\"*  \n*Expiry: \"The creep factor subsides. Your messages stop sounding like they have a hidden agenda.\"\
       *"
   - kind: hr
-  description: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -116,7 +117,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-creep
-    duration_turns: 2
+    duration_turns: 3
     effect: stat_penalty
     stat: Rizz
     effect_value: -2
@@ -126,8 +127,8 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced for\
-      \ more chaos from you)  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced for\
+      \ more chaos from you)  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Personal details leak into unrelated topics. A Wit message about mycelium accidentally includes a confession. A Charm compliment trails off into a memory. You can''t keep the
       personal stuff contained.'
@@ -147,8 +148,8 @@
     text: "*\"You meant to share one thing. You shared everything. The divorce. The therapist. The Costco membership. Steve.\"*  \n*Expiry: \"The overshare impulse subsides. You can hold a thought without\
       \ it trailing into confession.\"*"
   - kind: hr
-  description: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced\
-    \ for more chaos from you)  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced\
+    \ for more chaos from you)  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -156,7 +157,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-overshare
-    duration_turns: 1
+    duration_turns: 3
     effect: opponent_dc_increase
     stat: Chaos
     effect_value: 2
@@ -166,7 +167,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Structured thoughts derail mid-sentence. Tangents intrude. Even a careful recovery message accelerates into unexpected territory. Bullet points become manifestos.'
   - kind: table
@@ -185,7 +186,7 @@
     text: "*\"Your random humor wasn't random-fun. It was random-concerning. They're reconsidering this match.\"*  \n*Expiry: \"The manic energy subsides. Your thoughts stop accelerating past your ability\
       \ to type them.\"*"
   - kind: hr
-  description: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -193,7 +194,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-unhinged
-    duration_turns: 1
+    duration_turns: 3
     effect: disadvantage
     stat: Chaos
 - id: §2.the-pretentious
@@ -202,8 +203,8 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Wit miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n**Clears:**\
-      \ Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Wit miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n**Clears:**\
+      \ Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Condescension leaks in everywhere. References feel like showing off. A Rizz line sounds like a TED talk. An Honesty moment sounds like a lecture. You can''t stop explaining.'
   - kind: table
@@ -222,8 +223,8 @@
     text: "*\"You tried clever. You got condescending. There may be a TED talk reference. There was definitely a TED talk reference.\"*  \n*Expiry: \"The urge to explain subsides. You can make a point without\
       \ citing a source.\"*"
   - kind: hr
-  description: "**Triggered by:** Wit miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n\
-    **Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Wit miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n\
+    **Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -231,7 +232,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-pretentious
-    duration_turns: 1
+    duration_turns: 3
     effect: opponent_dc_increase
     stat: Rizz
     effect_value: 3
@@ -241,8 +242,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest,\
-      \ uses turn)"
+    text: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Meta-commentary intrudes. You narrate your own behaviour mid-message. A Charm attempt includes "I''m trying to be charming right now and I can feel it not working." Self-awareness
       becomes self-sabotage.'
@@ -262,8 +262,7 @@
     text: "*\"You started acknowledging the awkwardness and couldn't stop. You narrated your own failure. In real time. For three messages.\"*  \n*Expiry: \"The meta-loop breaks. You can say things without\
       \ immediately analyzing why you said them.\"*"
   - kind: hr
-  description: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest,\
-    \ uses turn)"
+  description: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -271,7 +270,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-spiral
-    duration_turns: 2
+    duration_turns: 3
     effect: disadvantage
     stat: Self-Awareness
 - id: §3.trap-summary-table
@@ -283,32 +282,32 @@
     rows:
     - Trap: The Cringe
       Stat: Charm
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Disadvantage on Charm
       Taint quality: Try-hard energy
     - Trap: The Creep
       Stat: Rizz
-      Duration: 2 turns
+      Duration: 3 turns
       Mechanical effect: −2 Rizz rolls
       Taint quality: Hidden agenda
     - Trap: The Overshare
       Stat: Honesty
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Opponent Chaos +2
       Taint quality: Personal details leak
     - Trap: The Unhinged
       Stat: Chaos
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Disadvantage on Chaos
       Taint quality: Message accelerates/derails
     - Trap: The Pretentious
       Stat: Wit
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Opponent Rizz +3
       Taint quality: Condescension / over-explains
     - Trap: The Spiral
       Stat: Self-Awareness
-      Duration: 2 turns
+      Duration: 3 turns
       Mechanical effect: Disadvantage on S-Awr
       Taint quality: Meta-commentary
     sep_cells:
@@ -318,7 +317,7 @@
     - '---'
     - '---'
   - kind: blockquote
-    text: 'All traps share the same clear method: Self-Awareness recovery roll, DC 12, −1 Interest, costs turn.'
+    text: 'All traps share the same clear method: pick any Self-Awareness option (selection disarms; SA fail triggers Spiral). The disarm fires on selection, before the SA roll resolves. Single slot — a newly activated trap replaces the currently active trap.'
   - kind: hr
   description: ''
   heading_level: 2

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -340,7 +340,11 @@ namespace Pinder.Core.Conversation
             {
                 foreach (var (statName, turnsRemaining) in data.ActiveTraps)
                 {
-                    if (Enum.TryParse<StatType>(statName, out var stat))
+                    // #369: parse case-insensitively. Snapshots have historically
+                    // stored stat names in lowercase ("selfawareness") in some
+                    // environments and TitleCase ("SelfAwareness") in others.
+                    // The TrapState round-trip must survive both.
+                    if (Enum.TryParse<StatType>(statName, ignoreCase: true, out var stat))
                     {
                         var definition = trapRegistry.GetTrap(stat);
                         if (definition != null)
@@ -567,6 +571,21 @@ namespace Pinder.Core.Conversation
             }
 
             var chosenOption = _currentOptions[optionIndex];
+
+            // ---- Trap SA-disarm (issue #371) ----
+            // When the chosen option's stat is Self-Awareness AND a trap is active,
+            // the trap is disarmed IMMEDIATELY — BEFORE the SA roll resolves and
+            // before any text-modification pipeline runs. The cleared trap does NOT
+            // corrupt this turn's message. If the SA roll subsequently fails, the
+            // failure tier may activate Spiral as a fresh trap (its turn 1 of 3 is
+            // this turn, taint via the failure-tier rewrite — no separate trap LLM
+            // call this turn).
+            string? trapClearedDisplayName = null;
+            if (chosenOption.Stat == StatType.SelfAwareness && _traps.HasActive)
+            {
+                trapClearedDisplayName = _traps.Active!.Definition.DisplayName;
+                _traps.Clear();
+            }
 
             // Denial +1 when Honesty was available but player chose a different stat (#272 — §7)
             if (_playerShadows != null
@@ -875,6 +894,47 @@ namespace Pinder.Core.Conversation
                 textDiffs.Add(new TextDiff(layerLabel, tierSpans, intendedTextForDelivery, deliveredMessage));
             }
 
+            // ---- Trap LLM overlay (issue #371) ----
+            // Fires only on PERSISTENCE turns: when a trap is currently active AND
+            // it was NOT activated this turn. The activation turn (turn 1 of 3) is
+            // already tainted by the failure-tier rewrite above, so adding the trap
+            // overlay on top would double-corrupt the message.
+            //
+            // Path mapping (final spec, see #371 latest comment):
+            //   - SA picked, trap was active → disarmed at start; _traps.HasActive
+            //     is false here UNLESS the SA roll just failed and re-activated
+            //     Spiral as a NEW trap (rollResult.ActivatedTrap != null). That's
+            //     the activation case — skip the overlay.
+            //   - Non-SA picked, trap persisting → _traps.HasActive AND
+            //     rollResult.ActivatedTrap is null. FIRE the overlay.
+            //   - Non-SA picked, roll just activated a fresh trap (replacing or
+            //     adding) → rollResult.ActivatedTrap != null. Skip the overlay
+            //     (this turn is the new trap's turn 1 of 3).
+            if (_traps.HasActive && rollResult.ActivatedTrap == null)
+            {
+                var activeTrap = _traps.Active!;
+                string trapInstruction = activeTrap.Definition.LlmInstruction;
+                string trapDisplayName = activeTrap.Definition.DisplayName;
+                if (!string.IsNullOrWhiteSpace(trapInstruction)
+                    && !string.IsNullOrEmpty(deliveredMessage)
+                    && deliveredMessage != "...")
+                {
+                    string beforeTrap = deliveredMessage;
+                    string opponentCtxForTrap = BuildOpponentContext(_opponent);
+                    progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayStarted));
+                    deliveredMessage = await _llm.ApplyTrapOverlayAsync(
+                        deliveredMessage, trapInstruction, trapDisplayName, opponentCtxForTrap)
+                        .ConfigureAwait(false);
+                    progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayCompleted, deliveredMessage));
+                    if (deliveredMessage != beforeTrap)
+                    {
+                        var trapSpans = WordDiff.Compute(beforeTrap, deliveredMessage);
+                        textDiffs.Add(new TextDiff(
+                            $"Trap ({trapDisplayName})", trapSpans, beforeTrap, deliveredMessage));
+                    }
+                }
+            }
+
             // 9. Check interest threshold crossing → narrative beat
             string? narrativeBeat = null;
             if (stateBefore != stateAfter)
@@ -1070,16 +1130,14 @@ namespace Pinder.Core.Conversation
             // 12. Append opponent message to history
             _history.Add((_opponent.DisplayName, opponentMessage));
 
-            // SA trap clear: SA success vs DC 12 clears oldest active trap (rules §clear)
-            if (chosenOption.Stat == StatType.SelfAwareness
-                && rollResult.IsSuccess
-                && rollResult.FinalTotal >= 12
-                && _traps.HasActive)
-            {
-                _traps.ClearOldest();
-            }
-
-            // 12b. Advance trap timers
+            // 12b. Advance trap timer (single-slot model). Decrements TurnsRemaining
+            // for the active trap (if any) and removes it when it reaches 0.
+            // Per #371: traps activated this turn (rollResult.ActivatedTrap)
+            // start at TurnsRemaining=3 — this AdvanceTurn brings them to 2,
+            // because the activation turn counts as turn 1 of 3.
+            // SA-disarm (handled at the top of this method) clears the trap before
+            // the pipeline runs, so AdvanceTurn here only ticks down a NEW trap if
+            // one was activated by the roll, OR a persisting trap on a non-SA pick.
             _traps.AdvanceTurn();
 
             // 13. Increment turn number
@@ -1117,7 +1175,8 @@ namespace Pinder.Core.Conversation
                 horninessInterestPenalty: horninessInterestPenalty,
                 horninessInterestBefore: horninessInterestBefore,
                 textDiffs: textDiffs.Count > 0 ? textDiffs : null,
-                shadowCheck: shadowCheckResult);
+                shadowCheck: shadowCheckResult,
+                trapClearedDisplayName: trapClearedDisplayName);
         }
 
         /// <summary>
@@ -1195,7 +1254,12 @@ namespace Pinder.Core.Conversation
             return ShadowThresholdEvaluator.GetThresholdLevel(shadowValue);
         }
 
-        private GameStateSnapshot CreateSnapshot()
+        /// <summary>
+        /// Build a fresh <see cref="GameStateSnapshot"/> for the current session state.
+        /// Public so test/debug code can observe restored or mid-flight state without
+        /// running a turn (e.g. the W2a #371 RestoreState round-trip tests).
+        /// </summary>
+        public GameStateSnapshot CreateSnapshot()
         {
             return GameSessionHelpers.CreateSnapshot(
                 _interest,

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -87,5 +87,15 @@ namespace Pinder.Core.Conversation
         {
             return Task.FromResult(message);
         }
+
+        /// <summary>
+        /// Returns the message unchanged (no trap overlay in test mode).
+        /// Used by the deterministic test harness so engine flow can be exercised
+        /// without an actual LLM round-trip.
+        /// </summary>
+        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+        {
+            return Task.FromResult(message);
+        }
     }
 }

--- a/src/Pinder.Core/Conversation/TurnProgress.cs
+++ b/src/Pinder.Core/Conversation/TurnProgress.cs
@@ -32,6 +32,12 @@ namespace Pinder.Core.Conversation
         /// <summary>Shadow corruption LLM returned; Text carries the rewritten message.</summary>
         ShadowCorruptionCompleted,
 
+        /// <summary>Trap overlay LLM call is about to run (issue #371; persistence turns only).</summary>
+        TrapOverlayStarted,
+
+        /// <summary>Trap overlay LLM returned; Text carries the rewritten message.</summary>
+        TrapOverlayCompleted,
+
         /// <summary>About to call the opponent-response LLM.</summary>
         OpponentResponseStarted,
 

--- a/src/Pinder.Core/Conversation/TurnResult.cs
+++ b/src/Pinder.Core/Conversation/TurnResult.cs
@@ -105,6 +105,14 @@ namespace Pinder.Core.Conversation
         /// <summary>Word-level diffs for each text transform layer that changed the message.</summary>
         public IReadOnlyList<TextDiff> TextDiffs { get; }
 
+        /// <summary>
+        /// Display name of the trap that was disarmed at the start of this turn
+        /// by the player selecting a Self-Awareness option (issue #371). Null when
+        /// no SA-disarm fired (no trap was active, or chosen option was not SA).
+        /// The frontend uses this signal to show a "Trap cleared" toast/event.
+        /// </summary>
+        public string? TrapClearedDisplayName { get; }
+
         public TurnResult(
             RollResult roll,
             string deliveredMessage,
@@ -131,7 +139,8 @@ namespace Pinder.Core.Conversation
             int horninessInterestPenalty = 0,
             int horninessInterestBefore = 0,
             IReadOnlyList<TextDiff>? textDiffs = null,
-            ShadowCheckResult shadowCheck = null)
+            ShadowCheckResult shadowCheck = null,
+            string? trapClearedDisplayName = null)
         {
             Roll = roll ?? throw new ArgumentNullException(nameof(roll));
             DeliveredMessage = deliveredMessage ?? throw new ArgumentNullException(nameof(deliveredMessage));
@@ -159,6 +168,7 @@ namespace Pinder.Core.Conversation
             HorninessInterestBefore = horninessInterestBefore;
             TextDiffs = textDiffs ?? Array.Empty<TextDiff>();
             ShadowCheck = shadowCheck ?? ShadowCheckResult.NotPerformed;
+            TrapClearedDisplayName = trapClearedDisplayName;
         }
     }
 }

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -48,5 +48,20 @@ namespace Pinder.Core.Interfaces
         /// Returns the corrupted message text.
         /// </summary>
         Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow);
+
+        /// <summary>
+        /// Apply a trap overlay to a delivered message (issue #371). Called on
+        /// trap PERSISTENCE turns (turn 2 or 3 of an active trap) for non-SA
+        /// option picks where the roll did not activate a fresh trap. The trap's
+        /// llm_instruction is used to rewrite the post-roll-modification message,
+        /// adding the trap's signature taint on top of the tier rewrite. Activation
+        /// turns are NOT routed through this method — their taint comes from the
+        /// failure-tier rewrite. Returns the modified message text.
+        /// </summary>
+        /// <param name="message">The current delivered message (post roll modification).</param>
+        /// <param name="trapInstruction">The active trap's <c>llm_instruction</c>.</param>
+        /// <param name="trapName">Display name of the active trap (used for logging / refusal-detection labelling).</param>
+        /// <param name="opponentContext">Optional compact opponent context (name, bio, items) to ground the overlay.</param>
+        Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null);
     }
 }

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -35,6 +35,14 @@ namespace Pinder.Core.Interfaces
         /// <summary>Shadow-stat corruption rewrite of a delivered message.</summary>
         public const string ShadowCorruption = "shadow_corruption";
 
+        /// <summary>
+        /// Trap overlay rewrite of a delivered message (#371). Fires only on
+        /// turns 2 and 3 of an active trap (the activation turn's taint is the
+        /// roll-modification, not a separate overlay). Adds a `Trap (X)`
+        /// text-diff layer when the rewrite changes the message.
+        /// </summary>
+        public const string TrapOverlay = "trap_overlay";
+
         /// <summary>Session-setup matchup analysis.</summary>
         public const string MatchupAnalysis = "matchup_analysis";
 

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -164,16 +164,18 @@ namespace Pinder.Core.Rolls
             int total = usedRoll + statMod + levelBonus;
             int finalTotal = total + externalBonus;
 
+            // Per #371 (W2a): single-slot trap state. Trap-activating failure tiers
+            // (Legendary / TropeTrap / Catastrophe) ALWAYS activate the stat's trap
+            // when the roll trips that tier — the new activation REPLACES whatever
+            // was active (single-slot rule). This is a behaviour change from the prior
+            // "only activate if not already active on this stat" guard.
             if (usedRoll == 1)
             {
                 tier = FailureTier.Legendary;
                 // Nat 1 activates a trap (rules: Legendary fail = trap)
-                if (!attackerTraps.IsActive(stat))
-                {
-                    newTrap = trapRegistry.GetTrap(stat);
-                    if (newTrap != null)
-                        attackerTraps.Activate(newTrap);
-                }
+                newTrap = trapRegistry.GetTrap(stat);
+                if (newTrap != null)
+                    attackerTraps.Activate(newTrap);
             }
             else if (usedRoll == 20 || finalTotal >= dc)
             {
@@ -188,24 +190,19 @@ namespace Pinder.Core.Rolls
                 else if (miss <= 9)
                 {
                     tier = FailureTier.TropeTrap;
-                    // Activate trap if one is defined and not already active on this stat
-                    if (!attackerTraps.IsActive(stat))
-                    {
-                        newTrap = trapRegistry.GetTrap(stat);
-                        if (newTrap != null)
-                            attackerTraps.Activate(newTrap);
-                    }
+                    // Activate the stat's trap (single-slot replacement, #371).
+                    newTrap = trapRegistry.GetTrap(stat);
+                    if (newTrap != null)
+                        attackerTraps.Activate(newTrap);
                 }
                 else
                 {
                     tier = FailureTier.Catastrophe;
-                    // Catastrophe also activates trap (rules §5: miss 10+ = -3 + trap)
-                    if (!attackerTraps.IsActive(stat))
-                    {
-                        newTrap = trapRegistry.GetTrap(stat);
-                        if (newTrap != null)
-                            attackerTraps.Activate(newTrap);
-                    }
+                    // Catastrophe also activates trap (rules §5: miss 10+ = -3 + trap).
+                    // Single-slot replacement under #371.
+                    newTrap = trapRegistry.GetTrap(stat);
+                    if (newTrap != null)
+                        attackerTraps.Activate(newTrap);
                 }
             }
 

--- a/src/Pinder.Core/Traps/TrapState.cs
+++ b/src/Pinder.Core/Traps/TrapState.cs
@@ -4,20 +4,44 @@ using System.Collections.Generic;
 namespace Pinder.Core.Traps
 {
     /// <summary>
-    /// Tracks currently active traps for a character in a conversation.
-    /// Traps persist across turns and taint ALL messages, not just the trapped stat.
+    /// Tracks the currently active trap for a character in a conversation.
+    ///
+    /// Single-slot design (issue #371 redesign): at most one trap is active at
+    /// any time. Activating a new trap REPLACES the existing one — traps no
+    /// longer stack. Every trap has a fixed 3-turn duration and self-deletes
+    /// after affecting the third turn.
+    ///
+    /// Per-stat lookup methods (<see cref="IsActive"/>, <see cref="GetActive"/>)
+    /// are preserved for the existing call sites in <c>RollEngine</c> — they
+    /// return state for the single active trap iff its stat matches.
     /// </summary>
     public sealed class TrapState
     {
-        private readonly Dictionary<StatType, ActiveTrap> _active = new Dictionary<StatType, ActiveTrap>();
+        // The fixed duration applied to every newly activated trap (#371).
+        // The activation turn counts as turn 1 of 3.
+        public const int FixedDurationTurns = 3;
+
+        private ActiveTrap? _active;
 
         /// <summary>True if any trap is currently active.</summary>
-        public bool HasActive => _active.Count > 0;
+        public bool HasActive => _active != null;
 
-        /// <summary>Activate a trap. Replaces an existing trap on the same stat.</summary>
+        /// <summary>The single active trap, or null when none is active.</summary>
+        public ActiveTrap? Active => _active;
+
+        /// <summary>
+        /// Returns the single active trap (or null when none is active).
+        /// Convenience accessor used by tests and by callers that don't care
+        /// which stat triggered the trap. Equivalent to <see cref="Active"/>.
+        /// </summary>
+        public ActiveTrap? Get() => _active;
+
+        /// <summary>Activate a trap. Replaces the existing active trap (if any).</summary>
         public void Activate(TrapDefinition definition)
         {
-            _active[definition.Stat] = new ActiveTrap(definition, definition.DurationTurns);
+            // Per #371: every trap is exactly 3 turns regardless of its
+            // declared duration_turns. The activation turn counts as turn 1 of 3.
+            _active = new ActiveTrap(definition, FixedDurationTurns);
         }
 
         /// <summary>
@@ -26,67 +50,70 @@ namespace Pinder.Core.Traps
         /// </summary>
         public void Activate(TrapDefinition definition, int turnsRemaining)
         {
-            _active[definition.Stat] = new ActiveTrap(definition, turnsRemaining);
+            _active = new ActiveTrap(definition, turnsRemaining);
         }
-
-        /// <summary>True if a trap is active on this stat.</summary>
-        public bool IsActive(StatType stat) => _active.ContainsKey(stat);
-
-        /// <summary>Returns the active trap for a stat, or null.</summary>
-        public ActiveTrap? GetActive(StatType stat)
-        {
-            _active.TryGetValue(stat, out var trap);
-            return trap;
-        }
-
-        /// <summary>All currently active traps (for LLM prompt taint assembly).</summary>
-        public IEnumerable<ActiveTrap> AllActive => _active.Values;
 
         /// <summary>
-        /// Advance all trap counters by one turn. Removes traps that have expired.
-        /// Call once at the end of each player turn.
+        /// True if a trap is active AND it was triggered by this stat.
+        /// (Single-slot model: at most one trap is active at a time.)
+        /// </summary>
+        public bool IsActive(StatType stat) => _active != null && _active.Definition.Stat == stat;
+
+        /// <summary>Returns the active trap iff its stat matches, else null.</summary>
+        public ActiveTrap? GetActive(StatType stat)
+        {
+            if (_active != null && _active.Definition.Stat == stat) return _active;
+            return null;
+        }
+
+        /// <summary>
+        /// All currently active traps. Single-slot: yields zero or one trap.
+        /// Kept as IEnumerable for backward compatibility with prompt-builder
+        /// and helper code that iterated the prior multi-slot collection.
+        /// </summary>
+        public IEnumerable<ActiveTrap> AllActive
+        {
+            get
+            {
+                if (_active != null) yield return _active;
+            }
+        }
+
+        /// <summary>
+        /// Advance the active trap's counter by one turn. Removes the trap
+        /// if it has reached zero. Call once at the end of each player turn
+        /// the trap's effects fired in (including the activation turn).
         /// </summary>
         public void AdvanceTurn()
         {
-            var toRemove = new List<StatType>();
-            foreach (var kv in _active)
-            {
-                kv.Value.DecrementTurn();
-                if (kv.Value.TurnsRemaining <= 0)
-                    toRemove.Add(kv.Key);
-            }
-            foreach (var key in toRemove)
-                _active.Remove(key);
+            if (_active == null) return;
+            _active.DecrementTurn();
+            if (_active.TurnsRemaining <= 0)
+                _active = null;
         }
-
-        /// <summary>Manually clear a trap (e.g. via clear method action).</summary>
-        public void Clear(StatType stat) => _active.Remove(stat);
-
-        /// <summary>Clear all traps.</summary>
-        public void ClearAll() => _active.Clear();
 
         /// <summary>
-        /// Clears the oldest active trap (the one with fewest turns remaining).
-        /// Used when SA roll succeeds vs DC 12 to allow a trap clear.
-        /// Does nothing if no traps are active.
+        /// Manually clear the active trap iff it matches the given stat.
+        /// Preserved for callers that target a specific stat. Single-slot model.
         /// </summary>
-        public void ClearOldest()
+        public void Clear(StatType stat)
         {
-            if (_active.Count == 0) return;
-
-            StatType? oldestKey = null;
-            int minTurns = int.MaxValue;
-            foreach (var kv in _active)
-            {
-                if (kv.Value.TurnsRemaining < minTurns)
-                {
-                    minTurns = kv.Value.TurnsRemaining;
-                    oldestKey = kv.Key;
-                }
-            }
-            if (oldestKey.HasValue)
-                _active.Remove(oldestKey.Value);
+            if (_active != null && _active.Definition.Stat == stat)
+                _active = null;
         }
+
+        /// <summary>Clear the active trap (if any) — used by SA disarm + RestoreState reset.</summary>
+        public void Clear() => _active = null;
+
+        /// <summary>Clear all traps. Equivalent to <see cref="Clear()"/> in the single-slot model.</summary>
+        public void ClearAll() => _active = null;
+
+        /// <summary>
+        /// Clears the oldest (== only) active trap. Preserved for backward
+        /// compatibility with #371's pre-redesign callers; in the single-slot
+        /// model this is identical to <see cref="Clear()"/>.
+        /// </summary>
+        public void ClearOldest() => _active = null;
     }
 
     /// <summary>

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -318,6 +318,58 @@ namespace Pinder.LlmAdapters.Anthropic
             }
         }
 
+        /// <summary>
+        /// Apply a trap overlay to a delivered message (issue #371). Routes to
+        /// Groq when configured; otherwise uses the Anthropic transport with the
+        /// trap-overlay system prompt. Returns the message unchanged on transport
+        /// failure or detected refusal.
+        /// </summary>
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
+            {
+                return await GroqOverlayApplier.ApplyTrapOverlayAsync(
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext)
+                    .ConfigureAwait(false);
+            }
+
+            string systemPrompt = "You are editing a text message for Pinder, a satirical comedy dating app. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the delivered message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no preamble, no refusals.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            string userContent = $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
+
+            try
+            {
+                var systemBlocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(systemPrompt);
+                var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                    _options.Model, _options.MaxTokens, systemBlocks, userContent,
+                    _options.DeliveryTemperature ?? 0.7);
+                var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+                var result = response.GetText()?.Trim();
+
+                if (string.IsNullOrWhiteSpace(result)) return message;
+
+                if (result.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    result.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    result.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return result;
+            }
+            catch
+            {
+                return message;
+            }
+        }
+
         // Backward-compatibility: expose static parse methods for tests
         // that reference AnthropicLlmAdapter.ParseDialogueOptions / ParseOpponentResponse
 

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -68,5 +68,69 @@ namespace Pinder.LlmAdapters.Groq
                 return message;
             }
         }
+
+        /// <summary>
+        /// Apply a trap overlay via the Groq overlay endpoint (issue #371).
+        /// Mirrors <see cref="ApplyHorninessOverlayAsync"/> but adds the trap name
+        /// to the prompt for grounding.
+        /// </summary>
+        public static async Task<string> ApplyTrapOverlayAsync(
+            string groqApiKey,
+            string model,
+            string message,
+            string trapInstruction,
+            string trapName,
+            string? opponentContext = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no refusals, no preamble.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            var payload = new
+            {
+                model = model,
+                max_tokens = 400,
+                messages = new[]
+                {
+                    new { role = "system", content = systemPrompt },
+                    new { role = "user", content = $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message." }
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.groq.com/openai/v1/chat/completions");
+            request.Headers.Add("Authorization", $"Bearer {groqApiKey}");
+            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await _http.SendAsync(request).ConfigureAwait(false);
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode) return message;
+
+                var json = JObject.Parse(body);
+                var text = json["choices"]?[0]?["message"]?["content"]?.Value<string>()?.Trim();
+
+                if (string.IsNullOrWhiteSpace(text)) return message;
+
+                if (text!.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    text.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    text.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return text;
+            }
+            catch
+            {
+                return message;
+            }
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -442,5 +442,15 @@ namespace Pinder.LlmAdapters.OpenAi
             // Shadow corruption via OpenAI transport — returns input unchanged (not yet implemented).
             return Task.FromResult(message);
         }
+
+        /// <summary>
+        /// Apply a trap overlay — returns input unchanged (OpenAI overlay not yet implemented).
+        /// Production deployments route trap overlays through <see cref="PinderLlmAdapter"/>; this
+        /// stub preserves the contract for non-overlay OpenAI adapter usage.
+        /// </summary>
+        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+        {
+            return Task.FromResult(message);
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -213,6 +213,55 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            // Route to Groq when configured — same path as horniness/shadow overlays.
+            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
+            {
+                return await GroqOverlayApplier.ApplyTrapOverlayAsync(
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext)
+                    .ConfigureAwait(false);
+            }
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no refusals, no preamble.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            string userContent = $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
+
+            try
+            {
+                double temperature = _options.DeliveryTemperature ?? 0.7;
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay)
+                    .ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(result)) return message;
+                string trimmed = result.Trim();
+
+                // Detect refusal — fall back to original message silently.
+                if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return trimmed;
+            }
+            catch
+            {
+                return message;
+            }
+        }
+
+        /// <inheritdoc />
         public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -186,6 +186,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -58,6 +58,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 [Fact]

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -53,6 +53,7 @@ namespace Pinder.Core.Tests
         }
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     [Trait("Category", "Core")]

--- a/tests/Pinder.Core.Tests/ComplianceBugFixTests.cs
+++ b/tests/Pinder.Core.Tests/ComplianceBugFixTests.cs
@@ -92,13 +92,20 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void Bug1_Nat1_DoesNotActivateTrap_WhenAlreadyActive()
+        public void Bug1_Nat1_ReactivatesTrap_PerSingleSlotReplacement()
         {
+            // Per #371 (W2a) single-slot replacement: a fresh trap-triggering
+            // failure tier (including Nat 1) ALWAYS activates the stat's trap,
+            // even if the same trap was already active. The new activation
+            // replaces the existing entry and resets TurnsRemaining to 3.
             var trapDef = new TrapDefinition("charm-trap", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 2, "instruction", "clear", "nat1");
+                TrapEffect.Disadvantage, 0, 3, "instruction", "clear", "nat1");
             var registry = new SingleTrapRegistry2(trapDef);
             var traps = new TrapState();
             traps.Activate(trapDef); // already active
+            // Simulate one turn elapsed, so TurnsRemaining was 2 before re-activation.
+            traps.AdvanceTurn();
+            Assert.Equal(2, traps.Get()!.TurnsRemaining);
 
             var attacker = MakeStats(charm: 10);
             var defender = MakeStats();
@@ -108,9 +115,11 @@ namespace Pinder.Core.Tests
                 registry, new FixedDice2(1));
 
             Assert.Equal(FailureTier.Legendary, result.Tier);
-            // No new trap activated (already active)
-            Assert.Null(result.ActivatedTrap);
+            Assert.NotNull(result.ActivatedTrap);
+            Assert.Equal("charm-trap", result.ActivatedTrap!.Id);
             Assert.True(traps.IsActive(StatType.Charm));
+            // Re-activation refreshed TurnsRemaining to FixedDurationTurns=3.
+            Assert.Equal(3, traps.Get()!.TurnsRemaining);
         }
 
         // ──────────────────────────────────────────────────────────────────────────
@@ -163,35 +172,34 @@ namespace Pinder.Core.Tests
         }
 
         // ──────────────────────────────────────────────────────────────────────────
-        // Bug 3: SA success vs DC 12 clears oldest active trap
+        // Bug 3 (W2a #371): single-slot trap — second Activate REPLACES the first;
+        // SA-DC-12-clears-oldest mechanic is obsolete (replaced by SA-selection-disarm).
         // ──────────────────────────────────────────────────────────────────────────
 
         [Fact]
-        public void TrapState_ClearOldest_RemovesOldestTrap()
+        public void TrapState_SecondActivate_ReplacesFirst()
         {
             var trap1 = new TrapDefinition("trap1", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 5, "i1", "c1", "n1");
+                TrapEffect.Disadvantage, 0, 3, "i1", "c1", "n1");
             var trap2 = new TrapDefinition("trap2", StatType.Rizz,
-                TrapEffect.Disadvantage, 0, 2, "i2", "c2", "n2");
+                TrapEffect.Disadvantage, 0, 3, "i2", "c2", "n2");
 
             var state = new TrapState();
-            state.Activate(trap1); // 5 turns remaining
-            state.Activate(trap2); // 2 turns remaining — oldest (fewest turns = soonest to expire)
+            state.Activate(trap1);
+            state.Activate(trap2); // replaces trap1 under #371 single-slot rule
 
-            state.ClearOldest();
-
-            // trap2 had fewest turns → cleared
-            Assert.False(state.IsActive(StatType.Rizz));
-            // trap1 still active
-            Assert.True(state.IsActive(StatType.Charm));
+            Assert.True(state.HasActive);
+            Assert.False(state.IsActive(StatType.Charm));
+            Assert.True(state.IsActive(StatType.Rizz));
+            Assert.Equal("trap2", state.Get()!.Definition.Id);
         }
 
         [Fact]
-        public void TrapState_ClearOldest_DoesNothingWhenEmpty()
+        public void TrapState_Clear_DoesNothingWhenEmpty()
         {
             var state = new TrapState();
             // Should not throw
-            state.ClearOldest();
+            state.Clear();
             Assert.False(state.HasActive);
         }
 

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -24,6 +24,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -20,6 +20,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
@@ -42,6 +43,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -240,6 +240,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
@@ -317,6 +317,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -219,6 +219,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -210,6 +210,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -231,6 +232,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -175,6 +175,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -28,23 +28,27 @@ namespace Pinder.Core.Tests
             Assert.Equal(9, GetInterest(session)); // 10 - 1
         }
 
-        // What: AC4 — Wait advances trap timers; trap with 1 turn expires (spec §3.7, edge case §5.4)
+        // What: AC4 — Wait advances trap timer; per #371 (W2a) every trap is
+        // fixed at 3 turns so three Wait() calls are needed to expire it.
         // Mutation: Fails if AdvanceTurn is not called (trap would remain active)
         [Fact]
         public void Wait_AdvancesTrapTimers_TrapExpires()
         {
             var trapDef = new TrapDefinition("TestTrap", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 1, "test", "clear", "nat1");
+                TrapEffect.Disadvantage, 0, 3, "test", "clear", "nat1");
             var session = MakeSession(diceValue: 15, saModifier: 3);
             ActivateTrapOnSession(session, trapDef);
 
-            session.Wait(); // trap with 1 turn remaining → expires
-
-            // After Wait, trap should be gone
+            // Activation ⇒ TurnsRemaining=3. Wait once: 2 remaining; twice: 1; thrice: expired.
+            session.Wait();
+            Assert.True(GetTrapState(session).HasActive);
+            session.Wait();
+            Assert.True(GetTrapState(session).HasActive);
+            session.Wait();
             Assert.False(GetTrapState(session).HasActive);
         }
 
-        // What: AC4 — Wait with trap that has multiple turns: doesn't expire yet
+        // What: AC4 — Wait with trap mid-cycle: doesn't expire on a single Wait
         // Mutation: Fails if all traps are cleared instead of just decrementing
         [Fact]
         public void Wait_AdvancesTrapTimers_TrapNotExpiredIfMultipleTurns()
@@ -54,7 +58,7 @@ namespace Pinder.Core.Tests
             var session = MakeSession(diceValue: 15, saModifier: 3);
             ActivateTrapOnSession(session, trapDef);
 
-            session.Wait(); // trap with 3 turns → 2 remaining
+            session.Wait(); // 3 → 2 remaining
 
             // Trap should still be active
             Assert.True(GetTrapState(session).HasActive);
@@ -282,6 +286,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class ThrowingLlmAdapter : ILlmAdapter
@@ -299,6 +304,7 @@ namespace Pinder.Core.Tests
                 => throw new InvalidOperationException("LLM should not be called for Wait");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StubTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -164,6 +164,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class TestClock : IGameClock

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -252,6 +252,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -753,6 +753,7 @@ namespace Pinder.Core.Tests.Integration
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -119,6 +119,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -280,6 +280,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -303,6 +304,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -256,6 +256,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -440,6 +440,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -174,6 +174,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -276,6 +276,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => Task.FromResult(message);
 
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)
                 => Task.FromResult("so when are we doing this?");

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -264,6 +264,11 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(message + " [shadow:" + shadow + "]");
             }
 
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+            {
+                return Task.FromResult(message);
+            }
+
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)
                 => Task.FromResult("steering question");
         }

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -63,6 +63,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -196,6 +196,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/JsonTrapRepositoryDataFileTests.cs
+++ b/tests/Pinder.Core.Tests/JsonTrapRepositoryDataFileTests.cs
@@ -44,15 +44,16 @@ namespace Pinder.Core.Tests
             Assert.Equal(new[] { "creep", "cringe", "overshare", "pretentious", "spiral", "unhinged" }, ids);
         }
 
+        // Per #371 (W2a): all traps now share duration_turns=3 and the new clear_method.
         [Theory]
-        [InlineData(StatType.Charm, "cringe", TrapEffect.Disadvantage, 0, 1)]
-        [InlineData(StatType.Rizz, "creep", TrapEffect.StatPenalty, 2, 2)]
-        [InlineData(StatType.Honesty, "overshare", TrapEffect.OpponentDCIncrease, 2, 1)]
-        [InlineData(StatType.Chaos, "unhinged", TrapEffect.Disadvantage, 0, 1)]
-        [InlineData(StatType.Wit, "pretentious", TrapEffect.OpponentDCIncrease, 3, 1)]
-        [InlineData(StatType.SelfAwareness, "spiral", TrapEffect.Disadvantage, 0, 2)]
+        [InlineData(StatType.Charm, "cringe", TrapEffect.Disadvantage, 0)]
+        [InlineData(StatType.Rizz, "creep", TrapEffect.StatPenalty, 2)]
+        [InlineData(StatType.Honesty, "overshare", TrapEffect.OpponentDCIncrease, 2)]
+        [InlineData(StatType.Chaos, "unhinged", TrapEffect.Disadvantage, 0)]
+        [InlineData(StatType.Wit, "pretentious", TrapEffect.OpponentDCIncrease, 3)]
+        [InlineData(StatType.SelfAwareness, "spiral", TrapEffect.Disadvantage, 0)]
         public void TrapsJson_TrapDefinition_MatchesExpected(
-            StatType stat, string expectedId, TrapEffect expectedEffect, int expectedValue, int expectedDuration)
+            StatType stat, string expectedId, TrapEffect expectedEffect, int expectedValue)
         {
             var json = LoadTrapsJson();
             var repo = new JsonTrapRepository(json);
@@ -63,9 +64,9 @@ namespace Pinder.Core.Tests
             Assert.Equal(stat, trap.Stat);
             Assert.Equal(expectedEffect, trap.Effect);
             Assert.Equal(expectedValue, trap.EffectValue);
-            Assert.Equal(expectedDuration, trap.DurationTurns);
+            Assert.Equal(3, trap.DurationTurns);
             Assert.False(string.IsNullOrEmpty(trap.LlmInstruction));
-            Assert.Equal("SA vs DC 12", trap.ClearMethod);
+            Assert.Equal("Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)", trap.ClearMethod);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -435,6 +435,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>Null trap registry for tests.</summary>

--- a/tests/Pinder.Core.Tests/RollEngineTests.cs
+++ b/tests/Pinder.Core.Tests/RollEngineTests.cs
@@ -247,14 +247,17 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void Catastrophe_DoesNotActivateTrap_WhenAlreadyActive()
+        public void Catastrophe_ReactivatesTrap_WhenAlreadyActive_PerSingleSlotRule()
         {
-            // If a trap is already active on the stat, Catastrophe should not replace it
+            // #371 (W2a): single-slot replacement — a Catastrophe roll always
+            // (re-)activates the stat's trap. The previous "don't replace if
+            // already active" guard is gone; the new activation refreshes the
+            // 3-turn timer and the new trap REPLACES whatever was previously active.
             var trapDef = new TrapDefinition("charm-trap", StatType.Charm,
                 TrapEffect.Disadvantage, 0, 2, "you're trapped", "cleared", "nat1 clear");
             var registry = new SingleTrapRegistry(trapDef);
             var traps = new TrapState();
-            // Pre-activate a trap
+            // Pre-activate a trap (will be replaced by the fresh activation)
             traps.Activate(trapDef);
 
             var baseStats = new Dictionary<StatType, int>
@@ -276,9 +279,12 @@ namespace Pinder.Core.Tests
                 registry, new FixedDice(9));
 
             Assert.Equal(FailureTier.Catastrophe, result.Tier);
-            // No new trap activated since one was already active
-            Assert.Null(result.ActivatedTrap);
+            // #371: new trap replaces the existing one (single-slot rule).
+            Assert.NotNull(result.ActivatedTrap);
+            Assert.Equal("charm-trap", result.ActivatedTrap!.Id);
             Assert.True(traps.IsActive(StatType.Charm));
+            // Fresh activation refreshes the timer to FixedDurationTurns (3).
+            Assert.Equal(TrapState.FixedDurationTurns, traps.Get()!.TurnsRemaining);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -652,6 +652,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1259,6 +1259,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that returns a Tell on the opponent's response for a specific stat.</summary>
@@ -1287,6 +1288,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
@@ -1310,6 +1312,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -642,6 +642,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -643,6 +643,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -718,6 +718,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
@@ -743,6 +744,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -789,6 +789,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -813,6 +814,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -335,6 +335,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -513,6 +513,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapDataFileValidationTests.cs
+++ b/tests/Pinder.Core.Tests/TrapDataFileValidationTests.cs
@@ -226,64 +226,33 @@ namespace Pinder.Core.Tests
 
         // === Duration turns ===
 
-        // Mutation: would catch if cringe duration is 2 instead of 1
-        [Fact]
-        public void Cringe_Duration_Is_1()
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of which trap.
+        // The data file's duration_turns is now 3 for every trap.
+        [Theory]
+        [InlineData(StatType.Charm)]
+        [InlineData(StatType.Rizz)]
+        [InlineData(StatType.Honesty)]
+        [InlineData(StatType.Chaos)]
+        [InlineData(StatType.Wit)]
+        [InlineData(StatType.SelfAwareness)]
+        public void AllTraps_Duration_Is_3(StatType stat)
         {
             var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Charm)!.DurationTurns);
-        }
-
-        // Mutation: would catch if creep duration is 1 instead of 2
-        [Fact]
-        public void Creep_Duration_Is_2()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(2, repo.GetTrap(StatType.Rizz)!.DurationTurns);
-        }
-
-        // Mutation: would catch if overshare duration is 2 instead of 1
-        [Fact]
-        public void Overshare_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Honesty)!.DurationTurns);
-        }
-
-        // Mutation: would catch if unhinged duration is 2 instead of 1
-        [Fact]
-        public void Unhinged_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Chaos)!.DurationTurns);
-        }
-
-        // Mutation: would catch if pretentious duration is 2 instead of 1
-        [Fact]
-        public void Pretentious_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Wit)!.DurationTurns);
-        }
-
-        // Mutation: would catch if spiral duration is 1 instead of 2
-        [Fact]
-        public void Spiral_Duration_Is_2()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(2, repo.GetTrap(StatType.SelfAwareness)!.DurationTurns);
+            Assert.Equal(3, repo.GetTrap(stat)!.DurationTurns);
         }
 
         // === Clear method ===
 
         // Mutation: would catch if any trap has wrong clear_method
+        // Per #371 (W2a): clear method is SA-option-selection, not a DC-12 roll.
         [Fact]
-        public void AllTraps_ClearMethod_Is_SA_vs_DC12()
+        public void AllTraps_ClearMethod_Is_PickAnySelfAwarenessOption()
         {
             var repo = CreateRepo();
+            const string expected = "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)";
             foreach (var trap in repo.GetAll())
             {
-                Assert.Equal("SA vs DC 12", trap.ClearMethod);
+                Assert.Equal(expected, trap.ClearMethod);
             }
         }
 

--- a/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
+++ b/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
@@ -1,0 +1,466 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.Core.Text;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// W2a (#371) trap-redesign engine tests.
+    ///
+    /// Mandatory acceptance scenarios:
+    ///  1. Trap activates on turn N. Turn N+1 player picks NON-SA. Trap LLM call
+    ///     fires (turn 2 of 3); `Trap (X)` text-diff layer added.
+    ///  2. Trap activates on turn N. Turn N+1 player picks SA. Trap cleared at
+    ///     start of ResolveTurnAsync; no Trap diff this turn.
+    ///  3. SA picked, SA roll fails (Misfire). Old trap cleared. Spiral activated
+    ///     as the new trap. This turn's diff is the failure-tier label, not
+    ///     `Trap (Spiral)`. Spiral's TurnsRemaining == 3 going into turn N+1.
+    ///  4. Turn N+1 (Spiral persistence): non-SA picked, roll succeeds. Trap LLM
+    ///     call fires for Spiral; `Trap (Spiral)` diff added; TurnsRemaining=1
+    ///     after AdvanceTurn.
+    ///  5. Turn N+2 (Spiral persistence): non-SA, success. Trap LLM call fires;
+    ///     TurnsRemaining=0 after AdvanceTurn; Spiral removed at end.
+    ///  6. Turn N+1 fresh roll-failure activates a NEW trap while old trap is
+    ///     mid-cycle. Old trap replaced. Roll-modification IS the new trap's
+    ///     turn-1 taint. NO separate trap LLM call this turn.
+    ///  7. Resume: trap state survives RestoreState (per now-folded #369).
+    /// </summary>
+    [Trait("Category", "Core")]
+    public sealed class TrapPipelineW2aTests
+    {
+        // ──────────────────────────────────────────────────────────────────
+        // Test plumbing
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// LLM adapter that:
+        ///  * always returns four options spanning Charm / Honesty / Wit / SelfAwareness
+        ///    (so SA disarm scenarios can be exercised).
+        ///  * tags the delivered message with the failure tier so we can detect
+        ///    whether a trap overlay actually rewrote the text.
+        ///  * tags the trap-overlay output so the text-diff layer fires.
+        /// </summary>
+        private sealed class W2aTrapLlmAdapter : ILlmAdapter
+        {
+            public List<DialogueContext> DialogueContexts { get; } = new();
+            public List<DeliveryContext> DeliveryContexts { get; } = new();
+            public List<OpponentContext> OpponentContexts { get; } = new();
+            public int TrapOverlayCalls { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                DialogueContexts.Add(context);
+                var options = new[]
+                {
+                    new DialogueOption(StatType.Charm,         "Charm option"),
+                    new DialogueOption(StatType.Honesty,       "Honesty option"),
+                    new DialogueOption(StatType.Wit,           "Wit option"),
+                    new DialogueOption(StatType.SelfAwareness, "SA option"),
+                };
+                return Task.FromResult(options);
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            {
+                DeliveryContexts.Add(context);
+                // Tag the message with the tier so it is observably different
+                // from the IntendedText (so a TextDiff is emitted on failure).
+                string text = context.Outcome == FailureTier.None
+                    ? context.ChosenOption.IntendedText
+                    : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
+                return Task.FromResult(text);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            {
+                OpponentContexts.Add(context);
+                return Task.FromResult(new OpponentResponse("..."));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null)
+            {
+                TrapOverlayCalls++;
+                // Mark the message so a Trap (X) text-diff is emitted.
+                return Task.FromResult($"[Trap:{trapName}] {message}");
+            }
+        }
+
+        /// <summary>
+        /// Trap registry that exposes one trap per stat. Stat → trap-name map matches
+        /// the production data shape (Charm → Cringe, SA → Spiral, etc.).
+        /// </summary>
+        private sealed class StubTrapRegistry : ITrapRegistry
+        {
+            private readonly Dictionary<StatType, TrapDefinition> _traps = new();
+            public StubTrapRegistry()
+            {
+                Register(StatType.Charm,         "cringe",      "Cringe");
+                Register(StatType.Rizz,          "creep",       "Creep");
+                Register(StatType.Honesty,       "overshare",   "Overshare");
+                Register(StatType.Chaos,         "unhinged",    "Unhinged");
+                Register(StatType.Wit,           "pretentious", "Pretentious");
+                Register(StatType.SelfAwareness, "spiral",      "Spiral");
+            }
+            private void Register(StatType stat, string id, string name)
+            {
+                _traps[stat] = new TrapDefinition(
+                    id, stat, TrapEffect.Disadvantage, 0, 3,
+                    llmInstruction: $"{name} taint instruction",
+                    clearMethod: "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
+                    nat1Bonus: "",
+                    displayName: name,
+                    summary: $"{name} trap summary.");
+            }
+            public TrapDefinition? GetTrap(StatType stat)
+            {
+                _traps.TryGetValue(stat, out var t);
+                return t;
+            }
+            public string? GetLlmInstruction(StatType stat)
+            {
+                _traps.TryGetValue(stat, out var t);
+                return t?.LlmInstruction;
+            }
+        }
+
+        private static StatBlock MakeStatBlock(int allStats = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm,         allStats },
+                    { StatType.Rizz,          allStats },
+                    { StatType.Honesty,       allStats },
+                    { StatType.Chaos,         allStats },
+                    { StatType.Wit,           allStats },
+                    { StatType.SelfAwareness, allStats }
+                },
+                new Dictionary<ShadowStatType, int>());
+        }
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        // The LLM adapter places SA at index 3 and the failing-charm trap option at 0.
+        private const int CharmIndex = 0;
+        private const int SaIndex = 3;
+        private const int WitIndex = 2;
+
+        /// <summary>
+        /// Dice roller that yields a queued sequence and falls back to a default
+        /// when the queue is empty. Avoids brittle dice-counting in tests where
+        /// downstream paths (ghost rolls, advantage/disadvantage, ComputeDelay)
+        /// vary by interest state.
+        /// </summary>
+        private sealed class ScriptedDice : IDiceRoller
+        {
+            private readonly Queue<int> _q;
+            private readonly int _default;
+            public ScriptedDice(int defaultRoll, params int[] script)
+            {
+                _default = defaultRoll;
+                _q = new Queue<int>(script);
+            }
+            public int Roll(int sides)
+            {
+                int v = _q.Count > 0 ? _q.Dequeue() : _default;
+                if (v < 1) v = 1;
+                if (v > sides) v = sides;
+                return v;
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // Tests
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// 1. Trap activates on turn N. Turn N+1: player picks NON-SA. Trap LLM
+        ///    overlay fires; the `Trap (X)` diff layer is appended; TurnsRemaining
+        ///    decrements from 2 → 1 after AdvanceTurn at end of turn N+1.
+        /// </summary>
+        [Fact]
+        public async Task PersistenceTurn_NonSaPick_FiresTrapOverlay_AndAddsTrapDiff()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // DC for stat=2 attacker, defender stats=2: stat-mod +2, defender-defence DC=14+2=16.
+            // Roll d20=4 → 4+2+0 = 6 → miss by 9 → TropeTrap → activates Cringe (Charm trap).
+            // T2 picks Charm again — trap on Charm = Disadvantage, so 2 d20s are rolled
+            // and the LOWER value is used. Both d20=18 → lower=18, total=20 ≥ DC → success.
+            var dice = new FixedDice(
+                5,            // ctor horniness
+                4,  10,       // T1: trip TropeTrap on Charm (activates Cringe)
+                18, 18, 10    // T2: 2 d20s under disadvantage — success on Charm
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // T1 — activate trap (turn 1 of 3, taint via roll-modification)
+            await session.StartTurnAsync();
+            var t1 = await session.ResolveTurnAsync(CharmIndex);
+            Assert.NotNull(t1.Roll.ActivatedTrap);
+            Assert.Equal("cringe", t1.Roll.ActivatedTrap!.Id);
+            // No Trap (Cringe) diff on activation turn (taint is the failure-tier rewrite).
+            Assert.DoesNotContain(t1.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            Assert.Equal(0, llm.TrapOverlayCalls);
+
+            // T2 — persistence; non-SA pick → Trap LLM call fires.
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(CharmIndex);
+            Assert.True(t2.Roll.IsSuccess, "T2 should succeed with d20=18");
+            Assert.Equal(1, llm.TrapOverlayCalls);
+            Assert.Contains(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Cringe)");
+        }
+
+        /// <summary>
+        /// 2. Trap activates on turn N. Turn N+1 player picks SA. Trap is cleared
+        ///    at start of ResolveTurnAsync, BEFORE the SA roll resolves. No Trap
+        ///    (X) diff layer on this turn even if the SA roll later succeeds.
+        /// </summary>
+        [Fact]
+        public async Task SaPick_DisarmsTrap_NoTrapDiffThisTurn_OnSuccess()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            var dice = new FixedDice(
+                5,           // ctor horniness
+                4,  10,      // T1: TropeTrap on Charm → Cringe activates
+                18, 10       // T2: SA pick, roll d20=18 → success → Cringe cleared, no Spiral
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex);
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(SaIndex);
+
+            Assert.True(t2.Roll.IsSuccess);
+            Assert.Equal("Cringe", t2.TrapClearedDisplayName);
+            // No trap-overlay LLM call this turn — disarm fired before pipeline.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // No active trap by end of turn (no Spiral activated since SA succeeded).
+            Assert.False(t2.StateAfter.ActiveTrapNames.Any());
+        }
+
+        /// <summary>
+        /// 3. Trap active. SA picked. SA roll fails into Misfire-or-worse. Old trap
+        ///    is cleared at start of ResolveTurnAsync. Spiral activates on the SA
+        ///    failure. The diff label for THIS turn is the failure tier (NOT
+        ///    Trap (Spiral)). Spiral's TurnsRemaining starts at 3, decremented to
+        ///    2 by end-of-turn AdvanceTurn.
+        /// </summary>
+        [Fact]
+        public async Task SaPick_OldTrapCleared_FailingSaActivatesSpiral_NoSeparateTrapOverlayThisTurn()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1 charm-trap (TropeTrap = miss by 6-9): roll 4 → miss by 9 → Cringe activates.
+            // T2 SA pick: need SA failure that activates a trap. Use d20=4 → SA total 6, DC 16,
+            // miss 10 → Catastrophe → Spiral activates (replacing Cringe).
+            var dice = new FixedDice(
+                5,         // ctor horniness
+                4, 10,     // T1: TropeTrap Charm
+                4, 10      // T2: SA → Catastrophe (also a trap-tier)
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex); // Cringe active
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(SaIndex); // disarms Cringe; SA fails → Spiral
+
+            Assert.False(t2.Roll.IsSuccess);
+            Assert.Equal(StatType.SelfAwareness, t2.Roll.Stat);
+            Assert.Equal("Cringe", t2.TrapClearedDisplayName);
+            // Spiral activated on this turn's roll
+            Assert.NotNull(t2.Roll.ActivatedTrap);
+            Assert.Equal("spiral", t2.Roll.ActivatedTrap!.Id);
+            // No separate trap LLM overlay on Spiral's activation turn.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // Active trap at end of turn = Spiral with TurnsRemaining=2 (3 - 1).
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal("spiral", t2.StateAfter.ActiveTrapNames[0]);
+            Assert.Equal(2, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+        }
+
+        /// <summary>
+        /// 4 + 5. Spiral persistence over two non-SA turns: trap overlay fires on
+        /// each, TurnsRemaining decrements 2 → 1 → 0; Spiral removed after turn 3.
+        /// </summary>
+        [Fact]
+        public async Task SpiralPersistence_TwoTurns_OverlayFires_AndExpires()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1: SA pick, Catastrophe → activates Spiral on turn N (turn 1 of 3).
+            // T2/T3/T4: non-SA Wit picks. Default to high d20 (18) so success is
+            // achieved even when interest-state side-effects (advantage / disadvantage /
+            // ghost-d4) consume extra dice. Script the T1 catastrophe roll explicitly.
+            var dice = new ScriptedDice(
+                defaultRoll: 18,
+                5,           // ctor horniness
+                4            // T1 d20 → 4+2 = 6 → miss by 10 → Catastrophe (Spiral activates)
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // T1
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(SaIndex);
+
+            // T2: Wit pick — Spiral persists, overlay fires.
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(WitIndex);
+            Assert.True(t2.Roll.IsSuccess);
+            Assert.Equal(1, llm.TrapOverlayCalls);
+            Assert.Contains(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Spiral)");
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal(1, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+
+            // T3: Wit pick — overlay fires; trap removed at end of turn (3 → 0).
+            await session.StartTurnAsync();
+            var t3 = await session.ResolveTurnAsync(WitIndex);
+            Assert.Equal(2, llm.TrapOverlayCalls);
+            Assert.Contains(t3.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Spiral)");
+            Assert.Empty(t3.StateAfter.ActiveTrapNames);
+
+            // T4: no trap, no overlay.
+            await session.StartTurnAsync();
+            var t4 = await session.ResolveTurnAsync(WitIndex);
+            Assert.Equal(2, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t4.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+        }
+
+        /// <summary>
+        /// 6. New trap activates while another is mid-cycle (non-SA pick).
+        /// New trap REPLACES the old one; this turn's roll-modification is the
+        /// new trap's turn-1 taint; NO separate trap LLM call this turn.
+        /// </summary>
+        [Fact]
+        public async Task PersistenceTurn_FreshFailureActivatesNewTrap_ReplacesOld_NoOverlay()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1: TropeTrap on Charm → Cringe activates.
+            // T2: pick Wit, roll d20=4 → miss by 9 → TropeTrap on Wit → Pretentious replaces Cringe.
+            //     Because a NEW trap activated this turn, the Trap-overlay step is SKIPPED.
+            var dice = new FixedDice(
+                5,
+                4, 10,    // T1: Charm TropeTrap
+                4, 10     // T2: Wit TropeTrap
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex);
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(WitIndex);
+
+            Assert.NotNull(t2.Roll.ActivatedTrap);
+            Assert.Equal("pretentious", t2.Roll.ActivatedTrap!.Id);
+            // NO trap LLM call on this turn — activation turns skip the overlay.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // Active trap at end of turn = Pretentious with TurnsRemaining=2 (3 - 1).
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal("pretentious", t2.StateAfter.ActiveTrapNames[0]);
+            Assert.Equal(2, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+        }
+
+        /// <summary>
+        /// 7. Resume path (#369 case-mismatch fold-in). RestoreState round-trips
+        /// trap state regardless of stat-string casing in the snapshot data.
+        /// </summary>
+        [Theory]
+        [InlineData("SelfAwareness")]
+        [InlineData("selfawareness")]
+        [InlineData("SELFAWARENESS")]
+        public async Task RestoreState_PreservesActiveTrap_CaseInsensitiveStat(string snapshotStatCase)
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, new FixedDice(5, 18, 18), registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            var data = new ResimulateData
+            {
+                TargetInterest = 12,
+                TurnNumber = 5,
+                MomentumStreak = 0,
+                ActiveTraps = new List<(string, int)> { (snapshotStatCase, 2) }
+            };
+
+            session.RestoreState(data, registry);
+
+            var start = await session.StartTurnAsync();
+            // After restore, the trap state should expose the spiral trap on the
+            // game-state snapshot regardless of the snapshot's stat-string casing.
+            Assert.Single(start.State.ActiveTrapNames);
+            Assert.Equal("spiral", start.State.ActiveTrapNames[0]);
+            Assert.Equal(2, start.State.ActiveTrapDetails[0].TurnsRemaining);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/TrapStateHasActiveTests.cs
+++ b/tests/Pinder.Core.Tests/TrapStateHasActiveTests.cs
@@ -7,8 +7,11 @@ namespace Pinder.Core.Tests
     [Trait("Category", "Core")]
     public class TrapStateHasActiveTests
     {
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of the
+        // definition's DurationTurns; the activation turn counts as turn 1
+        // of 3 so TurnsRemaining starts at 3.
         private static TrapDefinition MakeTrap(StatType stat) =>
-            new TrapDefinition($"trap-{stat}", stat, TrapEffect.Disadvantage, 0, 2,
+            new TrapDefinition($"trap-{stat}", stat, TrapEffect.Disadvantage, 0, 3,
                 "instruction", "clear", "nat1");
 
         [Fact]
@@ -31,18 +34,22 @@ namespace Pinder.Core.Tests
         {
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
-            state.Clear(StatType.Charm);
+            state.Clear();
             Assert.False(state.HasActive);
         }
 
         [Fact]
-        public void TwoTraps_ClearOne_HasActive_True()
+        public void SingleSlot_NewActivationReplacesOld()
         {
+            // Per #371: single-slot — a fresh Activate REPLACES whatever was active.
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
             state.Activate(MakeTrap(StatType.Wit));
-            state.Clear(StatType.Charm);
+
             Assert.True(state.HasActive);
+            Assert.False(state.IsActive(StatType.Charm));
+            Assert.True(state.IsActive(StatType.Wit));
+            Assert.Equal(StatType.Wit, state.Get()!.Definition.Stat);
         }
 
         [Fact]
@@ -50,21 +57,29 @@ namespace Pinder.Core.Tests
         {
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
-            state.Activate(MakeTrap(StatType.Wit));
             state.ClearAll();
             Assert.False(state.HasActive);
         }
 
         [Fact]
-        public void AdvanceTurn_ExpiresAll_HasActive_False()
+        public void AdvanceTurn_ExpiresAfterThreeTurns()
         {
+            // Activation counts as turn 1; after the activation turn TurnsRemaining
+            // decrements from 3 → 2 → 1 → 0 over three end-of-turn AdvanceTurn() calls.
             var state = new TrapState();
-            // Duration=2 turns, so after 2 advances all expire
             state.Activate(MakeTrap(StatType.Charm));
+
+            Assert.Equal(3, state.Get()!.TurnsRemaining);
             state.AdvanceTurn();
-            Assert.True(state.HasActive); // 1 turn remaining
+            Assert.True(state.HasActive);
+            Assert.Equal(2, state.Get()!.TurnsRemaining);
+
             state.AdvanceTurn();
-            Assert.False(state.HasActive); // expired
+            Assert.True(state.HasActive);
+            Assert.Equal(1, state.Get()!.TurnsRemaining);
+
+            state.AdvanceTurn();
+            Assert.False(state.HasActive); // expired after third AdvanceTurn
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -57,6 +57,7 @@ namespace Pinder.Core.Tests
         }
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     // ---------------------------------------------------------------
@@ -482,9 +483,13 @@ namespace Pinder.Core.Tests
     }
 
     /// <summary>
-    /// Regression: duration-1 traps must still be visible to delivery and opponent
-    /// LLM contexts on the turn they activate. Before #692, AdvanceTurn was called
-    /// before delivery, expiring duration-1 traps immediately.
+    /// Regression: a freshly-activated trap must still be visible to delivery and
+    /// opponent LLM contexts on the turn it activates. Before #692, AdvanceTurn was
+    /// called before delivery, expiring short-duration traps immediately.
+    ///
+    /// Per #371 (W2a) every trap is now fixed at 3 turns regardless of the
+    /// definition's DurationTurns; these tests use definition.DurationTurns=1 to
+    /// document the legacy data shape but TrapState.Activate clamps to 3 turns.
     /// </summary>
     [Trait("Category", "Core")]
     public sealed class TrapDuration1RegressionTests
@@ -555,41 +560,12 @@ namespace Pinder.Core.Tests
                 oppCtx.ActiveTrapInstructions!);
         }
 
-        [Fact]
-        public async Task Duration1Trap_ExpiresBeforeNextTurnDialogue()
-        {
-            // Duration=1: should be gone by next StartTurnAsync
-            var trapDef = new TrapDefinition(
-                "cringe_trap", StatType.Charm, TrapEffect.Disadvantage, 0, 1,
-                "You become extremely awkward.", "SA vs DC 12", "");
-
-            var trapRegistry = new TestTrapRegistry();
-            trapRegistry.Register(trapDef);
-
-            var capturingLlm = new CapturingLlmAdapter();
-
-            var dice = new FixedDice(
-                5,   // Constructor: horniness roll
-                4,   // Turn 1: TropeTrap
-                10,  // Turn 1: timing delay
-                20   // Turn 2: padding
-            );
-
-            var session = new GameSession(
-                MakeProfile("Player"), MakeProfile("Opponent"),
-                capturingLlm, dice, trapRegistry,
-                new GameSessionConfig(clock: TestHelpers.MakeClock()));
-
-            await session.StartTurnAsync();
-            await session.ResolveTurnAsync(0);
-
-            // Turn 2
-            dice.Enqueue(10);
-            await session.StartTurnAsync();
-
-            // Duration-1 trap should have expired after AdvanceTurn at end of turn 1
-            var turn2Context = capturingLlm.DialogueContexts[1];
-            Assert.Null(turn2Context.ActiveTrapInstructions);
-        }
+        // The previous Duration1Trap_ExpiresBeforeNextTurnDialogue test asserted
+        // that a duration_turns=1 trap expired after one AdvanceTurn. Under
+        // #371 (W2a) every trap is fixed at 3 turns regardless of the definition.
+        // The 3-turn lifecycle is covered by
+        // <see cref="TrapStateHasActiveTests.AdvanceTurn_ExpiresAfterThreeTurns"/>
+        // and end-to-end by the persistence-path engine tests in
+        // <see cref="TrapPipelineW2aTests"/>.
     }
 }

--- a/tests/Pinder.Core.Tests/TrapsJsonIssue306Tests.cs
+++ b/tests/Pinder.Core.Tests/TrapsJsonIssue306Tests.cs
@@ -147,32 +147,31 @@ namespace Pinder.Core.Tests
 
         // ── AC5: Correct duration turns ──
 
-        // Mutation: catches if duration_turns is wrong (e.g. defaults to 3 instead of explicit value)
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of which trap.
         [Theory]
-        [InlineData(StatType.Charm, 1)]
-        [InlineData(StatType.Rizz, 2)]
-        [InlineData(StatType.Honesty, 1)]
-        [InlineData(StatType.Chaos, 1)]
-        [InlineData(StatType.Wit, 1)]
-        [InlineData(StatType.SelfAwareness, 2)]
-        public void Trap_DurationTurns_MatchesExpected(StatType stat, int expectedDuration)
+        [InlineData(StatType.Charm)]
+        [InlineData(StatType.Rizz)]
+        [InlineData(StatType.Honesty)]
+        [InlineData(StatType.Chaos)]
+        [InlineData(StatType.Wit)]
+        [InlineData(StatType.SelfAwareness)]
+        public void Trap_DurationTurns_Is_3(StatType stat)
         {
             var repo = new JsonTrapRepository(LoadTrapsJson());
             var trap = repo.GetTrap(stat);
             Assert.NotNull(trap);
-            Assert.Equal(expectedDuration, trap!.DurationTurns);
+            Assert.Equal(3, trap!.DurationTurns);
         }
 
-        // ── AC6: Clear method is "SA vs DC 12" for all traps ──
-
-        // Mutation: catches if clear_method is empty or wrong
+        // ── AC6: Clear method (W2a #371): SA-option-selection ──
         [Fact]
-        public void AllTraps_ClearMethod_IsSaVsDc12()
+        public void AllTraps_ClearMethod_IsPickAnySelfAwarenessOption()
         {
             var repo = new JsonTrapRepository(LoadTrapsJson());
+            const string expected = "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)";
             foreach (var trap in repo.GetAll())
             {
-                Assert.Equal("SA vs DC 12", trap.ClearMethod);
+                Assert.Equal(expected, trap.ClearMethod);
             }
         }
 

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -77,6 +77,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion
@@ -477,31 +478,34 @@ namespace Pinder.Core.Tests
         }
 
         // ==================================================================
-        // AC8: TrapState.HasActive — after AdvanceTurn with mixed durations
+        // AC8 (W2a #371): TrapState single-slot model — HasActive after AdvanceTurn.
+        // Replaces the prior multi-slot mixed-duration test. Every trap is fixed
+        // at 3 turns and a fresh Activate REPLACES the existing trap.
         // ==================================================================
 
-        // Mutation: Fails if HasActive checks wrong collection or uses != instead of >
         [Fact]
         public void TrapState_HasActive_AfterPartialExpiry()
         {
             var state = new TrapState();
-            // Duration 1 trap (expires after 1 AdvanceTurn)
-            var shortTrap = new TrapDefinition("short", StatType.Charm,
+            // Definition's duration_turns is overridden to FixedDurationTurns=3
+            // by Activate(); the activation turn counts as turn 1 of 3.
+            var trap = new TrapDefinition("trap", StatType.Charm,
                 TrapEffect.Disadvantage, 0, 1, "i", "c", "n");
-            // Duration 2 trap (expires after 2 AdvanceTurns)  
-            var longTrap = new TrapDefinition("long", StatType.Wit,
-                TrapEffect.Disadvantage, 0, 2, "i", "c", "n");
 
-            state.Activate(shortTrap);
-            state.Activate(longTrap);
+            state.Activate(trap);
             Assert.True(state.HasActive);
+            Assert.Equal(3, state.Get()!.TurnsRemaining);
 
             state.AdvanceTurn();
-            // Short expired, long still has 1 turn
             Assert.True(state.HasActive);
+            Assert.Equal(2, state.Get()!.TurnsRemaining);
 
             state.AdvanceTurn();
-            // Both expired
+            Assert.True(state.HasActive);
+            Assert.Equal(1, state.Get()!.TurnsRemaining);
+
+            state.AdvanceTurn();
+            // Expired after 3 AdvanceTurn calls
             Assert.False(state.HasActive);
         }
 

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -424,6 +424,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -444,6 +444,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }


### PR DESCRIPTION
Implements the consolidated trap redesign per **decay256/pinder-web#371**.

Spec source: latest comment on decay256/pinder-web#371 (the third correction is authoritative).

## Engine changes
- `TrapState` becomes a single-slot field (was a per-stat `Dictionary<StatType, ActiveTrap>`).  Activate REPLACES the active trap.  Every trap is fixed at 3 turns regardless of `definition.duration_turns`; activation turn counts as turn 1 of 3.  Per-stat lookup methods (`IsActive(stat)`, `GetActive(stat)`) preserved for `RollEngine` callers.
- `GameSession.ResolveTurnAsync`:
    - **SA disarm**: when the player SELECTS a Self-Awareness option and a trap is active, the trap is cleared at the *start* of the method, BEFORE the SA roll resolves and before any text-modification pipeline runs.  The disarm fires regardless of SA roll outcome.
    - **Trap LLM overlay**: on PERSISTENCE turns (turn 2 or 3 of an active trap, non-SA pick, no fresh activation), the new `ApplyTrapOverlayAsync` rewrites the post-roll-modification message and adds a `Trap (X)` text-diff layer.  Activation turns are NOT overlaid; their taint is the failure-tier rewrite.
    - Old SA-DC-12-clears-trap mechanic removed.
- `RollEngine`: failure-tier-triggered activations always fire (single-slot replacement); the prior "don't replace if already on this stat" guard is gone.
- `ILlmAdapter.ApplyTrapOverlayAsync`: new method; implemented in `PinderLlmAdapter`, `AnthropicLlmAdapter`, `OpenAiLlmAdapter`, `NullLlmAdapter` — folds in #751 (the no-op stubs).
- `LlmPhase.TrapOverlay`: new typed phase id (per #299 pattern).
- `TurnResult.TrapClearedDisplayName`: new field for SA-disarm notification, enabling the frontend toast/event.
- `TurnProgressStage.TrapOverlayStarted`/`Completed`: new SSE progress stages.
- `RestoreState`: trap stat-string parsed case-insensitively (folds in #369 trap-resume case-mismatch).

## YAML changes
- `data/traps/traps.json` — every trap's `duration_turns: 3`; `clear_method` now reads `"Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"`.
- `rules/extracted/traps-enriched.yaml` — top-level paragraphs updated for SA-disarm and single-slot replacement; per-trap `Clears:` lines mirror the new clear method; `Stacking: multiple active traps stack` replaced with single-slot rule; −1 Interest cost language removed.

## Tests
- New `tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs` — 8 acceptance tests covering all four pipeline paths and the resume case.
- `TrapStateHasActiveTests`, `ComplianceBugFixTests`, `Wave0SpecTests`, `TrapDataFileValidationTests`, `TrapsJsonIssue306Tests`, `JsonTrapRepositoryDataFileTests`, `GameSessionWaitTests`, `TrapTaintInjectionTests`, `RollEngineTests` updated for the new shape.
- 36 in-test ILlmAdapter doubles in pinder-core/tests + pinder-web/src/Pinder.GameApi.Tests grew the new `ApplyTrapOverlayAsync` stub.

## DoD Evidence
- `dotnet build pinder-core/Pinder.Core.sln`: Build succeeded — 0 Warning(s), 0 Error(s).
- `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj`: 2471 passed, 18 skipped, 6 environmental skips (CharacterLoaderSpecTests with `design/examples` missing — pre-existing on this machine, unrelated).
- New W2a trap-pipeline tests: 8/8 pass.

## Merge order
1. Merge this PR first.
2. The pinder-web companion PR `fix/W2a-trap-redesign` then re-bumps `pinder-core` to the new merged SHA before merging.

Closes decay256/pinder-web#371. Folds in #369, #751.