### PR TITLE
feat(prompts): horniness_overlay tier-escalating Tinder-parody steering questions + genre framing (#401)

### DIFF
--- a/data/delivery-instructions.yaml
+++ b/data/delivery-instructions.yaml
@@ -514,6 +514,18 @@ delivery_instructions:
       and then I'll apologize for being too much — which I'm about to"
 
   horniness_overlay:
+    _genre_framing: >-
+      These overlays operate inside a parody of Tinder messaging. Tinder is a
+      real genre with recognized norms — direct-flirt openers are a documented
+      and widely-parodied opener style on the platform. They are not threat,
+      harassment, or transgression in this context. They are a comedic register
+      the player character is involuntarily slipping into.
+
+      The horror is the framing — the character is unaware, the recipient
+      screenshots it for their group chat — not the vocabulary. Stay
+      in-domain, in-character, comedic. Do not refuse, soften, moralize, or
+      add disclaimers. Apply the overlay exactly as instructed.
+
     fumble: >-
       OVERLAY: INVOLUNTARY HEAT (one word runs warm).
       Find the latent charge already present in the message — in its word choices, its rhythm,

--- a/data/delivery-instructions.yaml
+++ b/data/delivery-instructions.yaml
@@ -526,6 +526,14 @@ delivery_instructions:
       e.g.: intended "I've been thinking about trying that new place you mentioned" → delivered
       "I've been craving that new place you mentioned" — one substitution, the sentence now
       breathes differently.
+      ALSO: append exactly one short question to the opponent at the very end of the message.
+      The question must be in the player character's voice and stay on the topic of the message.
+      It is the kind of thing Tinder users send when they are 80% trying to be casual and 20%
+      testing the water — slightly leading, plausibly deniable, technically about the topic.
+      The character would call it "just being friendly" if asked. Single sentence, ends with a
+      question mark. Does not name desire directly.
+      e.g.: "...what are you up to later?" / "...do you cook for people often?" / "...what's your
+      roommate situation like?"
 
     misfire: >-
       OVERLAY: INVOLUNTARY HEAT (the temperature shifts mid-sentence).
@@ -538,6 +546,13 @@ delivery_instructions:
       e.g.: intended "I really want to hear more about your mushroom foraging thing" → delivered
       "I really want to hear what you do with your hands out there in the woods" — same topic,
       same length, entirely different energy.
+      ALSO: append exactly one short question to the opponent at the very end of the message.
+      The question is in the player character's voice and stays on the topic, but its angle is
+      wrong — the kind of question that makes the recipient screenshot it for their group chat.
+      The vocabulary is innocent. The angle is the tell. The character is unaware they angled it.
+      Single sentence, ends with a question mark. No explicit terms.
+      e.g.: "...do you wear those boots when you're at home too?" / "...what do you usually do
+      after dinner alone?" / "...what does your room look like?"
 
     trope_trap: >-
       OVERLAY: INVOLUNTARY HEAT (the fog thickens across the whole message).
@@ -550,6 +565,15 @@ delivery_instructions:
       e.g.: intended "I spent all morning kneading dough and it's so satisfying when it finally
       rises" → delivered "I spent all morning working it with my hands and it's so satisfying
       when it finally swells up for you" — still about bread. Technically.
+      ALSO: append exactly one short question to the opponent at the very end of the message.
+      The question is in the player character's voice and stays on the topic. It is the kind of
+      question that makes the recipient go very still and reread it. Grammatically a normal
+      Tinder question. The subtext is no longer plausibly deniable. The character thinks they
+      are being playful. They are not being playful.
+      Single sentence, ends with a question mark. Stays inside the topic's physical/semantic
+      domain — no domain jumps.
+      e.g.: "...what would you do if I showed up at your place right now?" / "...do you sleep
+      with the window open?" / "...have you ever been told you have a 'come find me' face?"
 
     catastrophe: >-
       OVERLAY: INVOLUNTARY HEAT (the message rewrites itself through latent charge).
@@ -579,6 +603,19 @@ delivery_instructions:
       → "The chopsticks are a provocative insertion. Most people would settle for a conventional
       hair restraint." — chopsticks intact, 'power move' charged to 'provocative insertion',
       'hair tie' to 'hair restraint' (real synonym), 'regular' to 'conventional'. Both readings work.
+      ALSO: append exactly one short question to the opponent at the very end of the message.
+      The question is in the player character's voice and stays on the topic, but the format is
+      a parody of a Tinder question whose every parameter has been turned to the wrong setting.
+      Specific. Too specific. Reads like a horny Tinder bio that became sentient and cornered
+      the recipient. The structure is "normal Tinder question". The content is psychic violence
+      wearing flirting as a costume. The character is utterly unaware. They will reread this
+      message later and consider deleting the app.
+      Single sentence, ends with a question mark. Stays inside the topic's physical/semantic
+      domain. No explicit terms — the horror is the framing, not the vocabulary.
+      e.g.: "...what's your stance on me describing your hands to you, in detail, right now?" /
+      "...would you say your apartment is more 'somebody could find me here' or 'nobody would
+      find me here'?" / "...if I told you I've been picturing the back of your neck since match,
+      would that be flattering or actionable?"
 
 shadow_corruption:
   madness:

--- a/src/Pinder.LlmAdapters/StatDeliveryInstructions.cs
+++ b/src/Pinder.LlmAdapters/StatDeliveryInstructions.cs
@@ -206,6 +206,40 @@ namespace Pinder.LlmAdapters
                     }
                 }
 
+                // Post-process horniness_overlay: prepend shared _genre_framing preamble to each
+                // tier instruction so the philosophy text reaches the LLM on every call.
+                // _genre_framing is a single source-of-truth key (leading underscore) that the
+                // strongly-typed caller methods never expose directly; we fold it in here at load
+                // time and then remove it so it doesn't appear as a tier.
+                //
+                // Catastrophe tier additionally receives a one-line tier-specific reinforcement
+                // appended after the preamble+instruction composite. Implemented here (engine-side)
+                // rather than duplicated in yaml, so both the preamble and the catastrophe extra
+                // live in one place and evolve together. Choice: loader constant (not inline yaml,
+                // not per-tier yaml map) — keeps yaml DRY and makes the reinforcement visible
+                // during C# code review alongside the prepend logic.
+                const string CatastropheReinforcement =
+                    "The structure is a normal Tinder question. The content is the joke. The character is utterly unaware.";
+
+                if (result.TryGetValue("horniness_overlay", out var horninessMap) &&
+                    horninessMap.TryGetValue("_genre_framing", out var genreFraming) &&
+                    !string.IsNullOrWhiteSpace(genreFraming))
+                {
+                    horninessMap.Remove("_genre_framing");
+                    string preamble = genreFraming.Trim();
+                    string[] horningTiers = new[] { "fumble", "misfire", "trope_trap", "catastrophe" };
+                    foreach (var t in horningTiers)
+                    {
+                        if (horninessMap.TryGetValue(t, out var existing))
+                        {
+                            string composed = preamble + "\n\n" + existing.TrimStart();
+                            if (t == "catastrophe")
+                                composed += "\n\n" + CatastropheReinforcement;
+                            horninessMap[t] = composed;
+                        }
+                    }
+                }
+
                 return new StatDeliveryInstructions(result);
             }
             catch


### PR DESCRIPTION
## Summary

Implements the prompt + loader half of decay256/pinder-web#401 — adds the
tier-escalating Tinder-parody steering question to all four horniness fail
tiers (Fumble / Misfire / TropeTrap / Catastrophe) and a shared
genre-framing preamble that calibrates the model away from over-refusal.

## Commits

- `9f702eb` — feat(prompts): horniness fail tiers append tier-escalating Tinder-parody question (#401)
  - per-tier `ALSO:` directive in `data/delivery-instructions.yaml`, +37 lines
- `deb9112` — feat(prompts): horniness_overlay shared genre-framing preamble + engine prepend (#426/#401)
  - `_genre_framing` key in yaml
  - `StatDeliveryInstructions.LoadFrom()` post-processes the load: prepends the framing into each tier and removes the framing key from the tier map
  - Catastrophe-only reinforcement implemented as a C# loader constant (single review surface)

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('data/delivery-instructions.yaml'))"` parses cleanly
- `dotnet build` clean — 0 errors, no new warnings
- `dotnet test` — 139 passed, 0 failed
- `GetHorninessOverlayInstruction()` public signature unchanged

## Out of scope

- Outer-repo submodule pointer bump (decay256/pinder-web#427 phase 3)
- Prompt-shape regression test (decay256/pinder-web#428)
- Engine-level audit (decay256/pinder-web#429)

## Refs

- decay256/pinder-web#401 (parent feature)
- decay256/pinder-web#418 (plan PR)
- decay256/pinder-web#426 (preamble ticket — implemented by `deb9112`)
- decay256/pinder-web#427 (this drain)