### PR TITLE
refactor(#788): stateless LLM adapter — opponent history moves to GameSession

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1303,7 +1303,8 @@ class Program
                     conversationHistory,
                     comboHistoryForSnapshot,
                     tellSnap,
-                    perTurnTextDiffs);
+                    perTurnTextDiffs,
+                    session.OpponentHistory);
 
                 string turnSnapPath = Path.Combine(playtestDir, $"{sessionSlug}.turn-{turn:D2}.snap.json");
                 File.WriteAllText(turnSnapPath, JsonSerializer.Serialize(turnSnap, new JsonSerializerOptions { WriteIndented = true }));
@@ -1602,7 +1603,8 @@ class Program
         List<(string Sender, string Text)> conversationHistory,
         List<(StatType Stat, bool Succeeded)> comboHistory,
         TellSnapshot? activeTell,
-        List<List<TextDiffSnapshot>>? perTurnTextDiffs = null)
+        List<List<TextDiffSnapshot>>? perTurnTextDiffs = null,
+        IReadOnlyList<Pinder.Core.Conversation.ConversationMessage>? opponentHistory = null)
     {
         var state = result.StateAfter;
 
@@ -1643,6 +1645,11 @@ class Program
             convEntries.Add(entry);
         }
 
+        // #788: project the engine-owned opponent history into the wire shape.
+        var opponentHistoryEntries = (opponentHistory ?? new List<Pinder.Core.Conversation.ConversationMessage>())
+            .Select(m => new OpponentHistoryEntry { Role = m.Role, Content = m.Content })
+            .ToList();
+
         return new TurnSnapshot
         {
             TurnNumber = turnNumber,
@@ -1661,6 +1668,7 @@ class Program
             SaOverthinkingTriggered = saOverthinkingTriggered,
             RizzCumulativeFailureCount = rizzCumulativeFailureCount,
             ConversationHistory = convEntries,
+            OpponentHistory = opponentHistoryEntries,
         };
     }
 
@@ -1724,6 +1732,7 @@ class Program
         snap.StatsUsedHistory ??= new List<string>();
         snap.HighestPctHistory ??= new List<bool>();
         snap.ConversationHistory ??= new List<ConversationEntry>();
+        snap.OpponentHistory ??= new List<OpponentHistoryEntry>();
 
         void Assume(string field, string defaultValue)
         {
@@ -1783,6 +1792,11 @@ class Program
                                      .ToList(),
             PendingTripleBonus   = snap.PendingTripleBonus,
             RizzCumulativeFailureCount = snap.RizzCumulativeFailureCount,
+            // #788: restore the engine-owned opponent LLM history so replay
+            // reproduces the same multi-turn context the original session ran with.
+            OpponentHistory      = (snap.OpponentHistory ?? new List<OpponentHistoryEntry>())
+                                     .Select(e => (e.Role, e.Content))
+                                     .ToList(),
         };
     }
 

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -72,6 +72,14 @@ namespace Pinder.SessionRunner.Snapshot
     ///     (issue #339) appears as one more entry in <c>TextDiffs</c> when
     ///     same-turn callback phrases were stripped from the delivered message.
     ///   </description></item>
+    ///   <item><description>
+    ///     <c>OpponentHistory</c> (issue #788): engine-owned opponent-LLM
+    ///     conversation history. Each entry carries <c>Role</c>
+    ///     (<c>"user"</c> or <c>"assistant"</c>) and <c>Content</c>. Survives
+    ///     snapshot/restore so a replayed session can reproduce the same
+    ///     multi-turn opponent context the original session ran with. Empty
+    ///     list when no opponent calls have resolved yet.
+    ///   </description></item>
     /// </list>
     /// </summary>
     public sealed class TurnSnapshot
@@ -110,6 +118,25 @@ namespace Pinder.SessionRunner.Snapshot
         /// Horniness / Shadow layers); opponent entries leave it empty.
         /// </summary>
         public List<ConversationEntry> ConversationHistory { get; set; } = new List<ConversationEntry>();
+
+        /// <summary>
+        /// Issue #788: engine-owned opponent-LLM conversation history at the
+        /// time of snapshot. Each entry's <see cref="OpponentHistoryEntry.Role"/>
+        /// is <c>"user"</c> or <c>"assistant"</c>. Empty when no opponent calls
+        /// have resolved yet.
+        /// </summary>
+        public List<OpponentHistoryEntry> OpponentHistory { get; set; } = new List<OpponentHistoryEntry>();
+    }
+
+    /// <summary>
+    /// Issue #788: one entry of opponent-LLM conversation history. <c>Role</c>
+    /// is the OpenAI/Anthropic wire role (<c>"user"</c> or <c>"assistant"</c>);
+    /// <c>Content</c> is the raw text content.
+    /// </summary>
+    public sealed class OpponentHistoryEntry
+    {
+        public string Role { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
     }
 
     /// <summary>Active trap state at the time of snapshot.</summary>

--- a/src/Pinder.Core/Conversation/ConversationMessage.cs
+++ b/src/Pinder.Core/Conversation/ConversationMessage.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Single entry in a stateful opponent conversation history (#788).
+    /// Plain value type carried as <c>IReadOnlyList&lt;ConversationMessage&gt;</c>
+    /// across the stateless <see cref="Pinder.Core.Interfaces.IStatefulLlmAdapter"/>
+    /// boundary so the engine, not the adapter, owns the conversation state.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Role"/> is one of <c>"user"</c> or <c>"assistant"</c> (lower-case,
+    /// matching the OpenAI / Anthropic wire conventions). The constructor normalises
+    /// arbitrary casing.
+    /// </para>
+    /// </remarks>
+    public sealed class ConversationMessage
+    {
+        public const string UserRole = "user";
+        public const string AssistantRole = "assistant";
+
+        /// <summary>Role string. Always <c>"user"</c> or <c>"assistant"</c>.</summary>
+        public string Role { get; }
+
+        /// <summary>Raw text content of the message. Never null (empty string allowed).</summary>
+        public string Content { get; }
+
+        public ConversationMessage(string role, string content)
+        {
+            if (role == null) throw new ArgumentNullException(nameof(role));
+            string normalized = role.Trim().ToLowerInvariant();
+            if (normalized != UserRole && normalized != AssistantRole)
+                throw new ArgumentException(
+                    $"Role must be '{UserRole}' or '{AssistantRole}'; got '{role}'.",
+                    nameof(role));
+            Role = normalized;
+            Content = content ?? string.Empty;
+        }
+
+        /// <summary>Creates a user-role message.</summary>
+        public static ConversationMessage User(string content) =>
+            new ConversationMessage(UserRole, content);
+
+        /// <summary>Creates an assistant-role message.</summary>
+        public static ConversationMessage Assistant(string content) =>
+            new ConversationMessage(AssistantRole, content);
+    }
+}

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -31,6 +31,12 @@ namespace Pinder.Core.Conversation
         private readonly TrapState _traps;
         private readonly List<(string Sender, string Text)> _history;
 
+        // #788: opponent LLM conversation history lives here, not in the adapter.
+        // The adapter is pure-stateless across calls; the engine passes this list
+        // in on every opponent call and appends the new entries returned by the
+        // adapter. Survives snapshot/restore via ResimulateData.OpponentHistory.
+        private readonly List<ConversationMessage> _opponentHistory = new List<ConversationMessage>();
+
         // Sprint 8 Wave 0: optional config fields
         private readonly IGameClock? _clock;
         private readonly SessionShadowTracker? _playerShadows;
@@ -187,12 +193,11 @@ namespace Pinder.Core.Conversation
             _steeringEngine = new SteeringEngine(steeringRng);
             _horninessEngine = new HorninessEngine(steeringRng);
 
-            // Stateful conversation session (#536)
-            // If the adapter supports stateful mode, start a persistent opponent session.
-            if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter stateful)
-            {
-                stateful.StartOpponentSession(_opponent.AssembledSystemPrompt);
-            }
+            // #788: stateful opponent context now lives on this GameSession
+            // (_opponentHistory). The adapter is pure-stateless and is fed the
+            // history on each opponent call. No initialisation needed here —
+            // the list starts empty and grows after every successful opponent
+            // call in ResolveTurnAsync.
         }
 
         /// <summary>
@@ -252,6 +257,16 @@ namespace Pinder.Core.Conversation
         /// </remarks>
         public System.Collections.Generic.IReadOnlyList<(string Sender, string Text)> ConversationHistory
             => _history;
+
+        /// <summary>
+        /// #788: opponent-LLM conversation history owned by the engine. Each
+        /// entry's role is <c>"user"</c> or <c>"assistant"</c>. Read-only view
+        /// over the live mutable list so callers see updates as turns resolve.
+        /// Survives snapshot/restore via
+        /// <see cref="ResimulateData.OpponentHistory"/>.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<ConversationMessage> OpponentHistory
+            => _opponentHistory;
 
         /// <summary>
         /// Build the conversation history view fed to subsequent LLM calls.
@@ -365,6 +380,25 @@ namespace Pinder.Core.Conversation
             _history.Clear();
             if (data.ConversationHistory != null)
                 _history.AddRange(data.ConversationHistory);
+
+            // Opponent LLM conversation history (#788)
+            _opponentHistory.Clear();
+            if (data.OpponentHistory != null)
+            {
+                foreach (var (role, content) in data.OpponentHistory)
+                {
+                    if (string.IsNullOrEmpty(role)) continue;
+                    try
+                    {
+                        _opponentHistory.Add(new ConversationMessage(role, content ?? string.Empty));
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Skip entries with unrecognized roles — forward-compatible
+                        // with snapshots that may have stored other role labels.
+                    }
+                }
+            }
 
             // Turn number
             _turnNumber = data.TurnNumber;
@@ -1170,9 +1204,38 @@ namespace Pinder.Core.Conversation
                 activeArchetypeDirective: opponentArchetypeDirective);
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.OpponentResponseStarted));
-            var opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
-            if (opponentResponse == null)
-                throw new InvalidOperationException("LLM adapter returned null opponent response");
+
+            // #788: route through IStatefulLlmAdapter when available so the
+            // adapter can build a multi-turn wire payload from the engine-owned
+            // _opponentHistory. The adapter returns the parsed response plus
+            // the entries to append to history; the engine appends them.
+            OpponentResponse opponentResponse;
+            if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter statefulLlm)
+            {
+                var statefulResult = await statefulLlm.GetOpponentResponseAsync(
+                    opponentContext,
+                    _opponentHistory,
+                    default).ConfigureAwait(false);
+                if (statefulResult == null)
+                    throw new InvalidOperationException("LLM adapter returned null stateful opponent result");
+                opponentResponse = statefulResult.Response;
+                if (opponentResponse == null)
+                    throw new InvalidOperationException("LLM adapter returned null opponent response");
+                if (statefulResult.NewHistoryEntries != null)
+                {
+                    foreach (var entry in statefulResult.NewHistoryEntries)
+                    {
+                        if (entry != null)
+                            _opponentHistory.Add(entry);
+                    }
+                }
+            }
+            else
+            {
+                opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
+                if (opponentResponse == null)
+                    throw new InvalidOperationException("LLM adapter returned null opponent response");
+            }
             string opponentMessage = opponentResponse.MessageText;
             progress?.Report(new TurnProgressEvent(TurnProgressStage.OpponentResponseCompleted, opponentMessage));
 
@@ -1322,7 +1385,8 @@ namespace Pinder.Core.Conversation
                 _momentumStreak,
                 _traps,
                 _turnNumber,
-                _comboTracker.HasTripleBonus);
+                _comboTracker.HasTripleBonus,
+                _opponentHistory);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/GameSessionHelpers.cs
+++ b/src/Pinder.Core/Conversation/GameSessionHelpers.cs
@@ -95,7 +95,8 @@ namespace Pinder.Core.Conversation
             int momentumStreak,
             TrapState traps,
             int turnNumber,
-            bool tripleBonusActive)
+            bool tripleBonusActive,
+            System.Collections.Generic.IReadOnlyList<ConversationMessage> opponentHistory = null)
         {
             var trapNames = traps.AllActive
                 .Select(t => t.Definition.Id)
@@ -109,6 +110,12 @@ namespace Pinder.Core.Conversation
                     penaltyDescription: FormatTrapPenalty(t.Definition)))
                 .ToArray();
 
+            // Snapshot a defensive copy of the opponent history so callers that
+            // hold the snapshot aren't observing later mutations.
+            ConversationMessage[] historySnapshot = opponentHistory == null
+                ? System.Array.Empty<ConversationMessage>()
+                : opponentHistory.ToArray();
+
             return new GameStateSnapshot(
                 interest: interest.Current,
                 state: state,
@@ -116,7 +123,8 @@ namespace Pinder.Core.Conversation
                 activeTrapNames: trapNames,
                 turnNumber: turnNumber,
                 tripleBonusActive: tripleBonusActive,
-                activeTrapDetails: trapDetails);
+                activeTrapDetails: trapDetails,
+                opponentHistory: historySnapshot);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Pinder.Core.Conversation
 {
     /// <summary>
@@ -26,6 +28,14 @@ namespace Pinder.Core.Conversation
         /// <summary>True if The Triple bonus is active for the current turn (+1 to all rolls).</summary>
         public bool TripleBonusActive { get; }
 
+        /// <summary>
+        /// #788: snapshot of the engine-owned opponent LLM conversation
+        /// history at the time the snapshot was taken. Each entry's role is
+        /// <c>"user"</c> or <c>"assistant"</c>. Always non-null — empty list
+        /// when no opponent calls have resolved yet.
+        /// </summary>
+        public IReadOnlyList<ConversationMessage> OpponentHistory { get; }
+
         public GameStateSnapshot(
             int interest,
             InterestState state,
@@ -33,7 +43,8 @@ namespace Pinder.Core.Conversation
             string[] activeTrapNames,
             int turnNumber,
             bool tripleBonusActive = false,
-            TrapDetail[] activeTrapDetails = null)
+            TrapDetail[] activeTrapDetails = null,
+            IReadOnlyList<ConversationMessage> opponentHistory = null)
         {
             Interest = interest;
             State = state;
@@ -42,6 +53,7 @@ namespace Pinder.Core.Conversation
             ActiveTrapDetails = activeTrapDetails ?? System.Array.Empty<TrapDetail>();
             TurnNumber = turnNumber;
             TripleBonusActive = tripleBonusActive;
+            OpponentHistory = opponentHistory ?? System.Array.Empty<ConversationMessage>();
         }
     }
 }

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Rolls;
@@ -11,15 +13,6 @@ namespace Pinder.Core.Conversation
     /// </summary>
     public sealed class NullLlmAdapter : ILlmAdapter, IStatefulLlmAdapter
     {
-        /// <inheritdoc />
-        public void StartOpponentSession(string opponentSystemPrompt)
-        {
-            // No-op: NullLlmAdapter does not maintain stateful sessions.
-        }
-
-        /// <inheritdoc />
-        public bool HasOpponentSession => false;
-
         /// <summary>
         /// Returns 4 generic dialogue options, one per stat family
         /// (Charm, Honesty, Wit, Chaos).
@@ -54,6 +47,24 @@ namespace Pinder.Core.Conversation
         public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
         {
             return Task.FromResult(new OpponentResponse("..."));
+        }
+
+        /// <inheritdoc />
+        public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+            OpponentContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
+            var resp = new OpponentResponse("...");
+            // NullLlmAdapter still records placeholder history entries so engine
+            // round-trips (snapshot/restore) and Phase 0 invariants behave the
+            // same as a real adapter.
+            var entries = new ConversationMessage[]
+            {
+                ConversationMessage.User(string.Empty),
+                ConversationMessage.Assistant("..."),
+            };
+            return Task.FromResult(new StatefulOpponentResult(resp, entries));
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/ResimulateData.cs
+++ b/src/Pinder.Core/Conversation/ResimulateData.cs
@@ -42,5 +42,14 @@ namespace Pinder.Core.Conversation
 
         /// <summary>Cumulative Rizz failure count for Despair shadow tracking.</summary>
         public int RizzCumulativeFailureCount { get; set; }
+
+        /// <summary>
+        /// Engine-owned opponent LLM conversation history (#788). Each entry is
+        /// a (role, content) pair where role is <c>"user"</c> or
+        /// <c>"assistant"</c>. Survives snapshot/restore so a replayed session
+        /// can reproduce the same multi-turn opponent context the original ran
+        /// with. Empty list = no prior turns.
+        /// </summary>
+        public List<(string Role, string Content)> OpponentHistory { get; set; } = new List<(string, string)>();
     }
 }

--- a/src/Pinder.Core/Conversation/StatefulOpponentResult.cs
+++ b/src/Pinder.Core/Conversation/StatefulOpponentResult.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Result of a stateful opponent call (#788). Wraps the parsed
+    /// <see cref="OpponentResponse"/> plus the conversation entries the
+    /// adapter wants the engine to append to its <c>_opponentHistory</c>.
+    ///
+    /// <para>
+    /// The adapter is the source of truth for "what content went on the wire
+    /// this turn" \u2014 it builds the user prompt from the
+    /// <see cref="OpponentContext"/> and knows what the assistant returned.
+    /// The engine is the source of truth for "where that history is stored."
+    /// This struct lets the adapter hand the engine exactly the entries it
+    /// needs to append, in order, without leaking adapter-internal prompt
+    /// shape into the engine.
+    /// </para>
+    /// </summary>
+    public sealed class StatefulOpponentResult
+    {
+        /// <summary>The parsed opponent response (text + signals).</summary>
+        public OpponentResponse Response { get; }
+
+        /// <summary>
+        /// New entries the engine should append to its opponent history.
+        /// Typically one user-role entry (the prompt this turn) followed by
+        /// one assistant-role entry (the response). May be empty when the
+        /// call short-circuited (e.g. the parsed response failed validation
+        /// and the adapter chose not to record the turn).
+        /// </summary>
+        public IReadOnlyList<ConversationMessage> NewHistoryEntries { get; }
+
+        public StatefulOpponentResult(
+            OpponentResponse response,
+            IReadOnlyList<ConversationMessage> newHistoryEntries)
+        {
+            Response = response ?? throw new System.ArgumentNullException(nameof(response));
+            NewHistoryEntries = newHistoryEntries ?? throw new System.ArgumentNullException(nameof(newHistoryEntries));
+        }
+    }
+}

--- a/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
@@ -1,28 +1,57 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
 
 namespace Pinder.Core.Interfaces
 {
     /// <summary>
-    /// Extended LLM adapter interface that supports persistent conversation sessions.
-    /// The opponent session accumulates context across turns so the opponent character
-    /// maintains real memory continuity. Options and delivery calls remain stateless
-    /// to prevent voice bleed between player and opponent roles.
+    /// LLM adapter interface that supports a multi-turn opponent conversation by
+    /// accepting the conversation history as a parameter on each call.
+    ///
+    /// <para>
+    /// As of #788 (Phase 1 of the #393 fast-gameplay refactor) the adapter is
+    /// pure-stateless: the <em>engine</em> owns the opponent conversation history
+    /// inside <see cref="Pinder.Core.Conversation.GameSession"/>. The adapter no
+    /// longer holds session state. This makes the adapter safe to share across
+    /// concurrent sessions and removes a class of accidental cross-session
+    /// context bleed.
+    /// </para>
+    ///
+    /// <para>
+    /// The base <see cref="ILlmAdapter.GetOpponentResponseAsync(OpponentContext)"/>
+    /// remains as the single-turn fallback (used by callers that don't carry an
+    /// opponent history yet). Stateful callers MUST go through the
+    /// history-passing overload below.
+    /// </para>
     /// </summary>
     public interface IStatefulLlmAdapter : ILlmAdapter
     {
         /// <summary>
-        /// Initializes a persistent opponent session with the given system prompt.
-        /// Subsequent GetOpponentResponseAsync calls will accumulate messages
-        /// in this session instead of being stateless.
+        /// Generate the opponent's next response, given the prior conversation
+        /// history accumulated by the engine. Stateless: implementations MUST NOT
+        /// retain any opponent-session field across calls.
         /// </summary>
-        /// <param name="opponentSystemPrompt">The assembled system prompt for the opponent character.</param>
-        void StartOpponentSession(string opponentSystemPrompt);
-
-        /// <summary>
-        /// Whether a persistent opponent session is currently active.
-        /// </summary>
-        bool HasOpponentSession { get; }
+        /// <param name="context">Opponent context for the current turn (system prompt, etc.).</param>
+        /// <param name="history">
+        /// Prior opponent conversation, in chronological order. Each entry's
+        /// <see cref="ConversationMessage.Role"/> is one of <c>"user"</c> or
+        /// <c>"assistant"</c>. The current-turn user prompt is NOT included —
+        /// the implementation derives it from <paramref name="context"/> and
+        /// appends it after the supplied history.
+        /// </param>
+        /// <param name="cancellationToken">Cooperative cancellation (#794 alignment).</param>
+        /// <returns>
+        /// A <see cref="StatefulOpponentResult"/> bundling the parsed response with
+        /// the new history entries the engine should append to its opponent
+        /// history (typically one user-role entry followed by one assistant-role
+        /// entry). The engine appends them verbatim and passes the grown list
+        /// in on the next call.
+        /// </returns>
+        Task<StatefulOpponentResult> GetOpponentResponseAsync(
+            OpponentContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Generate a steering question to append to the player's delivered message.

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.LlmAdapters.Groq;
 using Pinder.Core.Conversation;
@@ -36,9 +37,8 @@ namespace Pinder.LlmAdapters.Anthropic
         private readonly AnthropicOptions _options;
         private readonly AnthropicDebugLogger _debugLogger = new AnthropicDebugLogger();
 
-        // Stateful opponent session (#536)
-        private ConversationSession? _opponentSession;
-        private string? _opponentSystemPrompt;
+        // #788: opponent conversation state lives on GameSession, not here.
+        // The adapter is pure-stateless and safe for concurrent reuse across sessions.
 
         /// <summary>
         /// Creates adapter with internally-owned AnthropicClient.
@@ -61,15 +61,7 @@ namespace Pinder.LlmAdapters.Anthropic
             _client = new AnthropicClient(options.ApiKey, httpClient);
         }
 
-        /// <inheritdoc />
-        public void StartOpponentSession(string opponentSystemPrompt)
-        {
-            _opponentSystemPrompt = opponentSystemPrompt ?? throw new ArgumentNullException(nameof(opponentSystemPrompt));
-            _opponentSession = new ConversationSession();
-        }
 
-        /// <inheritdoc />
-        public bool HasOpponentSession => _opponentSession != null;
 
         /// <inheritdoc />
         public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
@@ -151,60 +143,88 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <inheritdoc />
         public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
         {
+            // #788: stateless single-turn fallback. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            return result.Response;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulOpponentResult> GetOpponentResponseAsync(
+            OpponentContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var userContent = SessionDocumentBuilder.BuildOpponentPrompt(context);
             var fullOpponentPrompt = SessionSystemPromptBuilder.BuildOpponent(context.OpponentPrompt, _options.GameDefinition);
             var systemBlocks = CacheBlockBuilder.BuildOpponentOnlySystemBlocks(fullOpponentPrompt);
 
             MessagesRequest request;
-            if (_opponentSession != null)
-            {
-                _opponentSession.AppendUser(userContent);
-                request = _opponentSession.BuildRequest(
-                    _options.Model,
-                    _options.MaxTokens,
-                    _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature,
-                    systemBlocks);
-            }
-            else
+            if (history.Count == 0)
             {
                 request = AnthropicRequestBuilders.BuildMessagesRequest(
                     _options.Model, _options.MaxTokens, systemBlocks, userContent,
                     _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature);
+            }
+            else
+            {
+                // Multi-turn: build a fresh ConversationSession per call from the
+                // engine-supplied history. The session object is purely a
+                // request-builder helper here — no state survives the call.
+                var ephemeral = new ConversationSession();
+                for (int i = 0; i < history.Count; i++)
+                {
+                    var msg = history[i];
+                    if (msg.Role == ConversationMessage.UserRole)
+                        ephemeral.AppendUser(msg.Content);
+                    else
+                        ephemeral.AppendAssistant(msg.Content);
+                }
+                ephemeral.AppendUser(userContent);
+                request = ephemeral.BuildRequest(
+                    _options.Model,
+                    _options.MaxTokens,
+                    _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature,
+                    systemBlocks);
             }
             AnthropicRequestBuilders.AttachTool(request, ToolSchemas.OpponentResponse);
 
             var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
             _debugLogger.LogDebug("opponent", context.CurrentTurn, request, response, _options.DebugDirectory);
 
+            OpponentResponse parsed;
+            string assistantTextForHistory;
+
             // Try structured tool_use first
             var toolInput = response.GetToolInput();
-            if (toolInput != null)
+            var toolParsed = toolInput != null
+                ? OpponentResponseParsers.ParseOpponentResponseTool(toolInput)
+                : null;
+            if (toolParsed != null)
             {
-                var parsed = OpponentResponseParsers.ParseOpponentResponseTool(toolInput);
-                if (parsed != null)
-                {
-                    if (_opponentSession != null)
-                    {
-                        _opponentSession.AppendAssistant(parsed.MessageText);
-                    }
-                    return parsed;
-                }
+                parsed = toolParsed;
+                assistantTextForHistory = toolParsed.MessageText ?? string.Empty;
+            }
+            else
+            {
+                // Fallback: text parsing with improvement pass
+                var responseText = response.GetText();
+                responseText = await AnthropicResponseImprover.ApplyImprovementAsync(
+                    _client, _options, systemBlocks, userContent, responseText,
+                    _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature).ConfigureAwait(false);
+                parsed = OpponentResponseParsers.ParseOpponentResponseText(responseText);
+                assistantTextForHistory = responseText ?? string.Empty;
             }
 
-            // Fallback: text parsing with improvement pass
-            var responseText = response.GetText();
-            responseText = await AnthropicResponseImprover.ApplyImprovementAsync(
-                _client, _options, systemBlocks, userContent, responseText,
-                _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature).ConfigureAwait(false);
-
-            if (_opponentSession != null)
+            var newEntries = new ConversationMessage[]
             {
-                _opponentSession.AppendAssistant(responseText);
-            }
-
-            return OpponentResponseParsers.ParseOpponentResponseText(responseText);
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(assistantTextForHistory),
+            };
+            return new StatefulOpponentResult(parsed, newEntries);
         }
 
         /// <inheritdoc />

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Pinder.Core.Conversation;
@@ -52,9 +53,8 @@ namespace Pinder.LlmAdapters.OpenAi
         private readonly OpenAiClient _client;
         private readonly OpenAiOptions _options;
 
-        // Stateful opponent session
-        private ConversationSession? _opponentSession;
-        private string? _opponentSystemPrompt;
+        // #788: opponent conversation state lives on GameSession, not here.
+        // The adapter is pure-stateless and safe for concurrent reuse across sessions.
 
         /// <summary>Creates adapter with internally-owned OpenAiClient.</summary>
         public OpenAiLlmAdapter(OpenAiOptions options)
@@ -71,15 +71,7 @@ namespace Pinder.LlmAdapters.OpenAi
             _client = new OpenAiClient(options.ApiKey, options.BaseUrl, httpClient);
         }
 
-        /// <inheritdoc />
-        public void StartOpponentSession(string opponentSystemPrompt)
-        {
-            _opponentSystemPrompt = opponentSystemPrompt ?? throw new ArgumentNullException(nameof(opponentSystemPrompt));
-            _opponentSession = new ConversationSession();
-        }
 
-        /// <inheritdoc />
-        public bool HasOpponentSession => _opponentSession != null;
 
         /// <inheritdoc />
         public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
@@ -113,31 +105,43 @@ namespace Pinder.LlmAdapters.OpenAi
         /// <inheritdoc />
         public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
         {
+            // #788: stateless single-turn fallback. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            return result.Response;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulOpponentResult> GetOpponentResponseAsync(
+            OpponentContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var userContent = SessionDocumentBuilder.BuildOpponentPrompt(context);
             var systemPrompt = SessionSystemPromptBuilder.BuildOpponent(context.OpponentPrompt, _options.GameDefinition);
 
             string requestJson;
-            if (_opponentSession != null)
-            {
-                // Stateful: accumulate messages
-                _opponentSession.AppendUser(userContent);
-                requestJson = BuildStatefulRequestJson(systemPrompt, _opponentSession, DefaultOpponentResponseTemperature);
-            }
-            else
+            if (history.Count == 0)
             {
                 requestJson = BuildRequestJson(systemPrompt, userContent, DefaultOpponentResponseTemperature);
             }
-
-            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
-
-            if (_opponentSession != null)
+            else
             {
-                _opponentSession.AppendAssistant(responseText);
+                requestJson = BuildStatefulRequestJson(systemPrompt, history, userContent, DefaultOpponentResponseTemperature);
             }
 
-            return ParseOpponentResponse(responseText);
+            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            var parsed = ParseOpponentResponse(responseText);
+
+            var newEntries = new ConversationMessage[]
+            {
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(responseText ?? string.Empty),
+            };
+            return new StatefulOpponentResult(parsed, newEntries);
         }
 
         /// <inheritdoc />
@@ -209,24 +213,26 @@ namespace Pinder.LlmAdapters.OpenAi
             return JsonConvert.SerializeObject(request);
         }
 
-        private string BuildStatefulRequestJson(string systemPrompt, ConversationSession session, double temperature)
+        /// <summary>
+        /// Builds a multi-turn /v1/chat/completions request from engine-supplied
+        /// history plus the current turn's user content. Pure function of inputs;
+        /// no adapter-side state read or written.
+        /// </summary>
+        private string BuildStatefulRequestJson(
+            string systemPrompt,
+            IReadOnlyList<ConversationMessage> priorHistory,
+            string currentUserContent,
+            double temperature)
         {
-            // Build messages array: system + all accumulated conversation messages
             var messages = new List<object>();
             messages.Add(new { role = "system", content = systemPrompt });
 
-            // Extract messages from the ConversationSession via its BuildRequest method
-            // We build an Anthropic request to get the messages, then translate
-            var anthropicRequest = session.BuildRequest(
-                _options.Model,
-                _options.MaxTokens,
-                temperature,
-                new ContentBlock[] { new ContentBlock { Type = "text", Text = systemPrompt } });
-
-            foreach (var msg in anthropicRequest.Messages)
+            for (int i = 0; i < priorHistory.Count; i++)
             {
+                var msg = priorHistory[i];
                 messages.Add(new { role = msg.Role, content = msg.Content });
             }
+            messages.Add(new { role = "user", content = currentUserContent });
 
             var request = new
             {

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
 using Pinder.Core.Interfaces;
@@ -27,29 +28,14 @@ namespace Pinder.LlmAdapters
         private readonly ILlmTransport _transport;
         private readonly PinderLlmAdapterOptions _options;
 
-        // Stateful opponent session
-        private ConversationSession? _opponentSession;
-        private string? _opponentSystemPrompt;
-        // Local parallel tracking for stateful history (for transports that lack multi-turn support)
-        private readonly List<(string Role, string Content)> _opponentHistory = new List<(string Role, string Content)>();
+        // #788: opponent conversation state lives on GameSession, not here.
+        // The adapter is pure-stateless and safe for concurrent reuse across sessions.
 
         public PinderLlmAdapter(ILlmTransport transport, PinderLlmAdapterOptions options)
         {
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
-
-        // ── IStatefulLlmAdapter ────────────────────────────────────────────
-
-        /// <inheritdoc />
-        public void StartOpponentSession(string opponentSystemPrompt)
-        {
-            _opponentSystemPrompt = opponentSystemPrompt ?? throw new ArgumentNullException(nameof(opponentSystemPrompt));
-            _opponentSession = new ConversationSession();
-        }
-
-        /// <inheritdoc />
-        public bool HasOpponentSession => _opponentSession != null;
 
         // ── ILlmAdapter ────────────────────────────────────────────────────
 
@@ -96,29 +82,52 @@ namespace Pinder.LlmAdapters
         /// <inheritdoc />
         public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
         {
+            // #788: stateless single-turn fallback path. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            return result.Response;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulOpponentResult> GetOpponentResponseAsync(
+            OpponentContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var userContent = SessionDocumentBuilder.BuildOpponentPrompt(context);
             var systemPrompt = SessionSystemPromptBuilder.BuildOpponent(context.OpponentPrompt, _options.GameDefinition);
             double temperature = _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature;
 
             string responseText;
-            if (_opponentSession != null)
+            if (history.Count == 0)
             {
-                // Stateful: accumulate user message, send the full history
-                _opponentSession.AppendUser(userContent);
-                _opponentHistory.Add(("user", userContent));
-                responseText = await SendStatefulOpponentAsync(systemPrompt, temperature).ConfigureAwait(false);
-                _opponentSession.AppendAssistant(responseText);
-                _opponentHistory.Add(("assistant", responseText));
-            }
-            else
-            {
+                // No prior turns — single-shot.
                 responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
                     .ConfigureAwait(false);
             }
+            else
+            {
+                // Multi-turn: flatten the supplied history into the user content
+                // (the transport contract is single-turn). The current turn's
+                // user content is appended last, mirroring Anthropic/OpenAI
+                // wire ordering.
+                responseText = await SendStatefulOpponentAsync(systemPrompt, userContent, history, temperature)
+                    .ConfigureAwait(false);
+            }
 
-            return OpponentResponseParsers.ParseOpponentResponseText(responseText);
+            var parsed = OpponentResponseParsers.ParseOpponentResponseText(responseText);
+
+            // Hand the engine the two new history entries to append: the user
+            // prompt we just sent and the assistant response we got back.
+            var newEntries = new ConversationMessage[]
+            {
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(responseText ?? string.Empty),
+            };
+            return new StatefulOpponentResult(parsed, newEntries);
         }
 
         /// <inheritdoc />
@@ -366,43 +375,38 @@ namespace Pinder.LlmAdapters
         // ── Private helpers ────────────────────────────────────────────────
 
         /// <summary>
-        /// Sends a stateful opponent request by building a multi-turn conversation
-        /// from the accumulated history and sending it via the transport.
-        /// The transport's SendAsync only supports single-turn (system + user), so for
-        /// stateful mode we flatten the accumulated history into the user message.
+        /// Sends a stateful opponent request by flattening the supplied history
+        /// into the user message. The transport contract is single-turn
+        /// (system + user), so prior exchanges are prefixed into the user payload
+        /// before the current turn's content. Pure function of its inputs — no
+        /// adapter-side state is read or written.
         /// </summary>
-        private async Task<string> SendStatefulOpponentAsync(string systemPrompt, double temperature)
+        private Task<string> SendStatefulOpponentAsync(
+            string systemPrompt,
+            string currentUserContent,
+            IReadOnlyList<ConversationMessage> priorHistory,
+            double temperature)
         {
-            if (_opponentHistory.Count == 0)
-                return await _transport.SendAsync(systemPrompt, "", temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
-                    .ConfigureAwait(false);
-
-            // The last message is the current user message (just appended)
-            if (_opponentHistory.Count == 1)
-            {
-                // Single user message — just send it directly
-                return await _transport.SendAsync(systemPrompt, _opponentHistory[0].Content, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
-                    .ConfigureAwait(false);
-            }
-
-            // Multi-turn: prefix prior exchanges into the user message for context
+            // Multi-turn: prefix prior exchanges into the user message for context.
             var contextBuilder = new StringBuilder();
             contextBuilder.AppendLine("[PREVIOUS CONVERSATION CONTEXT]");
-            for (int i = 0; i < _opponentHistory.Count - 1; i++)
+            for (int i = 0; i < priorHistory.Count; i++)
             {
-                var (role, content) = _opponentHistory[i];
-                string displayRole = string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase)
+                var msg = priorHistory[i];
+                string displayRole = string.Equals(msg.Role, ConversationMessage.AssistantRole, StringComparison.OrdinalIgnoreCase)
                     ? "OPPONENT" : "PLAYER";
-                contextBuilder.AppendLine($"[{displayRole}] {content}");
+                contextBuilder.AppendLine($"[{displayRole}] {msg.Content}");
             }
             contextBuilder.AppendLine();
             contextBuilder.AppendLine("[CURRENT TURN]");
+            contextBuilder.Append(currentUserContent);
 
-            // Last message is the current user prompt
-            contextBuilder.Append(_opponentHistory[_opponentHistory.Count - 1].Content);
-
-            return await _transport.SendAsync(systemPrompt, contextBuilder.ToString(), temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
-                .ConfigureAwait(false);
+            return _transport.SendAsync(
+                systemPrompt,
+                contextBuilder.ToString(),
+                temperature,
+                _options.MaxTokens,
+                phase: LlmPhase.OpponentResponse);
         }
 
         public void Dispose()

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
@@ -9,6 +10,16 @@ using Pinder.Core.Traps;
 
 namespace Pinder.Core.Tests.Conversation
 {
+    /// <summary>
+    /// Originally: locked the #536 stateful-adapter contract (StartOpponentSession on construction,
+    /// HasOpponentSession query). Updated for #788: the engine now owns opponent conversation
+    /// state, so the locked contract becomes:
+    /// <list type="bullet">
+    ///   <item><description><c>IStatefulLlmAdapter</c> exists and is implementable by stateless adapters.</description></item>
+    ///   <item><description><c>GameSession</c> constructor does NOT call any "start opponent session" hook.</description></item>
+    ///   <item><description><c>NullLlmAdapter</c> implements <c>IStatefulLlmAdapter</c> via the history-passing overload.</description></item>
+    /// </list>
+    /// </summary>
     [Trait("Category", "Core")]
     public class Issue536_StatefulAdapterTests
     {
@@ -18,35 +29,45 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
-                private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
+        private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
         {
-            public bool StartCalled { get; private set; }
-            public string? ReceivedPrompt { get; private set; }
-
-            public void StartOpponentSession(string opponentSystemPrompt)
-            {
-                StartCalled = true;
-                ReceivedPrompt = opponentSystemPrompt;
-            }
-
-            public bool HasOpponentSession => StartCalled;
+            // #788: track that the engine routed through the stateful overload, not just StateLESS one.
+            public int StatefulCallCount { get; private set; }
+            public IReadOnlyList<ConversationMessage>? LastHistorySeen { get; private set; }
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context) => Task.FromResult(new DialogueOption[0]);
             public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
             public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
+
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+            {
+                StatefulCallCount++;
+                LastHistorySeen = history;
+                return Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("...", null, null),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User("u"),
+                        ConversationMessage.Assistant("a"),
+                    }));
+            }
+
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
             public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
         }
 
-                private sealed class DummyDice : IDiceRoller
+        private sealed class DummyDice : IDiceRoller
         {
             public int Roll(int sides) => 10;
         }
@@ -74,14 +95,16 @@ namespace Pinder.Core.Tests.Conversation
             var player = MakeProfile("P1");
             var opponent = MakeProfile("P2");
 
-            // Plain ILlmAdapter — no stateful cast, should not throw
+            // Plain ILlmAdapter — no stateful cast, should not throw.
             var session = new GameSession(player, opponent, new DummyLlmAdapter(), new DummyDice(), new NullTrapRegistry(), new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
             Assert.NotNull(session);
         }
 
+        // #788 contract: GameSession.ctor MUST NOT call any session-start hook on the
+        // adapter. The opponent history is owned by the engine and starts empty.
         [Fact]
-        public void GameSession_Constructor_WiresStatefulSession()
+        public void GameSession_Constructor_DoesNotInvokeAdapterOnConstruction()
         {
             var player = MakeProfile("P1");
             var opponent = MakeProfile("P2");
@@ -89,9 +112,10 @@ namespace Pinder.Core.Tests.Conversation
 
             var session = new GameSession(player, opponent, statefulAdapter, new DummyDice(), new NullTrapRegistry(), new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
-            Assert.True(statefulAdapter.StartCalled, "GameSession should call StartOpponentSession on construction");
-            Assert.True(statefulAdapter.HasOpponentSession);
-            Assert.Equal("You are P2.", statefulAdapter.ReceivedPrompt);
+            Assert.Equal(0, statefulAdapter.StatefulCallCount);
+            Assert.NotNull(session);
+            // Engine-owned history starts empty — locks the new ownership boundary.
+            Assert.Empty(session.OpponentHistory);
         }
 
         [Fact]
@@ -99,12 +123,16 @@ namespace Pinder.Core.Tests.Conversation
         {
             var adapter = new NullLlmAdapter();
             Assert.True(adapter is IStatefulLlmAdapter);
+        }
 
-            var stateful = (IStatefulLlmAdapter)adapter;
-            // Should not throw
-            stateful.StartOpponentSession("test prompt");
-            // NullLlmAdapter always reports no session
-            Assert.False(stateful.HasOpponentSession);
+        // #788 sanity: the old StartOpponentSession / HasOpponentSession surface MUST be
+        // gone from the interface. If a regression re-introduces them, this test catches it.
+        [Fact]
+        public void IStatefulLlmAdapter_HasNoStartOpponentSessionOrHasOpponentSession()
+        {
+            var iface = typeof(IStatefulLlmAdapter);
+            Assert.Null(iface.GetMethod("StartOpponentSession"));
+            Assert.Null(iface.GetProperty("HasOpponentSession"));
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Issue #788: snapshot/restore round-trip for the engine-owned opponent
+    /// LLM history. Locks that <see cref="GameSession.OpponentHistory"/>
+    /// survives a <see cref="GameSession.RestoreState"/> call so a replayed
+    /// session can reproduce the same multi-turn opponent context the
+    /// original session ran with.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue788_SnapshotRoundTripTests
+    {
+        private static CharacterProfile MakeProfile(string name)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        [Fact]
+        public async Task PlayingTurns_AccumulatesOpponentHistory()
+        {
+            // Provide enough dice values for a few turns: ctor d10 + per-turn d20 main + d100 timing.
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5, 15, 50, 15, 50, 15, 50),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // Engine starts with empty opponent history.
+            Assert.Empty(session.OpponentHistory);
+
+            // Resolve one turn — NullLlmAdapter contributes one user + one assistant entry.
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.Equal(2, session.OpponentHistory.Count);
+            Assert.Equal(ConversationMessage.UserRole, session.OpponentHistory[0].Role);
+            Assert.Equal(ConversationMessage.AssistantRole, session.OpponentHistory[1].Role);
+        }
+
+        [Fact]
+        public void RestoreState_RebuildsOpponentHistoryFromResimData()
+        {
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            var resim = new ResimulateData
+            {
+                TargetInterest = session.CreateSnapshot().Interest,
+                TurnNumber = 2,
+                MomentumStreak = 0,
+                ShadowValues = new Dictionary<string, int>(),
+                ActiveTraps = new List<(string, int)>(),
+                ConversationHistory = new List<(string, string)>(),
+                ComboHistory = new List<(string, bool)>(),
+                PendingTripleBonus = false,
+                RizzCumulativeFailureCount = 0,
+                OpponentHistory = new List<(string, string)>
+                {
+                    ("user", "first user prompt"),
+                    ("assistant", "first opponent reply"),
+                    ("user", "second user prompt"),
+                    ("assistant", "second opponent reply"),
+                },
+            };
+            session.RestoreState(resim, new NullTrapRegistry());
+
+            Assert.Equal(4, session.OpponentHistory.Count);
+            Assert.Equal("user", session.OpponentHistory[0].Role);
+            Assert.Equal("first user prompt", session.OpponentHistory[0].Content);
+            Assert.Equal("assistant", session.OpponentHistory[1].Role);
+            Assert.Equal("first opponent reply", session.OpponentHistory[1].Content);
+            Assert.Equal("user", session.OpponentHistory[2].Role);
+            Assert.Equal("assistant", session.OpponentHistory[3].Role);
+            Assert.Equal("second opponent reply", session.OpponentHistory[3].Content);
+
+            // CreateSnapshot reflects the restored history.
+            var snap = session.CreateSnapshot();
+            Assert.Equal(4, snap.OpponentHistory.Count);
+            Assert.Equal("first opponent reply", snap.OpponentHistory[1].Content);
+        }
+
+        [Fact]
+        public void RestoreState_WithEmptyOpponentHistory_ClearsAndStaysEmpty()
+        {
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // Pre-load with garbage so we can prove RestoreState clears it.
+            session.RestoreState(new ResimulateData
+            {
+                TargetInterest = session.CreateSnapshot().Interest,
+                TurnNumber = 1,
+                OpponentHistory = new List<(string, string)>
+                {
+                    ("user", "stale"),
+                    ("assistant", "stale"),
+                },
+            }, new NullTrapRegistry());
+            Assert.Equal(2, session.OpponentHistory.Count);
+
+            // Now restore with empty opponent history — the list should clear.
+            session.RestoreState(new ResimulateData
+            {
+                TargetInterest = session.CreateSnapshot().Interest,
+                TurnNumber = 0,
+                OpponentHistory = new List<(string, string)>(),
+            }, new NullTrapRegistry());
+            Assert.Empty(session.OpponentHistory);
+        }
+
+        [Fact]
+        public async Task PlayedSession_SnapshotedAndReplayed_ReproducesOpponentHistory()
+        {
+            // Run A: play 2 turns straight, capture snapshot.
+            var sessionA = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5, 15, 50, 15, 50),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+            await sessionA.StartTurnAsync(); await sessionA.ResolveTurnAsync(0);
+            await sessionA.StartTurnAsync(); await sessionA.ResolveTurnAsync(0);
+            var snapA = sessionA.CreateSnapshot();
+            var historyA = sessionA.OpponentHistory.ToArray();
+
+            Assert.Equal(4, historyA.Length); // 2 turns × (user + assistant)
+
+            // Run B: fresh session, restore from A's history+state, verify equivalence.
+            var sessionB = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+            sessionB.RestoreState(new ResimulateData
+            {
+                TargetInterest = snapA.Interest,
+                TurnNumber = snapA.TurnNumber,
+                MomentumStreak = snapA.MomentumStreak,
+                ShadowValues = new Dictionary<string, int>(),
+                ActiveTraps = new List<(string, int)>(),
+                ConversationHistory = sessionA.ConversationHistory
+                    .Select(e => (e.Sender, e.Text)).ToList(),
+                ComboHistory = new List<(string, bool)>(),
+                PendingTripleBonus = snapA.TripleBonusActive,
+                OpponentHistory = historyA.Select(m => (m.Role, m.Content)).ToList(),
+            }, new NullTrapRegistry());
+
+            Assert.Equal(historyA.Length, sessionB.OpponentHistory.Count);
+            for (int i = 0; i < historyA.Length; i++)
+            {
+                Assert.Equal(historyA[i].Role, sessionB.OpponentHistory[i].Role);
+                Assert.Equal(historyA[i].Content, sessionB.OpponentHistory[i].Content);
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.Core.Rolls;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Issue #788 — fast-gameplay-readiness check.
+    ///
+    /// <para>
+    /// Locks the contract that the (now-stateless) <see cref="IStatefulLlmAdapter"/>
+    /// can serve concurrent calls without context bleed: three simultaneous
+    /// calls into the same adapter instance, each carrying their own history
+    /// list, return responses whose context never interleaves with the others.
+    /// </para>
+    ///
+    /// <para>
+    /// Before #788 this test would have failed: the adapter held
+    /// <c>_opponentHistory</c> as a private field, so two concurrent calls
+    /// would race-mutate it and each would see the other's appended
+    /// user/assistant turns. After #788 the adapter is stateless and the
+    /// engine owns the history list \u2014 calls are independent.
+    /// </para>
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue788_StatelessAdapterConcurrencyTests
+    {
+        /// <summary>
+        /// Stateless test adapter: echoes back the history it received as the
+        /// response text, so the test can prove which history the adapter
+        /// observed on each concurrent call.
+        /// </summary>
+        private sealed class EchoStatelessAdapter : IStatefulLlmAdapter
+        {
+            // Counts concurrent in-flight calls — proves they actually overlap.
+            private int _inFlight;
+            public int MaxInFlightObserved { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+                => Task.FromResult(System.Array.Empty<DialogueOption>());
+            public Task<string> DeliverMessageAsync(DeliveryContext context)
+                => Task.FromResult(string.Empty);
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+                => Task.FromResult(new OpponentResponse(string.Empty));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+                => Task.FromResult<string?>(null);
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+                => Task.FromResult(string.Empty);
+            public Task<string> ApplyHorninessOverlayAsync(string m, string i, string? oc = null, string? ad = null) => Task.FromResult(m);
+            public Task<string> ApplyShadowCorruptionAsync(string m, string i, ShadowStatType s, string? ad = null) => Task.FromResult(m);
+            public Task<string> ApplyTrapOverlayAsync(string m, string i, string n, string? oc = null, string? ad = null) => Task.FromResult(m);
+
+            public async Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                IReadOnlyList<ConversationMessage> history,
+                CancellationToken cancellationToken = default)
+            {
+                int now = Interlocked.Increment(ref _inFlight);
+                lock (this)
+                {
+                    if (now > MaxInFlightObserved) MaxInFlightObserved = now;
+                }
+                try
+                {
+                    // Yield to encourage actual interleaving across calls.
+                    await Task.Yield();
+                    await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+
+                    // Echo the history we observed, joined with markers so the
+                    // test can grep what each call saw.
+                    string echoed = string.Join(
+                        " | ",
+                        history.Select(h => $"{h.Role}:{h.Content}"));
+                    var response = new OpponentResponse($"ECHO[{echoed}]");
+                    var entries = new ConversationMessage[]
+                    {
+                        ConversationMessage.User($"call-{context.PlayerName}"),
+                        ConversationMessage.Assistant(response.MessageText),
+                    };
+                    return new StatefulOpponentResult(response, entries);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _inFlight);
+                }
+            }
+        }
+
+        private static OpponentContext MakeContext(string playerLabel) =>
+            new OpponentContext(
+                playerPrompt: "p",
+                opponentPrompt: "o",
+                conversationHistory: System.Array.Empty<(string, string)>(),
+                opponentLastMessage: string.Empty,
+                activeTraps: System.Array.Empty<string>(),
+                currentInterest: 12,
+                playerDeliveredMessage: string.Empty,
+                interestBefore: 12,
+                interestAfter: 12,
+                responseDelayMinutes: 0.0,
+                playerName: playerLabel);
+
+        [Fact]
+        public async Task ThreeConcurrentCalls_EachWithOwnHistory_ReturnNonInterleavedContext()
+        {
+            var adapter = new EchoStatelessAdapter();
+
+            // Three callers, each with their OWN distinct history list.
+            // If the adapter were storing history internally, the calls would
+            // see each other's history mixed in. Because it doesn't, each
+            // call's response should reflect only its own input history.
+            var historyA = new[] { ConversationMessage.User("uA"), ConversationMessage.Assistant("aA") };
+            var historyB = new[] { ConversationMessage.User("uB"), ConversationMessage.Assistant("aB") };
+            var historyC = new[] { ConversationMessage.User("uC"), ConversationMessage.Assistant("aC") };
+
+            // Fire all three concurrently.
+            var taskA = adapter.GetOpponentResponseAsync(MakeContext("A"), historyA);
+            var taskB = adapter.GetOpponentResponseAsync(MakeContext("B"), historyB);
+            var taskC = adapter.GetOpponentResponseAsync(MakeContext("C"), historyC);
+
+            var results = await Task.WhenAll(taskA, taskB, taskC).ConfigureAwait(false);
+
+            // Sanity: the three calls genuinely overlapped (so this isn't a
+            // serial-execution false-positive).
+            Assert.True(adapter.MaxInFlightObserved >= 2,
+                $"Expected concurrent execution; max in-flight was {adapter.MaxInFlightObserved}.");
+
+            // Each call's response echoes ONLY its own history — no bleed.
+            Assert.Contains("user:uA | assistant:aA", results[0].Response.MessageText);
+            Assert.DoesNotContain("uB", results[0].Response.MessageText);
+            Assert.DoesNotContain("uC", results[0].Response.MessageText);
+
+            Assert.Contains("user:uB | assistant:aB", results[1].Response.MessageText);
+            Assert.DoesNotContain("uA", results[1].Response.MessageText);
+            Assert.DoesNotContain("uC", results[1].Response.MessageText);
+
+            Assert.Contains("user:uC | assistant:aC", results[2].Response.MessageText);
+            Assert.DoesNotContain("uA", results[2].Response.MessageText);
+            Assert.DoesNotContain("uB", results[2].Response.MessageText);
+        }
+
+        // Static-shape lock: no public mutable instance field on PinderLlmAdapter
+        // (or its sibling adapters) should match the old opponent-session names
+        // (_opponentHistory, _opponentSession, _opponentSystemPrompt). If a
+        // regression re-introduces them, this catches it before runtime tests.
+        [Fact]
+        public void PinderLlmAdapter_HasNoOpponentSessionFields()
+        {
+            var adapterType = typeof(Pinder.LlmAdapters.PinderLlmAdapter);
+            var anthropicType = typeof(Pinder.LlmAdapters.Anthropic.AnthropicLlmAdapter);
+            var openAiType = typeof(Pinder.LlmAdapters.OpenAi.OpenAiLlmAdapter);
+
+            string[] forbidden = { "_opponentHistory", "_opponentSession", "_opponentSystemPrompt" };
+
+            foreach (var t in new[] { adapterType, anthropicType, openAiType })
+            {
+                foreach (var name in forbidden)
+                {
+                    var field = t.GetField(name,
+                        System.Reflection.BindingFlags.Instance |
+                        System.Reflection.BindingFlags.NonPublic |
+                        System.Reflection.BindingFlags.Public);
+                    Assert.True(field == null,
+                        $"{t.FullName} still has forbidden opponent-session field '{name}'. " +
+                        "Per #788, opponent conversation state lives on GameSession, not the adapter.");
+                }
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -240,8 +240,18 @@ namespace Pinder.Core.Tests
         {
             public DeliveryContext? CapturedDeliveryContext { get; private set; }
 
-            public void StartOpponentSession(string opponentSystemPrompt) { }
-            public bool HasOpponentSession => false;
+            // #788: stateful LLM adapter is now history-passing and stateless.
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                System.Collections.Generic.IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("..."),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User(string.Empty),
+                        ConversationMessage.Assistant("..."),
+                    }));
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
             {

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -225,8 +225,18 @@ namespace Pinder.Core.Tests
             public bool ShadowCorruptionCalled { get; private set; }
             public DialogueOption[] LastOptions { get; private set; } = System.Array.Empty<DialogueOption>();
 
-            public void StartOpponentSession(string opponentSystemPrompt) { }
-            public bool HasOpponentSession => false;
+            // #788: stateful LLM adapter is now history-passing and stateless.
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                System.Collections.Generic.IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("..."),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User(string.Empty),
+                        ConversationMessage.Assistant("..."),
+                    }));
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
             {

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -335,8 +335,18 @@ namespace Pinder.Core.Tests
             public bool HorninessOverlayCalled { get; private set; }
             public DialogueOption[] LastOptions { get; private set; } = System.Array.Empty<DialogueOption>();
 
-            public void StartOpponentSession(string opponentSystemPrompt) { }
-            public bool HasOpponentSession => false;
+            // #788: stateful LLM adapter is now history-passing and stateless.
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                System.Collections.Generic.IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("..."),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User(string.Empty),
+                        ConversationMessage.Assistant("..."),
+                    }));
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
             {


### PR DESCRIPTION
Phase 1 of the #393 fast-gameplay drain. The `IStatefulLlmAdapter` no longer retains opponent-session state across calls; the engine (`GameSession`) owns the opponent LLM conversation history and passes it in on every call.

## Why

The old design held `_opponentHistory` / `_opponentSession` / `_opponentSystemPrompt` as private fields on `PinderLlmAdapter` (and the per-provider adapters). That made the adapter stateful per session, blocking concurrent reuse and risking cross-session context bleed. With #393 fast-gameplay incoming, the adapter must be safe to share across many concurrent sessions.

## What changed

### Interface — `IStatefulLlmAdapter`
- Drop `StartOpponentSession(string)` and `HasOpponentSession`.
- Add `GetOpponentResponseAsync(OpponentContext, IReadOnlyList<ConversationMessage>, CancellationToken)` returning a `StatefulOpponentResult` (parsed response + entries to append).
- `CancellationToken` added pre-emptively for #794.

### New types
- `ConversationMessage(role, content)` — role is `\"user\"` or `\"assistant\"`.
- `StatefulOpponentResult { Response, NewHistoryEntries }` — bundles parsed response with the entries the engine should append.

### Adapters (all three made stateless)
- `PinderLlmAdapter`, `AnthropicLlmAdapter`, `OpenAiLlmAdapter`:
  - Remove the three opponent-session fields.
  - Build a fresh request from the engine-supplied history each call.
  - Return response + new history entries.
  - Base `ILlmAdapter.GetOpponentResponseAsync(ctx)` remains as a single-turn fallback, delegating to the stateful path with empty history.
- `NullLlmAdapter`: implements the new history-passing overload too.

### Engine — `GameSession`
- Owns `_opponentHistory: List<ConversationMessage>` (private; public read-only `OpponentHistory` accessor).
- Drops the `StartOpponentSession` constructor wiring.
- Routes `ResolveTurnAsync`'s opponent call through `IStatefulLlmAdapter` when available; appends each call's `NewHistoryEntries` to the engine list.

### Snapshot/restore path (CRITICAL)
- `ResimulateData.OpponentHistory` carries the engine history across snapshot/restore.
- `GameStateSnapshot.OpponentHistory` exposes the snapshot view (defensive copy).
- session-runner's `TurnSnapshot` adds `OpponentHistory: List<OpponentHistoryEntry>`; AGENTS.md schema-discipline comment block updated.
- `BuildResimulateData` hydrates `OpponentHistory` on replay.

## Tests

- **Phase 0 invariants (27/27 green)** — the wire-level contracts (I1 opponent history content, I5 snapshot equivalence, etc.) survive unchanged because the adapter still flattens history into the user message exactly as before. **This was the safety net per the brief.**
- **Issue536_RevertStatefulAdapterTests** rewritten to lock the new contract (no `Start`/`HasOpponentSession` on the interface; `GameSession` ctor doesn't touch the adapter; `OpponentHistory` starts empty).
- **Issue788_StatelessAdapterConcurrencyTests (NEW)** — three concurrent calls into the same adapter with their own history lists return non-interleaved responses; static-shape lock that no `_opponent*` field re-appears.
- **Issue788_SnapshotRoundTripTests (NEW)** — `RestoreState` rebuilds the engine opponent history from `ResimulateData`; played-and-replayed sessions reproduce the same opponent history.
- **Existing tests in #365/#399/#364** — in-test adapter doubles updated to the new history-passing surface.
- **Pinder.Core.Tests**: 6 pre-existing `CharacterLoaderSpec` failures (worktree `.git`-as-file, per task brief) and 1 pre-existing `Issue527` flake (state-dependent on `design/playtests/` directory; passes in isolation, same on origin/main). All other tests green.
- **Pinder.GameApi.Tests (pinder-web): 517/517 green** — the GameApi consumes `IStatefulLlmAdapter` via DI and the new interface is wire-compatible with that consumer.

## DoD evidence

\`\`\`
$ git grep -E '_opponentHistory\\b|_opponentSession\\b|StartOpponentSession\\b' pinder-core/src/Pinder.LlmAdapters
(no hits)
\`\`\`

\`\`\`
$ dotnet test --filter \"Category=Phase0\" --nologo
Passed!  - Failed:     0, Passed:    27, Skipped:     0, Total:    27
\`\`\`

\`\`\`
$ dotnet test src/Pinder.GameApi.Tests/Pinder.GameApi.Tests.csproj --nologo
Passed!  - Failed:     0, Passed:   517, Skipped:     0, Total:   517
\`\`\`

## Notes

- This pinder-core PR must be merged before the corresponding pinder-web parent PR. The orchestrator will rewrite the parent PR's submodule pointer post-squash.
- Self-approval blocked — see canonical lesson SELF-APPROVE-BLOCKED.

Closes #788
Refs #393