### PR TITLE
feat: i18n yaml foundation — 9 surface-aligned files for English locale

### DIFF
--- a/data/i18n/en/errors.yaml
+++ b/data/i18n/en/errors.yaml
@@ -1,0 +1,7 @@
+# Error toasts, empty states, failure banners.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  errors.session_not_found: "Session not found."
+  errors.failed_to_load_log: "Failed to load log ({status})."

--- a/data/i18n/en/events.yaml
+++ b/data/i18n/en/events.yaml
@@ -1,0 +1,15 @@
+# Event interpretations + titles. Consumed by event-box sprint (#442+).
+# Sprint: i18n string extraction (issue #435 Phase 1).
+# Variant rule (locked): 5 summary_variants per event_kind. Picker is
+# deterministic on (event_kind, turn_number).
+schema_version: 1
+locale: en
+events:
+  combo_hit:
+    title: "Combo!"
+    summary_variants:
+      - "You stacked the moment on top of the last one."
+      - "The thread you started two lines ago paid off."
+      - "Two beats in a row clicked into place."
+      - "Your last move set this one up. Both landed."
+      - "Pattern recognized. They felt the rhythm too."

--- a/data/i18n/en/game-end.yaml
+++ b/data/i18n/en/game-end.yaml
@@ -1,0 +1,7 @@
+# GameEndScreen copy.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  game_end.outcome_date_secured: "Date secured"
+  game_end.outcome_unmatched: "Unmatched"

--- a/data/i18n/en/glossary.yaml
+++ b/data/i18n/en/glossary.yaml
@@ -1,0 +1,7 @@
+# Gameplay glossary — stat names, mechanic terms.
+# Sprint: i18n string extraction (issue #435 Phase 1). Migrated in Phase 3.
+schema_version: 1
+locale: en
+strings:
+  glossary.charm: "Charm"
+  glossary.rizz: "Rizz"

--- a/data/i18n/en/replay.yaml
+++ b/data/i18n/en/replay.yaml
@@ -1,0 +1,7 @@
+# Session replay surface (public + owner).
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  replay.cta_try_pinder: "This was a Pinder game — try it yourself"
+  replay.transcript_button: "Transcript"

--- a/data/i18n/en/session-setup.yaml
+++ b/data/i18n/en/session-setup.yaml
@@ -1,0 +1,7 @@
+# Setup / onboarding flow.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  session_setup.title: "Set up your session"
+  session_setup.start_button: "Start the game"

--- a/data/i18n/en/sessions-page.yaml
+++ b/data/i18n/en/sessions-page.yaml
@@ -1,0 +1,7 @@
+# Sessions list page.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  sessions_page.title: "Sessions"
+  sessions_page.replay_button: "▶ Replay"

--- a/data/i18n/en/share.yaml
+++ b/data/i18n/en/share.yaml
@@ -1,0 +1,7 @@
+# Public share-page copy.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+schema_version: 1
+locale: en
+strings:
+  share.copy_link_button: "🔗 Copy link"
+  share.link_copied: "Link copied!"

--- a/data/i18n/en/ui.yaml
+++ b/data/i18n/en/ui.yaml
@@ -1,0 +1,8 @@
+# UI chrome — buttons, labels, modals, navigation, generic chrome.
+# Sprint: i18n string extraction (issue #435 Phase 1).
+# Schema: docs/plans/sprint-i18n-string-extraction.md §3.2
+schema_version: 1
+locale: en
+strings:
+  topnav.open_player_sheet: "Open player sheet"
+  topnav.open_opponent_sheet: "Open opponent sheet"


### PR DESCRIPTION
Sprint: i18n string extraction (pinder-web #435 Phase 1).

Adds 9 yaml files under `data/i18n/en/` with schema headers + 1-2 sample strings each. The frontend build script in pinder-web reads these via build-time codegen; Phase 1.5 will add a C# loader on this side for the simulator.

**Locked schema:**
```yaml
schema_version: 1
locale: en
strings:                      # flat key→string OR
  topnav.open_player_sheet: "Open player sheet"
events:                       # kind→{title, summary_variants[]}
  combo_hit:
    title: "Combo!"
    summary_variants: [...]   # 5 variants by convention
```

**Key convention (locked):** `surface.element_descriptor` — snake_case + dot-namespaced.

**Variant determinism (locked):** picker hashes `(kind, turn_number)` via FNV-1a-32 so web + engine pick the same variant byte-for-byte. Frontend implementation in `pinder-web/frontend/src/i18n/useText.ts`; Phase 1.5 will mirror in C#.

This PR pairs with pinder-web PR #469 (i18n sprint Phase 1).