### PR TITLE
refactor(#786): remove energy mechanics

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -584,14 +584,14 @@ class Program
             var mods = gameDef.HorninessTimeModifiers;
             var horninessModifiers = new Pinder.Core.Conversation.HorninessModifiers(
                 mods.Morning, mods.Afternoon, mods.Evening, mods.Overnight);
-            // dailyEnergy: unlimited in single-session sim (energy budget is a game-loop feature, not yet implemented)
-            clock = new Pinder.Core.Conversation.GameClock(now, horninessModifiers, dailyEnergy: int.MaxValue);
+            // Energy mechanics removed in #786.
+            clock = new Pinder.Core.Conversation.GameClock(now, horninessModifiers);
         }
         else
         {
             // Fallback: zero modifiers when game definition is unavailable
             var zeroModifiers = new Pinder.Core.Conversation.HorninessModifiers(0, 0, 0, 0);
-            clock = new Pinder.Core.Conversation.GameClock(now, zeroModifiers, dailyEnergy: int.MaxValue);
+            clock = new Pinder.Core.Conversation.GameClock(now, zeroModifiers);
         }
 
         // Display time-of-day info in session header

--- a/src/Pinder.Core/Conversation/GameClock.cs
+++ b/src/Pinder.Core/Conversation/GameClock.cs
@@ -30,54 +30,38 @@ namespace Pinder.Core.Conversation
     }
 
     /// <summary>
-    /// Simulated in-game clock that tracks time-of-day, provides horniness modifiers,
-    /// and manages a daily energy budget. Energy replenishes automatically when the
-    /// clock crosses midnight via <see cref="Advance"/> or <see cref="AdvanceTo"/>.
+    /// Simulated in-game clock that tracks time-of-day and provides horniness modifiers.
+    /// Energy mechanics were removed in #786 (deferred indefinitely; refactor blocker for #393).
     /// </summary>
     public sealed class GameClock : IGameClock
     {
-        private readonly int _dailyEnergy;
         private readonly HorninessModifiers _horninessModifiers;
 
         /// <summary>Current simulated time.</summary>
         public DateTimeOffset Now { get; private set; }
 
-        /// <summary>Remaining energy for the current in-game day.</summary>
-        public int RemainingEnergy { get; private set; }
-
         /// <summary>
         /// Creates a new GameClock starting at <paramref name="startTime"/>
-        /// with the specified daily energy budget and horniness modifiers.
+        /// with the specified horniness modifiers.
         /// </summary>
         /// <param name="startTime">Initial simulated time.</param>
         /// <param name="modifiers">
         /// Time-of-day horniness modifiers. Must not be null.
         /// </param>
-        /// <param name="dailyEnergy">
-        /// Energy budget per day. Default: 10. Must be &gt;= 0.
-        /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="modifiers"/> is null.
         /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when <paramref name="dailyEnergy"/> is negative.
-        /// </exception>
-        public GameClock(DateTimeOffset startTime, HorninessModifiers modifiers, int dailyEnergy = 10)
+        public GameClock(DateTimeOffset startTime, HorninessModifiers modifiers)
         {
             if (modifiers == null)
                 throw new ArgumentNullException(nameof(modifiers));
-            if (dailyEnergy < 0)
-                throw new ArgumentOutOfRangeException(nameof(dailyEnergy), "dailyEnergy must be non-negative");
 
             Now = startTime;
             _horninessModifiers = modifiers;
-            _dailyEnergy = dailyEnergy;
-            RemainingEnergy = dailyEnergy;
         }
 
         /// <summary>
         /// Advance the clock forward by the given amount.
-        /// If the advance crosses midnight, energy is replenished to dailyEnergy.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when <paramref name="amount"/> is zero or negative.
@@ -87,16 +71,11 @@ namespace Pinder.Core.Conversation
             if (amount <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(amount), "amount must be positive");
 
-            var oldDate = Now.Date;
             Now = Now.Add(amount);
-
-            if (Now.Date != oldDate)
-                RemainingEnergy = _dailyEnergy;
         }
 
         /// <summary>
         /// Advance the clock to the specified target time.
-        /// If the advance crosses midnight, energy is replenished to dailyEnergy.
         /// </summary>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="target"/> is less than or equal to <see cref="Now"/>.
@@ -106,11 +85,7 @@ namespace Pinder.Core.Conversation
             if (target <= Now)
                 throw new ArgumentException("target must be after Now", nameof(target));
 
-            var oldDate = Now.Date;
             Now = target;
-
-            if (Now.Date != oldDate)
-                RemainingEnergy = _dailyEnergy;
         }
 
         /// <summary>
@@ -139,26 +114,6 @@ namespace Pinder.Core.Conversation
             if (hour >= 12 && hour <= 17) return _horninessModifiers.Afternoon;
             if (hour >= 18 && hour <= 23) return _horninessModifiers.Evening;
             return _horninessModifiers.Overnight; // 00:00-08:59
-        }
-
-        /// <summary>
-        /// Attempt to consume the given amount of energy.
-        /// Returns true and deducts if sufficient energy remains.
-        /// Returns false without deducting if insufficient.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when <paramref name="amount"/> is zero or negative.
-        /// </exception>
-        public bool ConsumeEnergy(int amount)
-        {
-            if (amount <= 0)
-                throw new ArgumentOutOfRangeException(nameof(amount), "amount must be positive");
-
-            if (amount > RemainingEnergy)
-                return false;
-
-            RemainingEnergy -= amount;
-            return true;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -563,20 +563,7 @@ namespace Pinder.Core.Conversation
                 throw new ArgumentOutOfRangeException(nameof(optionIndex),
                     $"Option index {optionIndex} is out of range. Valid range: 0–{_currentOptions.Length - 1}.");
 
-            // Consume 1 energy from clock if available
-            if (_clock != null && !_clock.ConsumeEnergy(1))
-            {
-                _ended = true;
-                _outcome = GameOutcome.Unmatched;
-                // End-of-game Dread +1: conversation ended without date (energy depleted)
-                if (_playerShadows != null)
-                {
-                    _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
-                    var dreadEvents = _playerShadows.DrainGrowthEvents();
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents);
-                }
-                throw new GameEndedException(GameOutcome.Unmatched);
-            }
+            // Energy mechanics removed in #786 (deferred; blocked #393 fast-gameplay refactor).
 
             var chosenOption = _currentOptions[optionIndex];
 

--- a/src/Pinder.Core/Interfaces/IGameClock.cs
+++ b/src/Pinder.Core/Interfaces/IGameClock.cs
@@ -52,13 +52,5 @@ namespace Pinder.Core.Interfaces
         /// Morning=-2, Afternoon=0, Evening=+1, LateNight=+3, AfterTwoAm=+5.
         /// </summary>
         int GetHorninessModifier();
-
-        /// <summary>Energy remaining for the current day.</summary>
-        int RemainingEnergy { get; }
-
-        /// <summary>
-        /// Attempt to consume energy. Returns false if insufficient (no deduction on failure).
-        /// </summary>
-        bool ConsumeEnergy(int amount);
     }
 }

--- a/tests/Pinder.Core.Tests/GameClockSpecTests.cs
+++ b/tests/Pinder.Core.Tests/GameClockSpecTests.cs
@@ -9,6 +9,7 @@ namespace Pinder.Core.Tests
     /// Spec-driven tests for GameClock (issue #54, updated by issue #711).
     /// Based on docs/specs/issue-54-spec.md acceptance criteria.
     /// Issue #711: GetHorninessModifier() is now configurable via HorninessModifiers.
+    /// Issue #786: Energy mechanics removed. AC6/AC8-energy/edge-energy specs deleted.
     /// </summary>
     [Trait("Category", "Core")]
     public class GameClockSpecTests
@@ -200,97 +201,6 @@ namespace Pinder.Core.Tests
             Assert.Equal(66, clock4.GetHorninessModifier());
         }
 
-        // ===== AC6: DailyEnergy system =====
-
-        // Mutation: Would catch if default dailyEnergy was 0 or some other value instead of 10
-        [Fact]
-        public void AC6_DefaultDailyEnergy_Is10()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if ConsumeEnergy didn't deduct on success
-        [Fact]
-        public void AC6_ConsumeEnergy_DeductsOnSuccess()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 15);
-            Assert.True(clock.ConsumeEnergy(5));
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if ConsumeEnergy deducted even when insufficient
-        [Fact]
-        public void AC6_ConsumeEnergy_NoDeductionOnInsufficient()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 3);
-            Assert.False(clock.ConsumeEnergy(5));
-            Assert.Equal(3, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if ConsumeEnergy used > instead of >= for boundary
-        [Fact]
-        public void AC6_ConsumeEnergy_ExactlyRemainingSucceeds()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 7);
-            Assert.True(clock.ConsumeEnergy(7));
-            Assert.Equal(0, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if multiple consecutive consumes didn't accumulate
-        [Fact]
-        public void AC6_ConsumeEnergy_MultipleCalls_Accumulate()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 15);
-            Assert.True(clock.ConsumeEnergy(5));
-            Assert.Equal(10, clock.RemainingEnergy);
-            Assert.True(clock.ConsumeEnergy(10));
-            Assert.Equal(0, clock.RemainingEnergy);
-            Assert.False(clock.ConsumeEnergy(1));
-            Assert.Equal(0, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if midnight replenishment set energy to 0 instead of dailyEnergy
-        [Fact]
-        public void AC6_MidnightCrossing_ReplenishesToDailyEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 15);
-            clock.ConsumeEnergy(15);
-            Assert.Equal(0, clock.RemainingEnergy);
-
-            clock.Advance(TimeSpan.FromHours(2));
-            Assert.Equal(15, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if midnight replenishment used hardcoded 10 instead of constructor dailyEnergy
-        [Fact]
-        public void AC6_MidnightCrossing_ReplenishesToCustomDailyEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 20);
-            clock.ConsumeEnergy(20);
-            clock.Advance(TimeSpan.FromHours(2));
-            Assert.Equal(20, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if midnight detection was off-by-one (same day advance incorrectly replenishes)
-        [Fact]
-        public void AC6_SameDayAdvance_DoesNotReplenish()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(5);
-            clock.Advance(TimeSpan.FromHours(3));
-            Assert.Equal(5, clock.RemainingEnergy);
-        }
-
-        // Mutation: Would catch if zero dailyEnergy was rejected instead of allowed
-        [Fact]
-        public void AC6_ZeroDailyEnergy_AllConsumesFail()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 0);
-            Assert.Equal(0, clock.RemainingEnergy);
-            Assert.False(clock.ConsumeEnergy(1));
-        }
-
         // ===== AC7: Consumers inject IGameClock =====
 
         // Mutation: Would catch if GameClock couldn't be assigned to IGameClock variable
@@ -320,29 +230,7 @@ namespace Pinder.Core.Tests
             Assert.Equal(TimeOfDay.LateNight, clock.GetTimeOfDay());
         }
 
-        // Mutation: Would catch if AdvanceTo midnight crossing didn't trigger replenish
-        [Fact]
-        public void AC8_AdvanceTo_CrossingMidnight_ReplenishesEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(8);
-            Assert.Equal(2, clock.RemainingEnergy);
-
-            var target = new DateTimeOffset(2024, 1, 16, 1, 0, 0, TimeSpan.Zero);
-            clock.AdvanceTo(target);
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
         // ===== Error Conditions =====
-
-        // Mutation: Would catch if negative dailyEnergy was silently accepted
-        [Fact]
-        public void Error_Constructor_NegativeEnergy_Throws_ArgumentOutOfRangeException()
-        {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(
-                () => new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: -1));
-            Assert.NotNull(ex);
-        }
 
         // Mutation: Would catch if null modifiers was silently accepted
         [Fact]
@@ -387,38 +275,7 @@ namespace Pinder.Core.Tests
             Assert.Throws<ArgumentException>(() => clock.AdvanceTo(MakeTime(10)));
         }
 
-        // Mutation: Would catch if ConsumeEnergy(0) was silently accepted instead of throwing
-        [Fact]
-        public void Error_ConsumeEnergy_Zero_Throws_ArgumentOutOfRangeException()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => clock.ConsumeEnergy(0));
-        }
-
-        // Mutation: Would catch if ConsumeEnergy(-1) was silently accepted
-        [Fact]
-        public void Error_ConsumeEnergy_Negative_Throws_ArgumentOutOfRangeException()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => clock.ConsumeEnergy(-5));
-        }
-
         // ===== Edge Cases =====
-
-        // Mutation: Would catch if multiple midnight crossings didn't replenish
-        [Fact]
-        public void Edge_MultipleMidnightCrossings_StillReplenishes()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(10);
-            Assert.Equal(0, clock.RemainingEnergy);
-
-            // Advance 50 hours — crosses midnight at least twice
-            clock.Advance(TimeSpan.FromHours(50));
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
 
         // Mutation: Would catch if Advance didn't actually update Now
         [Fact]
@@ -457,16 +314,6 @@ namespace Pinder.Core.Tests
             Assert.Equal(MakeTime(10, 30), clock.Now);
         }
 
-        // Mutation: Would catch if energy replenish happened on same-day AdvanceTo
-        [Fact]
-        public void Edge_AdvanceTo_SameDay_NoReplenish()
-        {
-            var clock = new GameClock(MakeTime(8), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(6);
-            clock.AdvanceTo(MakeTime(20));
-            Assert.Equal(4, clock.RemainingEnergy);
-        }
-
         // Mutation: Would catch if GetTimeOfDay used minutes instead of just hour
         [Fact]
         public void Edge_GetTimeOfDay_MinutesIgnored()
@@ -482,20 +329,6 @@ namespace Pinder.Core.Tests
         {
             var clock = new GameClock(new DateTimeOffset(2024, 1, 15, 11, 59, 59, TimeSpan.Zero), DefaultModifiers);
             Assert.Equal(TimeOfDay.Morning, clock.GetTimeOfDay());
-        }
-
-        // Mutation: Would catch if consuming after replenish didn't work
-        [Fact]
-        public void Edge_ConsumeAfterMidnightReplenish()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(10);
-            clock.Advance(TimeSpan.FromHours(2)); // cross midnight
-            Assert.Equal(10, clock.RemainingEnergy);
-
-            // Should be able to consume again after replenish
-            Assert.True(clock.ConsumeEnergy(3));
-            Assert.Equal(7, clock.RemainingEnergy);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameClockTests.cs
+++ b/tests/Pinder.Core.Tests/GameClockTests.cs
@@ -5,6 +5,10 @@ using Xunit;
 
 namespace Pinder.Core.Tests
 {
+    /// <summary>
+    /// Time-of-day and horniness-modifier behaviour for <see cref="GameClock"/>.
+    /// Energy mechanics were removed in #786.
+    /// </summary>
     [Trait("Category", "Core")]
     public class GameClockTests
     {
@@ -21,34 +25,12 @@ namespace Pinder.Core.Tests
         // --- Constructor ---
 
         [Fact]
-        public void Constructor_SetsNowAndEnergy()
+        public void Constructor_SetsNow()
         {
             var start = MakeTime(10);
-            var clock = new GameClock(start, DefaultModifiers, dailyEnergy: 15);
+            var clock = new GameClock(start, DefaultModifiers);
 
             Assert.Equal(start, clock.Now);
-            Assert.Equal(15, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void Constructor_DefaultEnergy_Is10()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void Constructor_ZeroEnergy_Allowed()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 0);
-            Assert.Equal(0, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void Constructor_NegativeEnergy_Throws()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: -1));
         }
 
         [Fact]
@@ -134,35 +116,6 @@ namespace Pinder.Core.Tests
                 () => clock.Advance(TimeSpan.FromHours(-1)));
         }
 
-        [Fact]
-        public void Advance_CrossingMidnight_ReplenishesEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(7);
-            Assert.Equal(3, clock.RemainingEnergy);
-
-            clock.Advance(TimeSpan.FromHours(2)); // crosses midnight
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void Advance_SameDay_DoesNotReplenishEnergy()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(5);
-            clock.Advance(TimeSpan.FromHours(2));
-            Assert.Equal(5, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void Advance_MultipleMidnightCrossings_ReplenishesEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(10);
-            clock.Advance(TimeSpan.FromHours(50)); // crosses midnight twice
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
         // --- AdvanceTo ---
 
         [Fact]
@@ -188,75 +141,6 @@ namespace Pinder.Core.Tests
             var clock = new GameClock(MakeTime(10), DefaultModifiers);
             Assert.Throws<ArgumentException>(
                 () => clock.AdvanceTo(MakeTime(8)));
-        }
-
-        [Fact]
-        public void AdvanceTo_CrossingMidnight_ReplenishesEnergy()
-        {
-            var clock = new GameClock(MakeTime(23), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(8);
-            var target = new DateTimeOffset(2024, 1, 16, 1, 0, 0, TimeSpan.Zero);
-            clock.AdvanceTo(target);
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void AdvanceTo_SameDay_DoesNotReplenish()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 10);
-            clock.ConsumeEnergy(3);
-            clock.AdvanceTo(MakeTime(15));
-            Assert.Equal(7, clock.RemainingEnergy);
-        }
-
-        // --- ConsumeEnergy ---
-
-        [Fact]
-        public void ConsumeEnergy_Success()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 15);
-            Assert.True(clock.ConsumeEnergy(5));
-            Assert.Equal(10, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void ConsumeEnergy_ExactlyRemaining_Success()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 10);
-            Assert.True(clock.ConsumeEnergy(10));
-            Assert.Equal(0, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void ConsumeEnergy_Insufficient_ReturnsFalseNoDeduction()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 3);
-            Assert.False(clock.ConsumeEnergy(5));
-            Assert.Equal(3, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void ConsumeEnergy_ZeroAmount_Throws()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => clock.ConsumeEnergy(0));
-        }
-
-        [Fact]
-        public void ConsumeEnergy_NegativeAmount_Throws()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers);
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => clock.ConsumeEnergy(-1));
-        }
-
-        [Fact]
-        public void ConsumeEnergy_ZeroEnergyBudget_AlwaysFails()
-        {
-            var clock = new GameClock(MakeTime(10), DefaultModifiers, dailyEnergy: 0);
-            Assert.False(clock.ConsumeEnergy(1));
-            Assert.Equal(0, clock.RemainingEnergy);
         }
 
         // --- IGameClock interface conformance ---

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -134,12 +134,10 @@ namespace Pinder.Core.Tests
         private sealed class TestClock : IGameClock
         {
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => 10;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public TimeOfDay GetTimeOfDay() => TimeOfDay.Morning;
             public int GetHorninessModifier() => -2;
-            public bool ConsumeEnergy(int amount) => true;
         }
 
         private sealed class StubDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/GameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionTests.cs
@@ -420,12 +420,10 @@ namespace Pinder.Core.Tests
             private readonly int _mod;
             public ZeroModifierClock(int mod) => _mod = mod;
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => 100;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public Pinder.Core.Interfaces.TimeOfDay GetTimeOfDay() => Pinder.Core.Interfaces.TimeOfDay.Afternoon;
             public int GetHorninessModifier() => _mod;
-            public bool ConsumeEnergy(int amount) => true;
         }
 
         public static StatBlock MakeStatBlock(int allStats = 2, int allShadow = 0)

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -174,12 +174,10 @@ namespace Pinder.Core.Tests
             public TestClock(int horninessModifier) => _horninessModifier = horninessModifier;
 
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => 100;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public TimeOfDay GetTimeOfDay() => TimeOfDay.Afternoon;
             public int GetHorninessModifier() => _horninessModifier;
-            public bool ConsumeEnergy(int amount) => true;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -214,12 +214,10 @@ namespace Pinder.Core.Tests
             private readonly int _horninessModifier;
             public TestClock(int horninessModifier) => _horninessModifier = horninessModifier;
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => 100;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public TimeOfDay GetTimeOfDay() => TimeOfDay.Afternoon;
             public int GetHorninessModifier() => _horninessModifier;
-            public bool ConsumeEnergy(int amount) => true;
         }
 
         private sealed class CapturingLlmAdapter : ILlmAdapter

--- a/tests/Pinder.Core.Tests/HorninessTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessTests.cs
@@ -9,8 +9,13 @@ using Xunit;
 
 namespace Pinder.Core.Tests
 {
+    /// <summary>
+    /// Horniness-modifier behaviour driven by clock-of-day.
+    /// Energy mechanics were removed in #786; this file is the surviving horniness slice
+    /// of the former <c>HorninessAndEnergyTests</c>.
+    /// </summary>
     [Trait("Category", "Core")]
-    public class HorninessAndEnergyTests
+    public class HorninessTests
     {
         /// <summary>
         /// When a clock is present, session horniness = dice roll + clock modifier.
@@ -23,7 +28,7 @@ namespace Pinder.Core.Tests
         {
             // Dice queue: 7 (horniness roll), then enough for StartTurnAsync (no rolls needed there)
             var dice = new FixedDice(7);
-            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+            var clock = new ConfigurableClock(horninessModifier: 3);
 
             var config = new GameSessionConfig(clock: clock);
             var session = new GameSession(
@@ -59,7 +64,7 @@ namespace Pinder.Core.Tests
         {
             // FixedDice returns 15 for the horniness roll (not clamped to 1-10 in FixedDice)
             var dice = new FixedDice(15);
-            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+            var clock = new ConfigurableClock(horninessModifier: 3);
 
             var config = new GameSessionConfig(clock: clock);
             var session = new GameSession(
@@ -85,35 +90,6 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// When clock.ConsumeEnergy returns false, ResolveTurnAsync should throw GameEndedException
-        /// with Unmatched outcome.
-        /// </summary>
-        [Fact]
-        public async Task GameSession_EnergyDepletion_ThrowsGameEnded()
-        {
-            // Dice queue: 5 (horniness roll), then enough for StartTurnAsync
-            // ResolveTurnAsync will check energy before rolling, so no more dice needed if energy fails.
-            var dice = new FixedDice(5);
-            var clock = new ConfigurableClock(horninessModifier: 0, remainingEnergy: 0);
-
-            var config = new GameSessionConfig(clock: clock);
-            var session = new GameSession(
-                MakeProfile("Player"),
-                MakeProfile("Opponent"),
-                new NullLlmAdapter(),
-                dice,
-                new NullTrapRegistry(),
-                config);
-
-            var turn = await session.StartTurnAsync();
-            Assert.NotNull(turn);
-
-            var ex = await Assert.ThrowsAsync<GameEndedException>(
-                () => session.ResolveTurnAsync(0));
-            Assert.Equal(GameOutcome.Unmatched, ex.Outcome);
-        }
-
-        /// <summary>
         /// When horniness < 12, options retain original stats (no T2/T3 effect on options).
         /// When horniness >= 12 but < 18, RequiresRizzOption is set in context but options aren't all forced to Rizz.
         /// </summary>
@@ -122,7 +98,7 @@ namespace Pinder.Core.Tests
         {
             // dice=10 + modifier(+3) = 13 → T2 (>= 12), but not T3 (< 18)
             var dice = new FixedDice(10);
-            var clock = new ConfigurableClock(horninessModifier: 3, remainingEnergy: 10);
+            var clock = new ConfigurableClock(horninessModifier: 3);
 
             var config = new GameSessionConfig(clock: clock);
             var session = new GameSession(
@@ -147,17 +123,17 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Without a clock, horniness is still rolled (1d10) but with no time-of-day modifier.
-        /// No energy is consumed.
+        /// With a clock present, horniness is rolled (1d10) and the clock modifier applied.
+        /// ResolveTurnAsync should complete normally (energy mechanics removed in #786).
         /// </summary>
         [Fact]
-        public async Task GameSession_WithClock_HorninessRolled_NoEnergyCheck()
+        public async Task GameSession_WithClock_HorninessRolled_ResolvesNormally()
         {
             // Clock required. Horniness roll (1d10) = 5, then Turn 1: d20=15 (roll), d100=50 (timing delay)
             var dice = new FixedDice(
                 5,   // horniness roll
                 15, 50);
-            var clock = new ConfigurableClock(horninessModifier: 0, remainingEnergy: 100);
+            var clock = new ConfigurableClock(horninessModifier: 0);
             var config = new GameSessionConfig(clock: clock);
 
             var session = new GameSession(
@@ -183,7 +159,7 @@ namespace Pinder.Core.Tests
         public async Task GameSession_WithClock_HighHorniness_DoesNotForceRizz()
         {
             var dice = new FixedDice(20);
-            var clock = new ConfigurableClock(horninessModifier: 0, remainingEnergy: 100);
+            var clock = new ConfigurableClock(horninessModifier: 0);
             var config = new GameSessionConfig(clock: clock);
 
             var session = new GameSession(
@@ -218,27 +194,17 @@ namespace Pinder.Core.Tests
         private sealed class ConfigurableClock : IGameClock
         {
             private readonly int _horninessModifier;
-            private int _remainingEnergy;
 
-            public ConfigurableClock(int horninessModifier, int remainingEnergy)
+            public ConfigurableClock(int horninessModifier)
             {
                 _horninessModifier = horninessModifier;
-                _remainingEnergy = remainingEnergy;
             }
 
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => _remainingEnergy;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public TimeOfDay GetTimeOfDay() => TimeOfDay.LateNight;
             public int GetHorninessModifier() => _horninessModifier;
-
-            public bool ConsumeEnergy(int amount)
-            {
-                if (_remainingEnergy < amount) return false;
-                _remainingEnergy -= amount;
-                return true;
-            }
         }
     }
 }

--- a/tests/Pinder.Core.Tests/IGameClockTests.cs
+++ b/tests/Pinder.Core.Tests/IGameClockTests.cs
@@ -7,6 +7,7 @@ namespace Pinder.Core.Tests
     /// <summary>
     /// Tests for the IGameClock interface contract via a minimal FixedGameClock test double.
     /// Validates the TimeOfDay enum values and horniness modifier mapping.
+    /// Energy mechanics were removed in #786.
     /// </summary>
     [Trait("Category", "Core")]
     public class IGameClockTests
@@ -123,22 +124,6 @@ namespace Pinder.Core.Tests
             Assert.Throws<ArgumentException>(() => clock.AdvanceTo(start));
         }
 
-        [Fact]
-        public void FixedGameClock_ConsumeEnergy_Succeeds()
-        {
-            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero), energy: 10);
-            Assert.True(clock.ConsumeEnergy(5));
-            Assert.Equal(5, clock.RemainingEnergy);
-        }
-
-        [Fact]
-        public void FixedGameClock_ConsumeEnergy_Insufficient_ReturnsFalse()
-        {
-            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero), energy: 3);
-            Assert.False(clock.ConsumeEnergy(5));
-            Assert.Equal(3, clock.RemainingEnergy); // no deduction
-        }
-
         /// <summary>
         /// Boundary: hour 6 is Morning start, hour 11 is still Morning
         /// </summary>
@@ -168,12 +153,10 @@ namespace Pinder.Core.Tests
     internal sealed class FixedGameClock : IGameClock
     {
         public DateTimeOffset Now { get; private set; }
-        public int RemainingEnergy { get; private set; }
 
-        public FixedGameClock(DateTimeOffset now, int energy = 10)
+        public FixedGameClock(DateTimeOffset now)
         {
             Now = now;
-            RemainingEnergy = energy;
         }
 
         public void Advance(TimeSpan amount) => Now = Now.Add(amount);
@@ -206,13 +189,6 @@ namespace Pinder.Core.Tests
                 case TimeOfDay.AfterTwoAm: return 5;
                 default: return 0;
             }
-        }
-
-        public bool ConsumeEnergy(int amount)
-        {
-            if (amount > RemainingEnergy) return false;
-            RemainingEnergy -= amount;
-            return true;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -529,25 +529,6 @@ namespace Pinder.Core.Tests
             Assert.Equal(TimeOfDay.AfterTwoAm, clock.GetTimeOfDay());
         }
 
-        // Mutation: Fails if ConsumeEnergy with exact amount fails
-        [Fact]
-        public void FixedGameClock_ConsumeEnergy_ExactAmount_Succeeds()
-        {
-            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero), energy: 5);
-            Assert.True(clock.ConsumeEnergy(5));
-            Assert.Equal(0, clock.RemainingEnergy);
-        }
-
-        // Mutation: Fails if ConsumeEnergy deducts on failure
-        [Fact]
-        public void FixedGameClock_ConsumeEnergy_Insufficient_NoDeduction()
-        {
-            var clock = new FixedGameClock(new DateTimeOffset(2024, 1, 1, 8, 0, 0, TimeSpan.Zero), energy: 3);
-            bool result = clock.ConsumeEnergy(4);
-            Assert.False(result);
-            Assert.Equal(3, clock.RemainingEnergy);
-        }
-
         // Mutation: Fails if Advance doesn't actually change Now
         [Fact]
         public void FixedGameClock_Advance_ChangesTimeOfDay()
@@ -646,12 +627,10 @@ namespace Pinder.Core.Tests
         private sealed class TestFixedClock : IGameClock
         {
             public DateTimeOffset Now => DateTimeOffset.UtcNow;
-            public int RemainingEnergy => 10;
             public void Advance(TimeSpan amount) { }
             public void AdvanceTo(DateTimeOffset target) { }
             public TimeOfDay GetTimeOfDay() => TimeOfDay.Morning;
             public int GetHorninessModifier() => -2;
-            public bool ConsumeEnergy(int amount) => true;
         }
     }
 }


### PR DESCRIPTION
## What

Removes the partial energy-budget mechanic from `pinder-core`. Energy was never user-visible (zero frontend / zero backend references) and is being removed per #786 ahead of the #393 fast-gameplay refactor (so clock state doesn't have to be cloned per speculative branch).

## Source changes

- `IGameClock`: drop `RemainingEnergy` property + `ConsumeEnergy(int)` method. Time-modeling surface (`Now`, `Advance`, `AdvanceTo`, `GetTimeOfDay`, `GetHorninessModifier`) preserved unchanged.
- `GameClock`: drop `_dailyEnergy` field, `dailyEnergy` ctor param, midnight energy-replenish branches in `Advance`/`AdvanceTo`, and the `ConsumeEnergy` impl.
- `GameSession.ResolveTurnAsync`: drop the 'consume 1 energy or end game with Dread+1' early-return path at line 567. Time-of-day Dread mechanics elsewhere are untouched.
- `session-runner/Program.cs`: drop `dailyEnergy: int.MaxValue` ctor args.

## Test changes

- `HorninessAndEnergyTests.cs` (244 LOC, mixed) → `HorninessTests.cs`. Energy depletion test deleted; all 5 horniness tests preserved. `ConfigurableClock` helper de-energized.
- `GameClockTests.cs` / `GameClockSpecTests.cs`: energy-only `[Fact]`s removed, time-of-day + horniness specs preserved.
- `IGameClockTests.cs`: `FixedGameClock` test double de-energized.
- `Wave0SpecTests.cs`: `TestFixedClock` / `FixedGameClock(energy:)` callers fixed.
- `GameSessionConfigTests`, `GameSessionTests`, `HorninessAlwaysRolledTests`, `HorninessOverlayTests`: per-file `IGameClock` test doubles de-energized.

## Acceptance

- `git grep -E 'ConsumeEnergy|remainingEnergy|EnergyBudget' src/` → **0 hits**.
- `IGameClock` retains all time-modeling surface (see `IGameClock.cs` in this commit).
- All horniness / replay / snapshot / game-session tests pass: **374/374** in the relevant slice.
- Full `Pinder.Core.Tests` run: **2453 passed / 6 failed / 18 skipped / 2477 total**. The 6 failures are pre-existing in `CharacterLoaderSpecTests` — those tests look for a `.git` *directory* but worktrees (and submodule checkouts) use a `.git` *file*, so `FindPromptDir()` returns `null` and the tests `Assert.Fail` with `SKIPPED:`. Verified to fail identically on baseline `origin/main` with my changes stashed.
- Parent `Pinder.GameApi.Tests`: **446/446 passed** (paired-PR pinder-web side).

## Tripwire

The issue body and the orchestrator brief carry a 'STOP if deleting more than this list' tripwire. The diff is exactly: `ConsumeEnergy` decl + impl + GameSession.cs:567 call site + `_remainingEnergy`/`_dailyEnergy`/`RemainingEnergy`/`dailyEnergy` field/state/property/ctor-param + the energy-only tests + the energy-only paragraphs of `HorninessAndEnergyTests.cs` + the de-energized `IGameClock` test doubles. Time-modeling surface is unchanged.

## Companion PR

The pinder-web parent will get a separate PR that bumps the submodule pointer.

Closes #786