### PR TITLE
refactor(#794): thread CancellationToken through ResolveTurnAsync + LLM adapters

### DIFF
--- a/docs/development/regression-pins-787.md
+++ b/docs/development/regression-pins-787.md
@@ -129,15 +129,16 @@ actually use; that's what we lock.
 
 **What it locks:** when an `ILlmTransport.SendAsync` call throws mid-resolve
 (simulated `OperationCanceledException`, simulated 429-style HTTP exception,
-simulated network reset), the exception propagates AND the engine's turn
-counter does NOT advance. `StartTurnAsync` failures don't leak `_currentOptions`.
+simulated network reset) OR when a real `CancellationToken` is cancelled
+mid-turn (#794), the exception propagates AND the engine's turn counter does
+NOT advance. `StartTurnAsync` failures don't leak `_currentOptions`.
 
-**Documented gap:** pinder-core's non-streaming path has NO `CancellationToken`
-plumbing on `ResolveTurnAsync` or `ILlmTransport.SendAsync`. Cancellation is
-effected today by throwing from inside the transport — a `CancellationToken`
-would be an engine-level API change. F3 (cancellation mid-stream) is therefore
-tested via "throw OCE during opponent_response phase," which is the closest
-fixture pinder-core can support.
+**Resolved gap (#794):** `GameSession.ResolveTurnAsync(int, IProgress?, CancellationToken)`
+and `ILlmTransport.SendAsync(..., CancellationToken)` now accept a token and
+thread it through every awaited LLM adapter call (delivery, steering, trap
+overlay, horniness overlay, shadow corruption, opponent response). I6.4–I6.6
+and F3b exercise real `CancellationTokenSource.Cancel()` mid-turn; the legacy
+throw-OCE shape is preserved as I6.3 / F3a so the contract covers both.
 
 **Existing engine behaviour finding (flagged here, NOT fixed in this PR):**
 when `ResolveTurnAsync` throws between the dice roll and the delivery LLM call,

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
 using Pinder.Core.Interfaces;
@@ -425,9 +426,16 @@ namespace Pinder.Core.Conversation
         /// Start a new turn. Checks end conditions, determines advantage/disadvantage,
         /// and fetches dialogue options from the LLM adapter.
         /// </summary>
+        /// <param name="ct">
+        /// Cancellation token forwarded to the LLM adapter call (#794). Defaults to
+        /// <c>default</c> for backwards compatibility — existing callers that don't
+        /// pass a token continue to work unchanged.
+        /// </param>
         /// <exception cref="GameEndedException">If the game has already ended.</exception>
-        public async Task<TurnStart> StartTurnAsync()
+        /// <exception cref="OperationCanceledException">If <paramref name="ct"/> is cancelled.</exception>
+        public async Task<TurnStart> StartTurnAsync(CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             // Check if game already ended
             if (_ended)
                 throw new GameEndedException(_outcome!.Value);
@@ -543,7 +551,7 @@ namespace Pinder.Core.Conversation
                 availableStats: availableStats);
 
             // Get dialogue options from LLM
-            var rawOptions = await _llm.GetDialogueOptionsAsync(context).ConfigureAwait(false);
+            var rawOptions = await _llm.GetDialogueOptionsAsync(context, ct).ConfigureAwait(false);
 
             // Peek combos for each option (#46), enrich with weakness window (#49) and tell bonus (#50)
             var options = new DialogueOption[rawOptions.Length];
@@ -657,7 +665,7 @@ namespace Pinder.Core.Conversation
         /// <exception cref="GameEndedException">If the game has already ended.</exception>
         /// <exception cref="InvalidOperationException">If StartTurnAsync was not called first or index is invalid.</exception>
         public Task<TurnResult> ResolveTurnAsync(int optionIndex)
-            => ResolveTurnAsync(optionIndex, progress: null);
+            => ResolveTurnAsync(optionIndex, progress: null, ct: default);
 
         /// <summary>
         /// #789 Phase 2 (D1) — inject a specific <see cref="Pinder.Core.Rolls.PerOptionDicePool"/>
@@ -687,8 +695,29 @@ namespace Pinder.Core.Conversation
         /// per coarse stage of the multi-LLM resolution pipeline. Intended for
         /// the web session-runner's SSE endpoint — see <see cref="TurnProgressStage"/>.
         /// </summary>
-        public async Task<TurnResult> ResolveTurnAsync(int optionIndex, System.IProgress<TurnProgressEvent>? progress)
+        /// <remarks>
+        /// This overload exists for backward compatibility with callers that
+        /// pre-date the cancellation-token thread (#794). It delegates to the
+        /// CT-aware overload with <c>ct = default</c>.
+        /// </remarks>
+        public Task<TurnResult> ResolveTurnAsync(int optionIndex, System.IProgress<TurnProgressEvent>? progress)
+            => ResolveTurnAsync(optionIndex, progress, ct: default);
+
+        /// <summary>
+        /// Resolve the current turn with an optional progress reporter and
+        /// cancellation token. The token is forwarded to every awaited LLM
+        /// adapter call inside the resolution pipeline (steering, delivery,
+        /// trap overlay, horniness overlay, shadow corruption, opponent
+        /// response). When the token is cancelled mid-turn the engine surfaces
+        /// <see cref="OperationCanceledException"/> at the next adapter call;
+        /// the post-cancel observable invariants are documented in
+        /// <c>docs/development/regression-pins-787.md</c> and locked by the
+        /// Phase 0 I6 / F3 invariant tests (#794, prerequisite for the
+        /// fast-gameplay scheduler #425).
+        /// </summary>
+        public async Task<TurnResult> ResolveTurnAsync(int optionIndex, System.IProgress<TurnProgressEvent>? progress, CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
             if (_ended)
                 throw new GameEndedException(_outcome!.Value);
 
@@ -966,7 +995,7 @@ namespace Pinder.Core.Conversation
             // named DeliveredMessage for backward compatibility with the LLM
             // adapter contract.
             SteeringRollResult steeringResult = await _steeringEngine.AttemptSteeringRollAsync(
-                originalIntendedText, _player, _opponent, _llm, BuildHistoryForLlmContext()).ConfigureAwait(false);
+                originalIntendedText, _player, _opponent, _llm, BuildHistoryForLlmContext(), ct).ConfigureAwait(false);
             progress?.Report(new TurnProgressEvent(
                 TurnProgressStage.SteeringCompleted,
                 steeringResult.SteeringSucceeded ? steeringResult.SteeringQuestion : null));
@@ -1029,7 +1058,7 @@ namespace Pinder.Core.Conversation
                 activeArchetypeDirective: playerArchetypeDirectiveForDelivery);
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
-            string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext).ConfigureAwait(false);
+            string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext, ct).ConfigureAwait(false);
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryCompleted, deliveredMessage));
 
             // Tier modifier diff (SECOND per #364): intended+steering text vs
@@ -1076,7 +1105,7 @@ namespace Pinder.Core.Conversation
                     string opponentCtxForTrap = BuildOpponentContext(_opponent);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayStarted));
                     deliveredMessage = await _llm.ApplyTrapOverlayAsync(
-                        deliveredMessage, trapInstruction, trapDisplayName, opponentCtxForTrap, playerArchetypeDirectiveForDelivery)
+                        deliveredMessage, trapInstruction, trapDisplayName, opponentCtxForTrap, playerArchetypeDirectiveForDelivery, ct)
                         .ConfigureAwait(false);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayCompleted, deliveredMessage));
                     if (deliveredMessage != beforeTrap)
@@ -1119,7 +1148,7 @@ namespace Pinder.Core.Conversation
                     string beforeHorniness = deliveredMessage;
                     string opponentCtx = BuildOpponentContext(_opponent);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayStarted));
-                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
+                    deliveredMessage = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, instruction, opponentCtx, playerArchetypeDirectiveForDelivery, ct).ConfigureAwait(false);
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, deliveredMessage));
                     if (deliveredMessage != beforeHorniness)
                     {
@@ -1131,7 +1160,8 @@ namespace Pinder.Core.Conversation
                         // #314: layer ran but produced byte-identical output.
                         EmitTextLayerNoop("Horniness", beforeHorniness, deliveredMessage);
                     }
-                }).ConfigureAwait(false);
+                },
+                ct).ConfigureAwait(false);
 
             // #743/#399: Horniness §15 interest-penalty halving is intentionally
             // DEFERRED until AFTER the shadow check below. Reason: when a paired
@@ -1187,7 +1217,7 @@ namespace Pinder.Core.Conversation
                             string beforeShadow = deliveredMessage;
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionStarted));
                             deliveredMessage = await _llm.ApplyShadowCorruptionAsync(
-                                deliveredMessage, corruptionInstruction, pairedShadow.Value, playerArchetypeDirectiveForDelivery).ConfigureAwait(false);
+                                deliveredMessage, corruptionInstruction, pairedShadow.Value, playerArchetypeDirectiveForDelivery, ct).ConfigureAwait(false);
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionCompleted, deliveredMessage));
                             if (deliveredMessage != beforeShadow)
                             {
@@ -1327,13 +1357,14 @@ namespace Pinder.Core.Conversation
             // adapter can build a multi-turn wire payload from the engine-owned
             // _opponentHistory. The adapter returns the parsed response plus
             // the entries to append to history; the engine appends them.
+            // #794: thread cancellation token to underlying transport.
             OpponentResponse opponentResponse;
             if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter statefulLlm)
             {
                 var statefulResult = await statefulLlm.GetOpponentResponseAsync(
                     opponentContext,
                     _opponentHistory,
-                    default).ConfigureAwait(false);
+                    ct).ConfigureAwait(false);
                 if (statefulResult == null)
                     throw new InvalidOperationException("LLM adapter returned null stateful opponent result");
                 opponentResponse = statefulResult.Response;
@@ -1350,7 +1381,7 @@ namespace Pinder.Core.Conversation
             }
             else
             {
-                opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext).ConfigureAwait(false);
+                opponentResponse = await _llm.GetOpponentResponseAsync(opponentContext, ct).ConfigureAwait(false);
                 if (opponentResponse == null)
                     throw new InvalidOperationException("LLM adapter returned null opponent response");
             }

--- a/src/Pinder.Core/Conversation/HorninessEngine.cs
+++ b/src/Pinder.Core/Conversation/HorninessEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Rolls;
@@ -29,8 +30,10 @@ namespace Pinder.Core.Conversation
             string deliveredMessage,
             ILlmAdapter llm,
             object? statDeliveryInstructions,
-            Func<string, Task> applyOverlay)
+            Func<string, Task> applyOverlay,
+            CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             if (sessionHorniness <= 0 || playerShadows == null)
                 return HorninessCheckResult.NotPerformed;
 

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -17,8 +17,9 @@ namespace Pinder.Core.Conversation
         /// Returns 4 generic dialogue options, one per stat family
         /// (Charm, Honesty, Wit, Chaos).
         /// </summary>
-        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             var options = new[]
             {
                 new DialogueOption(StatType.Charm, "Hey, you come here often?"),
@@ -33,8 +34,9 @@ namespace Pinder.Core.Conversation
         /// Echoes the intended text with a failure tier prefix.
         /// Format: "[{tier}] {intendedText}" for failures, or the intended text as-is for success.
         /// </summary>
-        public Task<string> DeliverMessageAsync(DeliveryContext context)
+        public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             string message = context.Outcome == FailureTier.None
                 ? context.ChosenOption.IntendedText
                 : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
@@ -44,8 +46,9 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Returns a minimal placeholder OpponentResponse with "..." text and no signals.
         /// </summary>
-        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult(new OpponentResponse("..."));
         }
 
@@ -70,32 +73,36 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Always returns null (no narrative beat).
         /// </summary>
-        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult<string?>(null);
         }
 
         /// <summary>
         /// Returns a placeholder steering question.
         /// </summary>
-        public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult("so... when are we actually doing this?");
         }
 
         /// <summary>
         /// Returns the message unchanged (no LLM overlay in test mode).
         /// </summary>
-        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+        public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult(message);
         }
 
         /// <summary>
         /// Returns the message unchanged (no shadow corruption in test mode).
         /// </summary>
-        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+        public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult(message);
         }
 
@@ -104,8 +111,9 @@ namespace Pinder.Core.Conversation
         /// Used by the deterministic test harness so engine flow can be exercised
         /// without an actual LLM round-trip.
         /// </summary>
-        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult(message);
         }
     }

--- a/src/Pinder.Core/Conversation/SteeringEngine.cs
+++ b/src/Pinder.Core/Conversation/SteeringEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
 using Pinder.Core.Interfaces;
@@ -38,8 +39,10 @@ namespace Pinder.Core.Conversation
             CharacterProfile player,
             CharacterProfile opponent,
             ILlmAdapter llm,
-            IReadOnlyList<(string Sender, string Text)> history)
+            IReadOnlyList<(string Sender, string Text)> history,
+            CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             // Compute steering modifier: (playerCharm + playerWit + playerSA) / 3
             int playerCharm = player.Stats.GetEffective(StatType.Charm);
             int playerWit = player.Stats.GetEffective(StatType.Wit);
@@ -70,7 +73,14 @@ namespace Pinder.Core.Conversation
 
                 try
                 {
-                    steeringQuestion = await stateful.GetSteeringQuestionAsync(steeringContext).ConfigureAwait(false);
+                    steeringQuestion = await stateful.GetSteeringQuestionAsync(steeringContext, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Cancellation must propagate — this is the engine-level
+                    // cancellation contract (#794). Don't swallow it like a
+                    // generic LLM transport failure.
+                    throw;
                 }
                 catch
                 {

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
 using Pinder.Core.Stats;
@@ -8,30 +9,38 @@ namespace Pinder.Core.Interfaces
     /// Abstraction layer for all LLM interactions during a Pinder conversation.
     /// The actual provider (EigenCore, OpenAI, Anthropic, etc.) is injected at runtime.
     /// </summary>
+    /// <remarks>
+    /// All methods accept an optional <see cref="CancellationToken"/> (default
+    /// <c>default</c>) so the engine can honour cancellation propagated through
+    /// <see cref="Pinder.Core.Conversation.GameSession.ResolveTurnAsync(int, System.IProgress{TurnProgressEvent}?, CancellationToken)"/>.
+    /// Implementations MUST forward the token to their underlying transport call
+    /// — see <see cref="ILlmTransport.SendAsync"/> (#794, prerequisite for the
+    /// fast-gameplay scheduler #425).
+    /// </remarks>
     public interface ILlmAdapter
     {
         /// <summary>
         /// Generate 4 dialogue options for the player's turn.
         /// </summary>
-        Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context);
+        Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default);
 
         /// <summary>
         /// Deliver the chosen option with outcome degradation applied.
         /// Returns the player's message text (post-degradation).
         /// </summary>
-        Task<string> DeliverMessageAsync(DeliveryContext context);
+        Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default);
 
         /// <summary>
         /// Generate the opponent's response to the player's delivered message.
         /// Returns an OpponentResponse containing the message text and optional gameplay signals.
         /// </summary>
-        Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context);
+        Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default);
 
         /// <summary>
         /// Generate a narrative beat when interest crosses a threshold.
         /// Return null to skip the beat.
         /// </summary>
-        Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context);
+        Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default);
 
         /// <summary>
         /// Apply a horniness overlay to a delivered message.
@@ -44,7 +53,7 @@ namespace Pinder.Core.Interfaces
         /// (e.g. <c>"ACTIVE ARCHETYPE: The Peacock (clear)\n..."</c>) so the
         /// overlay rewrite respects the character's voice (#372).
         /// </param>
-        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null);
+        Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default);
 
         /// <summary>
         /// Apply a shadow corruption instruction to a delivered message.
@@ -56,7 +65,7 @@ namespace Pinder.Core.Interfaces
         /// Optional active archetype directive for the speaking character so
         /// the corrupted rewrite still sounds like the character (#372).
         /// </param>
-        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null);
+        Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default);
 
         /// <summary>
         /// Apply a trap overlay to a delivered message (issue #371). Called on
@@ -75,6 +84,6 @@ namespace Pinder.Core.Interfaces
         /// Optional active archetype directive for the speaking character so
         /// the trap-overlay rewrite still sounds like the character (#372 + #371 union).
         /// </param>
-        Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null);
+        Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default);
     }
 }

--- a/src/Pinder.Core/Interfaces/ILlmTransport.cs
+++ b/src/Pinder.Core/Interfaces/ILlmTransport.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Pinder.Core.Interfaces
@@ -23,7 +24,14 @@ namespace Pinder.Core.Interfaces
         /// for backwards compatibility — existing callers and ILlmTransport implementations
         /// do not need to change.
         /// </param>
+        /// <param name="ct">
+        /// Cancellation token (#794). Implementations MUST pass the token through to
+        /// the underlying HTTP call so a mid-turn cancel from the engine halts the
+        /// in-flight request and propagates <see cref="System.OperationCanceledException"/>.
+        /// Defaults to <c>default</c> for backwards compatibility — existing callers
+        /// that don't pass a token continue to work unchanged.
+        /// </param>
         /// <returns>Raw text response from the LLM.</returns>
-        Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null);
+        Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null, CancellationToken ct = default);
     }
 }

--- a/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
@@ -58,6 +58,11 @@ namespace Pinder.Core.Interfaces
         /// Called after a successful steering roll. The question should reference
         /// specifics from the conversation and nudge toward meeting up.
         /// </summary>
-        Task<string> GetSteeringQuestionAsync(SteeringContext context);
+        /// <param name="ct">
+        /// Cancellation token forwarded from <see cref="GameSession.ResolveTurnAsync(int, System.IProgress{TurnProgressEvent}?, CancellationToken)"/>
+        /// (#794). Implementations MUST pass this through to the underlying
+        /// transport so a mid-turn cancel halts the in-flight HTTP call.
+        /// </param>
+        Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default);
     }
 }

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -64,7 +64,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
 
         /// <inheritdoc />
-        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -77,7 +77,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature);
             AnthropicRequestBuilders.AttachTool(request, ToolSchemas.DialogueOptions);
 
-            var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+            var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
             _debugLogger.LogDebug("options", context.CurrentTurn, request, response, _options.DebugDirectory);
 
             // Try structured tool_use first, fall back to text parsing
@@ -94,12 +94,12 @@ namespace Pinder.LlmAdapters.Anthropic
                 ? optionsDraft
                 : await AnthropicResponseImprover.ApplyImprovementAsync(
                     _client, _options, systemBlocks, userContent, optionsDraft,
-                    _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature).ConfigureAwait(false);
+                    _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature, ct).ConfigureAwait(false);
             return DialogueOptionParsers.ParseDialogueOptionsText(optionsText);
         }
 
         /// <inheritdoc />
-        public async Task<string> DeliverMessageAsync(DeliveryContext context)
+        public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -113,7 +113,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 _options.DeliveryTemperature ?? DefaultDeliveryTemperature);
             AnthropicRequestBuilders.AttachTool(request, ToolSchemas.Delivery);
 
-            var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+            var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
             _debugLogger.LogDebug("delivery", context.CurrentTurn, request, response, _options.DebugDirectory);
 
             // Try structured tool_use first
@@ -136,16 +136,16 @@ namespace Pinder.LlmAdapters.Anthropic
             return applyImprovement
                 ? await AnthropicResponseImprover.ApplyImprovementAsync(
                     _client, _options, systemBlocks, userContent, deliveryDraft,
-                    _options.DeliveryTemperature ?? DefaultDeliveryTemperature).ConfigureAwait(false)
+                    _options.DeliveryTemperature ?? DefaultDeliveryTemperature, ct).ConfigureAwait(false)
                 : deliveryDraft;
         }
 
         /// <inheritdoc />
-        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
         {
             // #788: stateless single-turn fallback. Stateful callers route
             // through the IStatefulLlmAdapter overload that takes a history.
-            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
             return result.Response;
         }
 
@@ -192,7 +192,7 @@ namespace Pinder.LlmAdapters.Anthropic
             }
             AnthropicRequestBuilders.AttachTool(request, ToolSchemas.OpponentResponse);
 
-            var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+            var response = await _client.SendMessagesAsync(request, cancellationToken).ConfigureAwait(false);
             _debugLogger.LogDebug("opponent", context.CurrentTurn, request, response, _options.DebugDirectory);
 
             OpponentResponse parsed;
@@ -214,7 +214,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 var responseText = response.GetText();
                 responseText = await AnthropicResponseImprover.ApplyImprovementAsync(
                     _client, _options, systemBlocks, userContent, responseText,
-                    _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature).ConfigureAwait(false);
+                    _options.OpponentResponseTemperature ?? DefaultOpponentResponseTemperature, cancellationToken).ConfigureAwait(false);
                 parsed = OpponentResponseParsers.ParseOpponentResponseText(responseText);
                 assistantTextForHistory = responseText ?? string.Empty;
             }
@@ -228,7 +228,7 @@ namespace Pinder.LlmAdapters.Anthropic
         }
 
         /// <inheritdoc />
-        public async Task<string> GetSteeringQuestionAsync(SteeringContext context)
+        public async Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -255,7 +255,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
             var request = AnthropicRequestBuilders.BuildMessagesRequest(
                 _options.Model, _options.MaxTokens, systemBlocks, sb.ToString(), 0.9);
-            var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+            var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
 
             var question = response.GetText()?.Trim();
             if (string.IsNullOrWhiteSpace(question))
@@ -268,9 +268,10 @@ namespace Pinder.LlmAdapters.Anthropic
         }
 
         /// <inheritdoc />
-        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult<string?>(null);
         }
 
@@ -287,20 +288,20 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Apply a horniness overlay to a delivered message by calling the LLM.
         /// Routes to Groq when OverlayGroqModel and OverlayGroqApiKey are configured.
         /// </summary>
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective, ct)
                     .ConfigureAwait(false);
             }
             return await AnthropicOverlayApplier.ApplyHorninessOverlayAsync(
-                _client, _options, message, instruction, opponentContext, archetypeDirective).ConfigureAwait(false);
+                _client, _options, message, instruction, opponentContext, archetypeDirective, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -323,7 +324,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 var request = AnthropicRequestBuilders.BuildMessagesRequest(
                     _options.Model, _options.MaxTokens, systemBlocks, userContent,
                     _options.DeliveryTemperature ?? 0.7);
-                var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+                var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
                 var result = response.GetText()?.Trim();
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -335,6 +336,10 @@ namespace Pinder.LlmAdapters.Anthropic
                     return message;
 
                 return result;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {
@@ -348,7 +353,7 @@ namespace Pinder.LlmAdapters.Anthropic
         /// trap-overlay system prompt. Returns the message unchanged on transport
         /// failure or detected refusal.
         /// </summary>
-        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
                 return message;
@@ -356,7 +361,7 @@ namespace Pinder.LlmAdapters.Anthropic
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyTrapOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective, ct)
                     .ConfigureAwait(false);
             }
 
@@ -380,7 +385,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 var request = AnthropicRequestBuilders.BuildMessagesRequest(
                     _options.Model, _options.MaxTokens, systemBlocks, userContent,
                     _options.DeliveryTemperature ?? 0.7);
-                var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+                var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
                 var result = response.GetText()?.Trim();
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -391,6 +396,10 @@ namespace Pinder.LlmAdapters.Anthropic
                     return message;
 
                 return result;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicOverlayApplier.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.LlmAdapters.Anthropic.Dto;
 
@@ -19,7 +20,8 @@ namespace Pinder.LlmAdapters.Anthropic
             string message,
             string instruction,
             string? opponentContext = null,
-            string? archetypeDirective = null)
+            string? archetypeDirective = null,
+            CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -51,7 +53,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
             try
             {
-                var response = await client.SendMessagesAsync(request).ConfigureAwait(false);
+                var response = await client.SendMessagesAsync(request, ct).ConfigureAwait(false);
                 string result = response?.Content?[0]?.Text;
                 if (string.IsNullOrWhiteSpace(result)) return message;
                 string trimmed = result.Trim();
@@ -62,6 +64,10 @@ namespace Pinder.LlmAdapters.Anthropic
                     trimmed.IndexOf("I'd be happy to help", System.StringComparison.OrdinalIgnoreCase) >= 0)
                     return message;
                 return trimmed;
+            }
+            catch (System.OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicResponseImprover.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicResponseImprover.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.LlmAdapters.Anthropic.Dto;
 
@@ -20,7 +21,8 @@ namespace Pinder.LlmAdapters.Anthropic
             ContentBlock[] systemBlocks,
             string originalUserContent,
             string draft,
-            double temperature)
+            double temperature,
+            CancellationToken ct = default)
         {
             var improvementPrompt = options.GameDefinition?.ImprovementPrompt;
             if (string.IsNullOrWhiteSpace(improvementPrompt)) return draft;
@@ -42,7 +44,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 };
                 AnthropicRequestBuilders.AttachTool(improveRequest, ToolSchemas.Improvement);
 
-                var improveResponse = await client.SendMessagesAsync(improveRequest).ConfigureAwait(false);
+                var improveResponse = await client.SendMessagesAsync(improveRequest, ct).ConfigureAwait(false);
 
                 // Try structured tool_use first
                 var toolInput = improveResponse.GetToolInput();
@@ -60,6 +62,10 @@ namespace Pinder.LlmAdapters.Anthropic
                 // Strip evaluation block headers if the model included them in the output.
                 improvedText = StripImprovementEvaluation(improvedText, draft);
                 return string.IsNullOrWhiteSpace(improvedText) ? draft : improvedText;
+            }
+            catch (System.OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicTransport.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Interfaces;
 using Pinder.LlmAdapters.Anthropic.Dto;
@@ -35,7 +36,7 @@ namespace Pinder.LlmAdapters.Anthropic
         }
 
         /// <inheritdoc />
-        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null, CancellationToken ct = default)
         {
             // phase is metadata for decorators; the underlying provider has no use for it.
             _ = phase;
@@ -50,7 +51,9 @@ namespace Pinder.LlmAdapters.Anthropic
             var request = AnthropicRequestBuilders.BuildMessagesRequest(
                 _model, maxTokens, systemBlocks, userMessage, temperature);
 
-            var response = await _client.SendMessagesAsync(request).ConfigureAwait(false);
+            // #794: forward the engine-level cancellation token to the underlying
+            // HTTP call so a mid-turn Cancel() halts the in-flight request.
+            var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
             return response.GetText() ?? "";
         }
 

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,7 +18,8 @@ namespace Pinder.LlmAdapters.Groq
             string message,
             string instruction,
             string? opponentContext = null,
-            string? archetypeDirective = null)
+            string? archetypeDirective = null,
+            CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -53,7 +55,7 @@ namespace Pinder.LlmAdapters.Groq
 
             try
             {
-                var response = await _http.SendAsync(request).ConfigureAwait(false);
+                var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
                 var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) return message;
 
@@ -69,6 +71,10 @@ namespace Pinder.LlmAdapters.Groq
                     return message;
 
                 return text;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {
@@ -88,7 +94,8 @@ namespace Pinder.LlmAdapters.Groq
             string trapInstruction,
             string trapName,
             string? opponentContext = null,
-            string? archetypeDirective = null)
+            string? archetypeDirective = null,
+            CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
                 return message;
@@ -125,7 +132,7 @@ namespace Pinder.LlmAdapters.Groq
 
             try
             {
-                var response = await _http.SendAsync(request).ConfigureAwait(false);
+                var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
                 var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode) return message;
 
@@ -140,6 +147,10 @@ namespace Pinder.LlmAdapters.Groq
                     return message;
 
                 return text;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -74,7 +74,7 @@ namespace Pinder.LlmAdapters.OpenAi
 
 
         /// <inheritdoc />
-        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -82,13 +82,13 @@ namespace Pinder.LlmAdapters.OpenAi
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
 
             var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDialogueOptionsTemperature);
-            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            var responseText = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
 
             return ParseDialogueOptions(responseText);
         }
 
         /// <inheritdoc />
-        public async Task<string> DeliverMessageAsync(DeliveryContext context)
+        public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -97,17 +97,17 @@ namespace Pinder.LlmAdapters.OpenAi
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
 
             var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDeliveryTemperature);
-            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            var responseText = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
 
             return responseText;
         }
 
         /// <inheritdoc />
-        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
         {
             // #788: stateless single-turn fallback. Stateful callers route
             // through the IStatefulLlmAdapter overload that takes a history.
-            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
             return result.Response;
         }
 
@@ -133,7 +133,7 @@ namespace Pinder.LlmAdapters.OpenAi
                 requestJson = BuildStatefulRequestJson(systemPrompt, history, userContent, DefaultOpponentResponseTemperature);
             }
 
-            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            var responseText = await _client.SendChatCompletionAsync(requestJson, cancellationToken).ConfigureAwait(false);
             var parsed = ParseOpponentResponse(responseText);
 
             var newEntries = new ConversationMessage[]
@@ -145,7 +145,7 @@ namespace Pinder.LlmAdapters.OpenAi
         }
 
         /// <inheritdoc />
-        public async Task<string> GetSteeringQuestionAsync(SteeringContext context)
+        public async Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -169,7 +169,7 @@ namespace Pinder.LlmAdapters.OpenAi
 
             string fullPlayerPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
             var requestJson = BuildRequestJson(fullPlayerPrompt, sb.ToString(), 0.9);
-            var responseText = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            var responseText = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
 
             // #351: strip inline <thinking>/<reasoning> blocks — the steering
             // question is consumed verbatim by the player UI.
@@ -184,9 +184,10 @@ namespace Pinder.LlmAdapters.OpenAi
         }
 
         /// <inheritdoc />
-        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            ct.ThrowIfCancellationRequested();
             return Task.FromResult<string?>(null);
         }
 
@@ -450,7 +451,7 @@ namespace Pinder.LlmAdapters.OpenAi
         // false fallback to the un-overlaid message.
 
         /// <inheritdoc />
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -467,12 +468,12 @@ namespace Pinder.LlmAdapters.OpenAi
                 ? $"{archetypeDirective}\n\nOVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay (preserving the archetype voice above) and return the modified message."
                 : $"OVERLAY INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the overlay and return the modified message.";
 
-            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature)
+            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature, ct)
                 .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -487,12 +488,12 @@ namespace Pinder.LlmAdapters.OpenAi
                 ? $"{archetypeDirective}\n\nSHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above) and return the modified message."
                 : $"SHADOW CORRUPTION INSTRUCTION ({shadow}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption and return the modified message.";
 
-            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature)
+            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature, ct)
                 .ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
                 return message;
@@ -510,7 +511,7 @@ namespace Pinder.LlmAdapters.OpenAi
                 ? $"{archetypeDirective}\n\nTRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint (preserving the archetype voice above) and return the modified message."
                 : $"TRAP INSTRUCTION ({trapName}):\n{trapInstruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the trap taint and return the modified message.";
 
-            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature)
+            return await SendOverlayWithRefusalFallbackAsync(systemPrompt, userContent, message, DefaultDeliveryTemperature, ct)
                 .ConfigureAwait(false);
         }
 
@@ -522,12 +523,13 @@ namespace Pinder.LlmAdapters.OpenAi
         /// through to the player.
         /// </summary>
         private async Task<string> SendOverlayWithRefusalFallbackAsync(
-            string systemPrompt, string userContent, string originalMessage, double temperature)
+            string systemPrompt, string userContent, string originalMessage, double temperature,
+            CancellationToken ct = default)
         {
             try
             {
                 var requestJson = BuildRequestJson(systemPrompt, userContent, temperature);
-                var result = await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+                var result = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
                 if (string.IsNullOrWhiteSpace(result)) return originalMessage;
 
                 // #351: strip inline <thinking>/<reasoning> blocks before
@@ -542,6 +544,10 @@ namespace Pinder.LlmAdapters.OpenAi
                     return originalMessage;
 
                 return trimmed;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Pinder.Core.Interfaces;
@@ -37,7 +38,7 @@ namespace Pinder.LlmAdapters.OpenAi
         }
 
         /// <inheritdoc />
-        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+        public async Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null, CancellationToken ct = default)
         {
             // phase is metadata for decorators; the underlying provider has no use for it.
             _ = phase;
@@ -57,7 +58,9 @@ namespace Pinder.LlmAdapters.OpenAi
             };
 
             string requestJson = JsonConvert.SerializeObject(request);
-            return await _client.SendChatCompletionAsync(requestJson).ConfigureAwait(false);
+            // #794: forward the engine-level cancellation token to the underlying
+            // HTTP call so a mid-turn Cancel() halts the in-flight request.
+            return await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -40,7 +40,7 @@ namespace Pinder.LlmAdapters
         // ── ILlmAdapter ────────────────────────────────────────────────────
 
         /// <inheritdoc />
-        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -48,7 +48,7 @@ namespace Pinder.LlmAdapters
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
             double temperature = _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature;
 
-            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions)
+            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions, ct: ct)
                 .ConfigureAwait(false);
 
             var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText);
@@ -63,7 +63,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> DeliverMessageAsync(DeliveryContext context)
+        public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -73,18 +73,18 @@ namespace Pinder.LlmAdapters
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
             double temperature = _options.DeliveryTemperature ?? DefaultDeliveryTemperature;
 
-            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery)
+            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery, ct: ct)
                 .ConfigureAwait(false);
 
             return responseText ?? "";
         }
 
         /// <inheritdoc />
-        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public async Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
         {
             // #788: stateless single-turn fallback path. Stateful callers route
             // through the IStatefulLlmAdapter overload that takes a history.
-            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), default).ConfigureAwait(false);
+            var result = await GetOpponentResponseAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
             return result.Response;
         }
 
@@ -105,7 +105,7 @@ namespace Pinder.LlmAdapters
             if (history.Count == 0)
             {
                 // No prior turns — single-shot.
-                responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse)
+                responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.OpponentResponse, ct: cancellationToken)
                     .ConfigureAwait(false);
             }
             else
@@ -114,7 +114,7 @@ namespace Pinder.LlmAdapters
                 // (the transport contract is single-turn). The current turn's
                 // user content is appended last, mirroring Anthropic/OpenAI
                 // wire ordering.
-                responseText = await SendStatefulOpponentAsync(systemPrompt, userContent, history, temperature)
+                responseText = await SendStatefulOpponentAsync(systemPrompt, userContent, history, temperature, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -131,7 +131,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public async Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -153,7 +153,7 @@ namespace Pinder.LlmAdapters
 
             try
             {
-                var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.InterestChangeBeat)
+                var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.InterestChangeBeat, ct: ct)
                     .ConfigureAwait(false);
 
                 var trimmed = responseText?.Trim();
@@ -166,6 +166,12 @@ namespace Pinder.LlmAdapters
 
                 return trimmed;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Cancellation must propagate — don't bury OCE under the
+                // generic LLM-failure fallback (#794).
+                throw;
+            }
             catch
             {
                 return null;
@@ -173,7 +179,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -182,7 +188,7 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, opponentContext, archetypeDirective, ct)
                     .ConfigureAwait(false);
             }
 
@@ -205,7 +211,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay)
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -225,6 +231,10 @@ namespace Pinder.LlmAdapters
 
                 return trimmed;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
+            }
             catch
             {
                 return message;
@@ -232,7 +242,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+        public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
                 return message;
@@ -241,7 +251,7 @@ namespace Pinder.LlmAdapters
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyTrapOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, opponentContext, archetypeDirective, ct)
                     .ConfigureAwait(false);
             }
 
@@ -263,7 +273,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay)
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -280,6 +290,10 @@ namespace Pinder.LlmAdapters
 
                 return trimmed;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
+            }
             catch
             {
                 return message;
@@ -287,7 +301,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+        public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
                 return message;
@@ -307,7 +321,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption)
+                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
@@ -324,6 +338,10 @@ namespace Pinder.LlmAdapters
 
                 return trimmed;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
+            }
             catch
             {
                 return message;
@@ -331,7 +349,7 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<string> GetSteeringQuestionAsync(SteeringContext context)
+        public async Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -355,7 +373,7 @@ namespace Pinder.LlmAdapters
 
             string systemPrompt = SessionSystemPromptBuilder.BuildPlayer(context.PlayerPrompt, _options.GameDefinition);
 
-            var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.Steering)
+            var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.Steering, ct: ct)
                 .ConfigureAwait(false);
 
             // #351: strip inline <thinking>/<reasoning> blocks before any
@@ -385,7 +403,8 @@ namespace Pinder.LlmAdapters
             string systemPrompt,
             string currentUserContent,
             IReadOnlyList<ConversationMessage> priorHistory,
-            double temperature)
+            double temperature,
+            CancellationToken ct = default)
         {
             // Multi-turn: prefix prior exchanges into the user message for context.
             var contextBuilder = new StringBuilder();
@@ -406,7 +425,8 @@ namespace Pinder.LlmAdapters
                 contextBuilder.ToString(),
                 temperature,
                 _options.MaxTokens,
-                phase: LlmPhase.OpponentResponse);
+                phase: LlmPhase.OpponentResponse,
+                ct: ct);
         }
 
         public void Dispose()

--- a/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
+++ b/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
@@ -78,10 +78,11 @@ namespace Pinder.LlmAdapters
 
         public async Task<string> SendAsync(
             string systemPrompt, string userMessage,
-            double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+            double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+            CancellationToken ct = default)
         {
             string raw = await _inner
-                .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase)
+                .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct)
                 .ConfigureAwait(false);
             return Normalize(raw);
         }

--- a/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackBonusSpecTests.cs
@@ -169,24 +169,24 @@ namespace Pinder.Core.Tests
                 _optionSets.Enqueue(options);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 // Mutation: would catch if ResolveTurnAsync ignored CallbackTurnNumber and always set bonus to 0

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -41,24 +41,24 @@ namespace Pinder.Core.Tests
                 _optionSets.Enqueue(options);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 [Fact]

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -25,7 +25,7 @@ namespace Pinder.Core.Tests
             _optionSets.Enqueue(options);
         }
 
-        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
         {
             if (_optionSets.Count > 0)
                 return Task.FromResult(_optionSets.Dequeue());
@@ -37,23 +37,23 @@ namespace Pinder.Core.Tests
             });
         }
 
-        public Task<string> DeliverMessageAsync(DeliveryContext context)
+        public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
         {
             return Task.FromResult(context.ChosenOption.IntendedText);
         }
 
-        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
         {
             return Task.FromResult(new OpponentResponse("..."));
         }
 
-        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     [Trait("Category", "Core")]

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -18,13 +18,13 @@ namespace Pinder.Core.Tests.Conversation
     {
         private sealed class NullLlm : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new OpponentResponse("", null, null));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -25,13 +25,13 @@ namespace Pinder.Core.Tests.Conversation
     {
         private sealed class DummyLlmAdapter : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new OpponentResponse("", null, null));
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
 
         private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
@@ -40,9 +40,9 @@ namespace Pinder.Core.Tests.Conversation
             public int StatefulCallCount { get; private set; }
             public IReadOnlyList<ConversationMessage>? LastHistorySeen { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context) => Task.FromResult("");
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context) => Task.FromResult(new OpponentResponse("", null, null));
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new OpponentResponse("", null, null));
 
             public Task<StatefulOpponentResult> GetOpponentResponseAsync(
                 OpponentContext context,
@@ -60,11 +60,11 @@ namespace Pinder.Core.Tests.Conversation
                     }));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context) => Task.FromResult<string?>("");
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context) => Task.FromResult("test steering question");
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("test steering question");
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
 
         private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -43,19 +43,19 @@ namespace Pinder.Core.Tests.Conversation
             private int _inFlight;
             public int MaxInFlightObserved { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
                 => Task.FromResult(System.Array.Empty<DialogueOption>());
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
                 => Task.FromResult(string.Empty);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse(string.Empty));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult(string.Empty);
-            public Task<string> ApplyHorninessOverlayAsync(string m, string i, string? oc = null, string? ad = null) => Task.FromResult(m);
-            public Task<string> ApplyShadowCorruptionAsync(string m, string i, ShadowStatType s, string? ad = null) => Task.FromResult(m);
-            public Task<string> ApplyTrapOverlayAsync(string m, string i, string n, string? oc = null, string? ad = null) => Task.FromResult(m);
+            public Task<string> ApplyHorninessOverlayAsync(string m, string i, string? oc = null, string? ad = null, CancellationToken ct = default) => Task.FromResult(m);
+            public Task<string> ApplyShadowCorruptionAsync(string m, string i, ShadowStatType s, string? ad = null, CancellationToken ct = default) => Task.FromResult(m);
+            public Task<string> ApplyTrapOverlayAsync(string m, string i, string n, string? oc = null, string? ad = null, CancellationToken ct = default) => Task.FromResult(m);
 
             public async Task<StatefulOpponentResult> GetOpponentResponseAsync(
                 OpponentContext context,

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -213,7 +213,7 @@ namespace Pinder.Core.Tests
         /// </summary>
         private sealed class ScriptedLlm : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -224,23 +224,23 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult("delivered");
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new OpponentResponse("response"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestySpecTests.cs
@@ -307,17 +307,17 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
+++ b/tests/Pinder.Core.Tests/DenialSkipHonestyTests.cs
@@ -209,17 +209,17 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -200,17 +200,17 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -218,21 +218,21 @@ namespace Pinder.Core.Tests
             private readonly DialogueOption[][] _optionSets;
             private int _call;
             public RotatingLlmAdapter(DialogueOption[][] optionSets) => _optionSets = optionSets;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 var idx = _call < _optionSets.Length ? _call : _optionSets.Length - 1;
                 _call++;
                 return Task.FromResult(_optionSets[idx]);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionConfigTests.cs
@@ -155,7 +155,7 @@ namespace Pinder.Core.Tests
 
         private sealed class StubLlmAdapter : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -163,17 +163,17 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("delivered message");
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("opponent reply"));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -268,7 +268,7 @@ namespace Pinder.Core.Tests
 
         private sealed class StubLlmAdapter : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -276,35 +276,35 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("delivered message");
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("opponent reply"));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class ThrowingLlmAdapter : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class StubTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -142,7 +142,7 @@ namespace Pinder.Core.Tests
         {
             public List<DialogueContext> Contexts { get; } = new List<DialogueContext>();
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 Contexts.Add(context);
                 return Task.FromResult(new[]
@@ -154,17 +154,17 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class TestClock : IGameClock

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -224,7 +224,7 @@ namespace Pinder.Core.Tests
         {
             public List<DialogueContext> Contexts { get; } = new List<DialogueContext>();
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 Contexts.Add(context);
                 return Task.FromResult(new[]
@@ -236,21 +236,21 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -726,7 +726,7 @@ namespace Pinder.Core.Tests.Integration
                 _optionSets = new Queue<DialogueOption[]>(optionSets);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count == 0)
                     throw new InvalidOperationException(
@@ -734,7 +734,7 @@ namespace Pinder.Core.Tests.Integration
                 return Task.FromResult(_optionSets.Dequeue());
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 string message = context.Outcome == FailureTier.None
                     ? context.ChosenOption.IntendedText
@@ -742,18 +742,18 @@ namespace Pinder.Core.Tests.Integration
                 return Task.FromResult(message);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new OpponentResponse("..."));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -92,7 +92,7 @@ namespace Pinder.Core.Tests
             public DeliveryContext? CapturedDeliveryContext { get; private set; }
             public OpponentContext? CapturedOpponentContext { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -103,23 +103,23 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedDeliveryContext = context;
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedOpponentContext = context;
                 return Task.FromResult(new OpponentResponse("Reply from opponent"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -270,24 +270,24 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public CustomOptionsLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
         {
             private readonly Action<DialogueContext> _onGetOptions;
             public CapturingLlmAdapter(Action<DialogueContext> onGetOptions) => _onGetOptions = onGetOptions;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 _onGetOptions(context);
                 return Task.FromResult(new[]
@@ -296,15 +296,15 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryOpponentShadowThresholdsTests.cs
@@ -229,7 +229,7 @@ namespace Pinder.Core.Tests
                 _onOpponent = onOpponent;
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -238,25 +238,25 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 _onDeliver?.Invoke(context);
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 _onOpponent?.Invoke(context);
                 return Task.FromResult(new OpponentResponse("reply"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -413,7 +413,7 @@ namespace Pinder.Core.Tests
                 _onOpponent = onOpponent;
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -422,25 +422,25 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 _onDeliver?.Invoke(context);
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 _onOpponent?.Invoke(context);
                 return Task.FromResult(new OpponentResponse("reply"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult<string?>(null);
             }
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
+++ b/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
@@ -166,7 +166,7 @@ namespace Pinder.Core.Tests
         /// </summary>
         private sealed class EchoLlm : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -177,23 +177,23 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("Reply"));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
             // Byte-identical overlay returns \u2014 this is the case #314 covers.
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
         }
 

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -147,7 +147,7 @@ namespace Pinder.Core.Tests
             public DeliveryContext? CapturedDeliveryContext { get; private set; }
             public OpponentContext? CapturedOpponentContext { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new[]
                 {
                     new DialogueOption(StatType.Charm, "Hey there"),
@@ -156,25 +156,25 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedDeliveryContext = context;
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedOpponentContext = context;
                 return Task.FromResult(new OpponentResponse("Reply"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -253,7 +253,7 @@ namespace Pinder.Core.Tests
                         ConversationMessage.Assistant("..."),
                     }));
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -264,7 +264,7 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedDeliveryContext = context;
                 string intended = context.ChosenOption.IntendedText;
@@ -275,20 +275,20 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(intended.ToUpperInvariant());
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("so when are we doing this?");
         }
 

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -238,7 +238,7 @@ namespace Pinder.Core.Tests
                         ConversationMessage.Assistant("..."),
                     }));
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 LastOptions = new[]
                 {
@@ -250,7 +250,7 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 string intended = context.ChosenOption.IntendedText;
                 return Task.FromResult(context.Outcome == FailureTier.None
@@ -258,28 +258,28 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
             {
                 ShadowCorruptionCalled = true;
                 // Rewrite the message so a textDiff is emitted.
                 return Task.FromResult(message + " [shadow:" + shadow + "]");
             }
 
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(message);
             }
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -348,7 +348,7 @@ namespace Pinder.Core.Tests
                         ConversationMessage.Assistant("..."),
                     }));
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 LastOptions = new[]
                 {
@@ -360,7 +360,7 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 string intended = context.ChosenOption.IntendedText;
                 return Task.FromResult(context.Outcome == FailureTier.None
@@ -368,31 +368,31 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction,
-                string? opponentContext = null, string? archetypeDirective = null)
+                string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
             {
                 HorninessOverlayCalled = true;
                 return Task.FromResult(message + " [horniness-overlay]");
             }
 
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction,
-                ShadowStatType shadow, string? archetypeDirective = null)
+                ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
             {
                 ShadowCorruptionCalled = true;
                 return Task.FromResult(message + " [shadow:" + shadow + "]");
             }
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction,
-                string trapName, string? opponentContext = null, string? archetypeDirective = null)
+                string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context)
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -42,7 +42,7 @@ namespace Pinder.Core.Tests
         {
             public OpponentContext? CapturedOpponentContext { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new[]
                 {
@@ -50,20 +50,20 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedOpponentContext = context;
                 return Task.FromResult(new OpponentResponse("response"));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -165,7 +165,7 @@ namespace Pinder.Core.Tests
                 _targetStat = targetStat;
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 LastOptions = new[]
                 {
@@ -177,26 +177,26 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedDeliveryContext = context;
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 return Task.FromResult(new OpponentResponse("Reply from opponent"));
             }
 
-            public Task<string> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
 
         private sealed class FixedDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -425,17 +425,17 @@ namespace Pinder.Core.Tests
             private readonly DialogueOption[] _options;
             public CustomOptionsLlmAdapter(DialogueOption[] options) => _options = options;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>Null trap registry for tests.</summary>

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_F_FailureModes.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_F_FailureModes.cs
@@ -70,14 +70,17 @@ namespace Pinder.Core.Tests.Phase0
         }
 
         // F3 — cancellation token fires mid-stream.
-        // pinder-core's non-streaming path has NO CancellationToken plumbing
-        // (gap documented in I6). The closest fixture: transport throws
-        // OperationCanceledException during the streaming-equivalent phase
-        // (opponent_response, the longest call). Half-streamed responses
-        // are discarded by definition because non-streaming has no partial
-        // state. F3 is therefore a thin wrapper around the OCE assertion.
+        // Pre-#794: pinder-core's non-streaming path had NO CancellationToken
+        // plumbing. F3 was a thin wrapper around "transport throws OCE".
+        // Post-#794: the engine accepts a real CancellationToken on
+        // ResolveTurnAsync. F3 now exercises both shapes:
+        //   F3a (legacy): transport throws OCE during opponent_response.
+        //   F3b (new):    real CancellationTokenSource.Cancel() fires after
+        //                 delivery completes; the next awaited LLM call sees
+        //                 the cancelled token and surfaces OCE.
+        // Both must propagate cleanly with no half-written audit.
         [Fact]
-        public async Task F3_CancellationMidStream_FailsCleanly_NoHalfWrittenAudit()
+        public async Task F3a_TransportThrowsOCE_MidStream_FailsCleanly_NoHalfWrittenAudit()
         {
             var transport = new ExceptionInjectingTransport(
                 throwOnPhase: LlmPhase.OpponentResponse,
@@ -94,6 +97,37 @@ namespace Pinder.Core.Tests.Phase0
             // BEFORE the throw, but no opponent_response exchange was
             // committed because the throwing transport never delegated.
             Assert.Empty(inner.ExchangesByPhase(LlmPhase.OpponentResponse));
+        }
+
+        // F3b — real cancellation. CancellationTokenSource.Cancel() fires
+        // after the delivery phase completes; the engine's next awaited
+        // adapter call (overlay or opponent_response) sees the cancelled
+        // token and propagates OCE. This is the post-#794 invariant
+        // strengthened from a weaker "OCE-from-transport" smoke check.
+        [Fact]
+        public async Task F3b_RealCancel_AfterDelivery_FailsCleanly_NoHalfWrittenAudit()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new CancelOnPhaseTransport(
+                cancelOnPhase: LlmPhase.Delivery,
+                cts: cts);
+
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+            await session.StartTurnAsync(cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => session.ResolveTurnAsync(0, progress: null, ct: cts.Token));
+
+            // No turn advancement, no opponent_response written.
+            Assert.Equal(turnBefore, session.TurnNumber);
+            Assert.Empty(transport.Inner.ExchangesByPhase(LlmPhase.OpponentResponse));
         }
 
         // F4 — disk-full during audit write.
@@ -168,6 +202,49 @@ namespace Pinder.Core.Tests.Phase0
             public HttpRequestExceptionShim(string message) : base(message) { }
         }
 
+        /// <summary>
+        /// Helper transport for F3b (#794): calls
+        /// <see cref="CancellationTokenSource.Cancel"/> AFTER it produces a
+        /// successful response for the configured phase. The engine then
+        /// notices the cancellation on the next awaited adapter call and
+        /// surfaces <see cref="OperationCanceledException"/>.
+        /// </summary>
+        private sealed class CancelOnPhaseTransport : ILlmTransport
+        {
+            private readonly string _cancelOnPhase;
+            private readonly CancellationTokenSource _cts;
+            public RecordingLlmTransport Inner { get; }
+
+            public CancelOnPhaseTransport(string cancelOnPhase, CancellationTokenSource cts)
+            {
+                _cancelOnPhase = cancelOnPhase;
+                _cts = cts;
+                Inner = new RecordingLlmTransport { DefaultResponse = "" };
+                Inner.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                Inner.QueueDelivery(Phase0Fixtures.CannedDelivery);
+                Inner.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            }
+
+            public async Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                System.Threading.CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                var response = await Inner
+                    .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct)
+                    .ConfigureAwait(false);
+                if (string.Equals(phase, _cancelOnPhase, StringComparison.Ordinal))
+                {
+                    _cts.Cancel();
+                }
+                return response;
+            }
+        }
+
         private sealed class ExceptionInjectingTransport : ILlmTransport
         {
             private readonly string _throwOnPhase;
@@ -189,13 +266,15 @@ namespace Pinder.Core.Tests.Phase0
                 string userMessage,
                 double temperature = 0.9,
                 int maxTokens = 1024,
-                string? phase = null)
+                string? phase = null,
+                System.Threading.CancellationToken ct = default)
             {
+                ct.ThrowIfCancellationRequested();
                 if (string.Equals(phase, _throwOnPhase, StringComparison.Ordinal))
                 {
                     throw _exFactory();
                 }
-                return Inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase);
+                return Inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct);
             }
         }
     }

--- a/tests/Pinder.Core.Tests/Phase0/Phase0_I6_Cancellation.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0_I6_Cancellation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
@@ -9,34 +10,32 @@ namespace Pinder.Core.Tests.Phase0
 {
     /// <summary>
     /// Invariant I6 — cancellation discipline. When a turn fails mid-resolve
-    /// (the engine's only currently observable proxy for a "cancellation"),
+    /// (either via a transport throw OR via a real <see cref="CancellationToken"/>
+    /// cancellation now that #794 has threaded the token through
+    /// <see cref="GameSession.ResolveTurnAsync(int, System.IProgress{TurnProgressEvent}?, CancellationToken)"/>),
     /// state mutations after the failure point MUST NOT persist on the session.
     ///
     /// <para>
-    /// Documented gap (filed alongside this PR if not already on file): pinder-core's
-    /// <see cref="GameSession.ResolveTurnAsync(int)"/> does NOT accept a
-    /// <see cref="CancellationToken"/>. Neither does the non-streaming
-    /// <see cref="ILlmTransport.SendAsync"/>. Cancellation today is effected by
-    /// throwing from inside the transport (e.g. <see cref="OperationCanceledException"/>
-    /// from <c>HttpClient</c> on token cancellation). The streaming transport
-    /// (<see cref="IStreamingLlmTransport.SendStreamAsync"/>) honours a token,
-    /// but <c>GameSession</c> does not consume the streaming path. <c>F3</c>
-    /// (cancellation token fires mid-stream) is therefore tested via "transport
-    /// throws OCE during the opponent_response phase" rather than via a real
-    /// <c>CancellationToken</c>. This is the closest fixture pinder-core can
-    /// support without an engine-level API change.
+    /// History: pre-#794 the engine's <see cref="GameSession.ResolveTurnAsync(int)"/>
+    /// did NOT accept a <see cref="CancellationToken"/>, nor did
+    /// <see cref="ILlmTransport.SendAsync"/>. Cancellation could only be effected
+    /// by throwing <see cref="OperationCanceledException"/> from inside the
+    /// transport. Tests I6.1–I6.3 below preserve that legacy assertion shape.
+    /// I6.4–I6.6 (added in #794) exercise the new shape: a real
+    /// <c>CancellationTokenSource.Cancel()</c> mid-turn, propagated via the
+    /// CT-aware <see cref="GameSession.ResolveTurnAsync(int, System.IProgress{TurnProgressEvent}?, CancellationToken)"/>
+    /// overload through every awaited transport call.
     /// </para>
     ///
     /// <para>
-    /// What this test asserts: when the opponent_response transport call throws,
-    /// (a) the exception propagates to the caller, (b) turn-number advancement
-    /// does NOT happen, and (c) interest-meter mutations from the same turn
-    /// do NOT persist (the meter is rolled back to the pre-resolve state
-    /// because the exception fires before <c>_turnNumber++</c>). Steering
-    /// /horniness/shadow rolls do already mutate as part of the pre-opponent
-    /// pipeline; that scope is documented in <c>regression-pins-787.md</c>
-    /// and is the subject of Phase 1's #788 refactor (state-into-GameSession),
-    /// which will narrow the mutation window.
+    /// What these tests assert: when an LLM call surfaces cancellation, (a) the
+    /// exception propagates to the caller, (b) turn-number advancement does NOT
+    /// happen, and (c) interest-meter mutations from the same turn do NOT persist
+    /// (the meter is rolled back to the pre-resolve state because the exception
+    /// fires before <c>_turnNumber++</c>). Steering / horniness / shadow rolls
+    /// already mutate as part of the pre-opponent pipeline; that scope is
+    /// documented in <c>regression-pins-787.md</c> and is the subject of Phase 1's
+    /// #788 refactor.
     /// </para>
     /// </summary>
     [Trait("Category", "Phase0")]
@@ -124,6 +123,135 @@ namespace Pinder.Core.Tests.Phase0
             Assert.Equal(turnBefore, session.TurnNumber);
         }
 
+        // ── #794 — strengthened with real CancellationToken.Cancel() ───────
+
+        // I6.4 — real cancellation between stage 2 (delivery) and stage 3
+        // (opponent_response). The transport calls cts.Cancel() from inside
+        // the delivery phase callback so that the engine's NEXT awaited
+        // transport call (the trap/horniness overlay or opponent_response,
+        // depending on fixture) sees a cancelled token and surfaces OCE.
+        // Asserts:
+        //   (a) OCE propagates from ResolveTurnAsync.
+        //   (b) The turn counter does NOT advance.
+        //   (c) The opponent_response phase was never invoked (since the
+        //       cancellation fires before the engine reaches it).
+        [Fact]
+        public async Task RealCancel_AfterDeliveryBeforeOpponent_PropagatesOCE_NoTurnAdvance()
+        {
+            var cts = new CancellationTokenSource();
+            var transport = new CancellingTransport(
+                cancelOnPhase: LlmPhase.Delivery,
+                cts: cts);
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            int turnBefore = session.TurnNumber;
+            await session.StartTurnAsync(cts.Token);
+
+            // The CT-aware overload is what this test specifically validates.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => session.ResolveTurnAsync(0, progress: null, ct: cts.Token));
+
+            // Turn counter unchanged: cancellation fired before _turnNumber++.
+            Assert.Equal(turnBefore, session.TurnNumber);
+
+            // Opponent_response was never invoked.
+            Assert.Empty(transport.Inner.ExchangesByPhase(LlmPhase.OpponentResponse));
+        }
+
+        // I6.5 — cancellation BEFORE the engine even starts the resolution
+        // pipeline. Pre-cancelled token must short-circuit immediately.
+        [Fact]
+        public async Task RealCancel_PreResolveTurn_ThrowsImmediately()
+        {
+            var transport = new RecordingLlmTransport { DefaultResponse = "" };
+            transport.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            var adapter = Phase0Fixtures.MakeAdapter(transport);
+            var dice = new PlaybackDiceRoller(5, 15, 50);
+
+            var session = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                adapter, dice, new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+
+            await session.StartTurnAsync();
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel(); // pre-cancelled
+
+            int turnBefore = session.TurnNumber;
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => session.ResolveTurnAsync(0, progress: null, ct: cts.Token));
+
+            Assert.Equal(turnBefore, session.TurnNumber);
+            // No transport phase was invoked at all (engine bailed before any
+            // LLM call). The dialogue_options call from StartTurnAsync above
+            // is the only invocation we should see.
+            var phases = transport.Exchanges.Select(e => e.Phase).ToArray();
+            Assert.Equal(new[] { LlmPhase.DialogueOptions }, phases);
+        }
+
+        // I6.6 — backward-compat: the default-token overload still works
+        // exactly as before #794. Calling ResolveTurnAsync(int) (no token,
+        // no progress) on a non-cancelled flow must complete normally and
+        // produce the same result as the CT-aware overload with `default`.
+        [Fact]
+        public async Task DefaultToken_NonCancelledFlow_ZeroBehaviorImpact()
+        {
+            // Run #1: legacy single-arg overload (no CT).
+            var transport1 = new RecordingLlmTransport { DefaultResponse = "" };
+            transport1.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport1.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport1.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            var session1 = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                Phase0Fixtures.MakeAdapter(transport1),
+                new PlaybackDiceRoller(5, 15, 50),
+                new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+            await session1.StartTurnAsync();
+            var result1 = await session1.ResolveTurnAsync(0);
+
+            // Run #2: new CT-aware overload with default token.
+            var transport2 = new RecordingLlmTransport { DefaultResponse = "" };
+            transport2.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+            transport2.QueueDelivery(Phase0Fixtures.CannedDelivery);
+            transport2.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            var session2 = new GameSession(
+                Phase0Fixtures.MakeProfile("Player"),
+                Phase0Fixtures.MakeProfile("Opponent"),
+                Phase0Fixtures.MakeAdapter(transport2),
+                new PlaybackDiceRoller(5, 15, 50),
+                new NullTrapRegistry(),
+                Phase0Fixtures.MakeConfig());
+            await session2.StartTurnAsync(CancellationToken.None);
+            var result2 = await session2.ResolveTurnAsync(0, progress: null, ct: CancellationToken.None);
+
+            // Final state must be byte-identical at the observable level: the
+            // CT thread is supposed to be a pure-add to the surface, with zero
+            // behaviour change on the non-cancelled path.
+            Assert.Equal(session1.TurnNumber, session2.TurnNumber);
+            Assert.Equal(result1.IsGameOver, result2.IsGameOver);
+            Assert.Equal(result1.DeliveredMessage, result2.DeliveredMessage);
+            Assert.Equal(result1.OpponentMessage, result2.OpponentMessage);
+            Assert.Equal(result1.InterestDelta, result2.InterestDelta);
+            Assert.Equal(result1.Roll.FinalTotal, result2.Roll.FinalTotal);
+            // Same set of LLM phases invoked, same number of times, same order.
+            var phases1 = transport1.Exchanges.Select(e => e.Phase).ToArray();
+            var phases2 = transport2.Exchanges.Select(e => e.Phase).ToArray();
+            Assert.Equal(phases1, phases2);
+        }
+
         // ── Helper transport ──────────────────────────────────────────────
 
         private sealed class ThrowingTransport : ILlmTransport
@@ -150,13 +278,64 @@ namespace Pinder.Core.Tests.Phase0
                 string userMessage,
                 double temperature = 0.9,
                 int maxTokens = 1024,
-                string? phase = null)
+                string? phase = null,
+                CancellationToken ct = default)
             {
+                ct.ThrowIfCancellationRequested();
                 if (string.Equals(phase, _throwOnPhase, StringComparison.Ordinal))
                 {
                     throw _exFactory();
                 }
-                return _inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase);
+                return _inner.SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct);
+            }
+        }
+
+        /// <summary>
+        /// Helper transport that calls <see cref="CancellationTokenSource.Cancel"/>
+        /// when it sees the configured phase. Used by I6.4 to simulate a
+        /// real CT cancellation that fires AFTER one phase completes but
+        /// BEFORE the engine reaches the next awaited transport call.
+        /// </summary>
+        private sealed class CancellingTransport : ILlmTransport
+        {
+            private readonly string _cancelOnPhase;
+            private readonly CancellationTokenSource _cts;
+            public RecordingLlmTransport Inner { get; }
+
+            public CancellingTransport(string cancelOnPhase, CancellationTokenSource cts)
+            {
+                _cancelOnPhase = cancelOnPhase;
+                _cts = cts;
+                Inner = new RecordingLlmTransport { DefaultResponse = "" };
+                Inner.QueueDialogueOptions(Phase0Fixtures.CannedDialogueOptions);
+                Inner.QueueDelivery(Phase0Fixtures.CannedDelivery);
+                Inner.QueueOpponent(Phase0Fixtures.CannedOpponent);
+            }
+
+            public async Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                var response = await Inner
+                    .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct)
+                    .ConfigureAwait(false);
+                if (string.Equals(phase, _cancelOnPhase, StringComparison.Ordinal))
+                {
+                    // Cancel after producing a valid response, so the engine
+                    // happily processes the result of THIS phase and then
+                    // notices the cancellation on the NEXT awaited adapter
+                    // call. That is the realistic shape of an async
+                    // mid-turn cancel — the player picks a different option,
+                    // the orchestrator cancels the prior branch, the next
+                    // LLM round-trip throws OCE.
+                    _cts.Cancel();
+                }
+                return response;
             }
         }
     }

--- a/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
+++ b/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
@@ -93,8 +93,10 @@ namespace Pinder.Core.Tests.Phase0
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            string? phase = null)
+            string? phase = null,
+            System.Threading.CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             string ph = phase ?? LlmPhase.Unknown;
 
             string response;

--- a/tests/Pinder.Core.Tests/SessionSetup/StubLlmTransport.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/StubLlmTransport.cs
@@ -15,7 +15,8 @@ namespace Pinder.Core.Tests.SessionSetup
             string userMessage,
             double temperature = 0.9,
             int maxTokens = 1024,
-            string? phase = null) =>
+            string? phase = null,
+            System.Threading.CancellationToken ct = default) =>
             Task.FromResult(string.Empty);
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -665,20 +665,20 @@ namespace Pinder.Core.Tests
 
             public CustomLlmAdapter(DialogueOption[] options) => _options = options;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1257,17 +1257,17 @@ namespace Pinder.Core.Tests
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that returns a Tell on the opponent's response for a specific stat.</summary>
@@ -1276,7 +1276,7 @@ namespace Pinder.Core.Tests
             private readonly StatType _tellStat;
             public TellLlmAdapter(StatType tellStat) => _tellStat = tellStat;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 var options = new[]
                 {
@@ -1287,16 +1287,16 @@ namespace Pinder.Core.Tests
                 };
                 return Task.FromResult(options);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("...",
                     detectedTell: new Tell(_tellStat, $"Tell on {_tellStat}")));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
@@ -1306,21 +1306,21 @@ namespace Pinder.Core.Tests
             private int _call;
             public RotatingLlmAdapter(DialogueOption[][] optionSets) => _optionSets = optionSets;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 var idx = _call < _optionSets.Length ? _call : _optionSets.Length - 1;
                 _call++;
                 return Task.FromResult(_optionSets[idx]);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionSpecTests.cs
@@ -646,17 +646,17 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowReductionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowReductionTests.cs
@@ -637,17 +637,17 @@ namespace Pinder.Core.Tests
         {
             private readonly DialogueOption[] _options;
             public StubLlmAdapter(DialogueOption[] options) => _options = options;
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.cs
@@ -708,17 +708,17 @@ namespace Pinder.Core.Tests
             private readonly DialogueOption[] _options;
             public CustomOptionsLlmAdapter(DialogueOption[] options) => _options = options;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
@@ -727,7 +727,7 @@ namespace Pinder.Core.Tests
             private readonly Action<DialogueContext> _onGetOptions;
             public CapturingLlmAdapter(Action<DialogueContext> onGetOptions) => _onGetOptions = onGetOptions;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 _onGetOptions(context);
                 return Task.FromResult(new[]
@@ -736,15 +736,15 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -779,17 +779,17 @@ namespace Pinder.Core.Tests
             private readonly DialogueOption[] _options;
             public FixedOptionsLlmAdapter(DialogueOption[] options) => _options = options;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -797,7 +797,7 @@ namespace Pinder.Core.Tests
             private readonly Action<DialogueContext> _onGetOptions;
             public CapturingLlmAdapter(Action<DialogueContext> onGetOptions) => _onGetOptions = onGetOptions;
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 _onGetOptions(context);
                 return Task.FromResult(new[]
@@ -806,15 +806,15 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("..."));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -315,27 +315,27 @@ namespace Pinder.Core.Tests
                 _tells.Enqueue(tell);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 var tell = _tells.Count > 0 ? _tells.Dequeue() : null;
                 return Task.FromResult(new OpponentResponse("...", detectedTell: tell));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -493,27 +493,27 @@ namespace Pinder.Core.Tests
                 _tells.Enqueue(tell);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 var tell = _tells.Count > 0 ? _tells.Dequeue() : null;
                 return Task.FromResult(new OpponentResponse("...", detectedTell: tell));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
+++ b/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
@@ -55,7 +55,7 @@ namespace Pinder.Core.Tests
             public List<OpponentContext> OpponentContexts { get; } = new();
             public int TrapOverlayCalls { get; private set; }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 DialogueContexts.Add(context);
                 var options = new[]
@@ -68,7 +68,7 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(options);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 DeliveryContexts.Add(context);
                 // Tag the message with the tier so it is observably different
@@ -79,22 +79,22 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(text);
             }
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 OpponentContexts.Add(context);
                 return Task.FromResult(new OpponentResponse("..."));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null)
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
 
-            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null)
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
             {
                 TrapOverlayCalls++;
                 // Mark the message so a Trap (X) text-diff is emitted.

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -23,7 +23,7 @@ namespace Pinder.Core.Tests
         public List<DeliveryContext> DeliveryContexts { get; } = new List<DeliveryContext>();
         public List<OpponentContext> OpponentContexts { get; } = new List<OpponentContext>();
 
-        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
         {
             DialogueContexts.Add(context);
             var options = new[]
@@ -36,7 +36,7 @@ namespace Pinder.Core.Tests
             return Task.FromResult(options);
         }
 
-        public Task<string> DeliverMessageAsync(DeliveryContext context)
+        public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
         {
             DeliveryContexts.Add(context);
             string message = context.Outcome == FailureTier.None
@@ -45,19 +45,19 @@ namespace Pinder.Core.Tests
             return Task.FromResult(message);
         }
 
-        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+        public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
         {
             OpponentContexts.Add(context);
             return Task.FromResult(new OpponentResponse("..."));
         }
 
-        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+        public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
         {
             return Task.FromResult<string?>(null);
         }
-        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+        public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
     }
 
     // ---------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/Wave0SpecTests.cs
+++ b/tests/Pinder.Core.Tests/Wave0SpecTests.cs
@@ -67,17 +67,17 @@ namespace Pinder.Core.Tests
 
         private sealed class StubLlmAdapter : ILlmAdapter
         {
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Test option") });
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("delivered");
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new OpponentResponse("reply"));
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
 
                 #endregion

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -404,27 +404,27 @@ namespace Pinder.Core.Tests
             public void EnqueueWeaknessWindow(WeaknessWindow? window)
                 => _weaknessWindows.Enqueue(window);
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 var window = _weaknessWindows.Count > 0 ? _weaknessWindows.Dequeue() : null;
                 return Task.FromResult(new OpponentResponse("...", weaknessWindow: window));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -424,27 +424,27 @@ namespace Pinder.Core.Tests
                 _weaknessWindows.Enqueue(window);
             }
 
-            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context)
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
             {
                 if (_optionSets.Count > 0)
                     return Task.FromResult(_optionSets.Dequeue());
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context)
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(context.ChosenOption.IntendedText);
 
-            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context)
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
             {
                 var window = _weaknessWindows.Count > 0 ? _weaknessWindows.Dequeue() : null;
                 return Task.FromResult(new OpponentResponse("...", weaknessWindow: window));
             }
 
-            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context)
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
-            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
-            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+            public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue340_PunctuationNormalizingTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue340_PunctuationNormalizingTransportTests.cs
@@ -93,8 +93,10 @@ namespace Pinder.LlmAdapters.Tests
             }
 
             public Task<string> SendAsync(string systemPrompt, string userMessage,
-                double temperature = 0.9, int maxTokens = 1024, string? phase = null)
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
             {
+                ct.ThrowIfCancellationRequested();
                 LastSystem = systemPrompt;
                 LastUser = userMessage;
                 LastPhase = phase;


### PR DESCRIPTION
Closes #794. Wave 3-D of the #393 fast-gameplay drain.

## What changed

Threaded `CancellationToken` through `GameSession.ResolveTurnAsync` and every awaited LLM adapter call inside the resolution pipeline. This is a Phase 5 (`#425`) prerequisite filed during Phase 0 regression pinning (`#787`).

### Surface changes (all backward compatible — `ct = default`)
- **`ILlmAdapter`** (and `IStatefulLlmAdapter`) — every method takes `CancellationToken ct = default`: `GetDialogueOptionsAsync`, `DeliverMessageAsync`, `GetOpponentResponseAsync`, `GetInterestChangeBeatAsync`, `ApplyHorninessOverlayAsync`, `ApplyShadowCorruptionAsync`, `ApplyTrapOverlayAsync`, `GetSteeringQuestionAsync`.
- **`ILlmTransport.SendAsync`** — same.
- **`GameSession.ResolveTurnAsync(int, IProgress?, CancellationToken)`** — new overload threads `ct` to every awaited adapter call. Legacy single-arg + two-arg overloads delegate with `ct = default`.
- **`GameSession.StartTurnAsync(CancellationToken ct = default)`** — added.
- **`SteeringEngine.AttemptSteeringRollAsync`**, **`HorninessEngine.CheckAsync`** — accept and forward `ct`.

### Implementations updated
`NullLlmAdapter`, `PinderLlmAdapter`, `AnthropicLlmAdapter`, `OpenAiLlmAdapter`, `AnthropicTransport`, `OpenAiTransport`, `PunctuationNormalizingTransport`, `AnthropicOverlayApplier`, `AnthropicResponseImprover`, `GroqOverlayApplier`. Every implementation forwards the token to the underlying HTTP / `SendMessagesAsync` / `SendChatCompletionAsync` call. Catch handlers re-throw `OperationCanceledException` when `ct.IsCancellationRequested` so cancellation never gets buried under the generic LLM-failure fallback.

### Tests
- **Phase 0 I6 strengthened** — three new tests using real `CancellationTokenSource.Cancel()`:
  - `RealCancel_AfterDeliveryBeforeOpponent_PropagatesOCE_NoTurnAdvance` — Cancel() fires after delivery completes; engine surfaces OCE on next adapter call; opponent_response never invoked; turn counter unchanged.
  - `RealCancel_PreResolveTurn_ThrowsImmediately` — pre-cancelled token short-circuits with no LLM calls.
  - `DefaultToken_NonCancelledFlow_ZeroBehaviorImpact` — backward compat: legacy `ResolveTurnAsync(int)` and CT-aware `ResolveTurnAsync(int, null, CancellationToken.None)` produce byte-identical `TurnResult`.
  Legacy throw-OCE tests preserved as I6.1–I6.3.
- **Phase 0 F3 split** into `F3a_TransportThrowsOCE_MidStream` (legacy) and `F3b_RealCancel_AfterDelivery` (new).
- All 31 Phase 0 tests pass.
- Existing pinder-core test failures match `origin/main` exactly (pre-existing, unrelated).

## Out of scope
- Fast-gameplay scheduler (`#425` / Phase 5).
- Persistence-layer rollback (today persistence is end-of-turn only; cancellation before `WriteAsync` already means no postgres write — structurally fine).

## Documentation
- `docs/development/regression-pins-787.md` updated: I6 'Documented gap' replaced with 'Resolved gap (#794)'.