### PR TITLE
feat(#815): CharacterDefinitionWriter + format spec doc

### DIFF
--- a/docs/specs/character-file-format.md
+++ b/docs/specs/character-file-format.md
@@ -1,0 +1,87 @@
+# Character File Format — v1
+
+**Status:** v1 (`schema_version: 1`).
+**Schema file:** [`data/characters/character-schema.json`](../../data/characters/character-schema.json) (Draft 7).
+**Wire-shape POCO:** `Pinder.Core.Characters.CharacterDefinition`.
+**Reader:** `Pinder.SessionSetup.CharacterDefinitionLoader`.
+**Writer:** `Pinder.Core.Characters.CharacterDefinitionWriter`.
+
+This document is the canonical description of the on-disk format of a Pinder character. Everything below is intentionally short and prescriptive; the schema file and the C# POCO are the binding artifacts, and this doc explains them.
+
+## What is a character file?
+
+A single `.json` file in `data/characters/` (or, in a future ticket, anywhere a `DirectoryCharacterStore` is pointed at). The file is the artifact: send the file, drop it in someone else's characters directory, their game picks it up.
+
+A character file describes:
+
+- The character's **identity** (`character_id`, `name`).
+- The character's **presentation surface** to the opposing player (`gender_identity`, `bio`).
+- The character's **build** at creation time (`level`, `items`, `anatomy`, `allocation`).
+
+It does **not** describe:
+
+- Computed stat bonuses from items or anatomy (recomputed every load).
+- Live game state (turns played, current shadow stat values during a session, weakness windows, etc.). That belongs to `GameSession`, not the character file.
+
+## Identity: `character_id` vs. filename slug
+
+- `character_id` is a UUIDv4. **It is the canonical identity.** Two files with the same `character_id` describe the same character; they should not coexist in a single store.
+- The **filename slug** (e.g. `gerald.json`) is presentation only — a human-friendly handle for the file on disk. Renaming the file does not change the character's identity. Stores (see issue #816) MUST resolve `character_id → file` by reading each file's `character_id`, not by parsing the filename.
+- Renaming a file is safe. Editing a file's `character_id` is not (it forks the identity).
+
+## Schema versioning: `schema_version`
+
+- v1 files set `schema_version: 1`. The reader rejects any other value with a `FormatException`.
+- v1 has no migration story. There is no v0 → v1 shim; the prototype format was dropped wholesale when v1 was introduced.
+- Future versions (v2+) will need a migration step. The expected pattern is: bump the const in the schema, write a `CharacterDefinitionMigrator` that reads the lower-version POCO and projects to the higher-version POCO, and surface the migration result through `CharacterDefinitionLoader` so callers see the latest version regardless of what's on disk.
+
+## Allocation vs. bonuses split
+
+The on-disk `allocation` block carries **only player-authored values**:
+
+- `allocation.spent` — build points the player has assigned to each positive stat. Mutable in the gameplay sense (the player can redistribute), immutable as a value object on disk (rewrite the file when redistributing).
+- `allocation.unspent_pool` — build points not yet allocated. Starter files all set this to `0`; future "I leveled up but haven't picked where to put it" UX will increment this.
+- `allocation.shadows` — starting shadow values. Distinct from in-session shadow drift, which lives on `GameSession`.
+
+**Bonuses are never serialised.** When `CharacterDefinitionLoader.Load` runs, it hands the parsed `CharacterDefinition` to `CharacterAssembler`, which resolves item ids and anatomy tier ids against `IItemRepository` / `IAnatomyRepository` and recomputes the `CharacterProfile`'s effective stats fresh every time. This means: changing an item's stat modifier in `data/items/starter-items.json` propagates to every character that equips that item, with no migration of character files needed.
+
+## Property ordering & whitespace
+
+The file format is byte-stable. The writer guarantees:
+
+- Top-level property order: `schema_version`, `character_id`, `name`, `gender_identity`, `bio`, `level`, `items`, `anatomy`, `allocation`.
+- Inside `allocation`: `spent`, `unspent_pool`, `shadows`.
+- Inside `spent`: `charm`, `rizz`, `honesty`, `chaos`, `wit`, `self_awareness` (matches `StatType` enum).
+- Inside `shadows`: `madness`, `despair`, `denial`, `fixation`, `dread`, `overthinking` (matches `ShadowStatType` enum).
+- 2-space indent, single trailing newline (LF), UTF-8 without BOM.
+- `character_id` formatted with hyphens, lowercase (`Guid.ToString("D")`).
+- `Write(Parse(file)) == file` byte-equal for every starter file. The round-trip test (`CharacterDefinitionWriterTests.Write_ParsedStarterFile_RoundTripsByteEqual`) pins this contract; anyone editing the writer is expected to keep it green.
+
+## Sharing a character
+
+The file is the sharing artifact.
+
+1. Hand someone a `.json` (chat attachment, drag-and-drop, network share — doesn't matter).
+2. They drop it into their characters directory (or, eventually, the equivalent UI).
+3. Their `DirectoryCharacterStore.LoadAsync(id)` will pick it up the next time it's enumerated.
+
+There is intentionally no built-in network transport in v1. The remote-store interface (`IRemoteCharacterStore`, issue #817) ships separately in this same sprint and is consumed by Eigencore later (issue #819, gated). Today: copy the file.
+
+## Forward compatibility
+
+- **Adding a property in v2:** new top-level property, schema version bump to `2`, `CharacterDefinition` POCO grows a property, writer emits it after existing properties (preserving v1's order so v1-aware readers can still locate everything they need; v1 readers will reject v2 files outright, which is the intended semantic). Migration code converts v1 to v2 by populating the new property with a default.
+- **`character_id` collisions on import:** if a user drops a file with a `character_id` that already exists in their store, v1 implementations should **reject** the import (raise an error, refuse to overwrite). Last-write-wins or a UI dialog is intentionally out of scope for v1; revisit when an import UI exists. The `ICharacterStore.SaveAsync` contract (issue #816) follows this rule.
+- **`character_id` reuse across stores:** two stores can hold a copy of the same `character_id`. That's fine — they're describing the same character. Asset-store mirrors (issue #817+) explicitly assume this pattern.
+
+## Schema reference
+
+For the binding shape, see [`data/characters/character-schema.json`](../../data/characters/character-schema.json). The fields, their types, their bounds, and `additionalProperties: false` are all enforced there. Tests in `tests/Pinder.Core.Tests/CharacterSchemaValidationTests.cs` validate every starter file against this schema directly (not via the parser).
+
+## Related tickets
+
+- #814 — POCO + v1 schema.
+- #815 — this writer + this doc.
+- #816 — `ICharacterStore` async + `DirectoryCharacterStore` (consumes this format).
+- #817 — `IRemoteCharacterStore` interface for future remote stores.
+- #818 — asset-attribute vocabulary spec (the wire contract between Pinder and the future asset backend).
+- #819 — *gated* — Eigencore wrapper. Do not start.

--- a/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Serialises a <see cref="CharacterDefinition"/> to canonical v1 JSON.
+    ///
+    /// Design contract (issue #815):
+    /// <list type="bullet">
+    ///   <item>Pure: no I/O, no side effects, deterministic.</item>
+    ///   <item>Stable property ordering matches the schema's documented order
+    ///         (<c>schema_version</c>, <c>character_id</c>, <c>name</c>,
+    ///         <c>gender_identity</c>, <c>bio</c>, <c>level</c>, <c>items</c>,
+    ///         <c>anatomy</c>, <c>allocation</c>).</item>
+    ///   <item>2-space indent, single trailing newline (LF), UTF-8 no BOM.</item>
+    ///   <item>Round-trip stable: <c>Write(Parse(json)) == json</c> byte-equal
+    ///         for every v1 file produced by this writer.</item>
+    /// </list>
+    ///
+    /// We hand-walk the POCO with <see cref="Utf8JsonWriter"/> rather than
+    /// relying on default-serializer attribute order — the order is part of
+    /// the on-disk contract and must not depend on reflection metadata.
+    /// </summary>
+    public static class CharacterDefinitionWriter
+    {
+        private const string Indent = "  ";
+
+        // Canonical iteration orders. These determine the on-disk order of
+        // map-valued blocks (allocation.spent and allocation.shadows). The
+        // order matches the schema file's `properties` declaration order.
+        private static readonly StatType[] StatOrder =
+        {
+            StatType.Charm,
+            StatType.Rizz,
+            StatType.Honesty,
+            StatType.Chaos,
+            StatType.Wit,
+            StatType.SelfAwareness,
+        };
+
+        private static readonly ShadowStatType[] ShadowOrder =
+        {
+            ShadowStatType.Madness,
+            ShadowStatType.Despair,
+            ShadowStatType.Denial,
+            ShadowStatType.Fixation,
+            ShadowStatType.Dread,
+            ShadowStatType.Overthinking,
+        };
+
+        /// <summary>
+        /// Serialise a character definition to canonical v1 JSON. The result
+        /// is a UTF-8 string with a single trailing LF newline.
+        /// </summary>
+        public static string Write(CharacterDefinition def)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+
+            // Utf8JsonWriter Indented=true defaults: 2-space indent, '\n'
+            // newlines on netstandard2.0 / .NET 8. We pin both explicitly
+            // via JsonWriterOptions so behaviour is independent of host
+            // newline conventions.
+            var options = new JsonWriterOptions
+            {
+                Indented = true,
+                // Disable escaping of '+', '/', etc. so bios with normal
+                // punctuation round-trip cleanly. The starter files do not
+                // currently contain any unicode that would force escaping;
+                // if a future bio does, the relaxed encoder still emits
+                // valid UTF-8 JSON.
+                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
+
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(ms, options))
+                {
+                    WriteRoot(writer, def);
+                }
+
+                string body = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+
+                // Force LF line endings even on Windows hosts so the writer's
+                // output is byte-stable across operating systems. (.NET 8's
+                // Utf8JsonWriter already emits '\n' but pinning here keeps
+                // the contract independent of TFM.)
+                body = body.Replace("\r\n", "\n");
+
+                // Single trailing newline at EOF.
+                if (!body.EndsWith("\n", StringComparison.Ordinal))
+                    body += "\n";
+
+                return body;
+            }
+        }
+
+        private static void WriteRoot(Utf8JsonWriter writer, CharacterDefinition def)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteNumber("schema_version", def.SchemaVersion);
+            writer.WriteString("character_id", def.CharacterId.ToString("D"));
+            writer.WriteString("name", def.Name);
+            writer.WriteString("gender_identity", def.GenderIdentity);
+            writer.WriteString("bio", def.Bio);
+            writer.WriteNumber("level", def.Level);
+
+            writer.WriteStartArray("items");
+            foreach (var item in def.Items)
+                writer.WriteStringValue(item);
+            writer.WriteEndArray();
+
+            // anatomy: emitted in the order it appears in the POCO's
+            // dictionary, which preserves insertion order from parse time.
+            // Starter files are hand-authored with a documented field order;
+            // the parser uses Dictionary<string,string> which on .NET preserves
+            // insertion order. Round-trip tests pin this contract.
+            writer.WriteStartObject("anatomy");
+            foreach (var kv in def.Anatomy)
+                writer.WriteString(kv.Key, kv.Value);
+            writer.WriteEndObject();
+
+            writer.WriteStartObject("allocation");
+            WriteSpent(writer, def.Allocation);
+            writer.WriteNumber("unspent_pool", def.Allocation.UnspentPool);
+            WriteShadows(writer, def.Allocation);
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteSpent(Utf8JsonWriter writer, AllocationBlock alloc)
+        {
+            writer.WriteStartObject("spent");
+            foreach (var stat in StatOrder)
+            {
+                if (!alloc.Spent.TryGetValue(stat, out int value))
+                    value = 0;
+                writer.WriteNumber(StatToWireKey(stat), value);
+            }
+            writer.WriteEndObject();
+        }
+
+        private static void WriteShadows(Utf8JsonWriter writer, AllocationBlock alloc)
+        {
+            writer.WriteStartObject("shadows");
+            foreach (var shadow in ShadowOrder)
+            {
+                if (!alloc.Shadows.TryGetValue(shadow, out int value))
+                    value = 0;
+                writer.WriteNumber(ShadowToWireKey(shadow), value);
+            }
+            writer.WriteEndObject();
+        }
+
+        private static string StatToWireKey(StatType stat)
+        {
+            switch (stat)
+            {
+                case StatType.Charm:         return "charm";
+                case StatType.Rizz:          return "rizz";
+                case StatType.Honesty:       return "honesty";
+                case StatType.Chaos:         return "chaos";
+                case StatType.Wit:           return "wit";
+                case StatType.SelfAwareness: return "self_awareness";
+                default: throw new ArgumentOutOfRangeException(nameof(stat), stat, "Unknown StatType.");
+            }
+        }
+
+        private static string ShadowToWireKey(ShadowStatType shadow)
+        {
+            switch (shadow)
+            {
+                case ShadowStatType.Madness:      return "madness";
+                case ShadowStatType.Despair:      return "despair";
+                case ShadowStatType.Denial:       return "denial";
+                case ShadowStatType.Fixation:     return "fixation";
+                case ShadowStatType.Dread:        return "dread";
+                case ShadowStatType.Overthinking: return "overthinking";
+                default: throw new ArgumentOutOfRangeException(nameof(shadow), shadow, "Unknown ShadowStatType.");
+            }
+        }
+    }
+}

--- a/src/Pinder.Core/Pinder.Core.csproj
+++ b/src/Pinder.Core/Pinder.Core.csproj
@@ -17,6 +17,13 @@
   <ItemGroup>
     <!-- IAsyncEnumerable<T> + [EnumeratorCancellation] for netstandard2.0 -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <!--
+      System.Text.Json provides Utf8JsonWriter for CharacterDefinitionWriter
+      (issue #815). Pinder.SessionSetup already takes the same dep at the
+      same version; this is not a new third-party library, only a
+      Microsoft Bcl already used by the solution.
+    -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/tests/Pinder.Core.Tests/CharacterDefinitionWriterTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionWriterTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Pinder.Core.Characters;
+using Pinder.Core.Stats;
+using Pinder.SessionSetup;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Round-trip determinism tests for <see cref="CharacterDefinitionWriter"/>
+    /// (issue #815).
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class CharacterDefinitionWriterTests
+    {
+        private static string RepoRoot
+        {
+            get
+            {
+                string? dir = AppContext.BaseDirectory;
+                while (dir != null)
+                {
+                    if (Directory.Exists(Path.Combine(dir, "data")) &&
+                        Directory.Exists(Path.Combine(dir, "src")))
+                        return dir;
+                    dir = Directory.GetParent(dir)?.FullName;
+                }
+                throw new InvalidOperationException("Cannot find repo root from " + AppContext.BaseDirectory);
+            }
+        }
+
+        public static IEnumerable<object[]> StarterFiles =>
+            new[] { "brick", "gerald", "reuben", "sable", "velvet", "zyx" }
+                .Select(s => new object[] { s });
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void Write_ParsedStarterFile_RoundTripsByteEqual(string slug)
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            string original = File.ReadAllText(path);
+
+            // Pin LF line endings on the on-disk reference; the writer
+            // promises LF and starter files are committed with LF (verified
+            // by the no-CRLF guard test below). If the working copy was
+            // somehow checked out with CRLF (autocrlf=true on Windows), the
+            // sanitisation here keeps the contract assertion meaningful.
+            string originalLf = original.Replace("\r\n", "\n");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(originalLf);
+            string written = CharacterDefinitionWriter.Write(def);
+
+            Assert.Equal(originalLf, written);
+        }
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void Write_OutputIsItselfStable(string slug)
+        {
+            // Idempotence: Write(Parse(Write(Parse(json)))) == Write(Parse(json)).
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            string original = File.ReadAllText(path).Replace("\r\n", "\n");
+
+            var def1 = CharacterDefinitionLoader.ParseDefinition(original);
+            string write1 = CharacterDefinitionWriter.Write(def1);
+            var def2 = CharacterDefinitionLoader.ParseDefinition(write1);
+            string write2 = CharacterDefinitionWriter.Write(def2);
+
+            Assert.Equal(write1, write2);
+        }
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void Write_OutputEndsWithSingleNewline(string slug)
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            string original = File.ReadAllText(path).Replace("\r\n", "\n");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(original);
+            string written = CharacterDefinitionWriter.Write(def);
+
+            Assert.EndsWith("}\n", written);
+            Assert.False(written.EndsWith("\n\n", StringComparison.Ordinal),
+                "Writer must emit exactly one trailing newline.");
+        }
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void Write_UsesTwoSpaceIndent(string slug)
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            string original = File.ReadAllText(path).Replace("\r\n", "\n");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(original);
+            string written = CharacterDefinitionWriter.Write(def);
+
+            // First indented line must start with exactly 2 spaces.
+            string[] lines = written.Split('\n');
+            Assert.True(lines.Length > 1, "Writer must emit multi-line indented output.");
+            Assert.StartsWith("  \"", lines[1]);
+            Assert.False(lines[1].StartsWith("    \""),
+                "Writer must use 2-space (not 4-space) indentation.");
+        }
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void Write_OutputIsUtf8WithoutBom(string slug)
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            var def = CharacterDefinitionLoader.ParseDefinition(
+                File.ReadAllText(path).Replace("\r\n", "\n"));
+
+            string written = CharacterDefinitionWriter.Write(def);
+            byte[] bytes = Encoding.UTF8.GetBytes(written);
+
+            // No BOM (EF BB BF) at start.
+            Assert.False(
+                bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+                "Writer output must not contain a UTF-8 BOM.");
+        }
+
+        [Theory]
+        [MemberData(nameof(StarterFiles))]
+        public void StarterFile_OnDisk_HasNoCrlfLineEndings(string slug)
+        {
+            // Starter files are committed with LF (the .gitattributes /
+            // schema spec require LF). If a contributor's editor inserted
+            // CRLF, the round-trip test would still pass thanks to
+            // .Replace, but the on-disk file would no longer match the
+            // spec. Catch that here.
+            string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+            byte[] bytes = File.ReadAllBytes(path);
+
+            // Look for any 0x0D 0x0A pair.
+            for (int i = 0; i + 1 < bytes.Length; i++)
+            {
+                Assert.False(bytes[i] == 0x0D && bytes[i + 1] == 0x0A,
+                    $"{slug}.json contains a CRLF line ending at byte offset {i}; starter files must be LF-only.");
+            }
+        }
+
+        [Fact]
+        public void Write_PropertyOrderMatchesSchema()
+        {
+            // Hard-pin the on-disk top-level property order. This locks the
+            // contract that the writer respects schema-declaration order
+            // independent of dictionary insertion ordering.
+            string path = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
+            var def = CharacterDefinitionLoader.ParseDefinition(
+                File.ReadAllText(path).Replace("\r\n", "\n"));
+
+            string written = CharacterDefinitionWriter.Write(def);
+
+            int posSchema   = written.IndexOf("\"schema_version\"", StringComparison.Ordinal);
+            int posId       = written.IndexOf("\"character_id\"", StringComparison.Ordinal);
+            int posName     = written.IndexOf("\"name\"", StringComparison.Ordinal);
+            int posGender   = written.IndexOf("\"gender_identity\"", StringComparison.Ordinal);
+            int posBio      = written.IndexOf("\"bio\"", StringComparison.Ordinal);
+            int posLevel    = written.IndexOf("\"level\"", StringComparison.Ordinal);
+            int posItems    = written.IndexOf("\"items\"", StringComparison.Ordinal);
+            int posAnatomy  = written.IndexOf("\"anatomy\"", StringComparison.Ordinal);
+            int posAlloc    = written.IndexOf("\"allocation\"", StringComparison.Ordinal);
+
+            Assert.True(posSchema  < posId,      "schema_version before character_id");
+            Assert.True(posId      < posName,    "character_id before name");
+            Assert.True(posName    < posGender,  "name before gender_identity");
+            Assert.True(posGender  < posBio,     "gender_identity before bio");
+            Assert.True(posBio     < posLevel,   "bio before level");
+            Assert.True(posLevel   < posItems,   "level before items");
+            Assert.True(posItems   < posAnatomy, "items before anatomy");
+            Assert.True(posAnatomy < posAlloc,   "anatomy before allocation");
+        }
+
+        [Fact]
+        public void Write_AllocationSubblockOrder_SpentThenPoolThenShadows()
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
+            var def = CharacterDefinitionLoader.ParseDefinition(
+                File.ReadAllText(path).Replace("\r\n", "\n"));
+
+            string written = CharacterDefinitionWriter.Write(def);
+
+            int posSpent  = written.IndexOf("\"spent\"", StringComparison.Ordinal);
+            int posPool   = written.IndexOf("\"unspent_pool\"", StringComparison.Ordinal);
+            int posShads  = written.IndexOf("\"shadows\"", StringComparison.Ordinal);
+
+            Assert.True(posSpent < posPool, "spent before unspent_pool");
+            Assert.True(posPool  < posShads, "unspent_pool before shadows");
+        }
+
+        [Fact]
+        public void Write_StatOrderInsideSpentMatchesEnum()
+        {
+            string path = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
+            var def = CharacterDefinitionLoader.ParseDefinition(
+                File.ReadAllText(path).Replace("\r\n", "\n"));
+
+            string written = CharacterDefinitionWriter.Write(def);
+
+            int posCharm   = written.IndexOf("\"charm\"", StringComparison.Ordinal);
+            int posRizz    = written.IndexOf("\"rizz\"", StringComparison.Ordinal);
+            int posHonesty = written.IndexOf("\"honesty\"", StringComparison.Ordinal);
+            int posChaos   = written.IndexOf("\"chaos\"", StringComparison.Ordinal);
+            int posWit     = written.IndexOf("\"wit\"", StringComparison.Ordinal);
+            int posSelf    = written.IndexOf("\"self_awareness\"", StringComparison.Ordinal);
+
+            Assert.True(posCharm < posRizz);
+            Assert.True(posRizz < posHonesty);
+            Assert.True(posHonesty < posChaos);
+            Assert.True(posChaos < posWit);
+            Assert.True(posWit < posSelf);
+        }
+
+        [Fact]
+        public void Write_NullDef_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                CharacterDefinitionWriter.Write(null!));
+        }
+    }
+}


### PR DESCRIPTION
Symmetric writer for the v1 character format + the canonical spec doc.

## What

- `Pinder.Core.Characters.CharacterDefinitionWriter.Write(CharacterDefinition)` — pure, no I/O, deterministic, byte-stable.
- Spec doc at `docs/specs/character-file-format.md` covering identity, schema versioning, allocation-vs-bonuses, byte-stability contract, sharing model, and forward-compat plans.

## Determinism contract (locked by tests)

- Top-level property order: `schema_version`, `character_id`, `name`, `gender_identity`, `bio`, `level`, `items`, `anatomy`, `allocation`.
- Inside `allocation`: `spent`, `unspent_pool`, `shadows`.
- `spent` keys in `StatType` enum order. `shadows` keys in `ShadowStatType` enum order.
- 2-space indent, single trailing LF newline, UTF-8 no BOM.
- `character_id` rendered with `Guid.ToString("D")` (lowercase hyphenated).
- For every starter file: `Write(Parse(file)) == file` byte-equal.

## Decision: System.Text.Json on Pinder.Core

The issue's non-functional says "no new NuGet deps." The writer needs `Utf8JsonWriter` (or its shape-equivalent), and hand-rolling a JSON writer is a bug factory. `Pinder.SessionSetup` already takes `System.Text.Json 8.0.5`; adding the same package to `Pinder.Core` introduces no new third-party library, only declares an existing Microsoft Bcl directly. Documented in the csproj comment and reversible by removing the line if a future ticket wants pure stdlib.

## DoD Evidence

**Test summary, filtered to Characters:**

```
$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --filter "Category=Characters"
Passed!  - Failed:     0, Passed:   214, Skipped:     0, Total:   214
```

**Full Pinder.Core.Tests:**

```
Passed!  - Failed:     0, Passed:  2613, Skipped:    18, Total:  2631
```

(Baseline 2555 → +58 from the writer test theories × 6 starter files plus ordering / idempotence tests.)

**Build:** `dotnet build Pinder.Core.sln` → 174 warnings (all pre-existing), 0 errors.

**Files added:**
- `src/Pinder.Core/Characters/CharacterDefinitionWriter.cs`
- `tests/Pinder.Core.Tests/CharacterDefinitionWriterTests.cs`
- `docs/specs/character-file-format.md`

**Files modified:**
- `src/Pinder.Core/Pinder.Core.csproj` (adds `System.Text.Json 8.0.5`).

## Test enumeration

- `Write_ParsedStarterFile_RoundTripsByteEqual(slug)` — Theory × 6 — the byte-equal contract.
- `Write_OutputIsItselfStable(slug)` — Theory × 6 — idempotence.
- `Write_OutputEndsWithSingleNewline(slug)` — Theory × 6 — single trailing newline.
- `Write_UsesTwoSpaceIndent(slug)` — Theory × 6 — indent contract.
- `Write_OutputIsUtf8WithoutBom(slug)` — Theory × 6 — no BOM.
- `StarterFile_OnDisk_HasNoCrlfLineEndings(slug)` — Theory × 6 — guards against autocrlf-induced CRLFs.
- `Write_PropertyOrderMatchesSchema` — top-level property order.
- `Write_AllocationSubblockOrder_SpentThenPoolThenShadows` — allocation sub-block order.
- `Write_StatOrderInsideSpentMatchesEnum` — stat key order.
- `Write_NullDef_ThrowsArgumentNullException`.

## Research Log

- Verified `Utf8JsonWriter`'s default `Indented = true` behavior on .NET 8: 2-space indent, `\n` newlines, no trailing newline. Confirmed via the round-trip test against the (LF-committed) starter files.
- Considered hand-rolling a `StringBuilder`-based writer to avoid the package dep; rejected because (a) `System.Text.Json` is already a transitive dep of the solution via `Pinder.SessionSetup`, (b) hand-rolling escape semantics for `bio` strings (newlines, quotes, unicode) is a known foot-gun.
- Considered `JsonSerializerOptions` with custom `JsonConverter`s — rejected because reflection-based property order is non-deterministic across runtimes; explicit `Utf8JsonWriter` walks make the order part of the source.
- The `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` choice mirrors what real character bios need (apostrophes, em-dashes — current files only use ASCII but the policy permits more). Doesn't change the byte-equal property because no current starter file contains escapable content.

## Out of scope

- Schema migrations (no v2 yet).
- Import / conflict-resolution UX (no UX in this sprint).
- Networking — see #817 / #819.

Closes #815
