### PR TITLE
consolidate(W2): archetype directive plumbing + trap mechanic redesign (§7 union of #777 + #778)

### DIFF
--- a/data/traps/traps.json
+++ b/data/traps/traps.json
@@ -6,9 +6,9 @@
     "stat": "charm",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "You are aware of how you're coming across, which is making it worse. Every message is slightly over-explained or self-undermined. The more you try to be charming, the harder you try.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -18,9 +18,9 @@
     "stat": "rizz",
     "effect": "stat_penalty",
     "effect_value": 2,
-    "duration_turns": 2,
+    "duration_turns": 3,
     "llm_instruction": "Inject a subtle 'agenda' quality into ALL generated messages. On success: one line that could be read two ways. On failure: the entire message feels like it's leading somewhere uncomfortable.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -30,9 +30,9 @@
     "stat": "honesty",
     "effect": "opponent_dc_increase",
     "effect_value": 2,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject an accidental personal detail into ALL generated messages regardless of stat. On success: one parenthetical or aside that reveals something private. On failure: multiple personal details intrude and derail the message.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -42,9 +42,9 @@
     "stat": "chaos",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject momentum/acceleration into ALL generated messages. On success: one extra clause or tangent at the end that wasn't planned. On failure: the message progressively derails, starting controlled and ending somewhere completely different.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -54,9 +54,9 @@
     "stat": "wit",
     "effect": "opponent_dc_increase",
     "effect_value": 3,
-    "duration_turns": 1,
+    "duration_turns": 3,
     "llm_instruction": "Inject a condescending or over-explanatory quality into ALL generated messages. On success: one unnecessary clarification or reference. On failure: the message becomes pedagogical — explaining things the opponent didn't ask about.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   },
   {
@@ -66,9 +66,9 @@
     "stat": "self_awareness",
     "effect": "disadvantage",
     "effect_value": 0,
-    "duration_turns": 2,
+    "duration_turns": 3,
     "llm_instruction": "While this trap is active, inject meta-commentary into ALL generated messages. On success: one aside that acknowledges the conversation dynamic. On failure: the character narrates their own failure, creating a recursive self-awareness loop.",
-    "clear_method": "SA vs DC 12",
+    "clear_method": "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
     "nat1_bonus": ""
   }
 ]

--- a/rules/extracted/archetypes-enriched.yaml
+++ b/rules/extracted/archetypes-enriched.yaml
@@ -619,6 +619,111 @@
   description: The rarest and most appreciated archetype. Actually reads the bio. References something specific. As
   heading_level: 4
   compact_heading: true
+# ── Item / anatomy YAML referenced these names that were missing from
+#    §2 above. Added (#372) so ArchetypeCatalog has real behaviour text
+#    for every name the JSON data references — without these, GetBehavior
+#    would fall back to the bare placeholder "Follow {Name} behavioral
+#    pattern." which is what the LLM actually receives.
+- id: §2.the-pun-troll
+  section: §2
+  title: The Pun Troll
+  type: archetype_definition
+  stats:
+    high:
+    - Wit
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Fixation
+    low: []
+  level_range:
+  - 2
+  - 8
+  behavior: 'Cannot resist a wordplay. Every reply is contorted around a pun, a
+    homonym, or a stretched double-meaning the conversation didn''t ask for.
+    Genuine wit is occasionally in the tank — what kills it is the inability
+    to let a single message land without a pun retrofitted onto it.
+    Self-applauding. Will quote their own pun back in the next message in
+    case it was missed. The dating-app cousin of the dad-joke uncle.
+
+
+    *Sample lines:* "are you a librarian? because you''ve got me booked" ·
+    "sorry that was a pun-ishing line" · "I lentil-told you I''d find a way
+    to work beans into this"'
+  interference: {}
+  has_hr: true
+  tier: 2
+  description: Cannot resist a wordplay. Every reply is contorted around a pun, a homonym, or a stretched double-mean
+  heading_level: 4
+  compact_heading: true
+- id: §2.the-nice-guy
+  section: §2
+  title: The Nice Guy
+  type: archetype_definition
+  stats:
+    high:
+    - Charm
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Dread
+    - Denial
+    low: []
+  level_range:
+  - 1
+  - 6
+  behavior: 'Performs niceness as a transaction. Compliments are precise and
+    front-loaded; favours are tracked silently; "I''m one of the good ones"
+    is the stable belief underneath. Polite right up to the moment it stops
+    paying off, at which point niceness reveals itself as resentment that
+    was waiting for a trigger. The shorter, calmer cousin of The Exploding
+    Nice Guy — same engine, lower volume, same disappointment.
+
+
+    *Sample lines:* "you don''t see a lot of guys like me on here" · "I''m
+    just looking for someone real" · "most guys would have given up by now"'
+  interference: {}
+  has_hr: true
+  tier: 2
+  description: Performs niceness as a transaction. Compliments are precise and front-loaded; favours are tracked si
+  heading_level: 4
+  compact_heading: true
+- id: §2.the-2am-texter
+  section: §2
+  title: The 2AM Texter
+  type: archetype_definition
+  stats:
+    high:
+    - Rizz
+    - Chaos
+    low:
+    - Self-Awareness
+  shadows:
+    high:
+    - Horniness
+    - Overthinking
+    low: []
+  level_range:
+  - 3
+  - 9
+  behavior: 'Reliably resurfaces between 1am and 4am with messages that read
+    very differently than they would at noon. Lowered inhibition presented
+    as honesty. Sometimes a sincere late-night thought, more often a thinly
+    laundered booty-text. Has plausible deniability built in — "haha I was
+    so tired" — for whichever direction the morning takes. The platform''s
+    timestamp is doing more work than they realise.
+
+
+    *Sample lines:* "u up?" · "random thought but" · "don''t answer this
+    if you''re asleep" · "I''ve been thinking about you all day"'
+  interference: {}
+  has_hr: true
+  tier: 3
+  description: Reliably resurfaces between 1am and 4am with messages that read very differently than they would at
+  heading_level: 4
+  compact_heading: true
 - id: §3.archetype.hey-opener
   section: §3
   title: Archetype — The Hey Opener

--- a/rules/extracted/traps-enriched.yaml
+++ b/rules/extracted/traps-enriched.yaml
@@ -20,18 +20,19 @@
   type: interest_change
   blocks:
   - kind: paragraph
-    text: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 1–2 turns (defined per trap).  \n**Effect:** Two layers:\n1. **Mechanical**\
+    text: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 3 turns (fixed for all traps; activation turn counts as turn 1 of 3).  \n**Effect:** Two layers:\n1. **Mechanical**\
       \ — disadvantage on the triggering stat, or opponent's defense stat boosted\n2. **Prompt taint** — `llm_instruction` injected into the character system prompt for the duration; taints all generated\
       \ messages regardless of what stat is being rolled"
   - kind: paragraph
-    text: '**Clearing a trap:** Spend a turn on a Self-Awareness recovery roll (DC 12). Costs −1 Interest and the turn. The trap remains active until either the roll succeeds or duration expires.'
+    text: '**Disarm:** selecting any SA-stat option disarms the active trap immediately, before the SA roll resolves. Disarm fires regardless of whether the SA roll succeeds. A failed SA roll then triggers Spiral as the new active trap (this turn is Spiral''s turn 1 of 3, taint via roll-modification, no separate trap LLM call this turn).'
   - kind: paragraph
-    text: '**Stacking:** Multiple active traps stack. Each injects its `llm_instruction` independently. A character with The Cringe and The Spiral active is simultaneously try-hard and narrating their own
-      try-hardness.'
+    text: '**Single slot:** a newly activated trap replaces the currently active trap. Old trap''s remaining turns are discarded. The new trap''s first corruption turn IS the activation turn (taint via roll-modification, no separate trap LLM call).'
+  - kind: paragraph
+    text: '**Stacking:** single slot only; new activation replaces. Traps do not stack.'
   - kind: paragraph
     text: '**Nat 1 bonus:** Rolling a natural 1 on any roll while a trap is active escalates the trap''s DC modifier and adds a shadow stat bonus.'
   - kind: hr
-  description: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 1–2 turns (defined per trap).  \n**Effect:** Two layers:\n1. **Mechanical**\
+  description: "**Trigger:** Miss a roll by 6–9 (Trope Trap fail tier). The trap for the stat you rolled activates.  \n**Duration:** 3 turns (fixed for all traps; activation turn counts as turn 1 of 3).  \n**Effect:** Two layers:\n1. **Mechanical**\
     \ — disadvantage on the triggering stat, or opponent's defense stat boosted\n2. **Prompt taint** — `llm_instruction` injected into the character system prompt for the duration; taints all generated\
     \ messages regardless of what stat is being rolled"
   heading_level: 2
@@ -41,7 +42,7 @@
     - 9
   outcome:
     trap: true
-    duration_turns: 1
+    duration_turns: 3
 - id: §2.trap-reference
   section: §2
   title: Trap Reference
@@ -54,7 +55,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Charm miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Charm miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Everything sounds slightly try-hard. Compliments feel rehearsed. Humor has a "please laugh" energy. Even a successful Wit line has an aftertaste of desperation.'
   - kind: table
@@ -72,7 +73,7 @@
   - kind: blockquote
     text: "*\"Your smooth line landed like a pickup artist at a poetry reading. The emoji made it worse.\"*  \n*Expiry: \"The cringe fades. You can look at your own messages again without wincing.\"*"
   - kind: hr
-  description: "**Triggered by:** Charm miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Charm miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Charm rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -80,7 +81,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-cringe
-    duration_turns: 1
+    duration_turns: 3
     effect: disadvantage
     stat: Charm
 - id: §2.the-creep
@@ -89,7 +90,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Bold statements read as loaded. Innocent questions sound like they have an agenda. Even a kind Charm message feels like it''s building toward something uncomfortable.'
   - kind: table
@@ -108,7 +109,7 @@
     text: "*\"Your bold move didn't read as confident. It read as desperate. They visibly recoiled.\"*  \n*Expiry: \"The creep factor subsides. Your messages stop sounding like they have a hidden agenda.\"\
       *"
   - kind: hr
-  description: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Rizz miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** −2 to all Rizz rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -116,7 +117,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-creep
-    duration_turns: 2
+    duration_turns: 3
     effect: stat_penalty
     stat: Rizz
     effect_value: -2
@@ -126,8 +127,8 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced for\
-      \ more chaos from you)  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced for\
+      \ more chaos from you)  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Personal details leak into unrelated topics. A Wit message about mycelium accidentally includes a confession. A Charm compliment trails off into a memory. You can''t keep the
       personal stuff contained.'
@@ -147,8 +148,8 @@
     text: "*\"You meant to share one thing. You shared everything. The divorce. The therapist. The Costco membership. Steve.\"*  \n*Expiry: \"The overshare impulse subsides. You can hold a thought without\
       \ it trailing into confession.\"*"
   - kind: hr
-  description: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced\
-    \ for more chaos from you)  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Honesty miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Chaos defense +2 (Honesty DC increases by 2 — they've seen the overshare, they're braced\
+    \ for more chaos from you)  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -156,7 +157,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-overshare
-    duration_turns: 1
+    duration_turns: 3
     effect: opponent_dc_increase
     stat: Chaos
     effect_value: 2
@@ -166,7 +167,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Structured thoughts derail mid-sentence. Tangents intrude. Even a careful recovery message accelerates into unexpected territory. Bullet points become manifestos.'
   - kind: table
@@ -185,7 +186,7 @@
     text: "*\"Your random humor wasn't random-fun. It was random-concerning. They're reconsidering this match.\"*  \n*Expiry: \"The manic energy subsides. Your thoughts stop accelerating past your ability\
       \ to type them.\"*"
   - kind: hr
-  description: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Chaos miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Chaos rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -193,7 +194,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-unhinged
-    duration_turns: 1
+    duration_turns: 3
     effect: disadvantage
     stat: Chaos
 - id: §2.the-pretentious
@@ -202,8 +203,8 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Wit miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n**Clears:**\
-      \ Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+    text: "**Triggered by:** Wit miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n**Clears:**\
+      \ Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Condescension leaks in everywhere. References feel like showing off. A Rizz line sounds like a TED talk. An Honesty moment sounds like a lecture. You can''t stop explaining.'
   - kind: table
@@ -222,8 +223,8 @@
     text: "*\"You tried clever. You got condescending. There may be a TED talk reference. There was definitely a TED talk reference.\"*  \n*Expiry: \"The urge to explain subsides. You can make a point without\
       \ citing a source.\"*"
   - kind: hr
-  description: "**Triggered by:** Wit miss by 6+  \n**Duration:** 1 turn  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n\
-    **Clears:** Self-Awareness DC 12 (costs −1 Interest, uses turn)"
+  description: "**Triggered by:** Wit miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Opponent's Rizz defense +3 (Rizz DC increases by 3 — they become dismissive rather than impressed)  \n\
+    **Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -231,7 +232,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-pretentious
-    duration_turns: 1
+    duration_turns: 3
     effect: opponent_dc_increase
     stat: Rizz
     effect_value: 3
@@ -241,8 +242,7 @@
   type: table
   blocks:
   - kind: paragraph
-    text: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest,\
-      \ uses turn)"
+    text: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   - kind: paragraph
     text: '**What it does:** Meta-commentary intrudes. You narrate your own behaviour mid-message. A Charm attempt includes "I''m trying to be charming right now and I can feel it not working." Self-awareness
       becomes self-sabotage.'
@@ -262,8 +262,7 @@
     text: "*\"You started acknowledging the awkwardness and couldn't stop. You narrated your own failure. In real time. For three messages.\"*  \n*Expiry: \"The meta-loop breaks. You can say things without\
       \ immediately analyzing why you said them.\"*"
   - kind: hr
-  description: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 2 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Self-Awareness DC 12 (costs −1 Interest,\
-    \ uses turn)"
+  description: "**Triggered by:** Self-Awareness miss by 6+  \n**Duration:** 3 turns  \n**Mechanical effect:** Disadvantage on all Self-Awareness rolls  \n**Clears:** Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)"
   heading_level: 3
   compact_heading: true
   condition:
@@ -271,7 +270,7 @@
     miss_minimum: 6
   outcome:
     trap_name: the-spiral
-    duration_turns: 2
+    duration_turns: 3
     effect: disadvantage
     stat: Self-Awareness
 - id: §3.trap-summary-table
@@ -283,32 +282,32 @@
     rows:
     - Trap: The Cringe
       Stat: Charm
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Disadvantage on Charm
       Taint quality: Try-hard energy
     - Trap: The Creep
       Stat: Rizz
-      Duration: 2 turns
+      Duration: 3 turns
       Mechanical effect: −2 Rizz rolls
       Taint quality: Hidden agenda
     - Trap: The Overshare
       Stat: Honesty
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Opponent Chaos +2
       Taint quality: Personal details leak
     - Trap: The Unhinged
       Stat: Chaos
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Disadvantage on Chaos
       Taint quality: Message accelerates/derails
     - Trap: The Pretentious
       Stat: Wit
-      Duration: 1 turn
+      Duration: 3 turns
       Mechanical effect: Opponent Rizz +3
       Taint quality: Condescension / over-explains
     - Trap: The Spiral
       Stat: Self-Awareness
-      Duration: 2 turns
+      Duration: 3 turns
       Mechanical effect: Disadvantage on S-Awr
       Taint quality: Meta-commentary
     sep_cells:
@@ -318,7 +317,7 @@
     - '---'
     - '---'
   - kind: blockquote
-    text: 'All traps share the same clear method: Self-Awareness recovery roll, DC 12, −1 Interest, costs turn.'
+    text: 'All traps share the same clear method: pick any Self-Awareness option (selection disarms; SA fail triggers Spiral). The disarm fires on selection, before the SA roll resolves. Single slot — a newly activated trap replaces the currently active trap.'
   - kind: hr
   description: ''
   heading_level: 2

--- a/src/Pinder.Core/Characters/ActiveArchetype.cs
+++ b/src/Pinder.Core/Characters/ActiveArchetype.cs
@@ -16,14 +16,43 @@ namespace Pinder.Core.Characters
         public int Count { get; }
 
         /// <summary>
-        /// Interference level derived from count: 1-2 = "slight", 3-5 = "clear", 6+ = "dominant".
+        /// Total number of archetype-tendency votes across the character's full
+        /// build (every archetype, every fragment). Used to compute the
+        /// share-of-votes-based <see cref="InterferenceLevel"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Count"/> when not supplied — that yields
+        /// <c>ratio = 1.0</c> and the legacy "always dominant" behaviour. Real
+        /// callers (CharacterAssembler) supply the real total so the intensity
+        /// reflects how dominant the archetype actually is in the build, not
+        /// just the absolute count of votes.
+        /// </remarks>
+        public int TotalCount { get; }
+
+        /// <summary>
+        /// Interference level derived from this archetype's share of all
+        /// archetype-tendency votes in the build (#375):
+        ///   ≥ 0.7 → "dominant"  (a clear majority — the archetype is the build)
+        ///   ≥ 0.4 → "clear"     (a real lead but not crushing)
+        ///   else  → "slight"    (one of several voices)
+        ///
+        /// "Dominant" therefore requires the archetype to take roughly
+        /// 70%+ of the build's archetype votes, not just a single-vote
+        /// lead. Per the #375 acceptance tests:
+        ///   [Pun Troll: 2, Player: 1]      → 2/3 = 0.67 → "clear"
+        ///   [Pun Troll: 4, Player: 1]      → 4/5 = 0.80 → "dominant"
+        ///   [Pun Troll: 2, Player: 2]      → 2/4 = 0.50 → "clear" (tied)
+        ///   [Pun Troll: 1, Player: 1, ...] → 1/3 = 0.33 → "slight"
         /// </summary>
         public string InterferenceLevel
         {
             get
             {
-                if (Count >= 6) return "dominant";
-                if (Count >= 3) return "clear";
+                int total = TotalCount > 0 ? TotalCount : Count;
+                if (total <= 0) return "slight";
+                double ratio = (double)Count / (double)total;
+                if (ratio >= 0.7) return "dominant";
+                if (ratio >= 0.4) return "clear";
                 return "slight";
             }
         }
@@ -40,11 +69,25 @@ namespace Pinder.Core.Characters
             }
         }
 
-        public ActiveArchetype(string name, string behavior, int count)
+        /// <summary>
+        /// Construct an ActiveArchetype.
+        /// </summary>
+        /// <param name="name">Archetype display name.</param>
+        /// <param name="behavior">Behavioral instruction text.</param>
+        /// <param name="count">Vote count for this archetype.</param>
+        /// <param name="totalCount">
+        /// Total archetype-tendency vote count across the build. When omitted
+        /// (zero or negative), <paramref name="count"/> is used — preserving
+        /// the legacy "ratio = 1.0 = dominant" behaviour for callers that
+        /// haven't migrated yet. CharacterAssembler.ResolveActiveArchetype
+        /// always supplies the real total.
+        /// </param>
+        public ActiveArchetype(string name, string behavior, int count, int totalCount = 0)
         {
             Name = name ?? string.Empty;
             Behavior = behavior ?? string.Empty;
             Count = count;
+            TotalCount = totalCount > 0 ? totalCount : count;
         }
     }
 }

--- a/src/Pinder.Core/Characters/CharacterAssembler.cs
+++ b/src/Pinder.Core/Characters/CharacterAssembler.cs
@@ -193,6 +193,9 @@ namespace Pinder.Core.Characters
         /// Selects the active archetype from ranked archetypes based on character level.
         /// If characterLevel > 0, prefers the highest-count archetype whose level range
         /// includes the character's level. Falls back to highest-count overall.
+        /// The total archetype-tendency vote count is propagated to
+        /// <see cref="ActiveArchetype"/> so its <c>InterferenceLevel</c> reflects
+        /// share-of-votes (#375), not raw count.
         /// </summary>
         internal static ActiveArchetype ResolveActiveArchetype(
             IReadOnlyList<(string Archetype, int Count)> ranked,
@@ -200,6 +203,13 @@ namespace Pinder.Core.Characters
         {
             if (ranked == null || ranked.Count == 0)
                 return null;
+
+            // Compute total archetype-tendency votes across the entire ranked
+            // set so InterferenceLevel can be expressed as a share, not raw
+            // count (#375).
+            int totalCount = 0;
+            for (int i = 0; i < ranked.Count; i++)
+                totalCount += ranked[i].Count;
 
             // Try to find the highest-count archetype eligible at this level
             if (characterLevel > 0)
@@ -210,7 +220,7 @@ namespace Pinder.Core.Characters
                     if (def != null && def.IsEligibleAtLevel(characterLevel))
                     {
                         string behavior = ArchetypeCatalog.GetBehavior(entry.Archetype);
-                        return new ActiveArchetype(entry.Archetype, behavior, entry.Count);
+                        return new ActiveArchetype(entry.Archetype, behavior, entry.Count, totalCount);
                     }
                 }
             }
@@ -218,7 +228,7 @@ namespace Pinder.Core.Characters
             // Fallback: use the highest-count archetype overall
             var top = ranked[0];
             string topBehavior = ArchetypeCatalog.GetBehavior(top.Archetype);
-            return new ActiveArchetype(top.Archetype, topBehavior, top.Count);
+            return new ActiveArchetype(top.Archetype, topBehavior, top.Count, totalCount);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/DeliveryContext.cs
+++ b/src/Pinder.Core/Conversation/DeliveryContext.cs
@@ -61,6 +61,14 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public string StatFailureInstruction { get; }
 
+        /// <summary>
+        /// Active archetype directive for the player character (e.g.
+        /// <c>"ACTIVE ARCHETYPE: The Peacock (clear)\n..."</c>), or null if
+        /// the player has no active archetype. Threaded into the delivery LLM
+        /// prompt so the rewrite respects the character's voice (#372 / #375).
+        /// </summary>
+        public string ActiveArchetypeDirective { get; }
+
         public DeliveryContext(
             string playerPrompt,
             string opponentPrompt,
@@ -76,7 +84,8 @@ namespace Pinder.Core.Conversation
             string opponentName = "",
             int currentTurn = 0,
             bool isNat20 = false,
-            string statFailureInstruction = null)
+            string statFailureInstruction = null,
+            string activeArchetypeDirective = null)
         {
             PlayerPrompt = playerPrompt ?? throw new System.ArgumentNullException(nameof(playerPrompt));
             OpponentPrompt = opponentPrompt ?? throw new System.ArgumentNullException(nameof(opponentPrompt));
@@ -93,6 +102,7 @@ namespace Pinder.Core.Conversation
             CurrentTurn = currentTurn;
             IsNat20 = isNat20;
             StatFailureInstruction = statFailureInstruction;
+            ActiveArchetypeDirective = activeArchetypeDirective;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -838,6 +838,12 @@ namespace Pinder.Core.Conversation
                     chosenOption.IsUnhingedReplacement);
             }
 
+            // Resolve player archetype directive once for delivery + overlays
+            // (#372 / #375). The same directive flows into ApplyHorninessOverlay
+            // and ApplyShadowCorruption below so every LLM rewrite of the
+            // delivered message respects the player's voice.
+            string playerArchetypeDirectiveForDelivery = _player.ActiveArchetype?.Directive;
+
             var deliveryContext = new DeliveryContext(
                 playerPrompt: _player.AssembledSystemPrompt,
                 opponentPrompt: _opponent.AssembledSystemPrompt,
@@ -854,7 +860,8 @@ namespace Pinder.Core.Conversation
                 currentTurn: _turnNumber,
                 shadowThresholds: _currentShadowThresholds,
                 isNat20: rollResult.IsNatTwenty,
-                statFailureInstruction: statFailureInstruction);
+                statFailureInstruction: statFailureInstruction,
+                activeArchetypeDirective: playerArchetypeDirectiveForDelivery);
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
             string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext).ConfigureAwait(false);
@@ -898,7 +905,7 @@ namespace Pinder.Core.Conversation
                     string beforeHorniness = deliveredMessage;
                     string opponentCtx = BuildOpponentContext(_opponent);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayStarted));
-                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx).ConfigureAwait(false);
+                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, deliveredMessage));
                     if (deliveredMessage != beforeHorniness)
                     {
@@ -958,7 +965,7 @@ namespace Pinder.Core.Conversation
                             string beforeShadow = deliveredMessage;
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionStarted));
                             deliveredMessage = await _llm.ApplyShadowCorruptionAsync(
-                                deliveredMessage, corruptionInstruction, pairedShadow.Value).ConfigureAwait(false);
+                                deliveredMessage, corruptionInstruction, pairedShadow.Value, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionCompleted, deliveredMessage));
                             if (deliveredMessage != beforeShadow)
                             {

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -340,7 +340,11 @@ namespace Pinder.Core.Conversation
             {
                 foreach (var (statName, turnsRemaining) in data.ActiveTraps)
                 {
-                    if (Enum.TryParse<StatType>(statName, out var stat))
+                    // #369: parse case-insensitively. Snapshots have historically
+                    // stored stat names in lowercase ("selfawareness") in some
+                    // environments and TitleCase ("SelfAwareness") in others.
+                    // The TrapState round-trip must survive both.
+                    if (Enum.TryParse<StatType>(statName, ignoreCase: true, out var stat))
                     {
                         var definition = trapRegistry.GetTrap(stat);
                         if (definition != null)
@@ -567,6 +571,21 @@ namespace Pinder.Core.Conversation
             }
 
             var chosenOption = _currentOptions[optionIndex];
+
+            // ---- Trap SA-disarm (issue #371) ----
+            // When the chosen option's stat is Self-Awareness AND a trap is active,
+            // the trap is disarmed IMMEDIATELY — BEFORE the SA roll resolves and
+            // before any text-modification pipeline runs. The cleared trap does NOT
+            // corrupt this turn's message. If the SA roll subsequently fails, the
+            // failure tier may activate Spiral as a fresh trap (its turn 1 of 3 is
+            // this turn, taint via the failure-tier rewrite — no separate trap LLM
+            // call this turn).
+            string? trapClearedDisplayName = null;
+            if (chosenOption.Stat == StatType.SelfAwareness && _traps.HasActive)
+            {
+                trapClearedDisplayName = _traps.Active!.Definition.DisplayName;
+                _traps.Clear();
+            }
 
             // Denial +1 when Honesty was available but player chose a different stat (#272 — §7)
             if (_playerShadows != null
@@ -882,6 +901,47 @@ namespace Pinder.Core.Conversation
                 textDiffs.Add(new TextDiff(layerLabel, tierSpans, intendedTextForDelivery, deliveredMessage));
             }
 
+            // ---- Trap LLM overlay (issue #371) ----
+            // Fires only on PERSISTENCE turns: when a trap is currently active AND
+            // it was NOT activated this turn. The activation turn (turn 1 of 3) is
+            // already tainted by the failure-tier rewrite above, so adding the trap
+            // overlay on top would double-corrupt the message.
+            //
+            // Path mapping (final spec, see #371 latest comment):
+            //   - SA picked, trap was active → disarmed at start; _traps.HasActive
+            //     is false here UNLESS the SA roll just failed and re-activated
+            //     Spiral as a NEW trap (rollResult.ActivatedTrap != null). That's
+            //     the activation case — skip the overlay.
+            //   - Non-SA picked, trap persisting → _traps.HasActive AND
+            //     rollResult.ActivatedTrap is null. FIRE the overlay.
+            //   - Non-SA picked, roll just activated a fresh trap (replacing or
+            //     adding) → rollResult.ActivatedTrap != null. Skip the overlay
+            //     (this turn is the new trap's turn 1 of 3).
+            if (_traps.HasActive && rollResult.ActivatedTrap == null)
+            {
+                var activeTrap = _traps.Active!;
+                string trapInstruction = activeTrap.Definition.LlmInstruction;
+                string trapDisplayName = activeTrap.Definition.DisplayName;
+                if (!string.IsNullOrWhiteSpace(trapInstruction)
+                    && !string.IsNullOrEmpty(deliveredMessage)
+                    && deliveredMessage != "...")
+                {
+                    string beforeTrap = deliveredMessage;
+                    string opponentCtxForTrap = BuildOpponentContext(_opponent);
+                    progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayStarted));
+                    deliveredMessage = await _llm.ApplyTrapOverlayAsync(
+                        deliveredMessage, trapInstruction, trapDisplayName, opponentCtxForTrap, playerArchetypeDirectiveForDelivery)
+                        .ConfigureAwait(false);
+                    progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayCompleted, deliveredMessage));
+                    if (deliveredMessage != beforeTrap)
+                    {
+                        var trapSpans = WordDiff.Compute(beforeTrap, deliveredMessage);
+                        textDiffs.Add(new TextDiff(
+                            $"Trap ({trapDisplayName})", trapSpans, beforeTrap, deliveredMessage));
+                    }
+                }
+            }
+
             // 9. Check interest threshold crossing → narrative beat
             string? narrativeBeat = null;
             if (stateBefore != stateAfter)
@@ -1077,16 +1137,14 @@ namespace Pinder.Core.Conversation
             // 12. Append opponent message to history
             _history.Add((_opponent.DisplayName, opponentMessage));
 
-            // SA trap clear: SA success vs DC 12 clears oldest active trap (rules §clear)
-            if (chosenOption.Stat == StatType.SelfAwareness
-                && rollResult.IsSuccess
-                && rollResult.FinalTotal >= 12
-                && _traps.HasActive)
-            {
-                _traps.ClearOldest();
-            }
-
-            // 12b. Advance trap timers
+            // 12b. Advance trap timer (single-slot model). Decrements TurnsRemaining
+            // for the active trap (if any) and removes it when it reaches 0.
+            // Per #371: traps activated this turn (rollResult.ActivatedTrap)
+            // start at TurnsRemaining=3 — this AdvanceTurn brings them to 2,
+            // because the activation turn counts as turn 1 of 3.
+            // SA-disarm (handled at the top of this method) clears the trap before
+            // the pipeline runs, so AdvanceTurn here only ticks down a NEW trap if
+            // one was activated by the roll, OR a persisting trap on a non-SA pick.
             _traps.AdvanceTurn();
 
             // 13. Increment turn number
@@ -1124,7 +1182,8 @@ namespace Pinder.Core.Conversation
                 horninessInterestPenalty: horninessInterestPenalty,
                 horninessInterestBefore: horninessInterestBefore,
                 textDiffs: textDiffs.Count > 0 ? textDiffs : null,
-                shadowCheck: shadowCheckResult);
+                shadowCheck: shadowCheckResult,
+                trapClearedDisplayName: trapClearedDisplayName);
         }
 
         /// <summary>
@@ -1202,7 +1261,12 @@ namespace Pinder.Core.Conversation
             return ShadowThresholdEvaluator.GetThresholdLevel(shadowValue);
         }
 
-        private GameStateSnapshot CreateSnapshot()
+        /// <summary>
+        /// Build a fresh <see cref="GameStateSnapshot"/> for the current session state.
+        /// Public so test/debug code can observe restored or mid-flight state without
+        /// running a turn (e.g. the W2a #371 RestoreState round-trip tests).
+        /// </summary>
+        public GameStateSnapshot CreateSnapshot()
         {
             return GameSessionHelpers.CreateSnapshot(
                 _interest,

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -75,7 +75,7 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Returns the message unchanged (no LLM overlay in test mode).
         /// </summary>
-        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }
@@ -83,7 +83,7 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Returns the message unchanged (no shadow corruption in test mode).
         /// </summary>
-        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -87,5 +87,15 @@ namespace Pinder.Core.Conversation
         {
             return Task.FromResult(message);
         }
+
+        /// <summary>
+        /// Returns the message unchanged (no trap overlay in test mode).
+        /// Used by the deterministic test harness so engine flow can be exercised
+        /// without an actual LLM round-trip.
+        /// </summary>
+        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        {
+            return Task.FromResult(message);
+        }
     }
 }

--- a/src/Pinder.Core/Conversation/TurnProgress.cs
+++ b/src/Pinder.Core/Conversation/TurnProgress.cs
@@ -32,6 +32,12 @@ namespace Pinder.Core.Conversation
         /// <summary>Shadow corruption LLM returned; Text carries the rewritten message.</summary>
         ShadowCorruptionCompleted,
 
+        /// <summary>Trap overlay LLM call is about to run (issue #371; persistence turns only).</summary>
+        TrapOverlayStarted,
+
+        /// <summary>Trap overlay LLM returned; Text carries the rewritten message.</summary>
+        TrapOverlayCompleted,
+
         /// <summary>About to call the opponent-response LLM.</summary>
         OpponentResponseStarted,
 

--- a/src/Pinder.Core/Conversation/TurnResult.cs
+++ b/src/Pinder.Core/Conversation/TurnResult.cs
@@ -105,6 +105,14 @@ namespace Pinder.Core.Conversation
         /// <summary>Word-level diffs for each text transform layer that changed the message.</summary>
         public IReadOnlyList<TextDiff> TextDiffs { get; }
 
+        /// <summary>
+        /// Display name of the trap that was disarmed at the start of this turn
+        /// by the player selecting a Self-Awareness option (issue #371). Null when
+        /// no SA-disarm fired (no trap was active, or chosen option was not SA).
+        /// The frontend uses this signal to show a "Trap cleared" toast/event.
+        /// </summary>
+        public string? TrapClearedDisplayName { get; }
+
         public TurnResult(
             RollResult roll,
             string deliveredMessage,
@@ -131,7 +139,8 @@ namespace Pinder.Core.Conversation
             int horninessInterestPenalty = 0,
             int horninessInterestBefore = 0,
             IReadOnlyList<TextDiff>? textDiffs = null,
-            ShadowCheckResult shadowCheck = null)
+            ShadowCheckResult shadowCheck = null,
+            string? trapClearedDisplayName = null)
         {
             Roll = roll ?? throw new ArgumentNullException(nameof(roll));
             DeliveredMessage = deliveredMessage ?? throw new ArgumentNullException(nameof(deliveredMessage));
@@ -159,6 +168,7 @@ namespace Pinder.Core.Conversation
             HorninessInterestBefore = horninessInterestBefore;
             TextDiffs = textDiffs ?? Array.Empty<TextDiff>();
             ShadowCheck = shadowCheck ?? ShadowCheckResult.NotPerformed;
+            TrapClearedDisplayName = trapClearedDisplayName;
         }
     }
 }

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -57,5 +57,24 @@ namespace Pinder.Core.Interfaces
         /// the corrupted rewrite still sounds like the character (#372).
         /// </param>
         Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null);
+
+        /// <summary>
+        /// Apply a trap overlay to a delivered message (issue #371). Called on
+        /// trap PERSISTENCE turns (turn 2 or 3 of an active trap) for non-SA
+        /// option picks where the roll did not activate a fresh trap. The trap's
+        /// llm_instruction is used to rewrite the post-roll-modification message,
+        /// adding the trap's signature taint on top of the tier rewrite. Activation
+        /// turns are NOT routed through this method — their taint comes from the
+        /// failure-tier rewrite. Returns the modified message text.
+        /// </summary>
+        /// <param name="message">The current delivered message (post roll modification).</param>
+        /// <param name="trapInstruction">The active trap's <c>llm_instruction</c>.</param>
+        /// <param name="trapName">Display name of the active trap (used for logging / refusal-detection labelling).</param>
+        /// <param name="opponentContext">Optional compact opponent context (name, bio, items) to ground the overlay.</param>
+        /// <param name="archetypeDirective">
+        /// Optional active archetype directive for the speaking character so
+        /// the trap-overlay rewrite still sounds like the character (#372 + #371 union).
+        /// </param>
+        Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null);
     }
 }

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -39,7 +39,12 @@ namespace Pinder.Core.Interfaces
         /// Returns the modified message text.
         /// </summary>
         /// <param name="opponentContext">Optional compact opponent context (name, bio, items) to ground the overlay.</param>
-        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null);
+        /// <param name="archetypeDirective">
+        /// Optional active archetype directive for the speaking character
+        /// (e.g. <c>"ACTIVE ARCHETYPE: The Peacock (clear)\n..."</c>) so the
+        /// overlay rewrite respects the character's voice (#372).
+        /// </param>
+        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null);
 
         /// <summary>
         /// Apply a shadow corruption instruction to a delivered message.
@@ -47,6 +52,10 @@ namespace Pinder.Core.Interfaces
         /// the message is rewritten to show the corruption bleeding through.
         /// Returns the corrupted message text.
         /// </summary>
-        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow);
+        /// <param name="archetypeDirective">
+        /// Optional active archetype directive for the speaking character so
+        /// the corrupted rewrite still sounds like the character (#372).
+        /// </param>
+        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null);
     }
 }

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -35,6 +35,14 @@ namespace Pinder.Core.Interfaces
         /// <summary>Shadow-stat corruption rewrite of a delivered message.</summary>
         public const string ShadowCorruption = "shadow_corruption";
 
+        /// <summary>
+        /// Trap overlay rewrite of a delivered message (#371). Fires only on
+        /// turns 2 and 3 of an active trap (the activation turn's taint is the
+        /// roll-modification, not a separate overlay). Adds a `Trap (X)`
+        /// text-diff layer when the rewrite changes the message.
+        /// </summary>
+        public const string TrapOverlay = "trap_overlay";
+
         /// <summary>Session-setup matchup analysis.</summary>
         public const string MatchupAnalysis = "matchup_analysis";
 

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -164,16 +164,18 @@ namespace Pinder.Core.Rolls
             int total = usedRoll + statMod + levelBonus;
             int finalTotal = total + externalBonus;
 
+            // Per #371 (W2a): single-slot trap state. Trap-activating failure tiers
+            // (Legendary / TropeTrap / Catastrophe) ALWAYS activate the stat's trap
+            // when the roll trips that tier — the new activation REPLACES whatever
+            // was active (single-slot rule). This is a behaviour change from the prior
+            // "only activate if not already active on this stat" guard.
             if (usedRoll == 1)
             {
                 tier = FailureTier.Legendary;
                 // Nat 1 activates a trap (rules: Legendary fail = trap)
-                if (!attackerTraps.IsActive(stat))
-                {
-                    newTrap = trapRegistry.GetTrap(stat);
-                    if (newTrap != null)
-                        attackerTraps.Activate(newTrap);
-                }
+                newTrap = trapRegistry.GetTrap(stat);
+                if (newTrap != null)
+                    attackerTraps.Activate(newTrap);
             }
             else if (usedRoll == 20 || finalTotal >= dc)
             {
@@ -188,24 +190,19 @@ namespace Pinder.Core.Rolls
                 else if (miss <= 9)
                 {
                     tier = FailureTier.TropeTrap;
-                    // Activate trap if one is defined and not already active on this stat
-                    if (!attackerTraps.IsActive(stat))
-                    {
-                        newTrap = trapRegistry.GetTrap(stat);
-                        if (newTrap != null)
-                            attackerTraps.Activate(newTrap);
-                    }
+                    // Activate the stat's trap (single-slot replacement, #371).
+                    newTrap = trapRegistry.GetTrap(stat);
+                    if (newTrap != null)
+                        attackerTraps.Activate(newTrap);
                 }
                 else
                 {
                     tier = FailureTier.Catastrophe;
-                    // Catastrophe also activates trap (rules §5: miss 10+ = -3 + trap)
-                    if (!attackerTraps.IsActive(stat))
-                    {
-                        newTrap = trapRegistry.GetTrap(stat);
-                        if (newTrap != null)
-                            attackerTraps.Activate(newTrap);
-                    }
+                    // Catastrophe also activates trap (rules §5: miss 10+ = -3 + trap).
+                    // Single-slot replacement under #371.
+                    newTrap = trapRegistry.GetTrap(stat);
+                    if (newTrap != null)
+                        attackerTraps.Activate(newTrap);
                 }
             }
 

--- a/src/Pinder.Core/Traps/TrapState.cs
+++ b/src/Pinder.Core/Traps/TrapState.cs
@@ -4,20 +4,44 @@ using System.Collections.Generic;
 namespace Pinder.Core.Traps
 {
     /// <summary>
-    /// Tracks currently active traps for a character in a conversation.
-    /// Traps persist across turns and taint ALL messages, not just the trapped stat.
+    /// Tracks the currently active trap for a character in a conversation.
+    ///
+    /// Single-slot design (issue #371 redesign): at most one trap is active at
+    /// any time. Activating a new trap REPLACES the existing one — traps no
+    /// longer stack. Every trap has a fixed 3-turn duration and self-deletes
+    /// after affecting the third turn.
+    ///
+    /// Per-stat lookup methods (<see cref="IsActive"/>, <see cref="GetActive"/>)
+    /// are preserved for the existing call sites in <c>RollEngine</c> — they
+    /// return state for the single active trap iff its stat matches.
     /// </summary>
     public sealed class TrapState
     {
-        private readonly Dictionary<StatType, ActiveTrap> _active = new Dictionary<StatType, ActiveTrap>();
+        // The fixed duration applied to every newly activated trap (#371).
+        // The activation turn counts as turn 1 of 3.
+        public const int FixedDurationTurns = 3;
+
+        private ActiveTrap? _active;
 
         /// <summary>True if any trap is currently active.</summary>
-        public bool HasActive => _active.Count > 0;
+        public bool HasActive => _active != null;
 
-        /// <summary>Activate a trap. Replaces an existing trap on the same stat.</summary>
+        /// <summary>The single active trap, or null when none is active.</summary>
+        public ActiveTrap? Active => _active;
+
+        /// <summary>
+        /// Returns the single active trap (or null when none is active).
+        /// Convenience accessor used by tests and by callers that don't care
+        /// which stat triggered the trap. Equivalent to <see cref="Active"/>.
+        /// </summary>
+        public ActiveTrap? Get() => _active;
+
+        /// <summary>Activate a trap. Replaces the existing active trap (if any).</summary>
         public void Activate(TrapDefinition definition)
         {
-            _active[definition.Stat] = new ActiveTrap(definition, definition.DurationTurns);
+            // Per #371: every trap is exactly 3 turns regardless of its
+            // declared duration_turns. The activation turn counts as turn 1 of 3.
+            _active = new ActiveTrap(definition, FixedDurationTurns);
         }
 
         /// <summary>
@@ -26,67 +50,70 @@ namespace Pinder.Core.Traps
         /// </summary>
         public void Activate(TrapDefinition definition, int turnsRemaining)
         {
-            _active[definition.Stat] = new ActiveTrap(definition, turnsRemaining);
+            _active = new ActiveTrap(definition, turnsRemaining);
         }
-
-        /// <summary>True if a trap is active on this stat.</summary>
-        public bool IsActive(StatType stat) => _active.ContainsKey(stat);
-
-        /// <summary>Returns the active trap for a stat, or null.</summary>
-        public ActiveTrap? GetActive(StatType stat)
-        {
-            _active.TryGetValue(stat, out var trap);
-            return trap;
-        }
-
-        /// <summary>All currently active traps (for LLM prompt taint assembly).</summary>
-        public IEnumerable<ActiveTrap> AllActive => _active.Values;
 
         /// <summary>
-        /// Advance all trap counters by one turn. Removes traps that have expired.
-        /// Call once at the end of each player turn.
+        /// True if a trap is active AND it was triggered by this stat.
+        /// (Single-slot model: at most one trap is active at a time.)
+        /// </summary>
+        public bool IsActive(StatType stat) => _active != null && _active.Definition.Stat == stat;
+
+        /// <summary>Returns the active trap iff its stat matches, else null.</summary>
+        public ActiveTrap? GetActive(StatType stat)
+        {
+            if (_active != null && _active.Definition.Stat == stat) return _active;
+            return null;
+        }
+
+        /// <summary>
+        /// All currently active traps. Single-slot: yields zero or one trap.
+        /// Kept as IEnumerable for backward compatibility with prompt-builder
+        /// and helper code that iterated the prior multi-slot collection.
+        /// </summary>
+        public IEnumerable<ActiveTrap> AllActive
+        {
+            get
+            {
+                if (_active != null) yield return _active;
+            }
+        }
+
+        /// <summary>
+        /// Advance the active trap's counter by one turn. Removes the trap
+        /// if it has reached zero. Call once at the end of each player turn
+        /// the trap's effects fired in (including the activation turn).
         /// </summary>
         public void AdvanceTurn()
         {
-            var toRemove = new List<StatType>();
-            foreach (var kv in _active)
-            {
-                kv.Value.DecrementTurn();
-                if (kv.Value.TurnsRemaining <= 0)
-                    toRemove.Add(kv.Key);
-            }
-            foreach (var key in toRemove)
-                _active.Remove(key);
+            if (_active == null) return;
+            _active.DecrementTurn();
+            if (_active.TurnsRemaining <= 0)
+                _active = null;
         }
-
-        /// <summary>Manually clear a trap (e.g. via clear method action).</summary>
-        public void Clear(StatType stat) => _active.Remove(stat);
-
-        /// <summary>Clear all traps.</summary>
-        public void ClearAll() => _active.Clear();
 
         /// <summary>
-        /// Clears the oldest active trap (the one with fewest turns remaining).
-        /// Used when SA roll succeeds vs DC 12 to allow a trap clear.
-        /// Does nothing if no traps are active.
+        /// Manually clear the active trap iff it matches the given stat.
+        /// Preserved for callers that target a specific stat. Single-slot model.
         /// </summary>
-        public void ClearOldest()
+        public void Clear(StatType stat)
         {
-            if (_active.Count == 0) return;
-
-            StatType? oldestKey = null;
-            int minTurns = int.MaxValue;
-            foreach (var kv in _active)
-            {
-                if (kv.Value.TurnsRemaining < minTurns)
-                {
-                    minTurns = kv.Value.TurnsRemaining;
-                    oldestKey = kv.Key;
-                }
-            }
-            if (oldestKey.HasValue)
-                _active.Remove(oldestKey.Value);
+            if (_active != null && _active.Definition.Stat == stat)
+                _active = null;
         }
+
+        /// <summary>Clear the active trap (if any) — used by SA disarm + RestoreState reset.</summary>
+        public void Clear() => _active = null;
+
+        /// <summary>Clear all traps. Equivalent to <see cref="Clear()"/> in the single-slot model.</summary>
+        public void ClearAll() => _active = null;
+
+        /// <summary>
+        /// Clears the oldest (== only) active trap. Preserved for backward
+        /// compatibility with #371's pre-redesign callers; in the single-slot
+        /// model this is identical to <see cref="Clear()"/>.
+        /// </summary>
+        public void ClearOldest() => _active = null;
     }
 
     /// <summary>

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -322,6 +322,62 @@ namespace Pinder.LlmAdapters.Anthropic
             }
         }
 
+        /// <summary>
+        /// Apply a trap overlay to a delivered message (issue #371). Routes to
+        /// Groq when configured; otherwise uses the Anthropic transport with the
+        /// trap-overlay system prompt. Returns the message unchanged on transport
+        /// failure or detected refusal.
+        /// </summary>
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
+            {
+                return await GroqOverlayApplier.ApplyTrapOverlayAsync(
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective)
+                    .ConfigureAwait(false);
+            }
+
+            string systemPrompt = "You are editing a text message for Pinder, a satirical comedy dating app. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the delivered message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no preamble, no refusals.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            // Inject the speaker's active archetype directive (#372 + #371 union) so the
+            // trap-overlay rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nTRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint (preserving the archetype voice above) and return the modified message."
+                : $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
+
+            try
+            {
+                var systemBlocks = CacheBlockBuilder.BuildPlayerOnlySystemBlocks(systemPrompt);
+                var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                    _options.Model, _options.MaxTokens, systemBlocks, userContent,
+                    _options.DeliveryTemperature ?? 0.7);
+                var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+                var result = response.GetText()?.Trim();
+
+                if (string.IsNullOrWhiteSpace(result)) return message;
+
+                if (result.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    result.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    result.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return result;
+            }
+            catch
+            {
+                return message;
+            }
+        }
+
         // Backward-compatibility: expose static parse methods for tests
         // that reference AnthropicLlmAdapter.ParseDialogueOptions / ParseOpponentResponse
 

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -267,20 +267,20 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Apply a horniness overlay to a delivered message by calling the LLM.
         /// Routes to Groq when OverlayGroqModel and OverlayGroqApiKey are configured.
         /// </summary>
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
                     .ConfigureAwait(false);
             }
             return await AnthropicOverlayApplier.ApplyHorninessOverlayAsync(
-                _client, _options, message, instruction, opponentContext).ConfigureAwait(false);
+                _client, _options, message, instruction, opponentContext, archetypeDirective).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -291,7 +291,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 "Now the character's shadow stat is corrupting it further. " +
                 "Return ONLY the corrupted message text. No commentary, no preamble, no refusals.";
 
-            string userContent = $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // shadow-corrupted rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nSHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above) and return the modified message."
+                : $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
 
             try
             {

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
@@ -18,7 +18,8 @@ namespace Pinder.LlmAdapters.Anthropic
             AnthropicOptions options,
             string message,
             string instruction,
-            string? opponentContext = null)
+            string? opponentContext = null,
+            string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -35,7 +36,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 new ContentBlock { Type = "text", Text = systemPrompt }
             };
 
-            string userContent = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
 
             var request = AnthropicRequestBuilders.BuildMessagesRequest(
                 options.Model,

--- a/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
+++ b/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Characters;
+using YamlDotNet.RepresentationModel;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Loads <c>archetypes-enriched.yaml</c> at startup and registers each
+    /// archetype's <c>behavior</c> string with <see cref="ArchetypeCatalog"/>
+    /// so the LLM directive ("ACTIVE ARCHETYPE: ...") is sourced from the
+    /// canonical YAML rather than from hand-copied literals in
+    /// <see cref="ArchetypeCatalog"/>'s static initialiser (#372).
+    ///
+    /// <para>
+    /// The YAML structure is a flat list of section blocks; each archetype is
+    /// a block with <c>type: archetype_definition</c>, a <c>title</c> field
+    /// (e.g. <c>"The Peacock"</c>), and a <c>behavior</c> field (the multi-line
+    /// behavioural-instruction text).
+    /// </para>
+    ///
+    /// <para>
+    /// The hardcoded behaviour strings in <see cref="ArchetypeCatalog"/>'s
+    /// static initialiser remain as a degraded-mode fallback. If the YAML file
+    /// is missing, fails to parse, or lacks an entry for a given archetype,
+    /// the catalog falls back to the hand-copied literal (still better than
+    /// the bare placeholder <c>"Follow {Name} behavioral pattern."</c>).
+    /// </para>
+    /// </summary>
+    public static class ArchetypeYamlLoader
+    {
+        /// <summary>
+        /// Result of a load operation. Useful for logging at startup.
+        /// </summary>
+        public sealed class LoadResult
+        {
+            /// <summary>Number of (title, behavior) pairs registered with the catalog.</summary>
+            public int Registered { get; }
+
+            /// <summary>Names of archetype blocks skipped because they had no <c>behavior</c> text.</summary>
+            public IReadOnlyList<string> SkippedMissingBehavior { get; }
+
+            /// <summary>Error message when the YAML failed to parse, or null on success.</summary>
+            public string? Error { get; }
+
+            public LoadResult(int registered, IReadOnlyList<string> skippedMissingBehavior, string? error)
+            {
+                Registered = registered;
+                SkippedMissingBehavior = skippedMissingBehavior ?? Array.Empty<string>();
+                Error = error;
+            }
+        }
+
+        /// <summary>
+        /// Parse the supplied YAML text and register every archetype's
+        /// behaviour with <see cref="ArchetypeCatalog.RegisterBehavior"/>.
+        /// On any parse failure returns a <see cref="LoadResult"/> with
+        /// <c>Error</c> populated and <c>Registered = 0</c>; the catalog is
+        /// not modified in that case (callers should log the error so the
+        /// degraded fallback is visible).
+        /// </summary>
+        /// <param name="yamlContent">Full text of <c>archetypes-enriched.yaml</c>.</param>
+        /// <returns>Load summary.</returns>
+        public static LoadResult LoadFromYaml(string yamlContent)
+        {
+            if (string.IsNullOrWhiteSpace(yamlContent))
+                return new LoadResult(0, Array.Empty<string>(), "yaml content was empty");
+
+            int registered = 0;
+            var skipped = new List<string>();
+
+            try
+            {
+                var stream = new YamlStream();
+                using (var reader = new System.IO.StringReader(yamlContent))
+                    stream.Load(reader);
+
+                if (stream.Documents.Count == 0)
+                    return new LoadResult(0, skipped, "yaml had no documents");
+
+                if (!(stream.Documents[0].RootNode is YamlSequenceNode root))
+                    return new LoadResult(0, skipped, "yaml root was not a sequence");
+
+                foreach (var node in root.Children)
+                {
+                    if (!(node is YamlMappingNode block)) continue;
+
+                    string? type = GetScalar(block, "type");
+                    if (!string.Equals(type, "archetype_definition", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string? title = GetScalar(block, "title");
+                    string? behavior = GetScalar(block, "behavior");
+
+                    if (string.IsNullOrWhiteSpace(title))
+                        continue;
+
+                    if (string.IsNullOrWhiteSpace(behavior))
+                    {
+                        skipped.Add(title!);
+                        continue;
+                    }
+
+                    ArchetypeCatalog.RegisterBehavior(title!, behavior!);
+                    registered++;
+                }
+
+                return new LoadResult(registered, skipped, null);
+            }
+            catch (Exception ex)
+            {
+                return new LoadResult(0, skipped, ex.Message);
+            }
+        }
+
+        private static string? GetScalar(YamlMappingNode mapping, string key)
+        {
+            if (mapping.Children.TryGetValue(new YamlScalarNode(key), out var v) && v is YamlScalarNode scalar)
+                return scalar.Value;
+            return null;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -16,7 +16,8 @@ namespace Pinder.LlmAdapters.Groq
             string model,
             string message,
             string instruction,
-            string? opponentContext = null)
+            string? opponentContext = null,
+            string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -29,6 +30,12 @@ namespace Pinder.LlmAdapters.Groq
             if (!string.IsNullOrWhiteSpace(opponentContext))
                 systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
 
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+
             var payload = new
             {
                 model = model,
@@ -36,7 +43,7 @@ namespace Pinder.LlmAdapters.Groq
                 messages = new[]
                 {
                     new { role = "system", content = systemPrompt },
-                    new { role = "user", content = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message." }
+                    new { role = "user", content = userContent }
                 }
             };
 

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -75,5 +75,76 @@ namespace Pinder.LlmAdapters.Groq
                 return message;
             }
         }
+
+        /// <summary>
+        /// Apply a trap overlay via the Groq overlay endpoint (issue #371).
+        /// Mirrors <see cref="ApplyHorninessOverlayAsync"/> but adds the trap name
+        /// to the prompt for grounding.
+        /// </summary>
+        public static async Task<string> ApplyTrapOverlayAsync(
+            string groqApiKey,
+            string model,
+            string message,
+            string trapInstruction,
+            string trapName,
+            string? opponentContext = null,
+            string? archetypeDirective = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no refusals, no preamble.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            // Inject the speaker's active archetype directive (#372 + #371 union) so the
+            // trap-overlay rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nTRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint (preserving the archetype voice above) and return the modified message."
+                : $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
+
+            var payload = new
+            {
+                model = model,
+                max_tokens = 400,
+                messages = new[]
+                {
+                    new { role = "system", content = systemPrompt },
+                    new { role = "user", content = userContent }
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.groq.com/openai/v1/chat/completions");
+            request.Headers.Add("Authorization", $"Bearer {groqApiKey}");
+            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await _http.SendAsync(request).ConfigureAwait(false);
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode) return message;
+
+                var json = JObject.Parse(body);
+                var text = json["choices"]?[0]?["message"]?["content"]?.Value<string>()?.Trim();
+
+                if (string.IsNullOrWhiteSpace(text)) return message;
+
+                if (text!.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    text.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    text.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return text;
+            }
+            catch
+            {
+                return message;
+            }
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -431,13 +431,13 @@ namespace Pinder.LlmAdapters.OpenAi
         /// <summary>
         /// Apply a horniness overlay — returns input unchanged (OpenAI overlay not yet implemented).
         /// </summary>
-        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             return Task.FromResult(message);
         }
 
         /// <inheritdoc />
-        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             // Shadow corruption via OpenAI transport — returns input unchanged (not yet implemented).
             return Task.FromResult(message);

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -442,5 +442,15 @@ namespace Pinder.LlmAdapters.OpenAi
             // Shadow corruption via OpenAI transport — returns input unchanged (not yet implemented).
             return Task.FromResult(message);
         }
+
+        /// <summary>
+        /// Apply a trap overlay — returns input unchanged (OpenAI overlay not yet implemented).
+        /// Production deployments route trap overlays through <see cref="PinderLlmAdapter"/>; this
+        /// stub preserves the contract for non-overlay OpenAI adapter usage.
+        /// </summary>
+        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        {
+            return Task.FromResult(message);
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -218,6 +218,59 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+                return message;
+
+            // Route to Groq when configured — same path as horniness/shadow overlays.
+            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
+            {
+                return await GroqOverlayApplier.ApplyTrapOverlayAsync(
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective)
+                    .ConfigureAwait(false);
+            }
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
+                "A trap is currently corrupting the character's voice. " +
+                "Apply the trap instruction to rewrite the message so the trap's signature taint is visible. " +
+                "Return ONLY the rewritten message text. No commentary, no refusals, no preamble.";
+
+            if (!string.IsNullOrWhiteSpace(opponentContext))
+                systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
+
+            // Inject the speaker's active archetype directive (#372 + #371 union) so the
+            // trap-overlay rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nTRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint (preserving the archetype voice above) and return the modified message."
+                : $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
+
+            try
+            {
+                double temperature = _options.DeliveryTemperature ?? 0.7;
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay)
+                    .ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(result)) return message;
+                string trimmed = result.Trim();
+
+                // Detect refusal — fall back to original message silently.
+                if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return message;
+
+                return trimmed;
+            }
+            catch
+            {
+                return message;
+            }
+        }
+
+        /// <inheritdoc />
         public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -164,7 +164,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -173,7 +173,7 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
                     .ConfigureAwait(false);
             }
 
@@ -186,7 +186,12 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(opponentContext))
                 systemPrompt += $"\n\nThe message being sent is directed at this character:\n{opponentContext}";
 
-            string userContent = $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // overlay rewrite stays in the character's voice instead of
+            // collapsing to a generic horny rewrite.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
+                : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
 
             try
             {
@@ -213,7 +218,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -224,7 +229,11 @@ namespace Pinder.LlmAdapters
                 "Now the character's shadow stat is corrupting it further. " +
                 "Return ONLY the corrupted message text. No commentary, no preamble, no refusals.";
 
-            string userContent = $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
+            // Inject the speaker's active archetype directive (#372) so the
+            // shadow-corrupted rewrite still sounds like the character.
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nSHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above) and return the modified message."
+                : $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
 
             try
             {

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -179,6 +179,16 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine(deliveryTaint);
             }
 
+            // Inject active archetype directive (#372 / #375). Without this
+            // the delivery rewrite scrubs the archetype voice that the
+            // dialogue-options call already chose, leaving the actually-sent
+            // message generic.
+            if (!string.IsNullOrEmpty(context.ActiveArchetypeDirective))
+            {
+                sb.AppendLine();
+                sb.AppendLine(context.ActiveArchetypeDirective);
+            }
+
             sb.AppendLine();
 
             // Build roll context narrative from YAML or fallback

--- a/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
+++ b/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
@@ -24,10 +24,11 @@ namespace Pinder.Core.Tests
             // Act: level 4 — Peacock eligible (3-8), Sniper not (5-11)
             var result = CharacterAssembler.ResolveActiveArchetype(ranked, 4);
 
-            // Assert
+            // Assert: 5 / (5+3+2) = 0.50 → "clear" (#375 ratio rule).
             Assert.NotNull(result);
             Assert.Equal("The Peacock", result.Name);
             Assert.Equal(5, result.Count);
+            Assert.Equal(10, result.TotalCount);
             Assert.Equal("clear", result.InterferenceLevel);
         }
 
@@ -74,43 +75,75 @@ namespace Pinder.Core.Tests
             Assert.Equal("The Sniper", result.Name);
         }
 
+        // ── #375 ratio-based intensity tests ─────────────────────────────────────
+        // Intensity is now share-of-archetype-votes, not raw count, so a
+        // single-vote lead no longer gets "clear" or "dominant". The legacy
+        // single-arg ctor defaults TotalCount to Count, which gives ratio=1.0
+        // and therefore "dominant" — preserved for backward compatibility for
+        // callers that have not yet been migrated to pass totalCount.
+
         [Fact]
-        public void ActiveArchetype_InterferenceLevel_Slight()
+        public void ActiveArchetype_InterferenceLevel_LegacyCtor_DefaultsToDominant()
         {
+            // No total supplied → ratio = Count/Count = 1.0 → dominant.
+            // This preserves "always dominant" for callers that haven't
+            // migrated to pass totalCount, and keeps the public API
+            // source-compatible.
             var arch = new ActiveArchetype("Test", "behavior", 1);
-            Assert.Equal("slight", arch.InterferenceLevel);
-
-            arch = new ActiveArchetype("Test", "behavior", 2);
-            Assert.Equal("slight", arch.InterferenceLevel);
-        }
-
-        [Fact]
-        public void ActiveArchetype_InterferenceLevel_Clear()
-        {
-            var arch = new ActiveArchetype("Test", "behavior", 3);
-            Assert.Equal("clear", arch.InterferenceLevel);
-
-            arch = new ActiveArchetype("Test", "behavior", 5);
-            Assert.Equal("clear", arch.InterferenceLevel);
-        }
-
-        [Fact]
-        public void ActiveArchetype_InterferenceLevel_Dominant()
-        {
-            var arch = new ActiveArchetype("Test", "behavior", 6);
             Assert.Equal("dominant", arch.InterferenceLevel);
+            Assert.Equal(1, arch.TotalCount);
+        }
 
-            arch = new ActiveArchetype("Test", "behavior", 10);
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PunTroll2_Player1_IsClear()
+        {
+            // The #375 acceptance test: a 2-over-1 lead must NOT be "dominant".
+            // 2/3 = 0.67 → < 0.7 → "clear".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 2, totalCount: 3);
+            Assert.Equal("clear", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PunTroll4_Player1_IsDominant()
+        {
+            // The #375 acceptance test: a 4-over-1 lead IS "dominant".
+            // 4/5 = 0.80 → ≥ 0.7 → "dominant".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 4, totalCount: 5);
+            Assert.Equal("dominant", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_TiedBuild_IsClear()
+        {
+            // [Pun Troll: 2, Player: 2] → 2/4 = 0.50 → "clear" (tied lead).
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 2, totalCount: 4);
+            Assert.Equal("clear", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_OneVoiceAmongMany_IsSlight()
+        {
+            // 1/4 = 0.25 → < 0.4 → "slight".
+            var arch = new ActiveArchetype("The Pun Troll", "behavior", count: 1, totalCount: 4);
+            Assert.Equal("slight", arch.InterferenceLevel);
+        }
+
+        [Fact]
+        public void ActiveArchetype_InterferenceLevel_PureBuild_IsDominant()
+        {
+            // 4/4 = 1.0 → "dominant" (a build that votes one archetype only).
+            var arch = new ActiveArchetype("The Peacock", "behavior", count: 4, totalCount: 4);
             Assert.Equal("dominant", arch.InterferenceLevel);
         }
 
         [Fact]
         public void ActiveArchetype_Directive_ContainsNameAndBehavior()
         {
-            var arch = new ActiveArchetype("The Peacock", "Shows off constantly.", 4);
+            // Build of 4 votes total, this archetype gets 4 → dominant.
+            var arch = new ActiveArchetype("The Peacock", "Shows off constantly.", count: 4, totalCount: 4);
             var directive = arch.Directive;
 
-            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", directive);
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (dominant)", directive);
             Assert.Contains("Shows off constantly.", directive);
         }
 

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -186,6 +186,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -184,8 +184,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -56,8 +56,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 [Fact]

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -58,6 +58,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 [Fact]

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -53,6 +53,7 @@ namespace Pinder.Core.Tests
         }
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     [Trait("Category", "Core")]

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -51,8 +51,8 @@ namespace Pinder.Core.Tests
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     [Trait("Category", "Core")]

--- a/tests/Pinder.Core.Tests/ComplianceBugFixTests.cs
+++ b/tests/Pinder.Core.Tests/ComplianceBugFixTests.cs
@@ -92,13 +92,20 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void Bug1_Nat1_DoesNotActivateTrap_WhenAlreadyActive()
+        public void Bug1_Nat1_ReactivatesTrap_PerSingleSlotReplacement()
         {
+            // Per #371 (W2a) single-slot replacement: a fresh trap-triggering
+            // failure tier (including Nat 1) ALWAYS activates the stat's trap,
+            // even if the same trap was already active. The new activation
+            // replaces the existing entry and resets TurnsRemaining to 3.
             var trapDef = new TrapDefinition("charm-trap", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 2, "instruction", "clear", "nat1");
+                TrapEffect.Disadvantage, 0, 3, "instruction", "clear", "nat1");
             var registry = new SingleTrapRegistry2(trapDef);
             var traps = new TrapState();
             traps.Activate(trapDef); // already active
+            // Simulate one turn elapsed, so TurnsRemaining was 2 before re-activation.
+            traps.AdvanceTurn();
+            Assert.Equal(2, traps.Get()!.TurnsRemaining);
 
             var attacker = MakeStats(charm: 10);
             var defender = MakeStats();
@@ -108,9 +115,11 @@ namespace Pinder.Core.Tests
                 registry, new FixedDice2(1));
 
             Assert.Equal(FailureTier.Legendary, result.Tier);
-            // No new trap activated (already active)
-            Assert.Null(result.ActivatedTrap);
+            Assert.NotNull(result.ActivatedTrap);
+            Assert.Equal("charm-trap", result.ActivatedTrap!.Id);
             Assert.True(traps.IsActive(StatType.Charm));
+            // Re-activation refreshed TurnsRemaining to FixedDurationTurns=3.
+            Assert.Equal(3, traps.Get()!.TurnsRemaining);
         }
 
         // ──────────────────────────────────────────────────────────────────────────
@@ -163,35 +172,34 @@ namespace Pinder.Core.Tests
         }
 
         // ──────────────────────────────────────────────────────────────────────────
-        // Bug 3: SA success vs DC 12 clears oldest active trap
+        // Bug 3 (W2a #371): single-slot trap — second Activate REPLACES the first;
+        // SA-DC-12-clears-oldest mechanic is obsolete (replaced by SA-selection-disarm).
         // ──────────────────────────────────────────────────────────────────────────
 
         [Fact]
-        public void TrapState_ClearOldest_RemovesOldestTrap()
+        public void TrapState_SecondActivate_ReplacesFirst()
         {
             var trap1 = new TrapDefinition("trap1", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 5, "i1", "c1", "n1");
+                TrapEffect.Disadvantage, 0, 3, "i1", "c1", "n1");
             var trap2 = new TrapDefinition("trap2", StatType.Rizz,
-                TrapEffect.Disadvantage, 0, 2, "i2", "c2", "n2");
+                TrapEffect.Disadvantage, 0, 3, "i2", "c2", "n2");
 
             var state = new TrapState();
-            state.Activate(trap1); // 5 turns remaining
-            state.Activate(trap2); // 2 turns remaining — oldest (fewest turns = soonest to expire)
+            state.Activate(trap1);
+            state.Activate(trap2); // replaces trap1 under #371 single-slot rule
 
-            state.ClearOldest();
-
-            // trap2 had fewest turns → cleared
-            Assert.False(state.IsActive(StatType.Rizz));
-            // trap1 still active
-            Assert.True(state.IsActive(StatType.Charm));
+            Assert.True(state.HasActive);
+            Assert.False(state.IsActive(StatType.Charm));
+            Assert.True(state.IsActive(StatType.Rizz));
+            Assert.Equal("trap2", state.Get()!.Definition.Id);
         }
 
         [Fact]
-        public void TrapState_ClearOldest_DoesNothingWhenEmpty()
+        public void TrapState_Clear_DoesNothingWhenEmpty()
         {
             var state = new TrapState();
             // Should not throw
-            state.ClearOldest();
+            state.Clear();
             Assert.False(state.HasActive);
         }
 

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -24,6 +24,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -22,8 +22,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => Task.FromResult(message);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -18,8 +18,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
@@ -40,8 +40,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -20,6 +20,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
@@ -42,6 +43,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -238,8 +238,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -240,6 +240,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
@@ -315,8 +315,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
@@ -317,6 +317,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -219,6 +219,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -217,8 +217,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -210,6 +210,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -231,6 +232,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -208,8 +208,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -229,8 +229,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -173,8 +173,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -175,6 +175,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -280,8 +280,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class ThrowingLlmAdapter : ILlmAdapter
@@ -297,8 +297,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StubTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -28,23 +28,27 @@ namespace Pinder.Core.Tests
             Assert.Equal(9, GetInterest(session)); // 10 - 1
         }
 
-        // What: AC4 — Wait advances trap timers; trap with 1 turn expires (spec §3.7, edge case §5.4)
+        // What: AC4 — Wait advances trap timer; per #371 (W2a) every trap is
+        // fixed at 3 turns so three Wait() calls are needed to expire it.
         // Mutation: Fails if AdvanceTurn is not called (trap would remain active)
         [Fact]
         public void Wait_AdvancesTrapTimers_TrapExpires()
         {
             var trapDef = new TrapDefinition("TestTrap", StatType.Charm,
-                TrapEffect.Disadvantage, 0, 1, "test", "clear", "nat1");
+                TrapEffect.Disadvantage, 0, 3, "test", "clear", "nat1");
             var session = MakeSession(diceValue: 15, saModifier: 3);
             ActivateTrapOnSession(session, trapDef);
 
-            session.Wait(); // trap with 1 turn remaining → expires
-
-            // After Wait, trap should be gone
+            // Activation ⇒ TurnsRemaining=3. Wait once: 2 remaining; twice: 1; thrice: expired.
+            session.Wait();
+            Assert.True(GetTrapState(session).HasActive);
+            session.Wait();
+            Assert.True(GetTrapState(session).HasActive);
+            session.Wait();
             Assert.False(GetTrapState(session).HasActive);
         }
 
-        // What: AC4 — Wait with trap that has multiple turns: doesn't expire yet
+        // What: AC4 — Wait with trap mid-cycle: doesn't expire on a single Wait
         // Mutation: Fails if all traps are cleared instead of just decrementing
         [Fact]
         public void Wait_AdvancesTrapTimers_TrapNotExpiredIfMultipleTurns()
@@ -54,7 +58,7 @@ namespace Pinder.Core.Tests
             var session = MakeSession(diceValue: 15, saModifier: 3);
             ActivateTrapOnSession(session, trapDef);
 
-            session.Wait(); // trap with 3 turns → 2 remaining
+            session.Wait(); // 3 → 2 remaining
 
             // Trap should still be active
             Assert.True(GetTrapState(session).HasActive);
@@ -282,6 +286,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class ThrowingLlmAdapter : ILlmAdapter
@@ -299,6 +304,7 @@ namespace Pinder.Core.Tests
                 => throw new InvalidOperationException("LLM should not be called for Wait");
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StubTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -162,8 +162,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class TestClock : IGameClock

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -164,6 +164,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class TestClock : IGameClock

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -252,6 +252,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -247,10 +247,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
     }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -753,6 +753,7 @@ namespace Pinder.Core.Tests.Integration
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -751,8 +751,8 @@ namespace Pinder.Core.Tests.Integration
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -117,8 +117,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -119,6 +119,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -280,6 +280,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -303,6 +304,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -278,8 +278,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -301,8 +301,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -254,8 +254,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -256,6 +256,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -438,8 +438,8 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -440,6 +440,7 @@ namespace Pinder.Core.Tests
             }
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -174,6 +174,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -170,9 +170,9 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
     }

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -271,10 +271,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -276,6 +276,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
 
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)
                 => Task.FromResult("so when are we doing this?");

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -254,10 +254,10 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
             {
                 ShadowCorruptionCalled = true;
                 // Rewrite the message so a textDiff is emitted.

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -264,6 +264,11 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(message + " [shadow:" + shadow + "]");
             }
 
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+            {
+                return Task.FromResult(message);
+            }
+
             public Task<string> GetSteeringQuestionAsync(SteeringContext context)
                 => Task.FromResult("steering question");
         }

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -63,6 +63,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -61,8 +61,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -191,10 +191,10 @@ namespace Pinder.Core.Tests
             public Task<string> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
         }
 

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -196,6 +196,7 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
                 => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/JsonTrapRepositoryDataFileTests.cs
+++ b/tests/Pinder.Core.Tests/JsonTrapRepositoryDataFileTests.cs
@@ -44,15 +44,16 @@ namespace Pinder.Core.Tests
             Assert.Equal(new[] { "creep", "cringe", "overshare", "pretentious", "spiral", "unhinged" }, ids);
         }
 
+        // Per #371 (W2a): all traps now share duration_turns=3 and the new clear_method.
         [Theory]
-        [InlineData(StatType.Charm, "cringe", TrapEffect.Disadvantage, 0, 1)]
-        [InlineData(StatType.Rizz, "creep", TrapEffect.StatPenalty, 2, 2)]
-        [InlineData(StatType.Honesty, "overshare", TrapEffect.OpponentDCIncrease, 2, 1)]
-        [InlineData(StatType.Chaos, "unhinged", TrapEffect.Disadvantage, 0, 1)]
-        [InlineData(StatType.Wit, "pretentious", TrapEffect.OpponentDCIncrease, 3, 1)]
-        [InlineData(StatType.SelfAwareness, "spiral", TrapEffect.Disadvantage, 0, 2)]
+        [InlineData(StatType.Charm, "cringe", TrapEffect.Disadvantage, 0)]
+        [InlineData(StatType.Rizz, "creep", TrapEffect.StatPenalty, 2)]
+        [InlineData(StatType.Honesty, "overshare", TrapEffect.OpponentDCIncrease, 2)]
+        [InlineData(StatType.Chaos, "unhinged", TrapEffect.Disadvantage, 0)]
+        [InlineData(StatType.Wit, "pretentious", TrapEffect.OpponentDCIncrease, 3)]
+        [InlineData(StatType.SelfAwareness, "spiral", TrapEffect.Disadvantage, 0)]
         public void TrapsJson_TrapDefinition_MatchesExpected(
-            StatType stat, string expectedId, TrapEffect expectedEffect, int expectedValue, int expectedDuration)
+            StatType stat, string expectedId, TrapEffect expectedEffect, int expectedValue)
         {
             var json = LoadTrapsJson();
             var repo = new JsonTrapRepository(json);
@@ -63,9 +64,9 @@ namespace Pinder.Core.Tests
             Assert.Equal(stat, trap.Stat);
             Assert.Equal(expectedEffect, trap.Effect);
             Assert.Equal(expectedValue, trap.EffectValue);
-            Assert.Equal(expectedDuration, trap.DurationTurns);
+            Assert.Equal(3, trap.DurationTurns);
             Assert.False(string.IsNullOrEmpty(trap.LlmInstruction));
-            Assert.Equal("SA vs DC 12", trap.ClearMethod);
+            Assert.Equal("Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)", trap.ClearMethod);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -435,6 +435,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>Null trap registry for tests.</summary>

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -433,8 +433,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>Null trap registry for tests.</summary>

--- a/tests/Pinder.Core.Tests/RollEngineTests.cs
+++ b/tests/Pinder.Core.Tests/RollEngineTests.cs
@@ -247,14 +247,17 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void Catastrophe_DoesNotActivateTrap_WhenAlreadyActive()
+        public void Catastrophe_ReactivatesTrap_WhenAlreadyActive_PerSingleSlotRule()
         {
-            // If a trap is already active on the stat, Catastrophe should not replace it
+            // #371 (W2a): single-slot replacement — a Catastrophe roll always
+            // (re-)activates the stat's trap. The previous "don't replace if
+            // already active" guard is gone; the new activation refreshes the
+            // 3-turn timer and the new trap REPLACES whatever was previously active.
             var trapDef = new TrapDefinition("charm-trap", StatType.Charm,
                 TrapEffect.Disadvantage, 0, 2, "you're trapped", "cleared", "nat1 clear");
             var registry = new SingleTrapRegistry(trapDef);
             var traps = new TrapState();
-            // Pre-activate a trap
+            // Pre-activate a trap (will be replaced by the fresh activation)
             traps.Activate(trapDef);
 
             var baseStats = new Dictionary<StatType, int>
@@ -276,9 +279,12 @@ namespace Pinder.Core.Tests
                 registry, new FixedDice(9));
 
             Assert.Equal(FailureTier.Catastrophe, result.Tier);
-            // No new trap activated since one was already active
-            Assert.Null(result.ActivatedTrap);
+            // #371: new trap replaces the existing one (single-slot rule).
+            Assert.NotNull(result.ActivatedTrap);
+            Assert.Equal("charm-trap", result.ActivatedTrap!.Id);
             Assert.True(traps.IsActive(StatType.Charm));
+            // Fresh activation refreshes the timer to FixedDurationTurns (3).
+            Assert.Equal(TrapState.FixedDurationTurns, traps.Get()!.TurnsRemaining);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -650,8 +650,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -652,6 +652,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1257,8 +1257,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that returns a Tell on the opponent's response for a specific stat.</summary>
@@ -1285,8 +1285,8 @@ namespace Pinder.Core.Tests
                     detectedTell: new Tell(_tellStat, $"Tell on {_tellStat}")));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
@@ -1308,8 +1308,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1259,6 +1259,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that returns a Tell on the opponent's response for a specific stat.</summary>
@@ -1287,6 +1288,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
@@ -1310,6 +1312,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -640,8 +640,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -642,6 +642,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -641,8 +641,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -643,6 +643,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -716,8 +716,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
@@ -741,8 +741,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -718,6 +718,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
@@ -743,6 +744,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -787,8 +787,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -811,8 +811,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -789,6 +789,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -813,6 +814,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -335,6 +335,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -333,8 +333,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -513,6 +513,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -511,8 +511,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapDataFileValidationTests.cs
+++ b/tests/Pinder.Core.Tests/TrapDataFileValidationTests.cs
@@ -226,64 +226,33 @@ namespace Pinder.Core.Tests
 
         // === Duration turns ===
 
-        // Mutation: would catch if cringe duration is 2 instead of 1
-        [Fact]
-        public void Cringe_Duration_Is_1()
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of which trap.
+        // The data file's duration_turns is now 3 for every trap.
+        [Theory]
+        [InlineData(StatType.Charm)]
+        [InlineData(StatType.Rizz)]
+        [InlineData(StatType.Honesty)]
+        [InlineData(StatType.Chaos)]
+        [InlineData(StatType.Wit)]
+        [InlineData(StatType.SelfAwareness)]
+        public void AllTraps_Duration_Is_3(StatType stat)
         {
             var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Charm)!.DurationTurns);
-        }
-
-        // Mutation: would catch if creep duration is 1 instead of 2
-        [Fact]
-        public void Creep_Duration_Is_2()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(2, repo.GetTrap(StatType.Rizz)!.DurationTurns);
-        }
-
-        // Mutation: would catch if overshare duration is 2 instead of 1
-        [Fact]
-        public void Overshare_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Honesty)!.DurationTurns);
-        }
-
-        // Mutation: would catch if unhinged duration is 2 instead of 1
-        [Fact]
-        public void Unhinged_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Chaos)!.DurationTurns);
-        }
-
-        // Mutation: would catch if pretentious duration is 2 instead of 1
-        [Fact]
-        public void Pretentious_Duration_Is_1()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(1, repo.GetTrap(StatType.Wit)!.DurationTurns);
-        }
-
-        // Mutation: would catch if spiral duration is 1 instead of 2
-        [Fact]
-        public void Spiral_Duration_Is_2()
-        {
-            var repo = CreateRepo();
-            Assert.Equal(2, repo.GetTrap(StatType.SelfAwareness)!.DurationTurns);
+            Assert.Equal(3, repo.GetTrap(stat)!.DurationTurns);
         }
 
         // === Clear method ===
 
         // Mutation: would catch if any trap has wrong clear_method
+        // Per #371 (W2a): clear method is SA-option-selection, not a DC-12 roll.
         [Fact]
-        public void AllTraps_ClearMethod_Is_SA_vs_DC12()
+        public void AllTraps_ClearMethod_Is_PickAnySelfAwarenessOption()
         {
             var repo = CreateRepo();
+            const string expected = "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)";
             foreach (var trap in repo.GetAll())
             {
-                Assert.Equal("SA vs DC 12", trap.ClearMethod);
+                Assert.Equal(expected, trap.ClearMethod);
             }
         }
 

--- a/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
+++ b/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
@@ -1,0 +1,466 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.Core.Text;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// W2a (#371) trap-redesign engine tests.
+    ///
+    /// Mandatory acceptance scenarios:
+    ///  1. Trap activates on turn N. Turn N+1 player picks NON-SA. Trap LLM call
+    ///     fires (turn 2 of 3); `Trap (X)` text-diff layer added.
+    ///  2. Trap activates on turn N. Turn N+1 player picks SA. Trap cleared at
+    ///     start of ResolveTurnAsync; no Trap diff this turn.
+    ///  3. SA picked, SA roll fails (Misfire). Old trap cleared. Spiral activated
+    ///     as the new trap. This turn's diff is the failure-tier label, not
+    ///     `Trap (Spiral)`. Spiral's TurnsRemaining == 3 going into turn N+1.
+    ///  4. Turn N+1 (Spiral persistence): non-SA picked, roll succeeds. Trap LLM
+    ///     call fires for Spiral; `Trap (Spiral)` diff added; TurnsRemaining=1
+    ///     after AdvanceTurn.
+    ///  5. Turn N+2 (Spiral persistence): non-SA, success. Trap LLM call fires;
+    ///     TurnsRemaining=0 after AdvanceTurn; Spiral removed at end.
+    ///  6. Turn N+1 fresh roll-failure activates a NEW trap while old trap is
+    ///     mid-cycle. Old trap replaced. Roll-modification IS the new trap's
+    ///     turn-1 taint. NO separate trap LLM call this turn.
+    ///  7. Resume: trap state survives RestoreState (per now-folded #369).
+    /// </summary>
+    [Trait("Category", "Core")]
+    public sealed class TrapPipelineW2aTests
+    {
+        // ──────────────────────────────────────────────────────────────────
+        // Test plumbing
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// LLM adapter that:
+        ///  * always returns four options spanning Charm / Honesty / Wit / SelfAwareness
+        ///    (so SA disarm scenarios can be exercised).
+        ///  * tags the delivered message with the failure tier so we can detect
+        ///    whether a trap overlay actually rewrote the text.
+        ///  * tags the trap-overlay output so the text-diff layer fires.
+        /// </summary>
+        private sealed class W2aTrapLlmAdapter : ILlmAdapter
+        {
+            public List<DialogueContext> DialogueContexts { get; } = new();
+            public List<DeliveryContext> DeliveryContexts { get; } = new();
+            public List<OpponentContext> OpponentContexts { get; } = new();
+            public int TrapOverlayCalls { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            {
+                DialogueContexts.Add(context);
+                var options = new[]
+                {
+                    new DialogueOption(StatType.Charm,         "Charm option"),
+                    new DialogueOption(StatType.Honesty,       "Honesty option"),
+                    new DialogueOption(StatType.Wit,           "Wit option"),
+                    new DialogueOption(StatType.SelfAwareness, "SA option"),
+                };
+                return Task.FromResult(options);
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            {
+                DeliveryContexts.Add(context);
+                // Tag the message with the tier so it is observably different
+                // from the IntendedText (so a TextDiff is emitted on failure).
+                string text = context.Outcome == FailureTier.None
+                    ? context.ChosenOption.IntendedText
+                    : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
+                return Task.FromResult(text);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            {
+                OpponentContexts.Add(context);
+                return Task.FromResult(new OpponentResponse("..."));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+            {
+                TrapOverlayCalls++;
+                // Mark the message so a Trap (X) text-diff is emitted.
+                return Task.FromResult($"[Trap:{trapName}] {message}");
+            }
+        }
+
+        /// <summary>
+        /// Trap registry that exposes one trap per stat. Stat → trap-name map matches
+        /// the production data shape (Charm → Cringe, SA → Spiral, etc.).
+        /// </summary>
+        private sealed class StubTrapRegistry : ITrapRegistry
+        {
+            private readonly Dictionary<StatType, TrapDefinition> _traps = new();
+            public StubTrapRegistry()
+            {
+                Register(StatType.Charm,         "cringe",      "Cringe");
+                Register(StatType.Rizz,          "creep",       "Creep");
+                Register(StatType.Honesty,       "overshare",   "Overshare");
+                Register(StatType.Chaos,         "unhinged",    "Unhinged");
+                Register(StatType.Wit,           "pretentious", "Pretentious");
+                Register(StatType.SelfAwareness, "spiral",      "Spiral");
+            }
+            private void Register(StatType stat, string id, string name)
+            {
+                _traps[stat] = new TrapDefinition(
+                    id, stat, TrapEffect.Disadvantage, 0, 3,
+                    llmInstruction: $"{name} taint instruction",
+                    clearMethod: "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)",
+                    nat1Bonus: "",
+                    displayName: name,
+                    summary: $"{name} trap summary.");
+            }
+            public TrapDefinition? GetTrap(StatType stat)
+            {
+                _traps.TryGetValue(stat, out var t);
+                return t;
+            }
+            public string? GetLlmInstruction(StatType stat)
+            {
+                _traps.TryGetValue(stat, out var t);
+                return t?.LlmInstruction;
+            }
+        }
+
+        private static StatBlock MakeStatBlock(int allStats = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm,         allStats },
+                    { StatType.Rizz,          allStats },
+                    { StatType.Honesty,       allStats },
+                    { StatType.Chaos,         allStats },
+                    { StatType.Wit,           allStats },
+                    { StatType.SelfAwareness, allStats }
+                },
+                new Dictionary<ShadowStatType, int>());
+        }
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        // The LLM adapter places SA at index 3 and the failing-charm trap option at 0.
+        private const int CharmIndex = 0;
+        private const int SaIndex = 3;
+        private const int WitIndex = 2;
+
+        /// <summary>
+        /// Dice roller that yields a queued sequence and falls back to a default
+        /// when the queue is empty. Avoids brittle dice-counting in tests where
+        /// downstream paths (ghost rolls, advantage/disadvantage, ComputeDelay)
+        /// vary by interest state.
+        /// </summary>
+        private sealed class ScriptedDice : IDiceRoller
+        {
+            private readonly Queue<int> _q;
+            private readonly int _default;
+            public ScriptedDice(int defaultRoll, params int[] script)
+            {
+                _default = defaultRoll;
+                _q = new Queue<int>(script);
+            }
+            public int Roll(int sides)
+            {
+                int v = _q.Count > 0 ? _q.Dequeue() : _default;
+                if (v < 1) v = 1;
+                if (v > sides) v = sides;
+                return v;
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // Tests
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// 1. Trap activates on turn N. Turn N+1: player picks NON-SA. Trap LLM
+        ///    overlay fires; the `Trap (X)` diff layer is appended; TurnsRemaining
+        ///    decrements from 2 → 1 after AdvanceTurn at end of turn N+1.
+        /// </summary>
+        [Fact]
+        public async Task PersistenceTurn_NonSaPick_FiresTrapOverlay_AndAddsTrapDiff()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // DC for stat=2 attacker, defender stats=2: stat-mod +2, defender-defence DC=14+2=16.
+            // Roll d20=4 → 4+2+0 = 6 → miss by 9 → TropeTrap → activates Cringe (Charm trap).
+            // T2 picks Charm again — trap on Charm = Disadvantage, so 2 d20s are rolled
+            // and the LOWER value is used. Both d20=18 → lower=18, total=20 ≥ DC → success.
+            var dice = new FixedDice(
+                5,            // ctor horniness
+                4,  10,       // T1: trip TropeTrap on Charm (activates Cringe)
+                18, 18, 10    // T2: 2 d20s under disadvantage — success on Charm
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // T1 — activate trap (turn 1 of 3, taint via roll-modification)
+            await session.StartTurnAsync();
+            var t1 = await session.ResolveTurnAsync(CharmIndex);
+            Assert.NotNull(t1.Roll.ActivatedTrap);
+            Assert.Equal("cringe", t1.Roll.ActivatedTrap!.Id);
+            // No Trap (Cringe) diff on activation turn (taint is the failure-tier rewrite).
+            Assert.DoesNotContain(t1.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            Assert.Equal(0, llm.TrapOverlayCalls);
+
+            // T2 — persistence; non-SA pick → Trap LLM call fires.
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(CharmIndex);
+            Assert.True(t2.Roll.IsSuccess, "T2 should succeed with d20=18");
+            Assert.Equal(1, llm.TrapOverlayCalls);
+            Assert.Contains(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Cringe)");
+        }
+
+        /// <summary>
+        /// 2. Trap activates on turn N. Turn N+1 player picks SA. Trap is cleared
+        ///    at start of ResolveTurnAsync, BEFORE the SA roll resolves. No Trap
+        ///    (X) diff layer on this turn even if the SA roll later succeeds.
+        /// </summary>
+        [Fact]
+        public async Task SaPick_DisarmsTrap_NoTrapDiffThisTurn_OnSuccess()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            var dice = new FixedDice(
+                5,           // ctor horniness
+                4,  10,      // T1: TropeTrap on Charm → Cringe activates
+                18, 10       // T2: SA pick, roll d20=18 → success → Cringe cleared, no Spiral
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex);
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(SaIndex);
+
+            Assert.True(t2.Roll.IsSuccess);
+            Assert.Equal("Cringe", t2.TrapClearedDisplayName);
+            // No trap-overlay LLM call this turn — disarm fired before pipeline.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // No active trap by end of turn (no Spiral activated since SA succeeded).
+            Assert.False(t2.StateAfter.ActiveTrapNames.Any());
+        }
+
+        /// <summary>
+        /// 3. Trap active. SA picked. SA roll fails into Misfire-or-worse. Old trap
+        ///    is cleared at start of ResolveTurnAsync. Spiral activates on the SA
+        ///    failure. The diff label for THIS turn is the failure tier (NOT
+        ///    Trap (Spiral)). Spiral's TurnsRemaining starts at 3, decremented to
+        ///    2 by end-of-turn AdvanceTurn.
+        /// </summary>
+        [Fact]
+        public async Task SaPick_OldTrapCleared_FailingSaActivatesSpiral_NoSeparateTrapOverlayThisTurn()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1 charm-trap (TropeTrap = miss by 6-9): roll 4 → miss by 9 → Cringe activates.
+            // T2 SA pick: need SA failure that activates a trap. Use d20=4 → SA total 6, DC 16,
+            // miss 10 → Catastrophe → Spiral activates (replacing Cringe).
+            var dice = new FixedDice(
+                5,         // ctor horniness
+                4, 10,     // T1: TropeTrap Charm
+                4, 10      // T2: SA → Catastrophe (also a trap-tier)
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex); // Cringe active
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(SaIndex); // disarms Cringe; SA fails → Spiral
+
+            Assert.False(t2.Roll.IsSuccess);
+            Assert.Equal(StatType.SelfAwareness, t2.Roll.Stat);
+            Assert.Equal("Cringe", t2.TrapClearedDisplayName);
+            // Spiral activated on this turn's roll
+            Assert.NotNull(t2.Roll.ActivatedTrap);
+            Assert.Equal("spiral", t2.Roll.ActivatedTrap!.Id);
+            // No separate trap LLM overlay on Spiral's activation turn.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // Active trap at end of turn = Spiral with TurnsRemaining=2 (3 - 1).
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal("spiral", t2.StateAfter.ActiveTrapNames[0]);
+            Assert.Equal(2, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+        }
+
+        /// <summary>
+        /// 4 + 5. Spiral persistence over two non-SA turns: trap overlay fires on
+        /// each, TurnsRemaining decrements 2 → 1 → 0; Spiral removed after turn 3.
+        /// </summary>
+        [Fact]
+        public async Task SpiralPersistence_TwoTurns_OverlayFires_AndExpires()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1: SA pick, Catastrophe → activates Spiral on turn N (turn 1 of 3).
+            // T2/T3/T4: non-SA Wit picks. Default to high d20 (18) so success is
+            // achieved even when interest-state side-effects (advantage / disadvantage /
+            // ghost-d4) consume extra dice. Script the T1 catastrophe roll explicitly.
+            var dice = new ScriptedDice(
+                defaultRoll: 18,
+                5,           // ctor horniness
+                4            // T1 d20 → 4+2 = 6 → miss by 10 → Catastrophe (Spiral activates)
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // T1
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(SaIndex);
+
+            // T2: Wit pick — Spiral persists, overlay fires.
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(WitIndex);
+            Assert.True(t2.Roll.IsSuccess);
+            Assert.Equal(1, llm.TrapOverlayCalls);
+            Assert.Contains(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Spiral)");
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal(1, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+
+            // T3: Wit pick — overlay fires; trap removed at end of turn (3 → 0).
+            await session.StartTurnAsync();
+            var t3 = await session.ResolveTurnAsync(WitIndex);
+            Assert.Equal(2, llm.TrapOverlayCalls);
+            Assert.Contains(t3.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName == "Trap (Spiral)");
+            Assert.Empty(t3.StateAfter.ActiveTrapNames);
+
+            // T4: no trap, no overlay.
+            await session.StartTurnAsync();
+            var t4 = await session.ResolveTurnAsync(WitIndex);
+            Assert.Equal(2, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t4.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+        }
+
+        /// <summary>
+        /// 6. New trap activates while another is mid-cycle (non-SA pick).
+        /// New trap REPLACES the old one; this turn's roll-modification is the
+        /// new trap's turn-1 taint; NO separate trap LLM call this turn.
+        /// </summary>
+        [Fact]
+        public async Task PersistenceTurn_FreshFailureActivatesNewTrap_ReplacesOld_NoOverlay()
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+
+            // T1: TropeTrap on Charm → Cringe activates.
+            // T2: pick Wit, roll d20=4 → miss by 9 → TropeTrap on Wit → Pretentious replaces Cringe.
+            //     Because a NEW trap activated this turn, the Trap-overlay step is SKIPPED.
+            var dice = new FixedDice(
+                5,
+                4, 10,    // T1: Charm TropeTrap
+                4, 10     // T2: Wit TropeTrap
+            );
+
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, dice, registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(CharmIndex);
+
+            await session.StartTurnAsync();
+            var t2 = await session.ResolveTurnAsync(WitIndex);
+
+            Assert.NotNull(t2.Roll.ActivatedTrap);
+            Assert.Equal("pretentious", t2.Roll.ActivatedTrap!.Id);
+            // NO trap LLM call on this turn — activation turns skip the overlay.
+            Assert.Equal(0, llm.TrapOverlayCalls);
+            Assert.DoesNotContain(t2.TextDiffs ?? (IReadOnlyList<TextDiff>)System.Array.Empty<TextDiff>(),
+                d => d.LayerName.StartsWith("Trap ("));
+            // Active trap at end of turn = Pretentious with TurnsRemaining=2 (3 - 1).
+            Assert.Single(t2.StateAfter.ActiveTrapNames);
+            Assert.Equal("pretentious", t2.StateAfter.ActiveTrapNames[0]);
+            Assert.Equal(2, t2.StateAfter.ActiveTrapDetails[0].TurnsRemaining);
+        }
+
+        /// <summary>
+        /// 7. Resume path (#369 case-mismatch fold-in). RestoreState round-trips
+        /// trap state regardless of stat-string casing in the snapshot data.
+        /// </summary>
+        [Theory]
+        [InlineData("SelfAwareness")]
+        [InlineData("selfawareness")]
+        [InlineData("SELFAWARENESS")]
+        public async Task RestoreState_PreservesActiveTrap_CaseInsensitiveStat(string snapshotStatCase)
+        {
+            var llm = new W2aTrapLlmAdapter();
+            var registry = new StubTrapRegistry();
+            var session = new GameSession(
+                MakeProfile("Player"), MakeProfile("Opponent"),
+                llm, new FixedDice(5, 18, 18), registry,
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            var data = new ResimulateData
+            {
+                TargetInterest = 12,
+                TurnNumber = 5,
+                MomentumStreak = 0,
+                ActiveTraps = new List<(string, int)> { (snapshotStatCase, 2) }
+            };
+
+            session.RestoreState(data, registry);
+
+            var start = await session.StartTurnAsync();
+            // After restore, the trap state should expose the spiral trap on the
+            // game-state snapshot regardless of the snapshot's stat-string casing.
+            Assert.Single(start.State.ActiveTrapNames);
+            Assert.Equal("spiral", start.State.ActiveTrapNames[0]);
+            Assert.Equal(2, start.State.ActiveTrapDetails[0].TurnsRemaining);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/TrapStateHasActiveTests.cs
+++ b/tests/Pinder.Core.Tests/TrapStateHasActiveTests.cs
@@ -7,8 +7,11 @@ namespace Pinder.Core.Tests
     [Trait("Category", "Core")]
     public class TrapStateHasActiveTests
     {
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of the
+        // definition's DurationTurns; the activation turn counts as turn 1
+        // of 3 so TurnsRemaining starts at 3.
         private static TrapDefinition MakeTrap(StatType stat) =>
-            new TrapDefinition($"trap-{stat}", stat, TrapEffect.Disadvantage, 0, 2,
+            new TrapDefinition($"trap-{stat}", stat, TrapEffect.Disadvantage, 0, 3,
                 "instruction", "clear", "nat1");
 
         [Fact]
@@ -31,18 +34,22 @@ namespace Pinder.Core.Tests
         {
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
-            state.Clear(StatType.Charm);
+            state.Clear();
             Assert.False(state.HasActive);
         }
 
         [Fact]
-        public void TwoTraps_ClearOne_HasActive_True()
+        public void SingleSlot_NewActivationReplacesOld()
         {
+            // Per #371: single-slot — a fresh Activate REPLACES whatever was active.
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
             state.Activate(MakeTrap(StatType.Wit));
-            state.Clear(StatType.Charm);
+
             Assert.True(state.HasActive);
+            Assert.False(state.IsActive(StatType.Charm));
+            Assert.True(state.IsActive(StatType.Wit));
+            Assert.Equal(StatType.Wit, state.Get()!.Definition.Stat);
         }
 
         [Fact]
@@ -50,21 +57,29 @@ namespace Pinder.Core.Tests
         {
             var state = new TrapState();
             state.Activate(MakeTrap(StatType.Charm));
-            state.Activate(MakeTrap(StatType.Wit));
             state.ClearAll();
             Assert.False(state.HasActive);
         }
 
         [Fact]
-        public void AdvanceTurn_ExpiresAll_HasActive_False()
+        public void AdvanceTurn_ExpiresAfterThreeTurns()
         {
+            // Activation counts as turn 1; after the activation turn TurnsRemaining
+            // decrements from 3 → 2 → 1 → 0 over three end-of-turn AdvanceTurn() calls.
             var state = new TrapState();
-            // Duration=2 turns, so after 2 advances all expire
             state.Activate(MakeTrap(StatType.Charm));
+
+            Assert.Equal(3, state.Get()!.TurnsRemaining);
             state.AdvanceTurn();
-            Assert.True(state.HasActive); // 1 turn remaining
+            Assert.True(state.HasActive);
+            Assert.Equal(2, state.Get()!.TurnsRemaining);
+
             state.AdvanceTurn();
-            Assert.False(state.HasActive); // expired
+            Assert.True(state.HasActive);
+            Assert.Equal(1, state.Get()!.TurnsRemaining);
+
+            state.AdvanceTurn();
+            Assert.False(state.HasActive); // expired after third AdvanceTurn
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -55,8 +55,8 @@ namespace Pinder.Core.Tests
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     // ---------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -57,6 +57,7 @@ namespace Pinder.Core.Tests
         }
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     // ---------------------------------------------------------------
@@ -482,9 +483,13 @@ namespace Pinder.Core.Tests
     }
 
     /// <summary>
-    /// Regression: duration-1 traps must still be visible to delivery and opponent
-    /// LLM contexts on the turn they activate. Before #692, AdvanceTurn was called
-    /// before delivery, expiring duration-1 traps immediately.
+    /// Regression: a freshly-activated trap must still be visible to delivery and
+    /// opponent LLM contexts on the turn it activates. Before #692, AdvanceTurn was
+    /// called before delivery, expiring short-duration traps immediately.
+    ///
+    /// Per #371 (W2a) every trap is now fixed at 3 turns regardless of the
+    /// definition's DurationTurns; these tests use definition.DurationTurns=1 to
+    /// document the legacy data shape but TrapState.Activate clamps to 3 turns.
     /// </summary>
     [Trait("Category", "Core")]
     public sealed class TrapDuration1RegressionTests
@@ -555,41 +560,12 @@ namespace Pinder.Core.Tests
                 oppCtx.ActiveTrapInstructions!);
         }
 
-        [Fact]
-        public async Task Duration1Trap_ExpiresBeforeNextTurnDialogue()
-        {
-            // Duration=1: should be gone by next StartTurnAsync
-            var trapDef = new TrapDefinition(
-                "cringe_trap", StatType.Charm, TrapEffect.Disadvantage, 0, 1,
-                "You become extremely awkward.", "SA vs DC 12", "");
-
-            var trapRegistry = new TestTrapRegistry();
-            trapRegistry.Register(trapDef);
-
-            var capturingLlm = new CapturingLlmAdapter();
-
-            var dice = new FixedDice(
-                5,   // Constructor: horniness roll
-                4,   // Turn 1: TropeTrap
-                10,  // Turn 1: timing delay
-                20   // Turn 2: padding
-            );
-
-            var session = new GameSession(
-                MakeProfile("Player"), MakeProfile("Opponent"),
-                capturingLlm, dice, trapRegistry,
-                new GameSessionConfig(clock: TestHelpers.MakeClock()));
-
-            await session.StartTurnAsync();
-            await session.ResolveTurnAsync(0);
-
-            // Turn 2
-            dice.Enqueue(10);
-            await session.StartTurnAsync();
-
-            // Duration-1 trap should have expired after AdvanceTurn at end of turn 1
-            var turn2Context = capturingLlm.DialogueContexts[1];
-            Assert.Null(turn2Context.ActiveTrapInstructions);
-        }
+        // The previous Duration1Trap_ExpiresBeforeNextTurnDialogue test asserted
+        // that a duration_turns=1 trap expired after one AdvanceTurn. Under
+        // #371 (W2a) every trap is fixed at 3 turns regardless of the definition.
+        // The 3-turn lifecycle is covered by
+        // <see cref="TrapStateHasActiveTests.AdvanceTurn_ExpiresAfterThreeTurns"/>
+        // and end-to-end by the persistence-path engine tests in
+        // <see cref="TrapPipelineW2aTests"/>.
     }
 }

--- a/tests/Pinder.Core.Tests/TrapsJsonIssue306Tests.cs
+++ b/tests/Pinder.Core.Tests/TrapsJsonIssue306Tests.cs
@@ -147,32 +147,31 @@ namespace Pinder.Core.Tests
 
         // ── AC5: Correct duration turns ──
 
-        // Mutation: catches if duration_turns is wrong (e.g. defaults to 3 instead of explicit value)
+        // Per #371 (W2a): every trap is fixed at 3 turns regardless of which trap.
         [Theory]
-        [InlineData(StatType.Charm, 1)]
-        [InlineData(StatType.Rizz, 2)]
-        [InlineData(StatType.Honesty, 1)]
-        [InlineData(StatType.Chaos, 1)]
-        [InlineData(StatType.Wit, 1)]
-        [InlineData(StatType.SelfAwareness, 2)]
-        public void Trap_DurationTurns_MatchesExpected(StatType stat, int expectedDuration)
+        [InlineData(StatType.Charm)]
+        [InlineData(StatType.Rizz)]
+        [InlineData(StatType.Honesty)]
+        [InlineData(StatType.Chaos)]
+        [InlineData(StatType.Wit)]
+        [InlineData(StatType.SelfAwareness)]
+        public void Trap_DurationTurns_Is_3(StatType stat)
         {
             var repo = new JsonTrapRepository(LoadTrapsJson());
             var trap = repo.GetTrap(stat);
             Assert.NotNull(trap);
-            Assert.Equal(expectedDuration, trap!.DurationTurns);
+            Assert.Equal(3, trap!.DurationTurns);
         }
 
-        // ── AC6: Clear method is "SA vs DC 12" for all traps ──
-
-        // Mutation: catches if clear_method is empty or wrong
+        // ── AC6: Clear method (W2a #371): SA-option-selection ──
         [Fact]
-        public void AllTraps_ClearMethod_IsSaVsDc12()
+        public void AllTraps_ClearMethod_IsPickAnySelfAwarenessOption()
         {
             var repo = new JsonTrapRepository(LoadTrapsJson());
+            const string expected = "Pick any Self-Awareness option (selection disarms; SA fail triggers Spiral)";
             foreach (var trap in repo.GetAll())
             {
-                Assert.Equal("SA vs DC 12", trap.ClearMethod);
+                Assert.Equal(expected, trap.ClearMethod);
             }
         }
 

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -75,8 +75,8 @@ namespace Pinder.Core.Tests
                 => Task.FromResult(new OpponentResponse("reply"));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -77,6 +77,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion
@@ -477,31 +478,34 @@ namespace Pinder.Core.Tests
         }
 
         // ==================================================================
-        // AC8: TrapState.HasActive — after AdvanceTurn with mixed durations
+        // AC8 (W2a #371): TrapState single-slot model — HasActive after AdvanceTurn.
+        // Replaces the prior multi-slot mixed-duration test. Every trap is fixed
+        // at 3 turns and a fresh Activate REPLACES the existing trap.
         // ==================================================================
 
-        // Mutation: Fails if HasActive checks wrong collection or uses != instead of >
         [Fact]
         public void TrapState_HasActive_AfterPartialExpiry()
         {
             var state = new TrapState();
-            // Duration 1 trap (expires after 1 AdvanceTurn)
-            var shortTrap = new TrapDefinition("short", StatType.Charm,
+            // Definition's duration_turns is overridden to FixedDurationTurns=3
+            // by Activate(); the activation turn counts as turn 1 of 3.
+            var trap = new TrapDefinition("trap", StatType.Charm,
                 TrapEffect.Disadvantage, 0, 1, "i", "c", "n");
-            // Duration 2 trap (expires after 2 AdvanceTurns)  
-            var longTrap = new TrapDefinition("long", StatType.Wit,
-                TrapEffect.Disadvantage, 0, 2, "i", "c", "n");
 
-            state.Activate(shortTrap);
-            state.Activate(longTrap);
+            state.Activate(trap);
             Assert.True(state.HasActive);
+            Assert.Equal(3, state.Get()!.TurnsRemaining);
 
             state.AdvanceTurn();
-            // Short expired, long still has 1 turn
             Assert.True(state.HasActive);
+            Assert.Equal(2, state.Get()!.TurnsRemaining);
 
             state.AdvanceTurn();
-            // Both expired
+            Assert.True(state.HasActive);
+            Assert.Equal(1, state.Get()!.TurnsRemaining);
+
+            state.AdvanceTurn();
+            // Expired after 3 AdvanceTurn calls
             Assert.False(state.HasActive);
         }
 

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -424,6 +424,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -422,8 +422,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -444,6 +444,7 @@ namespace Pinder.Core.Tests
                 => Task.FromResult<string?>(null);
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -442,8 +442,8 @@ namespace Pinder.Core.Tests
 
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #372 / #375 \u2014 the active archetype directive must be injected into
+    /// the <c>delivery</c> LLM user prompt for any character with a non-null
+    /// ActiveArchetype. Before this fix, the directive only reached
+    /// <c>dialogue_options</c> + <c>opponent_response</c>, so the rewrite that
+    /// produces the actually-sent message scrubbed the archetype voice.
+    /// </summary>
+    [Trait("Category", "LlmAdapters")]
+    public class Issue372_ArchetypeDirectiveDeliveryTests
+    {
+        private const string SampleDirective =
+            "ACTIVE ARCHETYPE: The Peacock (clear)\nUses the opening message to establish status.";
+
+        private static DeliveryContext MakeDeliveryContext(
+            string activeArchetypeDirective = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 0)
+        {
+            return new DeliveryContext(
+                playerPrompt: "player prompt",
+                opponentPrompt: "opponent prompt",
+                conversationHistory: new List<(string Sender, string Text)>(),
+                opponentLastMessage: "",
+                chosenOption: new DialogueOption(StatType.Charm, "ok cool"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                playerName: "P",
+                opponentName: "O",
+                activeArchetypeDirective: activeArchetypeDirective);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_Success_ContainsActiveArchetypeDirective()
+        {
+            // Arrange
+            var ctx = MakeDeliveryContext(
+                activeArchetypeDirective: SampleDirective,
+                outcome: FailureTier.None,
+                beatDcBy: 7);
+
+            // Act
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+
+            // Assert
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", prompt);
+            Assert.Contains("Uses the opening message to establish status.", prompt);
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        [InlineData(FailureTier.Legendary)]
+        public void BuildDeliveryPrompt_Failure_ContainsActiveArchetypeDirective(FailureTier tier)
+        {
+            // Arrange
+            var ctx = MakeDeliveryContext(
+                activeArchetypeDirective: SampleDirective,
+                outcome: tier,
+                beatDcBy: -5);
+
+            // Act
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+
+            // Assert: directive must reach BOTH success and failure branches.
+            // Otherwise a Fumble/Catastrophe rewrite scrubs the archetype voice.
+            Assert.Contains("ACTIVE ARCHETYPE: The Peacock (clear)", prompt);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_NullDirective_DoesNotInjectAnything()
+        {
+            var ctx = MakeDeliveryContext(activeArchetypeDirective: null, beatDcBy: 4);
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", prompt);
+        }
+
+        [Fact]
+        public void BuildDeliveryPrompt_EmptyDirective_DoesNotInjectAnything()
+        {
+            var ctx = MakeDeliveryContext(activeArchetypeDirective: "", beatDcBy: 4);
+            string prompt = SessionDocumentBuilder.BuildDeliveryPrompt(ctx);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", prompt);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeYamlLoaderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeYamlLoaderTests.cs
@@ -1,0 +1,69 @@
+using Pinder.Core.Characters;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #372 \u2014 ArchetypeYamlLoader must parse the canonical
+    /// <c>archetypes-enriched.yaml</c> structure and register every block of
+    /// <c>type: archetype_definition</c> into <see cref="ArchetypeCatalog"/>.
+    /// </summary>
+    [Trait("Category", "LlmAdapters")]
+    public class Issue372_ArchetypeYamlLoaderTests
+    {
+        private const string SampleYaml = @"- id: header
+  type: definition
+  title: Header
+- id: archetype.fake-troll-9999
+  type: archetype_definition
+  title: The Fake Troll 9999
+  behavior: |
+    Loves wordplay. Cannot let a sentence land without a pun retrofitted.
+    Self-applauding.
+- id: archetype.empty-9999
+  type: archetype_definition
+  title: The Empty 9999
+  behavior: ''
+- id: not-an-archetype-9999
+  type: definition
+  title: Other
+";
+
+        [Fact]
+        public void LoadFromYaml_RegistersBehaviorForEachArchetypeDefinition()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml(SampleYaml);
+
+            // Sanity: parsed without error
+            Assert.Null(result.Error);
+            Assert.Equal(1, result.Registered);
+            Assert.Single(result.SkippedMissingBehavior);
+            Assert.Equal("The Empty 9999", result.SkippedMissingBehavior[0]);
+
+            // The behaviour must now be retrievable from the catalog.
+            string behavior = ArchetypeCatalog.GetBehavior("The Fake Troll 9999");
+            Assert.Contains("Loves wordplay", behavior);
+
+            // The non-archetype block must NOT have been registered.
+            string headerBehavior = ArchetypeCatalog.GetBehavior("Header");
+            Assert.Contains("behavioral pattern", headerBehavior); // bare placeholder
+        }
+
+        [Fact]
+        public void LoadFromYaml_EmptyInput_ReturnsErrorAndDoesNotMutateCatalog()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml("");
+            Assert.NotNull(result.Error);
+            Assert.Equal(0, result.Registered);
+        }
+
+        [Fact]
+        public void LoadFromYaml_MalformedYaml_ReturnsErrorWithoutThrowing()
+        {
+            var result = ArchetypeYamlLoader.LoadFromYaml("- id: incomplete\n  type: archetype_definition\n  title: [this is wrong\n  behavior: x");
+            Assert.NotNull(result.Error);
+            Assert.Equal(0, result.Registered);
+        }
+    }
+}


### PR DESCRIPTION
## Scope — §7 / CONSOLIDATOR-TRIGGER preventive consolidation

Per `LESSONS_LEARNED.md` §7 and the canonical `CONSOLIDATOR-TRIGGER` lesson, this PR consolidates two approved source PRs that have substantial real-file overlap on `ILlmAdapter` and the five adapter implementations. Naive serial-merge would have left the integrated `ILlmAdapter` with EITHER #777's archetype-directive parameter OR #778's new `ApplyTrapOverlayAsync` method — never both — silently producing a build that compiles but is missing one of the two intended features.

This PR is built by **rebuilding from the union of intended deltas** rather than from textual conflict markers, so both features end-to-end work coherently.

### Source PRs consolidated
- **#777** (`fix/W2b-archetype-plumbing`) — archetype directive plumbing + ratio-based intensity (`#372` `#375`).
- **#778** (`fix/W2a-trap-redesign`) — trap mechanic redesign (single slot, 3-turn duration, SA-disarm-on-selection) (`#371`, folds in `#369`).

Closes #371 #369 #372 #375 (the four issues these two PRs together resolve).

### What's in this PR

#### Both features end-to-end working

- **`ILlmAdapter`** has BOTH:
  - `archetypeDirective` parameter on `ApplyHorninessOverlayAsync`, `ApplyShadowCorruptionAsync` (#777).
  - New `ApplyTrapOverlayAsync(message, trapInstruction, trapName, opponentContext, archetypeDirective)` method (#778, extended to ALSO accept `archetypeDirective` per the union-of-deltas rule).
- **All five implementations** (`PinderLlmAdapter`, `AnthropicLlmAdapter`, `GroqOverlayApplier`, `OpenAiLlmAdapter`, `NullLlmAdapter`) implement the new method AND accept `archetypeDirective` on existing methods. The Groq route inside `ApplyTrapOverlayAsync` also threads `archetypeDirective` end-to-end.
- **`GameSession.ResolveTurnAsync`** has BOTH:
  - The trap mechanic redesign (4 paths: SA-disarm-on-selection, fresh activation, persistence overlay, replacement).
  - The archetype directive plumbed into delivery + horniness + shadow + trap-overlay LLM calls (so the trap rewrite stays in the character's voice — the union extension).
- **`LlmPhase.TrapOverlay`** + the existing #777 phase constants both present.
- **YAML data** updated for 3-turn trap duration, SA-disarm rule, single-slot replacement (`data/traps/traps.json`, `rules/extracted/traps-enriched.yaml`), AND missing archetype catalog entries (`rules/extracted/archetypes-enriched.yaml`).
- **`ArchetypeCatalog`** YAML-driven via `ArchetypeYamlLoader` (#777).
- **Test stubs** in 33 test files updated for the union of both interface changes — every test stub now stubs all three overlay methods with the integrated signatures.
- **8 new TrapPipelineW2aTests + 15 ActiveArchetype tests + 11 Issue372 LLM directive tests** — all pass.

### DoD Evidence

```
$ dotnet build Pinder.Core.sln -c Debug
    26 Warning(s)    (all pre-existing nullability + xunit hints)
    0 Error(s)

$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
Failed!  - Failed: 6, Passed: 2474, Skipped: 18, Total: 2498

$ dotnet test tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
Failed!  - Failed: 63, Passed: 922, Skipped: 9, Total: 994

$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --filter "FullyQualifiedName~TrapPipelineW2a|FullyQualifiedName~ActiveArchetype"
Passed!  - Failed: 0, Passed: 23, Skipped: 0, Total: 23
```

The 6 + 63 failures are **pre-existing on baseline `main`** — verified via a fresh worktree at `origin/main`:
- main baseline: Core 2488 (2464 ✓ / 6 ✗ / 18 ⏭), LlmAdapters 983 (911 ✓ / 63 ✗ / 9 ⏭).
- after #777: Core 2491 (+3), LlmAdapters 994 (+11).
- after integrated #778: Core 2498 (+7 W2a tests), LlmAdapters 994 (no change).

**No behavior loss** — test-count progression is monotonic and matches the union of source-PR test additions.

### Cherry-pick history

```
8e59831 fix(W2a): trap mechanic redesign — single slot, 3-turn duration, SA-disarm-on-selection (#371)
ce13588 test: bump ILlmAdapter test stubs for new archetypeDirective param (#372)
7f18eab feat(catalog): YAML-driven ArchetypeCatalog + add missing referenced archetypes (#372)
03c9140 fix(llm): thread archetype directive through overlay applier implementations (#372)
8ab5928 fix(llm): plumb archetype directive into delivery + overlay calls (#372 #375)
42d64c1 fix(characters): ratio-based archetype intensity tier (#375)
```

Six commits on top of `main` — the 5 commits from #777 followed by the single squashed commit from #778 (with the cherry-pick conflict resolution folded into the merge commit, applying the union-of-intended-deltas rule).

### Conflict-resolution log (non-trivial regions)

| Region | HEAD intent (#777) | Incoming intent (#778) | Resolution |
|--------|-------------------|------------------------|------------|
| `ILlmAdapter.cs` shadow + new method | Add `archetypeDirective` to `ApplyShadowCorruptionAsync` | Drop `archetypeDirective` from shadow, add new `ApplyTrapOverlayAsync(...)` without archetype param | Keep #777's `archetypeDirective` on shadow, add #778's new method, **extend new method with `archetypeDirective` param** (union of intended deltas — trap call should also be archetype-aware) |
| `PinderLlmAdapter.cs` shadow + new method | `archetypeDirective` plumbed through shadow user content | New `ApplyTrapOverlayAsync` body without archetype | Same: keep archetypeDirective on shadow, add new method body **with archetypeDirective threaded through Groq route AND user-content prefix** |
| `GroqOverlayApplier.cs` (auto-merged but needed extension) | already has archetypeDirective on horniness + shadow | added new static `ApplyTrapOverlayAsync` without archetype | Extended the new static method with `archetypeDirective = null` parameter and threaded it into the user-content payload |
| `AnthropicLlmAdapter.cs`, `OpenAiLlmAdapter.cs`, `NullLlmAdapter.cs` (auto-merged but needed extension) | archetypeDirective on existing methods | new ApplyTrapOverlayAsync stub without archetype | Extended each new method signature with `archetypeDirective = null`. For `AnthropicLlmAdapter` the Groq passthrough was updated to forward the parameter; the user-content also conditionally prepends the directive. |
| `GameSession.ResolveTurnAsync` — trap LLM call site | already passes `playerArchetypeDirectiveForDelivery` to horniness + shadow | added new `_llm.ApplyTrapOverlayAsync(...)` call without archetype | Updated trap call to also pass `playerArchetypeDirectiveForDelivery` so the trap LLM rewrite stays in the character's voice (the union-of-deltas extension) |
| 33 test-stub files (mechanical) | archetypeDirective on shadow/horniness | new ApplyTrapOverlayAsync stub | Added all three overlay methods with the integrated signatures (archetypeDirective on every overlay method) |

The "anti-pattern keep both" failure mode (two methods named `ApplyTrapOverlayAsync` with conflicting signatures, or duplicate `ApplyShadowCorruptionAsync`) was deliberately avoided: every conflict was resolved as ONE method with the union of parameters.

### Merge order

This is the **pinder-core-only** consolidation. The pinder-web side (PRs #383 + #384) consolidates separately AFTER this PR lands and the submodule SHA can be bumped on `pinder-web`'s `main`.

Per LESSONS_LEARNED §13 (submodule index-vs-working-tree drift), the pinder-web companion must:
1. Land this PR on `pinder-core` `main`.
2. Then in `pinder-web`: `cd pinder-core && git checkout main && git pull`.
3. `cd .. && git add pinder-core && git commit` — bumping the submodule pointer.
4. Open the consolidated pinder-web PR.
