### PR TITLE
feat(#814): CharacterDefinition POCO + v1 JSON schema

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -122,3 +122,33 @@ back if they appear without a `ConversationIndexing` call alongside.
 
 **Discovered in:** PR #767 brace-fix follow-up, surfaced in #769 and #774.
 Codified during the first pinder-core swarm-drain run.
+
+### GIT-WORKTREE-DOTGIT-IS-A-FILE
+
+**Symptom:** A test that walks up from `AppContext.BaseDirectory` looking
+for a repo-root marker `.git/` (as a directory) silently fails to find the
+root when the build runs inside a `git worktree` (such as the per-ticket
+worktrees this drain creates under `/tmp/work-*`). The test self-skips via
+`Assert.Fail("SKIPPED:")` and the implementer mistakes it for a "new"
+failure caused by their change.
+
+**Root cause:** In a primary checkout, `<repo-root>/.git` is a directory.
+In a worktree (`git worktree add ...`), `<worktree-root>/.git` is a regular
+*file* containing `gitdir: <path-to-real-gitdir>`. Code that uses
+`Directory.Exists(.git)` only to detect a repo root will return false in
+worktrees and never reach the resource it was looking for.
+
+**Fix:** Detect repo roots with `Directory.Exists(gitMarker) ||
+File.Exists(gitMarker)` (or use a different stable marker such as the
+project `.sln` file). Worktrees are the default execution environment for
+swarm-drain runs, so this matters every time.
+
+**Rule:** Any test or tool that walks up looking for a repo root MUST
+accept `.git` as either a directory or a file. Do not introduce new
+`.git`-as-directory-only checks. If a checkout-vs-worktree distinction is
+actually meaningful (rare), make the distinction explicit instead of
+letting it leak in via probing.
+
+**Discovered in:** #814 implementation run (sprint character-assets-v1).
+Six tests in `CharacterLoaderSpecTests` were spuriously failing in the
+worktree until `FindPromptDir()` was taught to accept the file form.

--- a/data/characters/brick.json
+++ b/data/characters/brick.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "6fd5f147-6e7f-434a-a842-637049f71345",
   "name": "Brick_haus",
   "gender_identity": "she/her",
   "bio": "CEO of knowing my worth. Don't waste my time.",
@@ -21,20 +23,23 @@
     "tattoos": "none",
     "eye_style": "hooded"
   },
-  "build_points": {
-    "charm": 5,
-    "rizz": 4,
-    "honesty": 3,
-    "chaos": 2,
-    "wit": 5,
-    "self_awareness": 2
-  },
-  "shadows": {
-    "madness": 2,
-    "despair": 0,
-    "denial": 5,
-    "fixation": 3,
-    "dread": 2,
-    "overthinking": 4
+  "allocation": {
+    "spent": {
+      "charm": 5,
+      "rizz": 4,
+      "honesty": 3,
+      "chaos": 2,
+      "wit": 5,
+      "self_awareness": 2
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 2,
+      "despair": 0,
+      "denial": 5,
+      "fixation": 3,
+      "dread": 2,
+      "overthinking": 4
+    }
   }
 }

--- a/data/characters/character-schema.json
+++ b/data/characters/character-schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pinder.dk-eigenvektor.de/schemas/character-v1.json",
+  "title": "Pinder Character v1",
+  "description": "On-disk shape of a Pinder character file. Describes player-authored allocation only; bonuses from items/anatomy are recomputed at load time and never serialised here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "character_id",
+    "name",
+    "gender_identity",
+    "bio",
+    "level",
+    "items",
+    "anatomy",
+    "allocation"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "description": "Schema version. v1 files MUST be exactly 1.",
+      "const": 1
+    },
+    "character_id": {
+      "type": "string",
+      "description": "UUIDv4 identity. Stable across renames; the filename slug is presentation only.",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Display name shown to opposing player and used in prompts."
+    },
+    "gender_identity": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Free-form gender identity string (e.g. \"he/him\", \"they/them\")."
+    },
+    "bio": {
+      "type": "string",
+      "description": "Short bio shown to opposing player."
+    },
+    "level": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 11,
+      "description": "Character level used for archetype eligibility and starter-points budget."
+    },
+    "items": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Equipped item ids; resolved against IItemRepository at load."
+    },
+    "anatomy": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "minLength": 1 },
+      "description": "Anatomy selections: parameter id (e.g. \"length\") -> tier id (e.g. \"short\")."
+    },
+    "allocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spent", "unspent_pool", "shadows"],
+      "description": "Player-authored build-point allocation block. Bonuses NOT included here.",
+      "properties": {
+        "spent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["charm", "rizz", "honesty", "chaos", "wit", "self_awareness"],
+          "properties": {
+            "charm":          { "type": "integer", "minimum": 0 },
+            "rizz":           { "type": "integer", "minimum": 0 },
+            "honesty":        { "type": "integer", "minimum": 0 },
+            "chaos":          { "type": "integer", "minimum": 0 },
+            "wit":            { "type": "integer", "minimum": 0 },
+            "self_awareness": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "unspent_pool": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Build points not yet allocated. Starter files all set this to 0."
+        },
+        "shadows": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["madness", "despair", "denial", "fixation", "dread", "overthinking"],
+          "properties": {
+            "madness":      { "type": "integer", "minimum": 0 },
+            "despair":      { "type": "integer", "minimum": 0 },
+            "denial":       { "type": "integer", "minimum": 0 },
+            "fixation":     { "type": "integer", "minimum": 0 },
+            "dread":        { "type": "integer", "minimum": 0 },
+            "overthinking": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/characters/gerald.json
+++ b/data/characters/gerald.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "59aa20f2-46d6-4adc-89c1-6ea17f815020",
   "name": "Gerald_42",
   "gender_identity": "he/him",
   "bio": "Just a normal guy who loves the gym, good food, and real connections.",
@@ -21,20 +23,23 @@
     "tattoos": "none",
     "eye_style": "wide"
   },
-  "build_points": {
-    "charm": 6,
-    "rizz": 5,
-    "honesty": 2,
-    "chaos": 4,
-    "wit": 2,
-    "self_awareness": 2
-  },
-  "shadows": {
-    "madness": 5,
-    "despair": 0,
-    "denial": 2,
-    "fixation": 4,
-    "dread": 3,
-    "overthinking": 2
+  "allocation": {
+    "spent": {
+      "charm": 6,
+      "rizz": 5,
+      "honesty": 2,
+      "chaos": 4,
+      "wit": 2,
+      "self_awareness": 2
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 5,
+      "despair": 0,
+      "denial": 2,
+      "fixation": 4,
+      "dread": 3,
+      "overthinking": 2
+    }
   }
 }

--- a/data/characters/reuben.json
+++ b/data/characters/reuben.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "f179a327-8aa5-443d-aa56-0e764f6ea3ce",
   "name": "Reuben_404",
   "gender_identity": "he/him",
   "bio": "accidentally deleted my thesis. starting fresh. no notes.",
@@ -21,20 +23,23 @@
     "tattoos": "one-meaningful",
     "eye_style": "soft"
   },
-  "build_points": {
-    "charm": 2,
-    "rizz": 3,
-    "honesty": 5,
-    "chaos": 6,
-    "wit": 4,
-    "self_awareness": 3
-  },
-  "shadows": {
-    "madness": 4,
-    "despair": 1,
-    "denial": 1,
-    "fixation": 3,
-    "dread": 5,
-    "overthinking": 7
+  "allocation": {
+    "spent": {
+      "charm": 2,
+      "rizz": 3,
+      "honesty": 5,
+      "chaos": 6,
+      "wit": 4,
+      "self_awareness": 3
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 4,
+      "despair": 1,
+      "denial": 1,
+      "fixation": 3,
+      "dread": 5,
+      "overthinking": 7
+    }
   }
 }

--- a/data/characters/sable.json
+++ b/data/characters/sable.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "8bde182a-9aec-4c15-b8f9-2f6edeb30752",
   "name": "Sable_xo",
   "gender_identity": "she/her",
   "bio": "looking for my person. if you're boring, swipe left babe.",
@@ -21,20 +23,23 @@
     "tattoos": "one-meaningful",
     "eye_style": "soft"
   },
-  "build_points": {
-    "charm": 4,
-    "rizz": 6,
-    "honesty": 3,
-    "chaos": 4,
-    "wit": 2,
-    "self_awareness": 2
-  },
-  "shadows": {
-    "madness": 3,
-    "despair": 0,
-    "denial": 2,
-    "fixation": 5,
-    "dread": 2,
-    "overthinking": 4
+  "allocation": {
+    "spent": {
+      "charm": 4,
+      "rizz": 6,
+      "honesty": 3,
+      "chaos": 4,
+      "wit": 2,
+      "self_awareness": 2
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 3,
+      "despair": 0,
+      "denial": 2,
+      "fixation": 5,
+      "dread": 2,
+      "overthinking": 4
+    }
   }
 }

--- a/data/characters/velvet.json
+++ b/data/characters/velvet.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "699b1fea-92d9-4f1e-8a39-b502052ae865",
   "name": "Velvet_Void",
   "gender_identity": "she/her",
   "bio": "if you have to ask, you're not invited.",
@@ -22,20 +24,23 @@
     "tattoos": "several",
     "eye_style": "intense"
   },
-  "build_points": {
-    "charm": 3,
-    "rizz": 3,
-    "honesty": 2,
-    "chaos": 5,
-    "wit": 4,
-    "self_awareness": 4
-  },
-  "shadows": {
-    "madness": 3,
-    "despair": 0,
-    "denial": 4,
-    "fixation": 2,
-    "dread": 5,
-    "overthinking": 3
+  "allocation": {
+    "spent": {
+      "charm": 3,
+      "rizz": 3,
+      "honesty": 2,
+      "chaos": 5,
+      "wit": 4,
+      "self_awareness": 4
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 3,
+      "despair": 0,
+      "denial": 4,
+      "fixation": 2,
+      "dread": 5,
+      "overthinking": 3
+    }
   }
 }

--- a/data/characters/zyx.json
+++ b/data/characters/zyx.json
@@ -1,4 +1,6 @@
 {
+  "schema_version": 1,
+  "character_id": "e6a72ae2-d73a-4b44-a474-63b21e8084ec",
   "name": "Zyx_444",
   "gender_identity": "they/them",
   "bio": "the mushroom knows. you'll understand when you're ready.",
@@ -22,20 +24,23 @@
     "tattoos": "none",
     "eye_style": "soft"
   },
-  "build_points": {
-    "charm": 2,
-    "rizz": 2,
-    "honesty": 5,
-    "chaos": 5,
-    "wit": 4,
-    "self_awareness": 3
-  },
-  "shadows": {
-    "madness": 6,
-    "despair": 0,
-    "denial": 1,
-    "fixation": 2,
-    "dread": 4,
-    "overthinking": 3
+  "allocation": {
+    "spent": {
+      "charm": 2,
+      "rizz": 2,
+      "honesty": 5,
+      "chaos": 5,
+      "wit": 4,
+      "self_awareness": 3
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 6,
+      "despair": 0,
+      "denial": 1,
+      "fixation": 2,
+      "dread": 4,
+      "overthinking": 3
+    }
   }
 }

--- a/src/Pinder.Core/Characters/CharacterDefinition.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinition.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Strongly-typed representation of an on-disk v1 character file
+    /// (<c>data/characters/*.json</c>).
+    ///
+    /// This is the wire-shape of the file system: parsed from JSON, used by
+    /// <c>CharacterDefinitionLoader</c> to drive <see cref="CharacterAssembler"/>,
+    /// and round-tripped back to JSON by the writer (see issue #815).
+    ///
+    /// Immutability: every property is a constructor-initialised read-only
+    /// reference. The POCO is sealed and exposes no mutators. The codebase is
+    /// pinned to <c>LangVersion=8.0</c>, so the issue's "init-only" wording is
+    /// implemented as an equivalent immutable-by-construction shape.
+    ///
+    /// Identity: <see cref="CharacterId"/> is the GUID identity. Filenames are
+    /// presentation-only slugs and are not part of the identity contract.
+    ///
+    /// Allocation vs. bonuses split: this POCO carries the player-authored
+    /// allocation (<see cref="Allocation"/>). Bonuses from items / anatomy are
+    /// computed every load by <see cref="CharacterAssembler"/> and are NOT
+    /// stored on disk.
+    /// </summary>
+    public sealed class CharacterDefinition
+    {
+        /// <summary>The integer schema version. v1 files MUST have this set to 1.</summary>
+        public const int CurrentSchemaVersion = 1;
+
+        /// <summary>v1. Reader rejects missing or unknown values.</summary>
+        public int SchemaVersion { get; }
+
+        /// <summary>UUIDv4 identity. Stable across renames; filename slug is presentation only.</summary>
+        public Guid CharacterId { get; }
+
+        /// <summary>Display name (e.g. "Reuben_404").</summary>
+        public string Name { get; }
+
+        /// <summary>Free-form gender identity string (e.g. "he/him", "they/them").</summary>
+        public string GenderIdentity { get; }
+
+        /// <summary>Short bio shown to opposing player.</summary>
+        public string Bio { get; }
+
+        /// <summary>Character level, 1..11.</summary>
+        public int Level { get; }
+
+        /// <summary>Equipped item ids (resolved against <c>IItemRepository</c>).</summary>
+        public IReadOnlyList<string> Items { get; }
+
+        /// <summary>
+        /// Anatomy selections. Map of parameter id (e.g. "length") to tier id
+        /// (e.g. "short"). Resolved against <c>IAnatomyRepository</c>.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Anatomy { get; }
+
+        /// <summary>Player-authored build-point allocation block.</summary>
+        public AllocationBlock Allocation { get; }
+
+        public CharacterDefinition(
+            int schemaVersion,
+            Guid characterId,
+            string name,
+            string genderIdentity,
+            string bio,
+            int level,
+            IReadOnlyList<string> items,
+            IReadOnlyDictionary<string, string> anatomy,
+            AllocationBlock allocation)
+        {
+            SchemaVersion = schemaVersion;
+            CharacterId = characterId;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            GenderIdentity = genderIdentity ?? throw new ArgumentNullException(nameof(genderIdentity));
+            Bio = bio ?? throw new ArgumentNullException(nameof(bio));
+            Level = level;
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+            Anatomy = anatomy ?? throw new ArgumentNullException(nameof(anatomy));
+            Allocation = allocation ?? throw new ArgumentNullException(nameof(allocation));
+        }
+    }
+
+    /// <summary>
+    /// Player-authored build-point allocation. Mutable state in the gameplay
+    /// sense (the player can redistribute), immutable in the value-object
+    /// sense (assign a new <see cref="AllocationBlock"/> when redistributing).
+    /// </summary>
+    public sealed class AllocationBlock
+    {
+        /// <summary>Build points spent on each positive stat.</summary>
+        public IReadOnlyDictionary<StatType, int> Spent { get; }
+
+        /// <summary>Unspent build-point pool. v1 starter files all set this to 0.</summary>
+        public int UnspentPool { get; }
+
+        /// <summary>Allocated shadow values.</summary>
+        public IReadOnlyDictionary<ShadowStatType, int> Shadows { get; }
+
+        public AllocationBlock(
+            IReadOnlyDictionary<StatType, int> spent,
+            int unspentPool,
+            IReadOnlyDictionary<ShadowStatType, int> shadows)
+        {
+            Spent = spent ?? throw new ArgumentNullException(nameof(spent));
+            UnspentPool = unspentPool;
+            Shadows = shadows ?? throw new ArgumentNullException(nameof(shadows));
+        }
+    }
+}

--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -13,19 +13,33 @@ using Pinder.Core.Traps;
 namespace Pinder.SessionSetup
 {
     /// <summary>
-    /// Loads a character definition JSON file and runs the full
-    /// CharacterAssembler + PromptBuilder pipeline to produce a CharacterProfile.
+    /// Loads a v1 character definition JSON file and runs the full
+    /// <see cref="CharacterAssembler"/> + <see cref="PromptBuilder"/> pipeline
+    /// to produce a <see cref="CharacterProfile"/>.
+    ///
+    /// v1 contract (issue #814):
+    ///   - <c>schema_version: 1</c> is required. Missing or unknown values throw
+    ///     <see cref="FormatException"/>.
+    ///   - <c>character_id</c> is a required UUIDv4. Malformed values throw.
+    ///   - On-disk shape stores allocation only (<c>allocation.spent</c>,
+    ///     <c>allocation.unspent_pool</c>, <c>allocation.shadows</c>); item /
+    ///     anatomy bonuses are recomputed every load.
+    ///
+    /// No back-compat with the prototype format.
     /// </summary>
     public static class CharacterDefinitionLoader
     {
+        /// <summary>The schema version this loader understands.</summary>
+        public const int SupportedSchemaVersion = CharacterDefinition.CurrentSchemaVersion;
+
         /// <summary>
         /// Load a character definition from a JSON file and assemble it into
-        /// a CharacterProfile ready for GameSession.
+        /// a <see cref="CharacterProfile"/> ready for GameSession.
         /// </summary>
         /// <param name="jsonPath">Absolute or relative path to the character definition JSON file.</param>
-        /// <param name="itemRepo">An IItemRepository loaded from starter-items.json.</param>
-        /// <param name="anatomyRepo">An IAnatomyRepository loaded from anatomy-parameters.json.</param>
-        /// <returns>A fully assembled CharacterProfile.</returns>
+        /// <param name="itemRepo">An <see cref="IItemRepository"/> loaded from starter-items.json.</param>
+        /// <param name="anatomyRepo">An <see cref="IAnatomyRepository"/> loaded from anatomy-parameters.json.</param>
+        /// <returns>A fully assembled <see cref="CharacterProfile"/>.</returns>
         /// <exception cref="FileNotFoundException">The file does not exist.</exception>
         /// <exception cref="FormatException">The JSON is malformed or missing required fields.</exception>
         public static CharacterProfile Load(
@@ -41,15 +55,11 @@ namespace Pinder.SessionSetup
         }
 
         /// <summary>
-        /// Parse a character definition JSON string and assemble it into a CharacterProfile.
-        /// Exposed publicly so callers (e.g. the GameApi character generator,
-        /// issues #330/#331) can validate freshly composed JSON without first
-        /// writing it to disk.
+        /// Parse a v1 character definition JSON string into a strongly-typed
+        /// <see cref="CharacterDefinition"/>. Pure: no I/O, no assembler call.
         /// </summary>
-        public static CharacterProfile Parse(
-            string json,
-            IItemRepository itemRepo,
-            IAnatomyRepository anatomyRepo)
+        /// <exception cref="FormatException">The JSON is malformed or violates the v1 schema.</exception>
+        public static CharacterDefinition ParseDefinition(string json)
         {
             JsonDocument doc;
             try
@@ -64,8 +74,12 @@ namespace Pinder.SessionSetup
             using (doc)
             {
                 var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                    throw new FormatException("Character definition root must be a JSON object.");
 
-                // Extract required fields
+                int schemaVersion = ParseSchemaVersion(root);
+                Guid characterId = ParseCharacterId(root);
+
                 string name = GetRequiredString(root, "name");
                 string genderIdentity = GetRequiredString(root, "gender_identity");
                 string bio = GetRequiredString(root, "bio");
@@ -74,49 +88,123 @@ namespace Pinder.SessionSetup
                 if (level < 1 || level > 11)
                     throw new FormatException($"Character level must be between 1 and 11, got: {level}");
 
-                // Parse items array
                 var items = ParseItemIds(root);
-
-                // Parse anatomy selections
                 var anatomy = ParseAnatomySelections(root);
+                var allocation = ParseAllocation(root);
 
-                // Parse build points
-                var buildPoints = ParseBuildPoints(root);
-
-                // Parse shadows (optional — defaults to all zeros)
-                var shadows = ParseShadows(root);
-
-                // Run assembly pipeline
-                var assembler = new CharacterAssembler(itemRepo, anatomyRepo);
-                var fragments = assembler.Assemble(items, anatomy, buildPoints, shadows, level);
-
-                // Build system prompt
-                string systemPrompt = PromptBuilder.BuildSystemPrompt(
-                    name, genderIdentity, bio, fragments, new TrapState());
-
-                // Join texting style fragments for voice reinforcement
-                string textingStyle = fragments.TextingStyleFragments.Count > 0
-                    ? string.Join(" | ", fragments.TextingStyleFragments)
-                    : string.Empty;
-
-                // Collect item display names for visible profile (shown to opposing player at T1)
-                var itemDisplayNames = new System.Collections.Generic.List<string>();
-                foreach (var itemId in items)
-                {
-                    var item = itemRepo.GetItem(itemId);
-                    if (item != null && !string.IsNullOrWhiteSpace(item.DisplayName))
-                        itemDisplayNames.Add(item.DisplayName);
-                }
-
-                // Construct CharacterProfile
-                return new CharacterProfile(
-                    fragments.Stats, systemPrompt, name, fragments.Timing, level,
-                    bio: bio,
-                    textingStyleFragment: textingStyle,
-                    activeArchetype: fragments.ActiveArchetype,
-                    equippedItemDisplayNames: itemDisplayNames,
-                    textingStyleSources: fragments.TextingStyleSources);
+                return new CharacterDefinition(
+                    schemaVersion,
+                    characterId,
+                    name,
+                    genderIdentity,
+                    bio,
+                    level,
+                    items,
+                    anatomy,
+                    allocation);
             }
+        }
+
+        /// <summary>
+        /// Parse a v1 character definition JSON string and assemble it into a
+        /// <see cref="CharacterProfile"/>. Exposed publicly so callers (e.g.
+        /// the GameApi character generator) can validate freshly composed JSON
+        /// without first writing it to disk.
+        /// </summary>
+        public static CharacterProfile Parse(
+            string json,
+            IItemRepository itemRepo,
+            IAnatomyRepository anatomyRepo)
+        {
+            if (itemRepo == null) throw new ArgumentNullException(nameof(itemRepo));
+            if (anatomyRepo == null) throw new ArgumentNullException(nameof(anatomyRepo));
+
+            CharacterDefinition def = ParseDefinition(json);
+            return Assemble(def, itemRepo, anatomyRepo);
+        }
+
+        /// <summary>
+        /// Run a parsed <see cref="CharacterDefinition"/> through the assembly
+        /// pipeline to produce a <see cref="CharacterProfile"/>. Bonuses are
+        /// derived from items / anatomy at this point and do NOT round-trip
+        /// back to the on-disk file.
+        /// </summary>
+        public static CharacterProfile Assemble(
+            CharacterDefinition def,
+            IItemRepository itemRepo,
+            IAnatomyRepository anatomyRepo)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            if (itemRepo == null) throw new ArgumentNullException(nameof(itemRepo));
+            if (anatomyRepo == null) throw new ArgumentNullException(nameof(anatomyRepo));
+
+            var assembler = new CharacterAssembler(itemRepo, anatomyRepo);
+            var fragments = assembler.Assemble(
+                def.Items,
+                def.Anatomy,
+                def.Allocation.Spent,
+                def.Allocation.Shadows,
+                def.Level);
+
+            string systemPrompt = PromptBuilder.BuildSystemPrompt(
+                def.Name, def.GenderIdentity, def.Bio, fragments, new TrapState());
+
+            string textingStyle = fragments.TextingStyleFragments.Count > 0
+                ? string.Join(" | ", fragments.TextingStyleFragments)
+                : string.Empty;
+
+            var itemDisplayNames = new List<string>();
+            foreach (var itemId in def.Items)
+            {
+                var item = itemRepo.GetItem(itemId);
+                if (item != null && !string.IsNullOrWhiteSpace(item.DisplayName))
+                    itemDisplayNames.Add(item.DisplayName);
+            }
+
+            return new CharacterProfile(
+                fragments.Stats, systemPrompt, def.Name, fragments.Timing, def.Level,
+                bio: def.Bio,
+                textingStyleFragment: textingStyle,
+                activeArchetype: fragments.ActiveArchetype,
+                equippedItemDisplayNames: itemDisplayNames,
+                textingStyleSources: fragments.TextingStyleSources);
+        }
+
+        // --- v1 schema parsing ------------------------------------------------
+
+        private static int ParseSchemaVersion(JsonElement root)
+        {
+            if (!root.TryGetProperty("schema_version", out var prop))
+            {
+                throw new FormatException(
+                    $"Character definition missing required field: schema_version (expected {SupportedSchemaVersion}).");
+            }
+            if (prop.ValueKind != JsonValueKind.Number || !prop.TryGetInt32(out int version))
+            {
+                throw new FormatException(
+                    $"Character definition schema_version must be an integer (expected {SupportedSchemaVersion}).");
+            }
+            if (version != SupportedSchemaVersion)
+            {
+                throw new FormatException(
+                    $"Unknown character schema_version: {version} (this loader supports v{SupportedSchemaVersion} only).");
+            }
+            return version;
+        }
+
+        private static Guid ParseCharacterId(JsonElement root)
+        {
+            if (!root.TryGetProperty("character_id", out var prop) ||
+                prop.ValueKind != JsonValueKind.String)
+            {
+                throw new FormatException("Character definition missing required field: character_id");
+            }
+            string raw = prop.GetString()!;
+            if (!Guid.TryParseExact(raw, "D", out var id))
+            {
+                throw new FormatException($"Character definition character_id is not a valid UUID: '{raw}'");
+            }
+            return id;
         }
 
         private static string GetRequiredString(JsonElement root, string fieldName)
@@ -173,35 +261,56 @@ namespace Pinder.SessionSetup
             return anatomy;
         }
 
-        private static Dictionary<StatType, int> ParseBuildPoints(JsonElement root)
+        private static AllocationBlock ParseAllocation(JsonElement root)
         {
-            if (!root.TryGetProperty("build_points", out var prop) ||
-                prop.ValueKind != JsonValueKind.Object)
+            if (!root.TryGetProperty("allocation", out var alloc) ||
+                alloc.ValueKind != JsonValueKind.Object)
             {
-                throw new FormatException("Character definition missing required field: build_points");
+                throw new FormatException("Character definition missing required field: allocation");
             }
 
-            var buildPoints = new Dictionary<StatType, int>();
+            var spent = ParseSpent(alloc);
+            int unspent = 0;
+            if (alloc.TryGetProperty("unspent_pool", out var pool))
+            {
+                if (pool.ValueKind != JsonValueKind.Number || !pool.TryGetInt32(out unspent))
+                    throw new FormatException("allocation.unspent_pool must be an integer.");
+                if (unspent < 0)
+                    throw new FormatException("allocation.unspent_pool must be non-negative.");
+            }
+            var shadows = ParseShadowsBlock(alloc);
+
+            return new AllocationBlock(spent, unspent, shadows);
+        }
+
+        private static Dictionary<StatType, int> ParseSpent(JsonElement alloc)
+        {
+            if (!alloc.TryGetProperty("spent", out var prop) ||
+                prop.ValueKind != JsonValueKind.Object)
+            {
+                throw new FormatException("Character definition missing required field: allocation.spent");
+            }
+
+            var spent = new Dictionary<StatType, int>();
             foreach (var kv in prop.EnumerateObject())
             {
                 if (!TryParseStatType(kv.Name, out var statType))
                     throw new FormatException($"Unknown stat type: {kv.Name}");
                 if (kv.Value.ValueKind != JsonValueKind.Number)
                     throw new FormatException($"Build point value for {kv.Name} must be a number");
-                buildPoints[statType] = kv.Value.GetInt32();
+                spent[statType] = kv.Value.GetInt32();
             }
-            return buildPoints;
+            return spent;
         }
 
-        private static Dictionary<ShadowStatType, int> ParseShadows(JsonElement root)
+        private static Dictionary<ShadowStatType, int> ParseShadowsBlock(JsonElement alloc)
         {
             var shadows = new Dictionary<ShadowStatType, int>();
-
             // Default all to 0
             foreach (ShadowStatType sst in Enum.GetValues(typeof(ShadowStatType)))
                 shadows[sst] = 0;
 
-            if (!root.TryGetProperty("shadows", out var prop) ||
+            if (!alloc.TryGetProperty("shadows", out var prop) ||
                 prop.ValueKind != JsonValueKind.Object)
             {
                 return shadows;

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -5,7 +5,6 @@ using Pinder.Core.Characters;
 using Pinder.Core.Data;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Stats;
-using Pinder.SessionRunner;
 using Pinder.SessionSetup;
 using Xunit;
 
@@ -43,6 +42,33 @@ namespace Pinder.Core.Tests
             return new JsonAnatomyRepository(json);
         }
 
+        private static readonly string[] AllStarterSlugs =
+            { "brick", "gerald", "reuben", "sable", "velvet", "zyx" };
+
+        // Reusable v1 fixture string (a minimally-valid file). Tests mutate
+        // copies of this to provoke negative cases.
+        private const string ValidV1Json = @"{
+            ""schema_version"": 1,
+            ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""name"": ""TestChar"",
+            ""gender_identity"": ""they/them"",
+            ""bio"": ""test bio"",
+            ""level"": 1,
+            ""items"": [],
+            ""anatomy"": {},
+            ""allocation"": {
+                ""spent"": {
+                    ""charm"": 1, ""rizz"": 1, ""honesty"": 1,
+                    ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1
+                },
+                ""unspent_pool"": 0,
+                ""shadows"": {
+                    ""madness"": 0, ""despair"": 0, ""denial"": 0,
+                    ""fixation"": 0, ""dread"": 0, ""overthinking"": 0
+                }
+            }
+        }";
+
         [Fact]
         public void Load_GeraldDefinition_ProducesValidProfile()
         {
@@ -62,20 +88,60 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void Load_AllFiveCharacters_Succeed()
+        public void Load_AllSixStarterCharacters_Succeed()
         {
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
-            var names = new[] { "gerald", "velvet", "sable", "brick", "zyx" };
 
-            foreach (var name in names)
+            foreach (var slug in AllStarterSlugs)
             {
-                string path = Path.Combine(RepoRoot, "data", "characters", $"{name}.json");
+                string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
                 var profile = CharacterDefinitionLoader.Load(path, itemRepo, anatomyRepo);
                 Assert.NotNull(profile);
-                Assert.False(string.IsNullOrEmpty(profile.DisplayName), $"{name} should have a display name");
-                Assert.True(profile.Level >= 1 && profile.Level <= 11, $"{name} level should be 1-11, got {profile.Level}");
+                Assert.False(string.IsNullOrEmpty(profile.DisplayName), $"{slug} should have a display name");
+                Assert.True(profile.Level >= 1 && profile.Level <= 11,
+                    $"{slug} level should be 1-11, got {profile.Level}");
             }
+        }
+
+        [Fact]
+        public void ParseDefinition_AllSixStarterFiles_ProduceWellFormedDefinitions()
+        {
+            foreach (var slug in AllStarterSlugs)
+            {
+                string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+                string json = File.ReadAllText(path);
+
+                var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+                Assert.Equal(1, def.SchemaVersion);
+                Assert.NotEqual(Guid.Empty, def.CharacterId);
+                Assert.False(string.IsNullOrWhiteSpace(def.Name));
+                Assert.False(string.IsNullOrWhiteSpace(def.GenderIdentity));
+                Assert.NotNull(def.Bio);
+                Assert.True(def.Level >= 1 && def.Level <= 11);
+                Assert.NotNull(def.Items);
+                Assert.NotNull(def.Anatomy);
+                Assert.NotNull(def.Allocation);
+                Assert.NotNull(def.Allocation.Spent);
+                Assert.NotNull(def.Allocation.Shadows);
+            }
+        }
+
+        [Fact]
+        public void ParseDefinition_AllStarterCharacterIdsAreUnique()
+        {
+            var ids = new HashSet<Guid>();
+            foreach (var slug in AllStarterSlugs)
+            {
+                string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+                string json = File.ReadAllText(path);
+                var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+                Assert.True(ids.Add(def.CharacterId),
+                    $"Duplicate character_id {def.CharacterId} found at {slug}.json");
+            }
+            Assert.Equal(AllStarterSlugs.Length, ids.Count);
         }
 
         [Fact]
@@ -87,11 +153,80 @@ namespace Pinder.Core.Tests
 
             var profile = CharacterDefinitionLoader.Load(path, itemRepo, anatomyRepo);
 
-            // Gerald has build_points: charm=6, rizz=5, etc.
-            // Plus item modifiers from his equipment
-            // The exact values depend on item data, but charm should be > 6 (build points + item mods)
+            // Gerald has allocation.spent.charm = 6, plus item modifiers from his
+            // equipment. The exact effective value depends on item data, but
+            // charm should be >= 6 (base allocation alone).
             int charm = profile.Stats.GetEffective(StatType.Charm);
             Assert.True(charm >= 6, $"Gerald's charm should be at least 6 (build points), got {charm}");
+        }
+
+        [Fact]
+        public void Parse_MissingSchemaVersion_ThrowsFormatException()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            string json = ValidV1Json.Replace("\"schema_version\": 1,", "");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
+            Assert.Contains("schema_version", ex.Message);
+        }
+
+        [Fact]
+        public void Parse_UnknownSchemaVersion_ThrowsFormatException()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            string json = ValidV1Json.Replace("\"schema_version\": 1,", "\"schema_version\": 2,");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
+            Assert.Contains("schema_version", ex.Message);
+            Assert.Contains("2", ex.Message);
+        }
+
+        [Fact]
+        public void Parse_MalformedSchemaVersion_ThrowsFormatException()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            string json = ValidV1Json.Replace("\"schema_version\": 1,", "\"schema_version\": \"v1\",");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
+            Assert.Contains("schema_version", ex.Message);
+        }
+
+        [Fact]
+        public void Parse_MissingCharacterId_ThrowsFormatException()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            string json = ValidV1Json.Replace(
+                "\"character_id\": \"550e8400-e29b-41d4-a716-446655440000\",", "");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
+            Assert.Contains("character_id", ex.Message);
+        }
+
+        [Fact]
+        public void Parse_MalformedCharacterId_ThrowsFormatException()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            string json = ValidV1Json.Replace(
+                "\"character_id\": \"550e8400-e29b-41d4-a716-446655440000\",",
+                "\"character_id\": \"not-a-uuid\",");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
+            Assert.Contains("character_id", ex.Message);
         }
 
         [Fact]
@@ -100,16 +235,22 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
+            // Construct a v1 file with allocation.shadows omitted entirely.
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""TestChar"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test bio"",
                 ""level"": 1,
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": {
-                    ""charm"": 1, ""rizz"": 1, ""honesty"": 1,
-                    ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1
+                ""allocation"": {
+                    ""spent"": {
+                        ""charm"": 1, ""rizz"": 1, ""honesty"": 1,
+                        ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1
+                    },
+                    ""unspent_pool"": 0
                 }
             }";
 
@@ -117,7 +258,6 @@ namespace Pinder.Core.Tests
 
             Assert.Equal("TestChar", profile.DisplayName);
             Assert.Equal(1, profile.Level);
-            // Shadows default to 0
             Assert.Equal(0, profile.Stats.GetShadow(ShadowStatType.Madness));
             Assert.Equal(0, profile.Stats.GetShadow(ShadowStatType.Despair));
         }
@@ -128,15 +268,7 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
-            // Missing "name" field
-            string json = @"{
-                ""gender_identity"": ""they/them"",
-                ""bio"": ""test"",
-                ""level"": 1,
-                ""items"": [],
-                ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
-            }";
+            string json = ValidV1Json.Replace("\"name\": \"TestChar\",", "");
 
             var ex = Assert.Throws<FormatException>(() =>
                 CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
@@ -149,15 +281,7 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
-            string json = @"{
-                ""name"": ""Test"",
-                ""gender_identity"": ""they/them"",
-                ""bio"": ""test"",
-                ""level"": 15,
-                ""items"": [],
-                ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
-            }";
+            string json = ValidV1Json.Replace("\"level\": 1,", "\"level\": 15,");
 
             var ex = Assert.Throws<FormatException>(() =>
                 CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
@@ -170,15 +294,9 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
-            string json = @"{
-                ""name"": ""Test"",
-                ""gender_identity"": ""they/them"",
-                ""bio"": ""test"",
-                ""level"": 1,
-                ""items"": [],
-                ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""invalid_stat"": 1 }
-            }";
+            string json = ValidV1Json.Replace(
+                "\"self_awareness\": 1\n                },",
+                "\"self_awareness\": 1, \"invalid_stat\": 1\n                },");
 
             var ex = Assert.Throws<FormatException>(() =>
                 CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
@@ -191,16 +309,9 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
-            string json = @"{
-                ""name"": ""Test"",
-                ""gender_identity"": ""they/them"",
-                ""bio"": ""test"",
-                ""level"": 1,
-                ""items"": [],
-                ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 },
-                ""shadows"": { ""invalid_shadow"": 5 }
-            }";
+            string json = ValidV1Json.Replace(
+                "\"overthinking\": 0\n                }\n            }",
+                "\"overthinking\": 0, \"invalid_shadow\": 5\n                }\n            }");
 
             var ex = Assert.Throws<FormatException>(() =>
                 CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
@@ -252,15 +363,24 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Bare"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""naked and proud"",
                 ""level"": 1,
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": {
-                    ""charm"": 3, ""rizz"": 2, ""honesty"": 1,
-                    ""chaos"": 0, ""wit"": 4, ""self_awareness"": 1
+                ""allocation"": {
+                    ""spent"": {
+                        ""charm"": 3, ""rizz"": 2, ""honesty"": 1,
+                        ""chaos"": 0, ""wit"": 4, ""self_awareness"": 1
+                    },
+                    ""unspent_pool"": 0,
+                    ""shadows"": {
+                        ""madness"": 0, ""despair"": 0, ""denial"": 0,
+                        ""fixation"": 0, ""dread"": 0, ""overthinking"": 0
+                    }
                 }
             }";
 

--- a/tests/Pinder.Core.Tests/CharacterLoaderSpecTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterLoaderSpecTests.cs
@@ -1011,10 +1011,14 @@ EFFECTIVE STATS
 
         private static string? FindPromptDir()
         {
+            // Walk up looking for a repo root marker. In a normal checkout
+            // `.git` is a directory; in a `git worktree` it is a regular
+            // file pointing at the parent's gitdir. Accept either.
             string? dir = AppContext.BaseDirectory;
             while (dir != null)
             {
-                if (Directory.Exists(Path.Combine(dir, ".git")))
+                string gitMarker = Path.Combine(dir, ".git");
+                if (Directory.Exists(gitMarker) || File.Exists(gitMarker))
                 {
                     string promptDir = Path.Combine(dir, "design", "examples");
                     return Directory.Exists(promptDir) ? promptDir : null;

--- a/tests/Pinder.Core.Tests/CharacterSchemaValidationTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterSchemaValidationTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Direct schema-file validation tests for issue #814. Walks the
+    /// JSON-Schema document at <c>data/characters/character-schema.json</c>
+    /// against the 6 starter files. Hand-rolled to avoid pulling in a new
+    /// runtime NuGet dep; covers the subset of Draft-7 actually used by
+    /// <c>character-schema.json</c> (object/array/integer/string,
+    /// <c>required</c>, <c>type</c>, <c>const</c>, <c>pattern</c>,
+    /// <c>minimum</c>, <c>maximum</c>, <c>minLength</c>,
+    /// <c>additionalProperties: false</c>, nested object schemas).
+    ///
+    /// If a future schema revision uses richer keywords this validator
+    /// won't notice them; that's fine — the parser's own tests already
+    /// pin behaviour and this file's job is just to demonstrate that the
+    /// declared schema and the starter files agree about shape.
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class CharacterSchemaValidationTests
+    {
+        private static string RepoRoot
+        {
+            get
+            {
+                string? dir = AppContext.BaseDirectory;
+                while (dir != null)
+                {
+                    if (Directory.Exists(Path.Combine(dir, "data")) &&
+                        Directory.Exists(Path.Combine(dir, "src")))
+                        return dir;
+                    dir = Directory.GetParent(dir)?.FullName;
+                }
+                throw new InvalidOperationException("Cannot find repo root from " + AppContext.BaseDirectory);
+            }
+        }
+
+        private static readonly string[] AllStarterSlugs =
+            { "brick", "gerald", "reuben", "sable", "velvet", "zyx" };
+
+        [Theory]
+        [InlineData("brick")]
+        [InlineData("gerald")]
+        [InlineData("reuben")]
+        [InlineData("sable")]
+        [InlineData("velvet")]
+        [InlineData("zyx")]
+        public void StarterFile_ValidatesAgainstCharacterSchema(string slug)
+        {
+            string schemaPath = Path.Combine(RepoRoot, "data", "characters", "character-schema.json");
+            string filePath = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+
+            using var schemaDoc = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            using var fileDoc = JsonDocument.Parse(File.ReadAllText(filePath));
+
+            var errors = new List<string>();
+            Validate(schemaDoc.RootElement, fileDoc.RootElement, slug, errors);
+
+            Assert.True(errors.Count == 0,
+                $"{slug}.json failed schema validation:\n  - " + string.Join("\n  - ", errors));
+        }
+
+        [Fact]
+        public void Schema_RejectsFileWithExtraTopLevelProperty()
+        {
+            string schemaPath = Path.Combine(RepoRoot, "data", "characters", "character-schema.json");
+            string filePath = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
+
+            // Inject an extra property at the top level. Schema has
+            // additionalProperties: false, so this MUST fail.
+            string mutated = File.ReadAllText(filePath).TrimEnd().TrimEnd('}')
+                + ",\n  \"unknown_extra\": \"nope\"\n}";
+
+            using var schemaDoc = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            using var fileDoc = JsonDocument.Parse(mutated);
+
+            var errors = new List<string>();
+            Validate(schemaDoc.RootElement, fileDoc.RootElement, "mutated", errors);
+
+            Assert.NotEmpty(errors);
+            Assert.Contains(errors, e => e.Contains("unknown_extra"));
+        }
+
+        [Fact]
+        public void Schema_RejectsFileWithWrongSchemaVersionConst()
+        {
+            string schemaPath = Path.Combine(RepoRoot, "data", "characters", "character-schema.json");
+            string filePath = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
+
+            // Replace schema_version: 1 with schema_version: 99.
+            string mutated = File.ReadAllText(filePath).Replace(
+                "\"schema_version\": 1,", "\"schema_version\": 99,");
+
+            using var schemaDoc = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            using var fileDoc = JsonDocument.Parse(mutated);
+
+            var errors = new List<string>();
+            Validate(schemaDoc.RootElement, fileDoc.RootElement, "mutated", errors);
+
+            Assert.NotEmpty(errors);
+            Assert.Contains(errors, e => e.Contains("schema_version"));
+        }
+
+        // -- minimal Draft-7 walker, tailored to this schema -------------------
+
+        private static void Validate(JsonElement schema, JsonElement instance, string path, List<string> errors)
+        {
+            // type
+            if (schema.TryGetProperty("type", out var typeProp))
+            {
+                string type = typeProp.GetString()!;
+                if (!MatchesType(type, instance))
+                {
+                    errors.Add($"{path}: expected type '{type}', got '{instance.ValueKind}'");
+                    return;
+                }
+            }
+
+            // const (we only use it on integer for schema_version)
+            if (schema.TryGetProperty("const", out var constProp))
+            {
+                if (!JsonElementsEqual(constProp, instance))
+                    errors.Add($"{path}: expected const value {constProp}, got {instance}");
+            }
+
+            // pattern (string only — used for character_id UUIDv4 check)
+            if (schema.TryGetProperty("pattern", out var patternProp) && instance.ValueKind == JsonValueKind.String)
+            {
+                var rx = new System.Text.RegularExpressions.Regex(patternProp.GetString()!);
+                if (!rx.IsMatch(instance.GetString()!))
+                    errors.Add($"{path}: value '{instance.GetString()}' does not match pattern {patternProp.GetString()}");
+            }
+
+            if (schema.TryGetProperty("minLength", out var minLen) && instance.ValueKind == JsonValueKind.String)
+            {
+                if (instance.GetString()!.Length < minLen.GetInt32())
+                    errors.Add($"{path}: string shorter than minLength {minLen.GetInt32()}");
+            }
+
+            if (schema.TryGetProperty("minimum", out var min) && instance.ValueKind == JsonValueKind.Number)
+            {
+                if (instance.GetInt32() < min.GetInt32())
+                    errors.Add($"{path}: value {instance.GetInt32()} below minimum {min.GetInt32()}");
+            }
+
+            if (schema.TryGetProperty("maximum", out var max) && instance.ValueKind == JsonValueKind.Number)
+            {
+                if (instance.GetInt32() > max.GetInt32())
+                    errors.Add($"{path}: value {instance.GetInt32()} above maximum {max.GetInt32()}");
+            }
+
+            // object: required + properties + additionalProperties
+            if (instance.ValueKind == JsonValueKind.Object)
+            {
+                var declaredProps = new HashSet<string>();
+                if (schema.TryGetProperty("properties", out var props))
+                {
+                    foreach (var p in props.EnumerateObject())
+                        declaredProps.Add(p.Name);
+                }
+
+                if (schema.TryGetProperty("required", out var req))
+                {
+                    foreach (var r in req.EnumerateArray())
+                    {
+                        string name = r.GetString()!;
+                        if (!instance.TryGetProperty(name, out _))
+                            errors.Add($"{path}: missing required property '{name}'");
+                    }
+                }
+
+                bool additionalAllowed = true;
+                if (schema.TryGetProperty("additionalProperties", out var addProp) &&
+                    addProp.ValueKind == JsonValueKind.False)
+                {
+                    additionalAllowed = false;
+                }
+
+                foreach (var member in instance.EnumerateObject())
+                {
+                    if (declaredProps.Contains(member.Name))
+                    {
+                        var subSchema = schema.GetProperty("properties").GetProperty(member.Name);
+                        Validate(subSchema, member.Value, $"{path}.{member.Name}", errors);
+                    }
+                    else if (!additionalAllowed)
+                    {
+                        errors.Add($"{path}: unexpected property '{member.Name}' (additionalProperties: false)");
+                    }
+                    else if (schema.TryGetProperty("additionalProperties", out var addSchema) &&
+                             addSchema.ValueKind == JsonValueKind.Object)
+                    {
+                        Validate(addSchema, member.Value, $"{path}.{member.Name}", errors);
+                    }
+                }
+            }
+
+            // array: items
+            if (instance.ValueKind == JsonValueKind.Array &&
+                schema.TryGetProperty("items", out var itemsSchema))
+            {
+                int i = 0;
+                foreach (var elem in instance.EnumerateArray())
+                {
+                    Validate(itemsSchema, elem, $"{path}[{i}]", errors);
+                    i++;
+                }
+            }
+        }
+
+        private static bool MatchesType(string declared, JsonElement instance)
+        {
+            switch (declared)
+            {
+                case "object":  return instance.ValueKind == JsonValueKind.Object;
+                case "array":   return instance.ValueKind == JsonValueKind.Array;
+                case "string":  return instance.ValueKind == JsonValueKind.String;
+                case "integer":
+                    return instance.ValueKind == JsonValueKind.Number &&
+                           instance.TryGetInt64(out _) &&
+                           !instance.GetRawText().Contains('.');
+                case "number":  return instance.ValueKind == JsonValueKind.Number;
+                case "boolean": return instance.ValueKind == JsonValueKind.True ||
+                                       instance.ValueKind == JsonValueKind.False;
+                case "null":    return instance.ValueKind == JsonValueKind.Null;
+                default:        return true; // unknown declared type — accept
+            }
+        }
+
+        private static bool JsonElementsEqual(JsonElement a, JsonElement b)
+        {
+            if (a.ValueKind != b.ValueKind) return false;
+            switch (a.ValueKind)
+            {
+                case JsonValueKind.Number: return a.GetRawText() == b.GetRawText();
+                case JsonValueKind.String: return a.GetString() == b.GetString();
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                case JsonValueKind.Null:
+                    return true;
+                default:
+                    return a.GetRawText() == b.GetRawText();
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
@@ -50,6 +50,10 @@ namespace Pinder.Core.Tests
             return new JsonAnatomyRepository(json);
         }
 
+        // Builds a minimally-valid v1 character JSON. Defaults to a fixed test
+        // character_id; pass `characterId: null` to omit the field entirely
+        // (used for negative tests that target the v1 schema_version /
+        // character_id requirements).
         private static string BuildMinimalJson(
             string name = "TestChar",
             string genderIdentity = "they/them",
@@ -58,23 +62,25 @@ namespace Pinder.Core.Tests
             string itemsArray = "[]",
             string anatomyBlock = "{}",
             string? buildPointsInner = null,
-            string? shadowsInner = null)
+            string? shadowsInner = null,
+            string? schemaVersion = "1",
+            string? characterId = "550e8400-e29b-41d4-a716-446655440000")
         {
             buildPointsInner ??= @"""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1";
+            shadowsInner ??= @"""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0";
 
-            var parts = new List<string>
-            {
-                $@"""name"": ""{name}""",
-                $@"""gender_identity"": ""{genderIdentity}""",
-                $@"""bio"": ""{bio}""",
-                $@"""level"": {level}",
-                $@"""items"": {itemsArray}",
-                $@"""anatomy"": {anatomyBlock}",
-                $@"""build_points"": {{ {buildPointsInner} }}"
-            };
-
-            if (shadowsInner != null)
-                parts.Add($@"""shadows"": {{ {shadowsInner} }}");
+            var parts = new List<string>();
+            if (schemaVersion != null)
+                parts.Add($@"""schema_version"": {schemaVersion}");
+            if (characterId != null)
+                parts.Add($@"""character_id"": ""{characterId}""");
+            parts.Add($@"""name"": ""{name}""");
+            parts.Add($@"""gender_identity"": ""{genderIdentity}""");
+            parts.Add($@"""bio"": ""{bio}""");
+            parts.Add($@"""level"": {level}");
+            parts.Add($@"""items"": {itemsArray}");
+            parts.Add($@"""anatomy"": {anatomyBlock}");
+            parts.Add($@"""allocation"": {{ ""spent"": {{ {buildPointsInner} }}, ""unspent_pool"": 0, ""shadows"": {{ {shadowsInner} }} }}");
 
             return "{ " + string.Join(", ", parts) + " }";
         }
@@ -192,6 +198,7 @@ namespace Pinder.Core.Tests
         [InlineData("sable")]
         [InlineData("brick")]
         [InlineData("zyx")]
+        [InlineData("reuben")]
         public void AC5_CharacterDefinitionFile_Exists(string name)
         {
             string path = Path.Combine(RepoRoot, "data", "characters", $"{name}.json");
@@ -205,6 +212,7 @@ namespace Pinder.Core.Tests
         [InlineData("sable")]
         [InlineData("brick")]
         [InlineData("zyx")]
+        [InlineData("reuben")]
         public void AC5_CharacterDefinition_LoadsSuccessfully(string name)
         {
             var itemRepo = LoadItemRepo();
@@ -233,6 +241,7 @@ namespace Pinder.Core.Tests
         [InlineData("sable")]
         [InlineData("brick")]
         [InlineData("zyx")]
+        [InlineData("reuben")]
         public void AC6_DataFileLocator_FindsCharacterDefinition(string name)
         {
             string relativePath = Path.Combine("data", "characters", $"{name}.json");
@@ -395,13 +404,16 @@ namespace Pinder.Core.Tests
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
+            // v1 file with name field elided.
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test"",
                 ""level"": 1,
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -417,12 +429,14 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""bio"": ""test"",
                 ""level"": 1,
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -438,12 +452,14 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""gender_identity"": ""they/them"",
                 ""level"": 1,
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -459,12 +475,14 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test"",
                 ""items"": [],
                 ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -480,12 +498,14 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test"",
                 ""level"": 1,
                 ""anatomy"": {},
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -501,12 +521,14 @@ namespace Pinder.Core.Tests
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test"",
                 ""level"": 1,
                 ""items"": [],
-                ""build_points"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }
+                ""allocation"": { ""spent"": { ""charm"": 1, ""rizz"": 1, ""honesty"": 1, ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1 }, ""unspent_pool"": 0, ""shadows"": { ""madness"": 0, ""despair"": 0, ""denial"": 0, ""fixation"": 0, ""dread"": 0, ""overthinking"": 0 } }
             }";
 
             var ex = Assert.Throws<FormatException>(() =>
@@ -514,14 +536,17 @@ namespace Pinder.Core.Tests
             Assert.Contains("anatomy", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
-        // Fails if: Missing "build_points" field not detected
+        // v1: "build_points" was renamed to "allocation.spent". Missing the
+        // entire allocation block now triggers the corresponding format error.
         [Fact]
-        public void Error_MissingBuildPoints_ThrowsFormatException()
+        public void Error_MissingAllocation_ThrowsFormatException()
         {
             var itemRepo = LoadItemRepo();
             var anatomyRepo = LoadAnatomyRepo();
 
             string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
                 ""name"": ""Test"",
                 ""gender_identity"": ""they/them"",
                 ""bio"": ""test"",
@@ -532,7 +557,7 @@ namespace Pinder.Core.Tests
 
             var ex = Assert.Throws<FormatException>(() =>
                 CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo));
-            Assert.Contains("build_points", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("allocation", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         // Fails if: Level validation doesn't reject level 0


### PR DESCRIPTION
Implements v1 character file format (no back-compat).

## What

- New sealed immutable POCO `Pinder.Core.Characters.CharacterDefinition` with nested `AllocationBlock`.
- New JSON Schema at `data/characters/character-schema.json` (Draft 7).
- `CharacterDefinitionLoader` split into `ParseDefinition` (pure, no I/O, no assembler), `Parse` (string → profile), `Load` (file → profile), and `Assemble` (definition + repos → profile).
- All 6 starter files hand-rewritten to v1 with freshly-minted UUIDv4 `character_id`s.
- No back-compat shim. The old top-level `build_points` / `shadows` blocks are dropped. Today's only consumers (`session-runner` and `Issue415_CharacterDefinitionLoaderSpecTests`) are migrated in this PR.

## Decision: immutable-by-construction instead of `init`-only

Issue #814 calls for "init-only properties." The codebase pins `LangVersion=8.0` across every project; `init` is a C# 9 feature. Bumping `LangVersion` for one POCO would broaden the diff well outside the ticket. The POCO is therefore sealed, exposes only `get` accessors initialised in the constructor, and has no mutators — same effective immutability guarantee. If a future ticket bumps the project to C# 9+, switching the accessors to `init` is a one-line change with no caller updates.

## Schema property order (informs writer in #815)

The on-disk canonical order is:

1. `schema_version`
2. `character_id`
3. `name`
4. `gender_identity`
5. `bio`
6. `level`
7. `items`
8. `anatomy`
9. `allocation` → (`spent`, `unspent_pool`, `shadows`)

All 6 starter files follow this order; the writer ticket (#815) will lock it in via byte-equal round-trip tests.

## DoD Evidence

**Tests filtered to the affected category:**

```
$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
Passed!  - Failed:     0, Passed:  2565, Skipped:    18, Total:  2583
```

(Baseline on origin/main was Passed: 2555. Net +10 from new v1-shape tests.)

**71 tests in the two files I touched:**

```
$ dotnet test --no-build --filter "FullyQualifiedName~CharacterDefinitionLoaderTests|FullyQualifiedName~Issue415_CharacterDefinitionLoaderSpecTests"
Passed!  - Failed:     0, Passed:    71, Skipped:     0, Total:    71
```

**Build:** `dotnet build Pinder.Core.sln` → 174 warnings (all pre-existing nullable / xunit analyzer noise), 0 errors.

**Schema file path:** `data/characters/character-schema.json` (Draft 7, validates `additionalProperties: false`).

**6 rewritten starter files + UUIDs:**

- `data/characters/brick.json` — `6fd5f147-6e7f-434a-a842-637049f71345`
- `data/characters/gerald.json` — `59aa20f2-46d6-4adc-89c1-6ea17f815020`
- `data/characters/reuben.json` — `f179a327-8aa5-443d-aa56-0e764f6ea3ce`
- `data/characters/sable.json` — `8bde182a-9aec-4c15-b8f9-2f6edeb30752`
- `data/characters/velvet.json` — `699b1fea-92d9-4f1e-8a39-b502052ae865`
- `data/characters/zyx.json` — `e6a72ae2-d73a-4b44-a474-63b21e8084ec`

All six are UUIDv4 (validated by the schema's regex). The new test `ParseDefinition_AllStarterCharacterIdsAreUnique` asserts this set.

**v1-required negative tests added:**

- `Parse_MissingSchemaVersion_ThrowsFormatException`
- `Parse_UnknownSchemaVersion_ThrowsFormatException`
- `Parse_MalformedSchemaVersion_ThrowsFormatException`
- `Parse_MissingCharacterId_ThrowsFormatException`
- `Parse_MalformedCharacterId_ThrowsFormatException`

**Drive-by fix:** `CharacterLoaderSpecTests.FindPromptDir` now accepts `.git` as either a directory or a file. Without this, six pre-existing tests spuriously fail in worktrees because `git worktree`'s `.git` is a file. Captured as lesson `GIT-WORKTREE-DOTGIT-IS-A-FILE` in `LESSONS_LEARNED.md`.

## Out of scope (deferred to subsequent tickets)

- Symmetric writer (#815).
- `ICharacterStore` abstraction (#816).
- `IRemoteCharacterStore` interface (#817).
- Asset-attribute vocabulary doc (#818).
- pinder-web `CharacterRepository` migration (follow-up after #816).

## Research Log

- Read `docs/specs/issue-415-spec.md` — confirmed it's the v0 contract; v1 supersedes the on-disk shape but the assembly pipeline contract (assembler call, `CharacterProfile` shape) is unchanged.
- Confirmed via `grep -rn "build_points"` that no production code outside the legacy tests references the renamed field; the matches in `rules/tools/_*.py` are unrelated game-rules concepts (base_positive_stats, stat_cap, etc.) sharing the same English phrase.
- Confirmed via `grep -rn "CharacterDefinitionLoader"` that only `session-runner/Program.cs` calls the file-loading entry point; no inline JSON construction outside tests.
- Verified UUIDv4 regex against all 6 generated ids (`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).
- LangVersion-pinning rationale comes from the existing `ConversationIndexing.cs` doc-comment + the explicit `LangVersion=8.0` in every csproj. Decided not to touch that pin in this ticket.

Closes #814
