### PR TITLE
feat(character): expose CharacterDefinitionLoader.Parse for in-memory validation (W3a; #330/#331)

### DIFF
--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -42,9 +42,11 @@ namespace Pinder.SessionSetup
 
         /// <summary>
         /// Parse a character definition JSON string and assemble it into a CharacterProfile.
-        /// Exposed for testing without file I/O.
+        /// Exposed publicly so callers (e.g. the GameApi character generator,
+        /// issues #330/#331) can validate freshly composed JSON without first
+        /// writing it to disk.
         /// </summary>
-        internal static CharacterProfile Parse(
+        public static CharacterProfile Parse(
             string json,
             IItemRepository itemRepo,
             IAnatomyRepository anatomyRepo)


### PR DESCRIPTION
Single-line behavior-neutral change to support pinder-web W3a (#330 + #331 character generation/refresh endpoints).

`CharacterDefinitionLoader.Parse(json, items, anatomy)` was `internal` (visible only via `InternalsVisibleTo Pinder.Core.Tests`). Promoting to `public` lets the new pinder-web `CharacterGenerator` validate freshly composed JSON in-memory without first writing it to disk and re-loading.

No behavior change — same code path, broader visibility.

## Closes
N/A — pinder-web side closes #330 + #331 via decay256/pinder-web#386.

## Merge order
This PR is independent and can merge before or after #780 (no file overlap).

## DoD
- `dotnet build` clean.
- `dotnet test tests/Pinder.Core.Tests` clean.
- 1 file changed, 4 insertions, 2 deletions.