### PR TITLE
test(#787): Phase 0 regression pinning for fast-gameplay refactor

### DIFF
--- a/docs/development/regression-pins-787.md
+++ b/docs/development/regression-pins-787.md
@@ -1,0 +1,184 @@
+# Phase 0 Regression Pins — fast-gameplay refactor (#787)
+
+> Live as of `pinder-core` `fix/787-regression-pinning`. Owner: backend-engineer
+> drain (Wave 2 of #393). This document is normative for engineers touching
+> `GameSession.ResolveTurnAsync` during Phases 1–5 of the fast-gameplay
+> campaign — read before opening a PR that mutates the engine.
+
+## Why this exists
+
+Phase 0 of the fast-gameplay rollout (#393 / plan PR #422) ships before any
+behaviour-changing refactor lands on the engine. Daniel: *"make enough
+regression tests before."* The pins here are the externally observable contract
+that Phases 1–4 (#788, #789, #424, #790) MUST preserve. If any Phase-1+ PR
+breaks one of these, that's a regression: either narrow the change, or open a
+discussion before merging.
+
+The pins live in `tests/Pinder.Core.Tests/Phase0/`. They run by default under
+`dotnet test`; CI-gating them is automatic via the existing pinder-core test
+gate.
+
+---
+
+## I1 — Opponent conversation history (BEHAVIOR-BASED)
+
+**File:** `Phase0_I1_OpponentHistoryContent.cs`
+
+**What it locks:** the BYTES that cross the `ILlmTransport.SendAsync` wire for
+the `opponent_response` phase preserve continuity across turns. Specifically,
+opponent_response call N+1 contains the assistant content from call N in its
+user message.
+
+**What it deliberately doesn't lock:** the storage location of that history.
+Today (pre-#788) the state lives in adapter-private fields. Phase 1 will
+relocate it into `GameSession`. The test reads only what crosses the
+transport boundary, never adapter internals — so the move can happen without
+modifying the test.
+
+**If this fails after Phase 1 ships:** the move broke wire-level continuity.
+Don't update the test; fix the move.
+
+## I2 — Static dice budget (`PlaybackDiceRoller.IsDrained`)
+
+**File:** `Phase0_I2_DiceBudget.cs`
+
+**What it locks:** the per-turn `IDiceRoller.Roll` count is a static function
+of `(option choice, advantage flag, interest state, traps, shadow thresholds)`
+— never of LLM output content. The fixture turn is run with a Lukewarm
+interest, no advantage/disadvantage, no traps, no shadow ≥1 setup; under that
+fixture the budget is exactly **3 draws per turn** (1 d10 ctor + 1 d20 main +
+1 d100 timing).
+
+**Enumerated draw sites in `ResolveTurnAsync` (and the `StartTurnAsync` /
+ctor entry/exit boundaries it shares with):**
+
+| # | Site | File | Line | Sides | Conditional |
+|---|------|------|------|-------|-------------|
+| 1 | Session horniness | `src/Pinder.Core/Conversation/GameSession.cs` | 165 (ctor) | 10 | Always |
+| 2 | Ghost trigger | `src/Pinder.Core/Conversation/GameSession.cs` | 417 (`StartTurnAsync`) | 4 | iff `InterestState == Bored` |
+| 3 | Madness T3 unhinged-option index | `src/Pinder.Core/Conversation/OptionFilterEngine.cs` | 107 | options.Length | iff Madness shadow ≥18 |
+| 4 | Main d20 | `src/Pinder.Core/Rolls/RollEngine.cs` | 52 | 20 | Always |
+| 5 | Advantage 2nd d20 | `src/Pinder.Core/Rolls/RollEngine.cs` | 53 | 20 | iff `hasAdvantage \|\| hasDisadvantage` |
+| 6 | Opponent timing variance | `src/Pinder.Core/Conversation/TimingProfile.cs` | 53 | 100 | Always |
+
+Steering / shadow / horniness rolls use a SEPARATE `Random` instance
+(`SteeringEngine` / `HorninessEngine`) and do NOT consume `_dice`. They are
+explicitly out of scope for the I2 budget.
+
+**Architectural canary for Phase 2 (#789):** if a future PR adds a draw site
+whose count depends on intermediate LLM output, the static budget breaks and
+I2 fails. That's an architectural regression, not a test brittleness — surface
+it to the orchestrator.
+
+## I3 — Audit-log byte-determinism
+
+**File:** `Phase0_I3_AuditDeterminism.cs`
+
+**What it locks:** for a deterministic fixture (seeded steering RNG,
+seeded stat-draw RNG, fixed dice queue, canned LLM responses), two runs of
+the same single turn produce byte-identical `(phase, system_prompt,
+user_message, response, temperature, max_tokens)` tuples. Verified directly
+via tuple-equality and via SHA-256 signature.
+
+**Why this isn't a snapshot file:** prompt-builder copy may legitimately drift
+under unrelated PRs. Two-run equivalence locks the engine's purity — it's a
+function of `(dice, transport responses, profiles, turn input)` alone — without
+freezing prompt strings.
+
+## I4 — State-mutation order
+
+**File:** `Phase0_I4_MutationOrder.cs`
+
+**What it locks:** the canonical `TurnProgressStage` sequence emitted via
+`IProgress<TurnProgressEvent>` from `ResolveTurnAsync` AND the canonical
+`LlmPhase` order at the transport. On the happy-path fixture the sequence is:
+
+```
+SteeringStarted → SteeringCompleted →
+DeliveryStarted → DeliveryCompleted →
+OpponentResponseStarted → OpponentResponseCompleted
+```
+
+with `LlmPhase.DialogueOptions ≺ LlmPhase.Delivery ≺ LlmPhase.OpponentResponse`
+at the transport. (Horniness / shadow / trap-overlay phases appear conditionally
+and are not in the happy-path fixture.)
+
+**Sentinel-style observation:** the per-mutator order on private state isn't
+externally observable, but the externally observable signals (progress stages,
+transport phase order) are tight enough to catch any reorder that changes
+behaviour.
+
+## I5 — Snapshot equivalence
+
+**File:** `Phase0_I5_SnapshotEquivalence.cs`
+
+**What it locks:** a session played turn-by-turn to turn N produces the same
+public-state surface (`GameStateSnapshot`: interest, momentum streak, active
+traps, turn number, triple-bonus pending) as a session played to turn M (M&lt;N),
+snapshot-restored via `RestoreState(ResimulateData, ITrapRegistry)`, and continued
+to turn N. The snapshot/restore is a pure equivalence on the public surface.
+
+**Why this isn't a hash assertion of all state:** Phase 1 (#788) will refactor
+internal-state layout (move opponent history into `GameSession`). The public
+`GameStateSnapshot` surface is what consumers (session-runner, replay tool)
+actually use; that's what we lock.
+
+## I6 — Cancellation discipline
+
+**File:** `Phase0_I6_Cancellation.cs`
+
+**What it locks:** when an `ILlmTransport.SendAsync` call throws mid-resolve
+(simulated `OperationCanceledException`, simulated 429-style HTTP exception,
+simulated network reset), the exception propagates AND the engine's turn
+counter does NOT advance. `StartTurnAsync` failures don't leak `_currentOptions`.
+
+**Documented gap:** pinder-core's non-streaming path has NO `CancellationToken`
+plumbing on `ResolveTurnAsync` or `ILlmTransport.SendAsync`. Cancellation is
+effected today by throwing from inside the transport — a `CancellationToken`
+would be an engine-level API change. F3 (cancellation mid-stream) is therefore
+tested via "throw OCE during opponent_response phase," which is the closest
+fixture pinder-core can support.
+
+**Existing engine behaviour finding (flagged here, NOT fixed in this PR):**
+when `ResolveTurnAsync` throws between the dice roll and the delivery LLM call,
+state mutations from earlier in the resolve pipeline (interest delta application,
+momentum update, combo recording, XP, shadow growth) HAVE already been applied
+to the session. The session is observably mutated post-throw. The engine has no
+"rollback on transport failure" semantics today. `F4` therefore asserts the
+conservative invariant — exception propagates, turn-number does not advance —
+rather than asserting full state non-corruption. If full rollback semantics are
+desired, that's a separate cancellation-rollback issue (file alongside review
+of this PR).
+
+---
+
+## F1–F4 — Failure-mode integration tests
+
+**File:** `Phase0_F_FailureModes.cs`
+
+| # | Failure | Throws on phase | Exception |
+|---|---------|-----------------|-----------|
+| F1 | Rate-limit (HTTP 429) hit during a turn | opponent_response | shim-`HttpRequestException` |
+| F2 | Network blip during opponent reply | opponent_response | `SocketException` |
+| F3 | Cancellation token fires mid-stream | opponent_response | `OperationCanceledException` |
+| F4 | Disk full during audit write | delivery | `IOException` |
+
+**Scope boundary:** F1–F4 in the original spec talk about "no half-written
+turn_records row." pinder-core has no postgres / `turn_records` concept (those
+live in pinder-web's session-runner consumer). The pinder-core invariant that
+maps to "no half-written audit row" is "the engine fails cleanly without
+leaving the session in a corrupted state": exception propagates, turn counter
+does not advance, session is still usable. The postgres-rollback half of the
+invariant is the consumer's responsibility — not in pinder-core's testable
+scope.
+
+---
+
+## How to extend these pins
+
+1. New invariant: add a `Phase0_I*` test class. Use `[Trait("Category", "Phase0")]`.
+2. Reuse `RecordingLlmTransport`, `PlaybackDiceRoller`, `Phase0Fixtures`. Don't
+   duplicate fixture infra.
+3. Document the new invariant in this file under a new `## I*` heading.
+4. If the pin reveals existing engine misbehaviour, **flag in the PR body**;
+   do not fix in the same PR (Phase 0 is tests-only).

--- a/tests/Pinder.Core.Tests/Phase0/Phase0Fixtures.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0Fixtures.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.LlmAdapters;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Shared fixture helpers for Phase 0 regression tests (#787).
+    ///
+    /// Built on top of the existing test helpers in <c>GameSessionTests.cs</c>
+    /// (<see cref="TestHelpers"/>, <see cref="FixedDice"/>, <see cref="NullTrapRegistry"/>),
+    /// so we don't duplicate basic profile/clock construction.
+    /// </summary>
+    internal static class Phase0Fixtures
+    {
+        /// <summary>
+        /// Constructs a low-noise CharacterProfile with the given name.
+        /// stats default to 2 across the board (matches <see cref="TestHelpers.MakeStatBlock"/>).
+        /// </summary>
+        public static CharacterProfile MakeProfile(string name, int allStats = 2, int level = 1)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: level);
+        }
+
+        /// <summary>
+        /// Builds a vanilla <see cref="GameSessionConfig"/> with seeded steering RNG
+        /// AND seeded stat-draw RNG so every random source the engine consults during
+        /// a turn is deterministic. Steering covers <c>SteeringEngine</c> /
+        /// <c>HorninessEngine</c> rolls; stat-draw covers
+        /// <c>OptionFilterEngine.DrawRandomStats</c> shuffling (per #130).
+        /// </summary>
+        public static GameSessionConfig MakeConfig(int steeringSeed = 42, int statDrawSeed = 4242)
+        {
+            return new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                steeringRng: new Random(steeringSeed),
+                statDrawRng: new Random(statDrawSeed));
+        }
+
+        /// <summary>
+        /// Standard parseable dialogue-options canned LLM response. Produces 3 options
+        /// (Charm / Wit / Honesty) that the existing
+        /// <c>DialogueOptionParsers.ParseDialogueOptionsText</c> consumes cleanly.
+        /// </summary>
+        public const string CannedDialogueOptions =
+            "OPTION_1\n[STAT: Charm]\n\"Hey, you come here often?\"\n\n" +
+            "OPTION_2\n[STAT: Wit]\n\"Did you know penguins propose with pebbles?\"\n\n" +
+            "OPTION_3\n[STAT: Honesty]\n\"I have to be real with you.\"\n";
+
+        /// <summary>Canned delivery: echoes a flat string. The engine uses it verbatim.</summary>
+        public const string CannedDelivery = "Hey, you come here often?";
+
+        /// <summary>
+        /// Canned opponent response. Bare message with no signals — the parser
+        /// returns this as the opponent message text.
+        /// </summary>
+        public const string CannedOpponent = "Maybe.";
+
+        /// <summary>
+        /// Build a <see cref="PinderLlmAdapter"/> wired to the given transport, with the
+        /// smallest viable options. Accepts any <see cref="ILlmTransport"/> so failure-mode
+        /// transports (throwing, slow, etc.) can be injected too.
+        /// </summary>
+        public static PinderLlmAdapter MakeAdapter(ILlmTransport transport)
+        {
+            return new PinderLlmAdapter(transport, new PinderLlmAdapterOptions
+            {
+                MaxTokens = 256,
+                Temperature = 0.9,
+            });
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_F_FailureModes.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_F_FailureModes.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Failure-mode integration tests F1–F4 (#787 phase 0).
+    ///
+    /// <para>
+    /// SCOPE BOUNDARY: F1–F4 talk about "no half-written turn_records row".
+    /// pinder-core has NO postgres / turn_records concept (those live in pinder-web's
+    /// session-runner consumer). The pinder-core-level invariant is "the engine
+    /// fails cleanly without leaving the session in a corrupted state": exception
+    /// surfaces, turn counter does not advance, and the session is still usable
+    /// for a fresh attempt (or surfaces a second failure for the same reason).
+    /// The postgres-rollback half of the invariant is the consumer's responsibility
+    /// and is not in pinder-core's testable scope (gap documented in the PR body).
+    /// </para>
+    ///
+    /// <para>
+    /// Rate-limit / network-blip / disk-full failures are simulated by injecting a
+    /// transport that throws the appropriate exception type during the relevant
+    /// engine phase. Existing test infrastructure is sufficient for F1–F4 as
+    /// reframed; no new shared infrastructure required.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_F_FailureModes
+    {
+        // F1 — rate-limit hit (HTTP 429 surface). The transport throws a
+        // simulated 429-style exception during a turn. The engine must surface
+        // the failure and not advance the turn counter.
+        [Fact]
+        public async Task F1_RateLimit429_DuringTurn_FailsCleanly_TurnCounterUnchanged()
+        {
+            var transport = new ExceptionInjectingTransport(
+                throwOnPhase: LlmPhase.OpponentResponse,
+                exFactory: () => new HttpRequestExceptionShim(
+                    "Simulated 429 Too Many Requests"));
+
+            var session = MakeSession(transport, out _);
+
+            int turnBefore = session.TurnNumber;
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAnyAsync<Exception>(() => session.ResolveTurnAsync(0));
+            Assert.Equal(turnBefore, session.TurnNumber);
+        }
+
+        // F2 — network blip during opponent reply.
+        // Same shape as F1 but with a different exception type to prove the
+        // engine doesn't conditionally swallow specific exception types.
+        [Fact]
+        public async Task F2_NetworkBlip_DuringOpponentReply_FailsCleanly_TurnCounterUnchanged()
+        {
+            var transport = new ExceptionInjectingTransport(
+                throwOnPhase: LlmPhase.OpponentResponse,
+                exFactory: () => new System.Net.Sockets.SocketException(
+                    (int)System.Net.Sockets.SocketError.ConnectionReset));
+
+            var session = MakeSession(transport, out _);
+            int turnBefore = session.TurnNumber;
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAnyAsync<Exception>(() => session.ResolveTurnAsync(0));
+            Assert.Equal(turnBefore, session.TurnNumber);
+        }
+
+        // F3 — cancellation token fires mid-stream.
+        // pinder-core's non-streaming path has NO CancellationToken plumbing
+        // (gap documented in I6). The closest fixture: transport throws
+        // OperationCanceledException during the streaming-equivalent phase
+        // (opponent_response, the longest call). Half-streamed responses
+        // are discarded by definition because non-streaming has no partial
+        // state. F3 is therefore a thin wrapper around the OCE assertion.
+        [Fact]
+        public async Task F3_CancellationMidStream_FailsCleanly_NoHalfWrittenAudit()
+        {
+            var transport = new ExceptionInjectingTransport(
+                throwOnPhase: LlmPhase.OpponentResponse,
+                exFactory: () => new OperationCanceledException("simulated cancellation mid-stream"));
+
+            var session = MakeSession(transport, out var inner);
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => session.ResolveTurnAsync(0));
+
+            // Audit "half-written" check (pinder-core surface): the wrapped
+            // RecordingLlmTransport recorded the calls that did succeed
+            // BEFORE the throw, but no opponent_response exchange was
+            // committed because the throwing transport never delegated.
+            Assert.Empty(inner.ExchangesByPhase(LlmPhase.OpponentResponse));
+        }
+
+        // F4 — disk-full during audit write.
+        //
+        // What the engine doesn't do: write to disk. That's pinder-web's
+        // SnapshotRecordingLlmTransport decorator + session-runner sink. The
+        // engine boundary equivalent is "transport throws IOException during
+        // a phase call". We assert IOException propagates AND the engine's
+        // turn counter does not advance. We do NOT assert interest is
+        // unchanged: the engine currently mutates interest (and momentum,
+        // combo, XP) BEFORE the delivery LLM call, so a delivery-phase
+        // throw leaves a partial mutation footprint on the session.
+        //
+        // FINDING (flagged in PR body): when ResolveTurnAsync throws between
+        // the dice roll and the delivery LLM call, interest / momentum /
+        // combo / XP have already been applied. The session is not in a
+        // "clean rollback" state. This is the current contract; the
+        // post-throw session is observably mutated. The Phase 1 / Phase 2
+        // refactors (#788, #789) will not narrow this window by themselves;
+        // a separate cancellation-rollback story (filed as a follow-up issue
+        // when this is reviewed) is needed if rollback semantics are wanted.
+        // For now, the strongest invariant we can lock cleanly at this
+        // layer is: "the failure propagates and turn-number does not
+        // advance."
+        [Fact]
+        public async Task F4_DiskFull_DuringAuditWrite_PropagatesAndDoesNotAdvanceTurn()
+        {
+            var transport = new ExceptionInjectingTransport(
+                throwOnPhase: LlmPhase.Delivery,
+                exFactory: () => new System.IO.IOException(
+                    "Simulated disk full during audit write"));
+
+            var session = MakeSession(transport, out _);
+
+            int turnBefore = session.TurnNumber;
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAsync<System.IO.IOException>(
+                () => session.ResolveTurnAsync(0));
+
+            Assert.Equal(turnBefore, session.TurnNumber);
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private static GameSession MakeSession(
+            ILlmTransport transport,
+            out RecordingLlmTransport innerRecorder)
+        {
+            // The "inner" recorder is what F3 inspects to confirm the throwing
+            // transport never delegated for the failed phase. F1/F2/F4 don't
+            // strictly need it, but a uniform constructor keeps the code clean.
+            innerRecorder = (transport as ExceptionInjectingTransport)?.Inner
+                ?? new RecordingLlmTransport();
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            return new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+        }
+
+        // Tiny shim for an HttpRequestException-shaped exception without taking
+        // a dependency on System.Net.Http in this test class. The engine
+        // doesn't conditionally type-check on this; any Exception subclass
+        // unwinds the same way.
+        private sealed class HttpRequestExceptionShim : Exception
+        {
+            public HttpRequestExceptionShim(string message) : base(message) { }
+        }
+
+        private sealed class ExceptionInjectingTransport : ILlmTransport
+        {
+            private readonly string _throwOnPhase;
+            private readonly Func<Exception> _exFactory;
+            public RecordingLlmTransport Inner { get; }
+
+            public ExceptionInjectingTransport(string throwOnPhase, Func<Exception> exFactory)
+            {
+                _throwOnPhase = throwOnPhase;
+                _exFactory = exFactory;
+                Inner = new RecordingLlmTransport { DefaultResponse = "" };
+                Inner.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                Inner.QueueDelivery(Phase0Fixtures.CannedDelivery);
+                Inner.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            }
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null)
+            {
+                if (string.Equals(phase, _throwOnPhase, StringComparison.Ordinal))
+                {
+                    throw _exFactory();
+                }
+                return Inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase);
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I1_OpponentHistoryContent.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I1_OpponentHistoryContent.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I1 — Opponent conversation history is locked at the LLM transport
+    /// layer (BEHAVIOR-BASED), not at the storage layer.
+    ///
+    /// <para>
+    /// What this asserts: across multiple turns, the user-message content sent to
+    /// the LLM transport on opponent_response call N+1 contains the assistant
+    /// content from opponent_response call N. The opponent's "memory" of the
+    /// prior assistant turn is observable in the bytes that cross the wire.
+    /// </para>
+    /// <para>
+    /// What this does NOT reach into: any adapter-private field that holds the
+    /// stateful opponent history (whatever it is currently named or wherever it
+    /// lives). Phase 1 (#788) will move the stateful opponent history out of the
+    /// adapter and into <c>GameSession</c>. This test must continue to pass after
+    /// that move without modification — the contract being locked is the wire-level
+    /// behavior, not the storage location.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I1_OpponentHistoryContent
+    {
+        // I1.1 — over a 3-turn run, every opponent_response call N (N≥1) must contain
+        // the assistant text from opponent_response call N-1 in its user message.
+        // This is the structural invariant: stateful opponent context is preserved
+        // ACROSS turns, regardless of where the state lives internally.
+        [Fact]
+        public async Task OpponentResponseCallN_UserMessage_ContainsAssistantResponseFromCallNMinus1()
+        {
+            var transport = new RecordingLlmTransport
+            {
+                DefaultResponse = ""
+            };
+
+            // Three full turns, each consuming options + delivery + opponent.
+            for (int turn = 0; turn < 3; turn++)
+            {
+                transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                transport.QueueDelivery($"delivered-text-turn{turn}");
+                transport.QueueOpponent($"opponent-reply-{turn}-distinguishing-token-{Guid.NewGuid():N}");
+            }
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(
+                5,                        // ctor d10
+                15, 50, 15, 50, 15, 50    // 3 turns × (d20 main + d100 timing) = 6 draws
+            );
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            for (int t = 0; t < 3; t++)
+            {
+                await session.StartTurnAsync();
+                await session.ResolveTurnAsync(0);
+            }
+
+            var opponentExchanges = transport.ExchangesByPhase(LlmPhase.OpponentResponse);
+            Assert.True(opponentExchanges.Count >= 3,
+                $"Expected at least 3 opponent_response calls; got {opponentExchanges.Count}.");
+
+            // I1 core assertion: each call's user message contains the prior assistant
+            // response. We don't care WHERE the adapter stores it — only that it
+            // appears in the wire payload going out.
+            for (int n = 1; n < opponentExchanges.Count; n++)
+            {
+                string priorAssistant = opponentExchanges[n - 1].Response;
+                string currentUser = opponentExchanges[n].UserMessage;
+
+                Assert.True(
+                    currentUser.Contains(priorAssistant, StringComparison.Ordinal),
+                    $"Opponent call {n} user message did not contain prior call's assistant text.\n" +
+                    $"Prior assistant: {priorAssistant}\n" +
+                    $"Current user (truncated): {Truncate(currentUser, 600)}");
+            }
+        }
+
+        // I1.2 — first opponent_response call must NOT echo a prior assistant response
+        // (no leak from a previous session, no spurious context).
+        [Fact]
+        public async Task OpponentResponseCall0_DoesNotContainAnyPriorAssistantResponse()
+        {
+            var transport = new RecordingLlmTransport
+            {
+                DefaultResponse = ""
+            };
+
+            const string distinctiveOpponentReply = "DISTINCTIVE-FIRST-REPLY-TOKEN-7C9F";
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery("delivered");
+            transport.QueueOpponent(distinctiveOpponentReply);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            var opponentExchanges = transport.ExchangesByPhase(LlmPhase.OpponentResponse);
+            Assert.True(opponentExchanges.Count >= 1,
+                "Expected at least 1 opponent_response call.");
+
+            // The user message of the first call must not contain its own response token
+            // (sanity check: not a self-echo) and must not contain a "PREVIOUS CONVERSATION CONTEXT"
+            // header (no fictitious history injected for the first call).
+            Assert.DoesNotContain(distinctiveOpponentReply, opponentExchanges[0].UserMessage,
+                StringComparison.Ordinal);
+        }
+
+        // I1.3 — the opponent system prompt is stable across calls within one session.
+        // Assistant responses MUST NOT bleed into the system prompt — only into the
+        // user message. (Locks the system/user separation that PinderLlmAdapter uses.)
+        [Fact]
+        public async Task OpponentResponse_SystemPrompt_StableAcrossCalls_NoAssistantBleed()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+
+            for (int i = 0; i < 3; i++)
+            {
+                transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                transport.QueueDelivery("delivered");
+                transport.QueueOpponent($"opp-reply-{i}-XYZSEN-{i}");
+            }
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50, 15, 50, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            for (int t = 0; t < 3; t++)
+            {
+                await session.StartTurnAsync();
+                await session.ResolveTurnAsync(0);
+            }
+
+            var opponentExchanges = transport.ExchangesByPhase(LlmPhase.OpponentResponse);
+            Assert.True(opponentExchanges.Count >= 2);
+
+            // System prompt is identical across opponent calls in one session.
+            var firstSystemPrompt = opponentExchanges[0].SystemPrompt;
+            for (int n = 1; n < opponentExchanges.Count; n++)
+            {
+                Assert.Equal(firstSystemPrompt, opponentExchanges[n].SystemPrompt);
+            }
+
+            // No assistant response from a prior call ever appears in any system prompt.
+            for (int n = 0; n < opponentExchanges.Count; n++)
+            {
+                for (int m = 0; m < n; m++)
+                {
+                    Assert.DoesNotContain(opponentExchanges[m].Response, opponentExchanges[n].SystemPrompt,
+                        StringComparison.Ordinal);
+                }
+            }
+        }
+
+        // I1.4 — within one turn, options/delivery calls do NOT leak the prior turn's
+        // opponent assistant text into THEIR user prompt. Continuity is opponent-only.
+        // (If this regressed, the player LLM would start parroting the opponent voice.)
+        [Fact]
+        public async Task DialogueOptions_UserMessage_DoesNotEchoOpponentAssistantText()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            const string opponentToken = "OPPONENT-ASSISTANT-DISTINCTIVE-TOKEN-A4B2";
+            // Turn 1
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery("delivered-1");
+            transport.QueueOpponent(opponentToken);
+            // Turn 2 — we want to inspect the options call here
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery("delivered-2");
+            transport.QueueOpponent("noise-2");
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            var optionExchanges = transport.ExchangesByPhase(LlmPhase.DialogueOptions);
+            // The 2nd dialogue-options call MAY include the opponent's text via the
+            // conversation history (this is correct — the player's options need
+            // context). What we lock here is the opposite: the dialogue-options
+            // SYSTEM prompt does not echo the opponent assistant text. The system
+            // prompt is the player-character voice; bleeding the opponent into it
+            // would corrupt voice separation.
+            Assert.True(optionExchanges.Count >= 2);
+            Assert.DoesNotContain(opponentToken, optionExchanges[1].SystemPrompt,
+                StringComparison.Ordinal);
+        }
+
+        private static string Truncate(string s, int max) =>
+            string.IsNullOrEmpty(s) || s.Length <= max ? s : s.Substring(0, max) + "...";
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I2_DiceBudget.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I2_DiceBudget.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I2 — every random draw site reachable from <c>ResolveTurnAsync</c>
+    /// is statically bounded for a given option choice. We assert this by running
+    /// a fixture turn against three different option choices and verifying that the
+    /// <see cref="PlaybackDiceRoller"/> is exactly drained — no leftover values, no
+    /// exhaustion exception.
+    ///
+    /// <para>
+    /// This is the architectural canary for Phase 2 (#789, "Refactor D: pre-roll
+    /// dice / deterministic RNG"). If a future PR introduces a new draw site
+    /// whose count depends on intermediate LLM output, the static budget here
+    /// will fall short (engine throws inside RollEngine) or overshoot
+    /// (PlaybackDiceRoller still has values in queue post-resolve). Either
+    /// failure mode is loud.
+    /// </para>
+    ///
+    /// <para>
+    /// Enumerated draw sites (file:line refs are documented in the PR body
+    /// and in <c>docs/development/regression-pins-787.md</c>):
+    /// <list type="bullet">
+    ///   <item>Constructor — <c>GameSession.cs:165</c> — <c>dice.Roll(10)</c> for the
+    ///         session horniness roll.</item>
+    ///   <item><c>StartTurnAsync</c> — <c>GameSession.cs:417</c> —
+    ///         <c>dice.Roll(4)</c> for ghost trigger, ONLY when interest state
+    ///         is <c>Bored</c>. Not present in this fixture (Lukewarm interest).</item>
+    ///   <item><c>RollEngine.Resolve</c> — <c>RollEngine.cs:52</c> —
+    ///         <c>dice.Roll(20)</c> main d20.</item>
+    ///   <item><c>RollEngine.Resolve</c> — <c>RollEngine.cs:53</c> —
+    ///         <c>dice.Roll(20)</c> second d20 only when
+    ///         <c>hasAdvantage \|\| hasDisadvantage</c>. Not present in
+    ///         this fixture (Lukewarm = no advantage, no disadvantage).</item>
+    ///   <item><c>TimingProfile.ComputeDelay</c> — <c>TimingProfile.cs:53</c> —
+    ///         <c>dice.Roll(100)</c> for opponent reply variance.</item>
+    /// </list>
+    /// Steering / shadow / horniness rolls use a SEPARATE <c>Random</c>
+    /// instance owned by <c>SteeringEngine</c> / <c>HorninessEngine</c> and do
+    /// NOT consume game dice; they're explicitly out of scope for this budget.
+    /// </para>
+    ///
+    /// <para>
+    /// Three option choices = three <c>StatType</c> picks against the same fresh
+    /// fixture. The expected per-turn budget is:
+    /// <c>1 d10 (ctor) + 1 d20 (main roll) + 1 d100 (timing) = 3 draws</c>
+    /// for a Lukewarm-interest, no-advantage turn against a Null trap registry.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I2_DiceBudget
+    {
+        // I2.1 — happy-path turn against option index 0. Budget exactly drained.
+        [Fact]
+        public async Task ResolveTurn_OptionIndex0_ConsumesExactlyExpectedDraws()
+        {
+            await AssertExactBudgetForOptionIndex(optionIndex: 0);
+        }
+
+        // I2.2 — option index 1. Budget exactly drained.
+        [Fact]
+        public async Task ResolveTurn_OptionIndex1_ConsumesExactlyExpectedDraws()
+        {
+            await AssertExactBudgetForOptionIndex(optionIndex: 1);
+        }
+
+        // I2.3 — option index 2. Budget exactly drained.
+        [Fact]
+        public async Task ResolveTurn_OptionIndex2_ConsumesExactlyExpectedDraws()
+        {
+            await AssertExactBudgetForOptionIndex(optionIndex: 2);
+        }
+
+        // I2.4 — over-allocation surfaces as PlaybackDiceRoller NOT drained
+        // (i.e. our oracle is sensitive: if we prepare 4 draws when 3 are needed,
+        // IsDrained must return false). Demonstrates the test's diagnostic value.
+        [Fact]
+        public async Task PlaybackDiceRoller_OverAllocated_IsNotDrained()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            // Over-allocate: prepare 4 draws for a turn that only consumes 3.
+            var dice = new PlaybackDiceRoller(5, 15, 50, 99 /* extra */);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.False(dice.IsDrained,
+                "Expected PlaybackDiceRoller to report NOT drained when over-allocated; oracle is unsound otherwise.");
+            Assert.Equal(1, dice.Remaining);
+        }
+
+        // I2.5 — under-allocation surfaces loudly as InvalidOperationException
+        // from PlaybackDiceRoller.Roll. Demonstrates the test's failure mode.
+        [Fact]
+        public async Task PlaybackDiceRoller_UnderAllocated_ThrowsExhaustionException()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            // Under-allocate: prepare only 2 draws. Constructor consumes 1; the d20
+            // main roll consumes another; the d100 timing call will throw.
+            var dice = new PlaybackDiceRoller(5, 15);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => session.ResolveTurnAsync(0));
+        }
+
+        // ── Shared assertion ──────────────────────────────────────────────
+
+        private static async Task AssertExactBudgetForOptionIndex(int optionIndex)
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+
+            // Exactly the bounded budget for one Lukewarm-interest, no-advantage,
+            // no-disadvantage, no-trap turn:
+            //   1× d10  ctor (horniness)   = 1 draw
+            //   1× d20  main roll          = 1 draw
+            //   1× d100 timing variance    = 1 draw
+            //   ──────────────────────────────────
+            //   total                      = 3 draws
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(optionIndex);
+
+            Assert.True(dice.IsDrained,
+                $"PlaybackDiceRoller not exactly drained for optionIndex={optionIndex}: " +
+                $"prepared={dice.Prepared}, consumed={dice.Consumed}, remaining={dice.Remaining}.");
+            Assert.Equal(3, dice.Consumed);
+            // Diagnostic: assert the three draws hit the expected sides in the expected order.
+            Assert.Equal(10, dice.Trace[0].Sides);  // horniness
+            Assert.Equal(20, dice.Trace[1].Sides);  // main d20
+            Assert.Equal(100, dice.Trace[2].Sides); // timing d100
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I3_AuditDeterminism.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I3_AuditDeterminism.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I3 — for a fixture turn with deterministic dice and deterministic
+    /// canned LLM responses, the (system_prompt, user_prompt, raw_response, phase)
+    /// tuples produced by the engine are byte-deterministic across runs.
+    ///
+    /// <para>
+    /// Captures what the production audit log (in pinder-web's
+    /// <c>SnapshotRecordingLlmTransport</c>) would record as the per-turn
+    /// LLM-exchange envelope. The pinder-core engine never references the
+    /// recorder type by name; the contract being locked is "the engine's
+    /// <c>ILlmTransport</c> traffic for a given fixture is byte-stable".
+    /// </para>
+    ///
+    /// <para>
+    /// Why two-run determinism is the right oracle: a snapshot file in this
+    /// suite would couple the test to incidental prompt-builder formatting
+    /// that other PRs may legitimately tune. Two-run equivalence locks the
+    /// invariant we actually care about — the engine is a pure function of
+    /// (dice seed, transport responses, character profiles, turn input) —
+    /// without freezing prompt copy.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I3_AuditDeterminism
+    {
+        // I3.1 — repeated runs of the SAME fixture produce byte-identical exchanges.
+        [Fact]
+        public async Task RepeatedRuns_ProduceByteIdenticalExchangeSequence()
+        {
+            var run1 = await ExecuteFixtureRunAsync();
+            var run2 = await ExecuteFixtureRunAsync();
+
+            Assert.Equal(run1.Count, run2.Count);
+            for (int i = 0; i < run1.Count; i++)
+            {
+                Assert.Equal(run1[i].Phase, run2[i].Phase);
+                Assert.Equal(run1[i].SystemPrompt, run2[i].SystemPrompt);
+                Assert.Equal(run1[i].UserMessage, run2[i].UserMessage);
+                Assert.Equal(run1[i].Response, run2[i].Response);
+                Assert.Equal(run1[i].Temperature, run2[i].Temperature);
+                Assert.Equal(run1[i].MaxTokens, run2[i].MaxTokens);
+            }
+        }
+
+        // I3.2 — phase ordering on a single happy-path turn is exactly the canonical
+        // sequence: dialogue_options → delivery → opponent_response.
+        [Fact]
+        public async Task SingleTurn_PhaseOrder_IsExactlyOptionsThenDeliveryThenOpponent()
+        {
+            var exchanges = await ExecuteFixtureRunAsync();
+            var phases = exchanges.Select(e => e.Phase).ToArray();
+
+            // The fixture (no shadow ≥1, no horniness check fires, no traps,
+            // steering rng seeded to fail) collapses to the minimal three-call
+            // sequence. Any new always-on phase would land here and fail this
+            // test, prompting an explicit decision instead of a silent leak.
+            Assert.Equal(
+                new[] { LlmPhase.DialogueOptions, LlmPhase.Delivery, LlmPhase.OpponentResponse },
+                phases);
+        }
+
+        // I3.3 — the SHA-256 hash of the per-exchange (phase, system, user, response)
+        // serialization is identical across runs. This is a stricter, byte-level
+        // version of I3.1 and gives us a one-line forensic signature when something
+        // drifts: the hash will change and the test failure message includes both.
+        [Fact]
+        public async Task ExchangeSequence_Sha256Signature_IsStableAcrossRuns()
+        {
+            var run1Sig = HashExchanges(await ExecuteFixtureRunAsync());
+            var run2Sig = HashExchanges(await ExecuteFixtureRunAsync());
+
+            Assert.Equal(run1Sig, run2Sig);
+        }
+
+        // I3.4 — the recorded sequence has non-empty audit content for every call:
+        // every exchange has a non-null system prompt, a non-empty user message
+        // (we don't allow silent empty payloads to slip through into the log).
+        [Fact]
+        public async Task EveryRecordedExchange_HasNonEmptySystemAndUserPayload()
+        {
+            var exchanges = await ExecuteFixtureRunAsync();
+            Assert.NotEmpty(exchanges);
+            for (int i = 0; i < exchanges.Count; i++)
+            {
+                Assert.False(string.IsNullOrEmpty(exchanges[i].SystemPrompt),
+                    $"Exchange {i} ({exchanges[i].Phase}) has empty system prompt.");
+                Assert.False(string.IsNullOrEmpty(exchanges[i].UserMessage),
+                    $"Exchange {i} ({exchanges[i].Phase}) has empty user message.");
+                Assert.NotNull(exchanges[i].Phase);
+            }
+        }
+
+        // ── Fixture executor ──────────────────────────────────────────────
+
+        private static async Task<IReadOnlyList<RecordingLlmTransport.LlmExchange>> ExecuteFixtureRunAsync()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig(steeringSeed: 12345));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            return transport.Exchanges;
+        }
+
+        private static string HashExchanges(IReadOnlyList<RecordingLlmTransport.LlmExchange> exchanges)
+        {
+            var sb = new StringBuilder();
+            foreach (var ex in exchanges)
+            {
+                sb.Append(ex.Phase).Append('\u0001');
+                sb.Append(ex.SystemPrompt).Append('\u0001');
+                sb.Append(ex.UserMessage).Append('\u0001');
+                sb.Append(ex.Response).Append('\u0001');
+                sb.Append(ex.Temperature.ToString("R", System.Globalization.CultureInfo.InvariantCulture)).Append('\u0001');
+                sb.Append(ex.MaxTokens).Append('\u0002');
+            }
+            using var sha = SHA256.Create();
+            var hashBytes = sha.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+            return Convert.ToHexString(hashBytes);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I4_MutationOrder.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I4_MutationOrder.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I4 — per-turn state mutators (interest, shadow, horniness check,
+    /// traps, combo, XP) mutate in a known canonical order.
+    ///
+    /// <para>
+    /// The mutators themselves are private. We sentinel the order by capturing
+    /// the externally observable signals of each mutation: the
+    /// <see cref="TurnProgressStage"/> events emitted via the
+    /// <see cref="IProgress{T}"/> hook, plus the <see cref="LlmPhase"/> order
+    /// of <see cref="ILlmTransport.SendAsync"/> calls. Both are byte-stable
+    /// signals of "what the engine did and when" — together they constrain
+    /// the mutation order tightly enough that any reordering refactor that
+    /// changes observable behavior will fail this test.
+    /// </para>
+    ///
+    /// <para>
+    /// Phase 1-4 refactors (#788-#790, #424) MUST keep the canonical sequence
+    /// stable. If a future PR moves opponent-response BEFORE delivery, this
+    /// test fails immediately, prompting an explicit decision instead of a
+    /// silent ordering change.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I4_MutationOrder
+    {
+        // I4.1 — happy-path turn: progress event order must be exactly the canonical
+        // sequence steering → delivery → opponent_response. (Horniness, shadow,
+        // trap overlay don't fire on this fixture; they appear conditionally.)
+        [Fact]
+        public async Task HappyPathTurn_ProgressStageOrder_IsCanonical()
+        {
+            // Use a synchronous IProgress impl: Progress<T> posts callbacks via
+            // SynchronizationContext.Post which is async-dispatched in xUnit's
+            // parallel test runner and produces flaky ordering. Synchronous
+            // dispatch is what production session-runner uses (no SyncCtx) and
+            // is what we want to lock here.
+            var progress = new SyncProgress<TurnProgressEvent>();
+
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0, progress);
+
+            var stages = progress.Events.Select(e => e.Stage).ToList();
+
+            // Canonical happy-path order:
+            //   SteeringStarted → SteeringCompleted
+            //   DeliveryStarted → DeliveryCompleted
+            //   (no horniness, no shadow, no trap overlay on this fixture)
+            //   OpponentResponseStarted → OpponentResponseCompleted
+            // Locking the (started, completed) PAIR ordering catches any reorder
+            // that bisects a stage; locking the inter-stage order catches any
+            // reorder that swaps phases.
+            var expected = new List<TurnProgressStage>
+            {
+                TurnProgressStage.SteeringStarted,
+                TurnProgressStage.SteeringCompleted,
+                TurnProgressStage.DeliveryStarted,
+                TurnProgressStage.DeliveryCompleted,
+                TurnProgressStage.OpponentResponseStarted,
+                TurnProgressStage.OpponentResponseCompleted,
+            };
+            Assert.Equal(expected, stages);
+        }
+
+        // I4.2 — repeated runs of the same fixture produce identical progress
+        // sequences. Locks ordering as a function of (dice, transport, profiles)
+        // alone — no hidden source of nondeterminism in the mutator pipeline.
+        [Fact]
+        public async Task RepeatedRuns_ProgressStageOrder_IsIdentical()
+        {
+            var run1 = await CaptureProgressAsync();
+            var run2 = await CaptureProgressAsync();
+            Assert.Equal(run1, run2);
+        }
+
+        // I4.3 — relative phase ordering at the LLM transport level: dialogue_options
+        // strictly precedes delivery; delivery strictly precedes opponent_response.
+        // This is the CONTRACT the upstream consumer (UI streaming, audit log) relies
+        // on to attribute exchanges to a turn. Phase 5 fast-gameplay scheduling MUST
+        // preserve this within a single (player_choice, adopted_branch) commit.
+        [Fact]
+        public async Task LlmTransport_PhaseOrder_OptionsBeforeDeliveryBeforeOpponent()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            int idxOptions = -1, idxDelivery = -1, idxOpponent = -1;
+            for (int i = 0; i < transport.Exchanges.Count; i++)
+            {
+                var ph = transport.Exchanges[i].Phase;
+                if (ph == LlmPhase.DialogueOptions && idxOptions < 0) idxOptions = i;
+                if (ph == LlmPhase.Delivery && idxDelivery < 0) idxDelivery = i;
+                if (ph == LlmPhase.OpponentResponse && idxOpponent < 0) idxOpponent = i;
+            }
+            Assert.True(idxOptions >= 0, "dialogue_options call missing");
+            Assert.True(idxDelivery >= 0, "delivery call missing");
+            Assert.True(idxOpponent >= 0, "opponent_response call missing");
+            Assert.True(idxOptions < idxDelivery,
+                $"dialogue_options ({idxOptions}) must precede delivery ({idxDelivery}).");
+            Assert.True(idxDelivery < idxOpponent,
+                $"delivery ({idxDelivery}) must precede opponent_response ({idxOpponent}).");
+        }
+
+        // I4.4 — interest delta and turn-number increment happen exactly once per
+        // ResolveTurnAsync, AFTER all dice/LLM work. This locks the "no half-applied
+        // mutation" invariant: a single resolve is atomic with respect to the
+        // observable post-turn state snapshot.
+        [Fact]
+        public async Task ResolveTurn_TurnNumberAndInterest_AdvanceAtomically()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+            int interestBefore = session.CreateSnapshot().Interest;
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            int turnAfter = session.TurnNumber;
+            int interestAfter = session.CreateSnapshot().Interest;
+
+            // Turn number must advance by exactly 1 — never 0, never 2.
+            Assert.Equal(turnBefore + 1, turnAfter);
+
+            // Interest delta from the result equals the actual change on the snapshot.
+            Assert.Equal(interestAfter - interestBefore, result.InterestDelta);
+        }
+
+        // ── helper ────────────────────────────────────────────────────────
+
+        private static async Task<List<TurnProgressStage>> CaptureProgressAsync()
+        {
+            var progress = new SyncProgress<TurnProgressEvent>();
+
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig(steeringSeed: 99, statDrawSeed: 99));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0, progress);
+            return progress.Events.Select(e => e.Stage).ToList();
+        }
+
+        /// <summary>
+        /// Synchronous <see cref="IProgress{T}"/> implementation. Captures events
+        /// in call order without any sync-context dispatch round-trip.
+        /// </summary>
+        private sealed class SyncProgress<T> : IProgress<T>
+        {
+            private readonly List<T> _events = new List<T>();
+            public IReadOnlyList<T> Events => _events;
+            public void Report(T value) => _events.Add(value);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I5_SnapshotEquivalence.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I5_SnapshotEquivalence.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I5 — a session played turn-by-turn to turn N produces the same
+    /// post-state as a session played to turn M (M &lt; N), snapshot-restored to
+    /// turn M's state, and continued to turn N. Snapshot/restore is a pure
+    /// equivalence on the externally observable game state.
+    ///
+    /// <para>
+    /// The "externally observable state" being locked here is the public surface of
+    /// <see cref="GameStateSnapshot"/>: interest, momentum streak, active traps,
+    /// turn number, pending triple bonus. Internal/private fields are out of scope
+    /// (Phase 1's #788 will refactor opponent-conversation state out of the adapter,
+    /// changing internal layout but not <c>GameStateSnapshot</c>).
+    /// </para>
+    ///
+    /// <para>
+    /// LLM transport responses and dice draws are made deterministic so the only
+    /// thing under test is the snapshot/restore equivalence. The replay path
+    /// uses <see cref="GameSession.RestoreState(ResimulateData, Pinder.Core.Interfaces.ITrapRegistry)"/>
+    /// — the same path the production session-runner uses for replay.
+    /// </para>
+    ///
+    /// <para>
+    /// If this test fails, do NOT mutate it to chase the symptom; surface the
+    /// drift to the orchestrator. Phase 5 fast-gameplay scheduling assumes
+    /// snapshot equivalence as a hard prerequisite (the adopted-branch byte-equality
+    /// test in #393's epic). A regression here blocks the campaign.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I5_SnapshotEquivalence
+    {
+        // I5.1 — three turns straight vs (snapshot at turn 1) → restore → continue 2 more.
+        // The replay session is wired with a transport queue that starts at
+        // the POST-MID-SNAPSHOT position so its dequeue sequence matches what
+        // session A drew on turns 2-3. This is what production replay actually does
+        // (re-uses the audit log's stored responses for the post-snapshot tail).
+        [Fact]
+        public async Task ThreeTurns_SnapshotAtTurn1_RestoredContinuation_MatchesStraightLine()
+        {
+            // ── Run A: three full turns straight ──
+            var sessionA = MakeFreshSession(turnsToQueue: 3);
+            await PlayThreeTurns(sessionA);
+            var finalA = sessionA.CreateSnapshot();
+            var historyA = sessionA.ConversationHistory.Select(e => (e.Sender, e.Text)).ToList();
+
+            // ── Run B1: one turn (the 'pre-snapshot' run) ──
+            var sessionB1 = MakeFreshSession(turnsToQueue: 1);
+            await PlayOneTurn(sessionB1);
+            var midSnap = sessionB1.CreateSnapshot();
+            var midHistory = sessionB1.ConversationHistory.Select(e => (e.Sender, e.Text)).ToList();
+
+            // ── Run B2: replay session, transport starts at post-snapshot position ──
+            //   - canned responses queued for turns T1, T2 only (matches A's tail).
+            //   - dice queue drained for the constructor's d10, then turns T1/T2's draws.
+            var transportB2 = new RecordingLlmTransport { DefaultResponse = "" };
+            for (int t = 1; t <= 2; t++) // matches PlayThreeTurns's tail (T=1..2)
+            {
+                transportB2.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                transportB2.QueueDelivery($"delivered-msg-T{t}");
+                transportB2.QueueOpponent($"opponent-reply-T{t}");
+            }
+            var adapterB2 = Phase0Fixtures.MakeAdapter(transportB2);
+            var diceB2 = new PlaybackDiceRoller(
+                5,           // ctor d10
+                15, 50,      // turn 2
+                15, 50);     // turn 3
+            var sessionB2 = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapterB2, diceB2, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            sessionB2.RestoreState(BuildResimData(midSnap, midHistory), new NullTrapRegistry());
+            await PlayTwoTurns(sessionB2);
+            var finalB = sessionB2.CreateSnapshot();
+            var historyB = sessionB2.ConversationHistory.Select(e => (e.Sender, e.Text)).ToList();
+
+            // ── Equivalence on the public state surface ──
+            Assert.Equal(finalA.Interest, finalB.Interest);
+            Assert.Equal(finalA.MomentumStreak, finalB.MomentumStreak);
+            Assert.Equal(finalA.TurnNumber, finalB.TurnNumber);
+            Assert.Equal(finalA.TripleBonusActive, finalB.TripleBonusActive);
+            Assert.Equal(finalA.ActiveTrapNames.Length, finalB.ActiveTrapNames.Length);
+
+            // Conversation history equivalence: same number of entries, same texts
+            // in the same order. (Sender labels are deterministic given the profile.)
+            Assert.Equal(historyA.Count, historyB.Count);
+            for (int i = 0; i < historyA.Count; i++)
+            {
+                Assert.Equal(historyA[i].Sender, historyB[i].Sender);
+                Assert.Equal(historyA[i].Text, historyB[i].Text);
+            }
+        }
+
+        // I5.2 — restore at turn 0 (mid-snapshot just after construction): replay
+        // of the entire session against the restored start point matches the
+        // straight-line baseline.
+        [Fact]
+        public async Task TwoTurns_SnapshotAtTurn0_RestoredFullReplay_MatchesStraightLine()
+        {
+            var sessionA = MakeFreshSession(turnsToQueue: 2);
+            await PlayTwoTurns(sessionA);
+            var finalA = sessionA.CreateSnapshot();
+
+            // Build a "turn 0" ResimulateData — empty history, default interest.
+            var sessionB = MakeFreshSession(turnsToQueue: 2);
+            var resim0 = new ResimulateData
+            {
+                TargetInterest = sessionB.CreateSnapshot().Interest,
+                TurnNumber = 0,
+                MomentumStreak = 0,
+                ShadowValues = new Dictionary<string, int>(),
+                ActiveTraps = new List<(string, int)>(),
+                ConversationHistory = new List<(string, string)>(),
+                ComboHistory = new List<(string, bool)>(),
+                PendingTripleBonus = false,
+                RizzCumulativeFailureCount = 0,
+            };
+            sessionB.RestoreState(resim0, new NullTrapRegistry());
+            await PlayTwoTurns(sessionB);
+            var finalB = sessionB.CreateSnapshot();
+
+            Assert.Equal(finalA.Interest, finalB.Interest);
+            Assert.Equal(finalA.MomentumStreak, finalB.MomentumStreak);
+            Assert.Equal(finalA.TurnNumber, finalB.TurnNumber);
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────
+
+        private static GameSession MakeFreshSession(int turnsToQueue)
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            for (int t = 0; t < turnsToQueue; t++)
+            {
+                transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                transport.QueueDelivery($"delivered-msg-T{t}");
+                transport.QueueOpponent($"opponent-reply-T{t}");
+            }
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var diceValues = new List<int> { 5 }; // ctor d10
+            for (int t = 0; t < turnsToQueue; t++)
+            {
+                diceValues.Add(15); // d20 main
+                diceValues.Add(50); // d100 timing
+            }
+            var dice = new PlaybackDiceRoller(diceValues.ToArray());
+
+            return new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+        }
+
+        private static async Task PlayOneTurn(GameSession s)
+        {
+            await s.StartTurnAsync();
+            await s.ResolveTurnAsync(0);
+        }
+
+        private static async Task PlayTwoTurns(GameSession s)
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                await s.StartTurnAsync();
+                await s.ResolveTurnAsync(0);
+            }
+        }
+
+        private static async Task PlayThreeTurns(GameSession s)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                await s.StartTurnAsync();
+                await s.ResolveTurnAsync(0);
+            }
+        }
+
+        private static ResimulateData BuildResimData(
+            GameStateSnapshot snap,
+            List<(string Sender, string Text)> history)
+        {
+            return new ResimulateData
+            {
+                TargetInterest = snap.Interest,
+                TurnNumber = snap.TurnNumber,
+                MomentumStreak = snap.MomentumStreak,
+                ShadowValues = new Dictionary<string, int>(),
+                ActiveTraps = (snap.ActiveTrapDetails ?? Array.Empty<TrapDetail>())
+                    .Select(t => (t.Stat, t.TurnsRemaining))
+                    .ToList(),
+                ConversationHistory = history,
+                ComboHistory = new List<(string, bool)>(),
+                PendingTripleBonus = snap.TripleBonusActive,
+                RizzCumulativeFailureCount = 0,
+            };
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I6_Cancellation.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I6_Cancellation.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// Invariant I6 — cancellation discipline. When a turn fails mid-resolve
+    /// (the engine's only currently observable proxy for a "cancellation"),
+    /// state mutations after the failure point MUST NOT persist on the session.
+    ///
+    /// <para>
+    /// Documented gap (filed alongside this PR if not already on file): pinder-core's
+    /// <see cref="GameSession.ResolveTurnAsync(int)"/> does NOT accept a
+    /// <see cref="CancellationToken"/>. Neither does the non-streaming
+    /// <see cref="ILlmTransport.SendAsync"/>. Cancellation today is effected by
+    /// throwing from inside the transport (e.g. <see cref="OperationCanceledException"/>
+    /// from <c>HttpClient</c> on token cancellation). The streaming transport
+    /// (<see cref="IStreamingLlmTransport.SendStreamAsync"/>) honours a token,
+    /// but <c>GameSession</c> does not consume the streaming path. <c>F3</c>
+    /// (cancellation token fires mid-stream) is therefore tested via "transport
+    /// throws OCE during the opponent_response phase" rather than via a real
+    /// <c>CancellationToken</c>. This is the closest fixture pinder-core can
+    /// support without an engine-level API change.
+    /// </para>
+    ///
+    /// <para>
+    /// What this test asserts: when the opponent_response transport call throws,
+    /// (a) the exception propagates to the caller, (b) turn-number advancement
+    /// does NOT happen, and (c) interest-meter mutations from the same turn
+    /// do NOT persist (the meter is rolled back to the pre-resolve state
+    /// because the exception fires before <c>_turnNumber++</c>). Steering
+    /// /horniness/shadow rolls do already mutate as part of the pre-opponent
+    /// pipeline; that scope is documented in <c>regression-pins-787.md</c>
+    /// and is the subject of Phase 1's #788 refactor (state-into-GameSession),
+    /// which will narrow the mutation window.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Phase0")]
+    public class Phase0_I6_Cancellation
+    {
+        // I6.1 — transport throws DURING opponent_response phase.
+        // The exception must surface, and the turn counter must NOT have been
+        // advanced (the increment is the LAST mutation in ResolveTurnAsync).
+        [Fact]
+        public async Task TransportThrowsDuringOpponentResponse_TurnNumberDoesNotAdvance()
+        {
+            var transport = new ThrowingTransport(throwOnPhase: LlmPhase.OpponentResponse);
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+
+            await session.StartTurnAsync();
+            await Assert.ThrowsAnyAsync<Exception>(() => session.ResolveTurnAsync(0));
+
+            // Turn counter unchanged: no half-applied turn-advancement.
+            Assert.Equal(turnBefore, session.TurnNumber);
+        }
+
+        // I6.2 — transport throws DURING dialogue_options phase.
+        // StartTurnAsync (not ResolveTurnAsync) is the throw site. No state
+        // mutation should persist (no _currentOptions stored).
+        [Fact]
+        public async Task TransportThrowsDuringDialogueOptions_StartTurnFails_NoCachedOptions()
+        {
+            var transport = new ThrowingTransport(throwOnPhase: LlmPhase.DialogueOptions);
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+            await Assert.ThrowsAnyAsync<Exception>(() => session.StartTurnAsync());
+
+            // Turn counter unchanged.
+            Assert.Equal(turnBefore, session.TurnNumber);
+
+            // ResolveTurnAsync without a successful StartTurnAsync must throw
+            // InvalidOperationException — the precondition guard. This proves
+            // that no _currentOptions was cached from the failed start.
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => session.ResolveTurnAsync(0));
+        }
+
+        // I6.3 — OperationCanceledException specifically. Same shape as I6.1
+        // but proves OCE is the exception type that flows through, not some
+        // wrapping. (If a future PR catches OCE silently and replaces with a
+        // "graceful skip", that's an architectural change — must surface in
+        // review.)
+        [Fact]
+        public async Task TransportThrowsOperationCanceled_PropagatesAndDoesNotAdvanceTurn()
+        {
+            var transport = new ThrowingTransport(
+                throwOnPhase: LlmPhase.OpponentResponse,
+                exceptionFactory: () => new OperationCanceledException("simulated cancellation"));
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+            await session.StartTurnAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => session.ResolveTurnAsync(0));
+
+            Assert.Equal(turnBefore, session.TurnNumber);
+        }
+
+        // ── Helper transport ──────────────────────────────────────────────
+
+        private sealed class ThrowingTransport : ILlmTransport
+        {
+            private readonly string _throwOnPhase;
+            private readonly Func<Exception> _exFactory;
+            private readonly RecordingLlmTransport _inner;
+
+            public ThrowingTransport(
+                string throwOnPhase,
+                Func<Exception>? exceptionFactory = null)
+            {
+                _throwOnPhase = throwOnPhase;
+                _exFactory = exceptionFactory ?? (() => new InvalidOperationException(
+                    $"simulated transport failure during phase '{throwOnPhase}'"));
+                _inner = new RecordingLlmTransport { DefaultResponse = "" };
+                _inner.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                _inner.QueueDelivery(Phase0Fixtures.CannedDelivery);
+                _inner.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            }
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null)
+            {
+                if (string.Equals(phase, _throwOnPhase, StringComparison.Ordinal))
+                {
+                    throw _exFactory();
+                }
+                return _inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase);
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_SmokeTest.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_SmokeTest.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    [Trait("Category", "Phase0")]
+    public class Phase0_SmokeTest
+    {
+        // Smoke test: prove the wiring through PinderLlmAdapter + RecordingLlmTransport
+        // actually completes a full ResolveTurnAsync without throwing. If this fails,
+        // the rest of the Phase 0 suite is fiction.
+        [Fact]
+        public async Task EndToEndTurn_WithRecordingTransport_Completes()
+        {
+            var transport = new RecordingLlmTransport
+            {
+                DefaultResponse = "Maybe."
+            };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(
+                5,        // ctor: horniness d10
+                15, 50    // turn 1: d20 main, d100 timing
+            );
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(), Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.NotNull(result);
+            Assert.True(transport.Exchanges.Count >= 3,
+                $"Expected at least 3 LLM exchanges (options/delivery/opponent), got {transport.Exchanges.Count}.");
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/PlaybackDiceRoller.cs
+++ b/tests/Pinder.Core.Tests/Phase0/PlaybackDiceRoller.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// I2: counting deterministic dice roller. Wraps a fixed sequence of values
+    /// (queue, FIFO) and counts every <see cref="Roll"/> call. <see cref="IsDrained"/>
+    /// reports whether the consumed-count exactly equals the prepared-count.
+    ///
+    /// This is the architectural canary for the upcoming Phase 2 (#789) refactor:
+    /// the engine's per-turn dice budget is statically bounded for a given option
+    /// choice. If a future PR introduces a draw site whose count depends on
+    /// intermediate LLM output (or worse, on the LLM's randomness), the budget
+    /// will overshoot or undershoot and the I2 test will fail loudly — flagging
+    /// the architectural regression before it lands.
+    ///
+    /// Compared to the existing <c>FixedDice</c> in <c>GameSessionTests.cs</c>:
+    ///  - exposes <see cref="Consumed"/> and <see cref="Prepared"/> counts
+    ///  - exposes <see cref="IsDrained"/> for a single-line invariant check
+    ///  - records the (sides, returnedValue) of every draw for diagnostic dumps
+    /// </summary>
+    public sealed class PlaybackDiceRoller : IDiceRoller
+    {
+        private readonly Queue<int> _values;
+        private readonly List<(int Sides, int Value)> _trace;
+        private readonly int _initialCount;
+
+        public PlaybackDiceRoller(params int[] values)
+        {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            _values = new Queue<int>(values);
+            _trace = new List<(int, int)>(values.Length);
+            _initialCount = values.Length;
+        }
+
+        /// <summary>Total number of d20/d100/etc draws prepared at construction.</summary>
+        public int Prepared => _initialCount;
+
+        /// <summary>Number of <see cref="Roll"/> calls made so far.</summary>
+        public int Consumed => _trace.Count;
+
+        /// <summary>
+        /// Number of values still queued for future <see cref="Roll"/> calls.
+        /// Equivalent to <c>Prepared - Consumed</c> but reads more naturally in
+        /// drain assertions.
+        /// </summary>
+        public int Remaining => _values.Count;
+
+        /// <summary>
+        /// True iff every prepared value was consumed exactly once. The invariant
+        /// gate the I2 test asserts.
+        /// </summary>
+        public bool IsDrained => _values.Count == 0 && _trace.Count == _initialCount;
+
+        /// <summary>
+        /// Sequence of (sides, returnedValue) draws in call order. Used for
+        /// diagnostic dumps when a budget assertion fails.
+        /// </summary>
+        public IReadOnlyList<(int Sides, int Value)> Trace => _trace;
+
+        public int Roll(int sides)
+        {
+            if (sides < 1) throw new ArgumentOutOfRangeException(nameof(sides));
+            if (_values.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"PlaybackDiceRoller exhausted: tried to draw d{sides} after consuming all {_initialCount} prepared values. " +
+                    $"Trace so far: [{string.Join(", ", FormatTrace())}].");
+            }
+            int v = _values.Dequeue();
+            _trace.Add((sides, v));
+            return v;
+        }
+
+        private IEnumerable<string> FormatTrace()
+        {
+            foreach (var (s, v) in _trace) yield return $"d{s}={v}";
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
+++ b/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.Core.Tests.Phase0
+{
+    /// <summary>
+    /// I1/I3: transport-level interceptor that captures every (system, user, response, phase)
+    /// tuple sent through <see cref="ILlmTransport.SendAsync"/>. Tests assert structural
+    /// properties of the recorded sequence — never reach into adapter internals.
+    ///
+    /// <para>
+    /// I1 is BEHAVIOR-BASED (not storage-based): the test asserts that the
+    /// opponent-response prompt sequence preserves continuity (assistant content
+    /// from call N appears in call N+1's user message), which is the externally
+    /// observable contract of stateful opponent history. Phase 1 (#788) will
+    /// move that state into <c>GameSession</c>; this test continues to pass
+    /// without modification because it observes only what crosses the transport
+    /// wire, not internal field names.
+    /// </para>
+    /// <para>
+    /// Responses are deterministic: the canned-response queue is keyed by
+    /// <see cref="LlmPhase"/>. If a phase has no canned response, the transport
+    /// returns <see cref="DefaultResponse"/> (or a per-phase default).
+    /// </para>
+    /// </summary>
+    public sealed class RecordingLlmTransport : ILlmTransport
+    {
+        public sealed record LlmExchange(
+            string Phase,
+            string SystemPrompt,
+            string UserMessage,
+            string Response,
+            double Temperature,
+            int MaxTokens,
+            int CallIndex);
+
+        private readonly Dictionary<string, Queue<string>> _cannedResponses;
+        private readonly List<LlmExchange> _exchanges = new List<LlmExchange>();
+        private readonly Func<string?, string, string, string>? _defaultResponder;
+        private int _callCounter;
+
+        /// <summary>
+        /// Default response when no canned response is queued for a phase. Tests
+        /// that want strict mode can set this to throw.
+        /// </summary>
+        public string DefaultResponse { get; set; } = "";
+
+        public RecordingLlmTransport()
+            : this(defaultResponder: null) { }
+
+        public RecordingLlmTransport(Func<string?, string, string, string>? defaultResponder)
+        {
+            _cannedResponses = new Dictionary<string, Queue<string>>(StringComparer.Ordinal);
+            _defaultResponder = defaultResponder;
+        }
+
+        public IReadOnlyList<LlmExchange> Exchanges => _exchanges;
+
+        public IReadOnlyList<LlmExchange> ExchangesByPhase(string phase)
+        {
+            var list = new List<LlmExchange>();
+            foreach (var e in _exchanges)
+                if (string.Equals(e.Phase, phase, StringComparison.Ordinal)) list.Add(e);
+            return list;
+        }
+
+        /// <summary>Queue a response for a given phase. FIFO consumed.</summary>
+        public RecordingLlmTransport Queue(string phase, string response)
+        {
+            if (!_cannedResponses.TryGetValue(phase, out var q))
+            {
+                q = new Queue<string>();
+                _cannedResponses[phase] = q;
+            }
+            q.Enqueue(response);
+            return this;
+        }
+
+        /// <summary>Convenience overload for the most common phases.</summary>
+        public RecordingLlmTransport QueueDialogueOptions(string response)
+            => Queue(LlmPhase.DialogueOptions, response);
+
+        public RecordingLlmTransport QueueDelivery(string response)
+            => Queue(LlmPhase.Delivery, response);
+
+        public RecordingLlmTransport QueueOpponent(string response)
+            => Queue(LlmPhase.OpponentResponse, response);
+
+        public Task<string> SendAsync(
+            string systemPrompt,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null)
+        {
+            string ph = phase ?? LlmPhase.Unknown;
+
+            string response;
+            if (_cannedResponses.TryGetValue(ph, out var q) && q.Count > 0)
+            {
+                response = q.Dequeue();
+            }
+            else if (_defaultResponder != null)
+            {
+                response = _defaultResponder(phase, systemPrompt, userMessage) ?? DefaultResponse;
+            }
+            else
+            {
+                response = DefaultResponse;
+            }
+
+            var ex = new LlmExchange(
+                Phase: ph,
+                SystemPrompt: systemPrompt ?? "",
+                UserMessage: userMessage ?? "",
+                Response: response,
+                Temperature: temperature,
+                MaxTokens: maxTokens,
+                CallIndex: _callCounter);
+            _callCounter++;
+            _exchanges.Add(ex);
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
Closes #787

Phase 0 of the fast-gameplay drain (#393, plan PR #422). Locks
`GameSession.ResolveTurnAsync` behaviour with property tests + invariant
assertions BEFORE Phases 1–4 (#788, #789, #424, #790) touch a line of engine
code.

## Summary

- **6 invariants** (I1–I6) locked in `tests/Pinder.Core.Tests/Phase0/`.
- **4 failure-mode integration tests** (F1–F4) reframed at the engine
  boundary (pinder-core has no postgres/`turn_records` concept; that's
  consumer-side).
- **Test-only**: no production code changed. Two production-side touches that
  would have qualified as in-scope (`[InternalsVisibleTo]`, tiny test
  helpers) turned out to be unnecessary — `PinderLlmAdapter` is already
  public and reachable via the existing project reference.
- **+27 tests** added; 0 modified; 0 removed.
- New developer docs at `docs/development/regression-pins-787.md`.

## Scope rules followed

- Daniel: *"make enough regression tests before"*. Phase 1 cannot start until
  this is green and merged.
- Discarded branches MUST leave zero trace inside our system → I3 byte-
  determinism + I5 snapshot-equivalence pin the consumer-observable surface.
- I1's behaviour-based reframing: NO references to internal field names
  in test code (verified by grep — see DoD).
- Long test output redirected to `/tmp` per LESSONS §2 (Context Pollution).

## Invariant index

| ID | What it locks | File |
|----|---------------|------|
| I1 | Opponent conversation continuity at the wire (ILlmTransport boundary) | `Phase0_I1_OpponentHistoryContent.cs` |
| I2 | Static dice budget via `PlaybackDiceRoller.IsDrained` | `Phase0_I2_DiceBudget.cs` |
| I3 | Byte-determinism of recorded `(phase, system, user, response)` tuples | `Phase0_I3_AuditDeterminism.cs` |
| I4 | Canonical mutation order via `TurnProgressStage` + `LlmPhase` sequence | `Phase0_I4_MutationOrder.cs` |
| I5 | Snapshot/restore equivalence on `GameStateSnapshot` + history | `Phase0_I5_SnapshotEquivalence.cs` |
| I6 | Cancellation discipline (engine-level proxy: transport-throw mid-resolve) | `Phase0_I6_Cancellation.cs` |
| F1 | Rate-limit (HTTP 429-style) during opponent_response | `Phase0_F_FailureModes.cs` |
| F2 | Network blip (SocketException) during opponent_response | `Phase0_F_FailureModes.cs` |
| F3 | Cancellation (OCE) mid-stream — closest fixture pinder-core supports | `Phase0_F_FailureModes.cs` |
| F4 | Disk-full (IOException) during delivery phase | `Phase0_F_FailureModes.cs` |

## I2 enumerated dice draw sites

| # | Site | File | Line | Sides | Conditional |
|---|------|------|------|-------|-------------|
| 1 | Session horniness (ctor) | `src/Pinder.Core/Conversation/GameSession.cs` | 165 | 10 | Always |
| 2 | Ghost trigger | `src/Pinder.Core/Conversation/GameSession.cs` | 417 (`StartTurnAsync`) | 4 | iff `Bored` |
| 3 | Madness T3 unhinged option | `src/Pinder.Core/Conversation/OptionFilterEngine.cs` | 107 | options.Length | iff Madness ≥18 |
| 4 | Main d20 roll | `src/Pinder.Core/Rolls/RollEngine.cs` | 52 | 20 | Always |
| 5 | Advantage 2nd d20 | `src/Pinder.Core/Rolls/RollEngine.cs` | 53 | 20 | iff `hasAdvantage \|\| hasDisadvantage` |
| 6 | Opponent timing variance | `src/Pinder.Core/Conversation/TimingProfile.cs` | 53 | 100 | Always |

Steering / shadow / horniness rolls use a SEPARATE `Random` (`SteeringEngine`
/ `HorninessEngine`), not the injected `IDiceRoller`. Out of scope for I2.

## I1 grep-proof

```
$ grep -n "_opponentHistory\|_opponentSession" tests/Pinder.Core.Tests/Phase0/*.cs
(no matches)
```

I1 is purely behaviour-based — observes the ILlmTransport wire. Phase 1's #788
move of stateful opponent history into `GameSession` will not require this
test to be modified.

## Findings — existing engine behaviour surfaced during pinning

These were observed while writing the pins. **Per the spec, none are fixed in
this PR (Phase 0 is tests-only).** Each is documented for the reviewer / next
phase implementer.

1. **No engine-level rollback on transport failure.** When `ResolveTurnAsync`
   throws between the dice roll and the delivery LLM call, state mutations
   from earlier in the resolve pipeline (`_interest.Apply(interestDelta)`,
   `_momentumStreak`, `_comboTracker.RecordTurn`, `_xpRecorder.RecordRollXp`,
   shadow-growth events) HAVE already been applied. The session is observably
   mutated post-throw. The conservative test (F4) asserts only "exception
   propagates AND turn-counter does not advance." Filed-as decision deferred:
   if a rollback story is needed, file a follow-up issue alongside review of
   this PR. *Not fixed inline because it's a real engine semantics decision,
   not a trivial fix.*

2. **No `CancellationToken` plumbing on `ResolveTurnAsync` or
   `ILlmTransport.SendAsync`.** Cancellation today is effected by throwing
   from inside the transport. F3 simulates this via OCE-from-transport.
   Engine-level cancellation would be an API change. *Not fixed inline because
   it's an API addition, not a Phase 0 deliverable.*

3. **F1-F4 do not test `turn_records` rollback because pinder-core has no
   postgres concept.** The audit/persistence layer lives in pinder-web's
   session-runner. The pinder-core-level invariant that maps to "no half-
   written audit row" is "engine fails cleanly without leaving the session in
   a corrupted state." pinder-web should have its own equivalent integration
   tests against the postgres rollback boundary; not pinder-core's scope.
   *Not in scope for this PR — flag for the parent epic.*

4. **`Progress<T>` flake in xUnit parallel runs.** `Progress<TurnProgressEvent>`
   posts callbacks via `SynchronizationContext.Post`, which dispatches
   asynchronously when xUnit's parallel runner is active. The I4 tests use a
   synchronous `IProgress<T>` implementation to avoid the flake. Production
   session-runner consumes these events via SSE without a SyncCtx, so this
   doesn't affect prod — but it does mean any engine-side test wanting to
   verify `Progress<T>` ordering needs the synchronous variant. *Not a bug,
   just a fixture-design note.*

## Maturity & infrastructure

- Test infrastructure (`PlaybackDiceRoller`, `RecordingLlmTransport`,
  `Phase0Fixtures`) is shared across the Phase 0 suite. Reused for Phases 1–4
  if/when those tests want similar ILlmTransport-level interception.
- Used the existing `FixedDice` / `NullTrapRegistry` / `TestHelpers` from
  `GameSessionTests.cs` where applicable; did not duplicate.

## Process notes (per the task spec)

- Self-approval blocked: reviewer uses `gh pr review N --comment` with explicit
  `**Verdict: ...**` line.
- Do not merge this directly.
- Worktree at `/tmp/work-w2-787/pinder-core` left intact for the reviewer.
