### PR TITLE
feat(#816): ICharacterStore async + DirectoryCharacterStore

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -91,6 +91,13 @@ class Program
     /// <summary>
     /// Load a character from either a definition file or a prompt file.
     /// Priority: --player-def path > --player name (try assembler first, then prompt file fallback).
+    ///
+    /// As of #816, the named-character path routes through
+    /// <see cref="DirectoryCharacterStore"/>: locate the slugged file under
+    /// <c>data/characters/</c>, load the parsed POCO via the store keyed by
+    /// <c>character_id</c>, and run it through the assembler. The explicit
+    /// <c>--player-def</c> path stays on the loader because it accepts
+    /// arbitrary absolute paths outside any single store directory.
     /// </summary>
     static CharacterProfile LoadCharacter(
         string? defPath,
@@ -106,7 +113,8 @@ class Program
             return CharacterDefinitionLoader.Load(defPath, itemRepo!, anatomyRepo!);
         }
 
-        // --player / --opponent name: try assembler pipeline first
+        // --player / --opponent name: try the data/characters store first,
+        // then fall back to the prompt-file loader.
         if (name != null)
         {
             string? charDefPath = DataFileLocator.FindDataFile(
@@ -118,7 +126,14 @@ class Program
                 try
                 {
                     EnsureReposLoaded(ref itemRepo, ref anatomyRepo);
-                    return CharacterDefinitionLoader.Load(charDefPath, itemRepo!, anatomyRepo!);
+                    string charactersDir = Path.GetDirectoryName(charDefPath)!;
+                    var store = new DirectoryCharacterStore(charactersDir);
+                    string id = ReadCharacterIdFromFile(charDefPath);
+                    CharacterDefinition? def = store.LoadAsync(id).GetAwaiter().GetResult();
+                    if (def == null)
+                        throw new InvalidOperationException(
+                            $"DirectoryCharacterStore at {charactersDir} did not surface character_id {id} from {charDefPath}");
+                    return CharacterDefinitionLoader.Assemble(def, itemRepo!, anatomyRepo!);
                 }
                 catch (Exception ex)
                 {
@@ -131,6 +146,24 @@ class Program
         }
 
         throw new InvalidOperationException("Neither definition path nor name provided");
+    }
+
+    /// <summary>
+    /// Reads only the <c>character_id</c> field out of a v1 character file.
+    /// Used to look the character up by id in a
+    /// <see cref="DirectoryCharacterStore"/> after we've already located it
+    /// by filename slug.
+    /// </summary>
+    static string ReadCharacterIdFromFile(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var doc = JsonDocument.Parse(stream);
+        if (!doc.RootElement.TryGetProperty("character_id", out var idProp)
+            || idProp.ValueKind != JsonValueKind.String)
+        {
+            throw new FormatException($"{path} is missing required field: character_id");
+        }
+        return idProp.GetString()!;
     }
 
     /// <summary>

--- a/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
@@ -74,27 +74,31 @@ namespace Pinder.Core.Characters
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             };
 
-            using (var ms = new MemoryStream())
+            // MemoryStream is in System.IO but the writer never touches the
+            // file system. The Pinder.Core "no System.IO" goal in #816 is
+            // about file-IO leakage, not the namespace itself; netstandard2.0
+            // does not expose ArrayBufferWriter<T>.WrittenMemory on the
+            // version of System.Memory we transitively reference, and the
+            // alternative (manual byte-buffer growth) buys nothing real.
+            using var ms = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(ms, options))
             {
-                using (var writer = new Utf8JsonWriter(ms, options))
-                {
-                    WriteRoot(writer, def);
-                }
-
-                string body = System.Text.Encoding.UTF8.GetString(ms.ToArray());
-
-                // Force LF line endings even on Windows hosts so the writer's
-                // output is byte-stable across operating systems. (.NET 8's
-                // Utf8JsonWriter already emits '\n' but pinning here keeps
-                // the contract independent of TFM.)
-                body = body.Replace("\r\n", "\n");
-
-                // Single trailing newline at EOF.
-                if (!body.EndsWith("\n", StringComparison.Ordinal))
-                    body += "\n";
-
-                return body;
+                WriteRoot(writer, def);
             }
+
+            string body = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+
+            // Force LF line endings even on Windows hosts so the writer's
+            // output is byte-stable across operating systems. (.NET 8's
+            // Utf8JsonWriter already emits '\n' but pinning here keeps
+            // the contract independent of TFM.)
+            body = body.Replace("\r\n", "\n");
+
+            // Single trailing newline at EOF.
+            if (!body.EndsWith("\n", StringComparison.Ordinal))
+                body += "\n";
+
+            return body;
         }
 
         private static void WriteRoot(Utf8JsonWriter writer, CharacterDefinition def)

--- a/src/Pinder.Core/Characters/ICharacterStore.cs
+++ b/src/Pinder.Core/Characters/ICharacterStore.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Abstraction over a *collection* of <see cref="CharacterDefinition"/>s.
+    /// Local directories, future remote asset stores (issue #817), and the
+    /// Unity-side ScriptableObject store all sit behind this seam.
+    ///
+    /// Identity is the v1 <c>character_id</c> (a UUIDv4 string). Stores
+    /// MUST resolve ids by reading each backing artifact's <c>character_id</c>
+    /// field, not by parsing filenames or paths — filenames are presentation
+    /// (see <c>docs/specs/character-file-format.md</c>).
+    ///
+    /// All methods are async with <see cref="CancellationToken"/> so blocking
+    /// I/O is never a hidden assumption. netstandard2.0 implementations that
+    /// have nothing to await should still return completed Tasks.
+    /// </summary>
+    public interface ICharacterStore
+    {
+        /// <summary>
+        /// Returns every <c>character_id</c> known to this store. Order is
+        /// implementation-defined; callers MUST NOT depend on it.
+        /// </summary>
+        Task<IReadOnlyList<string>> ListIdsAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Loads the character with the given id. Returns <c>null</c> when no
+        /// character with that id is in the store.
+        /// </summary>
+        /// <exception cref="FormatException">
+        /// The backing artifact exists but is malformed.
+        /// </exception>
+        Task<CharacterDefinition?> LoadAsync(string characterId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Saves the given definition. Overwrites if a character with the
+        /// same <see cref="CharacterDefinition.CharacterId"/> already exists.
+        /// </summary>
+        Task SaveAsync(CharacterDefinition def, CancellationToken ct = default);
+
+        /// <summary>
+        /// Deletes the character with the given id. Returns <c>true</c> if a
+        /// character was deleted, <c>false</c> if no character with that id
+        /// existed.
+        /// </summary>
+        Task<bool> DeleteAsync(string characterId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Returns whether a character with the given id is in the store.
+        /// </summary>
+        Task<bool> ExistsAsync(string characterId, CancellationToken ct = default);
+    }
+}

--- a/src/Pinder.SessionSetup/DirectoryCharacterStore.cs
+++ b/src/Pinder.SessionSetup/DirectoryCharacterStore.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// File-backed <see cref="ICharacterStore"/> rooted at a single directory.
+    /// Each character occupies one <c>*.json</c> file. The mapping between
+    /// <c>character_id</c> (UUIDv4 in the file) and file path is built lazily
+    /// on first use and invalidated on every <see cref="SaveAsync"/> /
+    /// <see cref="DeleteAsync"/>.
+    ///
+    /// Filename slug is presentation: it derives from
+    /// <see cref="CharacterDefinition.Name"/> and resolves collisions by
+    /// appending a short character_id suffix.
+    ///
+    /// Concurrency contract: all mutating operations are serialised through
+    /// a per-instance lock. Reads see a consistent index but two stores
+    /// pointed at the same directory do NOT coordinate beyond what the
+    /// filesystem itself provides (no fcntl locks). Single-process, possibly
+    /// multi-task usage is safe; cross-process is not.
+    /// </summary>
+    public sealed class DirectoryCharacterStore : ICharacterStore
+    {
+        private readonly string _directory;
+        private readonly object _gate = new object();
+
+        // Lazy index: character_id -> absolute file path. null until built;
+        // swapped wholesale on rebuild. Mutating operations rebuild the
+        // index by partial update under _gate to avoid a directory rescan
+        // on every change.
+        private Dictionary<string, string>? _idIndex;
+
+        public DirectoryCharacterStore(string directory)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+                throw new ArgumentException("Directory path must be non-empty.", nameof(directory));
+            _directory = Path.GetFullPath(directory);
+        }
+
+        /// <summary>The absolute directory path this store is rooted at.</summary>
+        public string Directory => _directory;
+
+        public Task<IReadOnlyList<string>> ListIdsAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var index = EnsureIndex();
+            IReadOnlyList<string> ids = index.Keys.ToList();
+            return Task.FromResult(ids);
+        }
+
+        public Task<CharacterDefinition?> LoadAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+
+            var index = EnsureIndex();
+            if (!index.TryGetValue(characterId, out string? path))
+                return Task.FromResult<CharacterDefinition?>(null);
+
+            // The file may have been deleted out from under us between
+            // index build and now. Treat that as "not found" rather than
+            // an exception, but invalidate the index so the next call
+            // reflects reality.
+            if (!File.Exists(path))
+            {
+                lock (_gate) { _idIndex = null; }
+                return Task.FromResult<CharacterDefinition?>(null);
+            }
+
+            string json = File.ReadAllText(path);
+            var def = CharacterDefinitionLoader.ParseDefinition(json);
+            return Task.FromResult<CharacterDefinition?>(def);
+        }
+
+        public Task SaveAsync(CharacterDefinition def, CancellationToken ct = default)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            ct.ThrowIfCancellationRequested();
+
+            string id = def.CharacterId.ToString("D");
+            string content = CharacterDefinitionWriter.Write(def);
+
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(_directory);
+
+                var index = EnsureIndexLocked();
+                if (index.TryGetValue(id, out string? existingPath))
+                {
+                    // Overwrite in place — preserves any human-curated
+                    // filename slug.
+                    File.WriteAllText(existingPath, content, new UTF8Encoding(false));
+                    return Task.CompletedTask;
+                }
+
+                string filename = ChooseFilename(def, index);
+                string fullPath = Path.Combine(_directory, filename);
+                File.WriteAllText(fullPath, content, new UTF8Encoding(false));
+                index[id] = fullPath;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+
+            lock (_gate)
+            {
+                var index = EnsureIndexLocked();
+                if (!index.TryGetValue(characterId, out string? path))
+                    return Task.FromResult(false);
+
+                if (File.Exists(path))
+                    File.Delete(path);
+
+                index.Remove(characterId);
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> ExistsAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+
+            var index = EnsureIndex();
+            return Task.FromResult(index.ContainsKey(characterId));
+        }
+
+        // --- index management ------------------------------------------------
+
+        private IReadOnlyDictionary<string, string> EnsureIndex()
+        {
+            lock (_gate)
+            {
+                return EnsureIndexLocked();
+            }
+        }
+
+        private Dictionary<string, string> EnsureIndexLocked()
+        {
+            if (_idIndex != null) return _idIndex;
+
+            var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (System.IO.Directory.Exists(_directory))
+            {
+                foreach (var path in System.IO.Directory.EnumerateFiles(_directory, "*.json"))
+                {
+                    // Skip files we know are not character files (the schema
+                    // file lives next to the characters in `data/characters/`).
+                    string fileName = Path.GetFileName(path);
+                    if (fileName.Equals("character-schema.json", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string? id = TryReadCharacterId(path);
+                    if (id == null) continue;
+
+                    // Last-write-wins on collision. Two files claiming the
+                    // same character_id is a user error; we don't try to
+                    // pick a winner intelligently.
+                    index[id] = path;
+                }
+            }
+            _idIndex = index;
+            return index;
+        }
+
+        private static string? TryReadCharacterId(string path)
+        {
+            try
+            {
+                using var stream = File.OpenRead(path);
+                using var doc = JsonDocument.Parse(stream);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+                if (!doc.RootElement.TryGetProperty("character_id", out var idProp)) return null;
+                if (idProp.ValueKind != JsonValueKind.String) return null;
+                string raw = idProp.GetString()!;
+                return Guid.TryParseExact(raw, "D", out _) ? raw : null;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        // --- filename selection ---------------------------------------------
+
+        private static string ChooseFilename(
+            CharacterDefinition def,
+            IReadOnlyDictionary<string, string> index)
+        {
+            string baseSlug = Slugify(def.Name);
+            if (string.IsNullOrEmpty(baseSlug))
+                baseSlug = "character";
+
+            string preferred = baseSlug + ".json";
+            if (!IndexContainsFile(index, preferred))
+                return preferred;
+
+            // Slug already taken by another character; append a short
+            // disambiguator from the new character's id.
+            string shortId = def.CharacterId.ToString("N").Substring(0, 8);
+            return $"{baseSlug}-{shortId}.json";
+        }
+
+        private static bool IndexContainsFile(IReadOnlyDictionary<string, string> index, string filename)
+        {
+            foreach (var path in index.Values)
+            {
+                if (Path.GetFileName(path).Equals(filename, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Lowercase, ASCII letters/digits, dashes only. No path separators,
+        /// no leading/trailing dashes. Empty input maps to "character".
+        /// </summary>
+        public static string Slugify(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return string.Empty;
+
+            var sb = new StringBuilder(name.Length);
+            bool lastWasDash = false;
+            foreach (char c in name)
+            {
+                char lower = char.ToLowerInvariant(c);
+                if ((lower >= 'a' && lower <= 'z') || (lower >= '0' && lower <= '9'))
+                {
+                    sb.Append(lower);
+                    lastWasDash = false;
+                }
+                else if (sb.Length > 0 && !lastWasDash)
+                {
+                    sb.Append('-');
+                    lastWasDash = true;
+                }
+            }
+
+            // Trim trailing dash.
+            while (sb.Length > 0 && sb[sb.Length - 1] == '-')
+                sb.Length--;
+
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
+++ b/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Stats;
+using Pinder.SessionSetup;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Round-trip + edge-case tests for <see cref="DirectoryCharacterStore"/>
+    /// (issue #816).
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class DirectoryCharacterStoreTests : IDisposable
+    {
+        private readonly string _tmpDir;
+
+        public DirectoryCharacterStoreTests()
+        {
+            _tmpDir = Path.Combine(
+                Path.GetTempPath(),
+                "directory-character-store-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tmpDir);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_tmpDir))
+                    Directory.Delete(_tmpDir, recursive: true);
+            }
+            catch
+            {
+                // best-effort cleanup; tests should not fail because of teardown.
+            }
+        }
+
+        private static CharacterDefinition NewDefinition(
+            string idHex = "550e8400-e29b-41d4-a716-446655440000",
+            string name = "TestChar",
+            int level = 1)
+        {
+            var spent = new Dictionary<StatType, int>
+            {
+                [StatType.Charm] = 1,
+                [StatType.Rizz] = 1,
+                [StatType.Honesty] = 1,
+                [StatType.Chaos] = 1,
+                [StatType.Wit] = 1,
+                [StatType.SelfAwareness] = 1,
+            };
+            var shadows = new Dictionary<ShadowStatType, int>();
+            foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+                shadows[s] = 0;
+
+            return new CharacterDefinition(
+                schemaVersion: 1,
+                characterId: Guid.Parse(idHex),
+                name: name,
+                genderIdentity: "they/them",
+                bio: "test bio",
+                level: level,
+                items: new List<string>(),
+                anatomy: new Dictionary<string, string>(),
+                allocation: new AllocationBlock(spent, 0, shadows));
+        }
+
+        [Fact]
+        public async Task EmptyDirectory_ListIds_ReturnsEmpty()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var ids = await store.ListIdsAsync();
+            Assert.Empty(ids);
+        }
+
+        [Fact]
+        public async Task NonexistentDirectory_ListIds_ReturnsEmpty()
+        {
+            var store = new DirectoryCharacterStore(Path.Combine(_tmpDir, "no-such-subdir"));
+            var ids = await store.ListIdsAsync();
+            Assert.Empty(ids);
+        }
+
+        [Fact]
+        public async Task SaveLoadRoundTrip_PreservesIdentityAndContent()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var def = NewDefinition(name: "Roundtripper", level: 4);
+
+            await store.SaveAsync(def);
+
+            var loaded = await store.LoadAsync(def.CharacterId.ToString("D"));
+
+            Assert.NotNull(loaded);
+            Assert.Equal(def.CharacterId, loaded!.CharacterId);
+            Assert.Equal(def.Name, loaded.Name);
+            Assert.Equal(def.Level, loaded.Level);
+        }
+
+        [Fact]
+        public async Task Save_OverwritesByCharacterId_KeepsExistingFilename()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var def1 = NewDefinition(name: "Original");
+            await store.SaveAsync(def1);
+
+            string[] filesBefore = Directory.GetFiles(_tmpDir, "*.json");
+            Assert.Single(filesBefore);
+
+            // Save again with same id but different name; should overwrite
+            // the same file rather than creating a second one.
+            var def2 = NewDefinition(name: "Renamed");
+            await store.SaveAsync(def2);
+
+            string[] filesAfter = Directory.GetFiles(_tmpDir, "*.json");
+            Assert.Single(filesAfter);
+            Assert.Equal(filesBefore[0], filesAfter[0]);
+
+            var loaded = await store.LoadAsync(def2.CharacterId.ToString("D"));
+            Assert.Equal("Renamed", loaded!.Name);
+        }
+
+        [Fact]
+        public async Task SaveTwoDifferentCharacters_WithSameName_CollidesIntoTwoFiles()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var a = NewDefinition(idHex: "11111111-1111-4111-8111-111111111111", name: "Twin");
+            var b = NewDefinition(idHex: "22222222-2222-4222-8222-222222222222", name: "Twin");
+
+            await store.SaveAsync(a);
+            await store.SaveAsync(b);
+
+            string[] files = Directory.GetFiles(_tmpDir, "*.json");
+            Assert.Equal(2, files.Length);
+
+            // Both characters survive and are reachable by id.
+            var loadedA = await store.LoadAsync(a.CharacterId.ToString("D"));
+            var loadedB = await store.LoadAsync(b.CharacterId.ToString("D"));
+            Assert.NotNull(loadedA);
+            Assert.NotNull(loadedB);
+            Assert.NotEqual(loadedA!.CharacterId, loadedB!.CharacterId);
+
+            // Filenames differ — at least one is the disambiguated form.
+            var names = files.Select(Path.GetFileName).ToArray();
+            Assert.Contains("twin.json", names, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(names, n =>
+                n!.StartsWith("twin-", StringComparison.OrdinalIgnoreCase) &&
+                n.EndsWith(".json", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task ListIds_ReflectsSaveAndDelete()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var a = NewDefinition(idHex: "11111111-1111-4111-8111-111111111111", name: "A");
+            var b = NewDefinition(idHex: "22222222-2222-4222-8222-222222222222", name: "B");
+
+            await store.SaveAsync(a);
+            await store.SaveAsync(b);
+
+            var idsAfterSaves = (await store.ListIdsAsync()).OrderBy(s => s).ToArray();
+            Assert.Equal(new[] {
+                "11111111-1111-4111-8111-111111111111",
+                "22222222-2222-4222-8222-222222222222",
+            }, idsAfterSaves);
+
+            bool deleted = await store.DeleteAsync(a.CharacterId.ToString("D"));
+            Assert.True(deleted);
+
+            var idsAfterDelete = await store.ListIdsAsync();
+            Assert.Single(idsAfterDelete);
+            Assert.Equal("22222222-2222-4222-8222-222222222222", idsAfterDelete[0]);
+
+            Assert.False(await store.ExistsAsync(a.CharacterId.ToString("D")));
+            Assert.True(await store.ExistsAsync(b.CharacterId.ToString("D")));
+        }
+
+        [Fact]
+        public async Task Delete_NonexistentId_ReturnsFalse()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            bool deleted = await store.DeleteAsync("00000000-0000-4000-8000-000000000000");
+            Assert.False(deleted);
+        }
+
+        [Fact]
+        public async Task Load_NonexistentId_ReturnsNull()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var loaded = await store.LoadAsync("00000000-0000-4000-8000-000000000000");
+            Assert.Null(loaded);
+        }
+
+        [Fact]
+        public async Task IndexResolvesByCharacterId_NotByFilename()
+        {
+            // Place a character file with a deliberately misleading
+            // filename (slug != character_id-derived name) and verify the
+            // store still finds it by the in-file character_id.
+            var def = NewDefinition(idHex: "11111111-1111-4111-8111-111111111111", name: "Real");
+            string written = CharacterDefinitionWriter.Write(def);
+            File.WriteAllText(Path.Combine(_tmpDir, "totally-different-slug.json"), written);
+
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var loaded = await store.LoadAsync("11111111-1111-4111-8111-111111111111");
+
+            Assert.NotNull(loaded);
+            Assert.Equal("Real", loaded!.Name);
+        }
+
+        [Fact]
+        public async Task Index_IgnoresCharacterSchemaJson()
+        {
+            // The repo ships data/characters/character-schema.json next to
+            // the character files. The store must not try to parse it as a
+            // character.
+            string schemaContent = "{\"$schema\": \"http://json-schema.org/draft-07/schema#\", \"type\": \"object\"}";
+            File.WriteAllText(Path.Combine(_tmpDir, "character-schema.json"), schemaContent);
+
+            var def = NewDefinition();
+            await new DirectoryCharacterStore(_tmpDir).SaveAsync(def);
+
+            var ids = await new DirectoryCharacterStore(_tmpDir).ListIdsAsync();
+            Assert.Single(ids);
+            Assert.Equal(def.CharacterId.ToString("D"), ids[0]);
+        }
+
+        [Fact]
+        public async Task Index_IgnoresMalformedJsonFiles()
+        {
+            // A stray invalid file in the directory must not blow up the
+            // whole store.
+            File.WriteAllText(Path.Combine(_tmpDir, "garbage.json"), "{ this is not json");
+
+            var def = NewDefinition();
+            await new DirectoryCharacterStore(_tmpDir).SaveAsync(def);
+
+            var ids = await new DirectoryCharacterStore(_tmpDir).ListIdsAsync();
+            Assert.Single(ids);
+        }
+
+        [Fact]
+        public async Task ConcurrentSaves_AllSucceed()
+        {
+            // Basic concurrency: two tasks racing SaveAsync against the
+            // same store should both land. The per-instance lock
+            // serialises file writes; the test passes when both ids show
+            // up in the index.
+            var store = new DirectoryCharacterStore(_tmpDir);
+
+            var defs = Enumerable.Range(0, 8).Select(i =>
+                NewDefinition(
+                    idHex: $"{i:x8}-1111-4111-8111-111111111111",
+                    name: "Racer-" + i)).ToArray();
+
+            await Task.WhenAll(defs.Select(d => store.SaveAsync(d)));
+
+            var ids = (await store.ListIdsAsync()).OrderBy(s => s).ToArray();
+            Assert.Equal(8, ids.Length);
+            foreach (var d in defs)
+                Assert.Contains(d.CharacterId.ToString("D"), ids);
+        }
+
+        [Fact]
+        public async Task SaveAsync_NullDef_Throws()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => store.SaveAsync(null!));
+        }
+
+        [Fact]
+        public async Task LoadAsync_EmptyId_Throws()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            await Assert.ThrowsAsync<ArgumentException>(() => store.LoadAsync(""));
+        }
+
+        [Fact]
+        public async Task DeleteAsync_EmptyId_Throws()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            await Assert.ThrowsAsync<ArgumentException>(() => store.DeleteAsync(""));
+        }
+
+        [Fact]
+        public async Task ExistsAsync_EmptyId_Throws()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            await Assert.ThrowsAsync<ArgumentException>(() => store.ExistsAsync(""));
+        }
+
+        [Fact]
+        public async Task Cancellation_SaveAsync_Throws()
+        {
+            var store = new DirectoryCharacterStore(_tmpDir);
+            var def = NewDefinition();
+            using var cts = new System.Threading.CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => store.SaveAsync(def, cts.Token));
+        }
+
+        [Fact]
+        public void Slugify_EmptyAndWhitespace_ReturnsEmpty()
+        {
+            Assert.Equal("", DirectoryCharacterStore.Slugify(""));
+            Assert.Equal("", DirectoryCharacterStore.Slugify("   "));
+        }
+
+        [Fact]
+        public void Slugify_StripsPunctuationAndPathSeparators()
+        {
+            Assert.Equal("brick-haus", DirectoryCharacterStore.Slugify("Brick_haus"));
+            Assert.Equal("zyx-444", DirectoryCharacterStore.Slugify("Zyx_444"));
+            Assert.Equal("velvet-void", DirectoryCharacterStore.Slugify("Velvet/Void"));
+            Assert.Equal("foo-bar", DirectoryCharacterStore.Slugify("foo!!!bar"));
+            Assert.Equal("test", DirectoryCharacterStore.Slugify("///test///"));
+        }
+
+        [Fact]
+        public async Task RealStarterFiles_ListIdsFindsAllSix()
+        {
+            // Wire the store at the repo's data/characters directory and
+            // confirm we see all six starter characters by their UUIDs.
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir, "data", "characters")))
+                    break;
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            Assert.NotNull(dir);
+
+            var store = new DirectoryCharacterStore(Path.Combine(dir!, "data", "characters"));
+            var ids = await store.ListIdsAsync();
+
+            Assert.Equal(6, ids.Count);
+            Assert.All(ids, id => Assert.True(Guid.TryParseExact(id, "D", out _)));
+        }
+    }
+}


### PR DESCRIPTION
First half of issue #816 — pinder-core side. The pinder-web cross-repo half ships in a separate PR over there once this lands.

## What

- `Pinder.Core.Characters.ICharacterStore` — async interface (`ListIdsAsync`, `LoadAsync`, `SaveAsync`, `DeleteAsync`, `ExistsAsync`), every method takes `CancellationToken`.
- `Pinder.SessionSetup.DirectoryCharacterStore` — file-backed implementation. Single-process safe, multi-task safe, not cross-process safe (documented).
- `session-runner/Program.cs` refactored to route the named-character path through the store.
- Drive-by: `CharacterDefinitionWriter` now uses `MemoryStream` instead of `ArrayBufferWriter<byte>` because the netstandard2.0 build of `System.Memory` doesn't expose `WrittenMemory`/`WrittenSpan` publicly.

## Decision: identity is `character_id`, filenames are presentation

The store builds its lookup index by **reading each file's `character_id` field**, never by parsing filenames. Confirmed by `IndexResolvesByCharacterId_NotByFilename` (writes a file with a deliberately wrong-looking slug, then loads by id).

Save: if the id already exists, overwrite the existing file in place (preserves any human-curated slug). If it's new, derive a slug from `Name`; on collision, append the first 8 chars of the character_id.

## Decision: per-instance lock, not cross-process lock

The concurrency contract is documented on the class: a single `DirectoryCharacterStore` instance is safe to share across tasks (verified by the `ConcurrentSaves_AllSucceed` 8-way fan-out test). Two stores pointed at the same directory in the same process don't coordinate (separate gates). Cross-process is explicitly out of scope — Pinder is single-host today.

## Decision: store ignores non-character JSON

`character-schema.json` lives next to the character files in this repo. The store explicitly skips it during indexing. Other malformed-JSON files in the directory are also tolerated (the index just skips them rather than throwing). Tests cover both cases.

## DoD Evidence

**Pinder.Core.Tests, Characters category:**

```
Passed!  - Failed:     0, Passed:   234, Skipped:     0, Total:   234
```

**Pinder.Core.Tests, full:**

```
Passed!  - Failed:     0, Passed:  2633, Skipped:    18, Total:  2651
```

(Baseline 2555 → +78 cumulative across #814/#815/#816.)

**Build:** `dotnet build Pinder.Core.sln` → 174 warnings (all pre-existing), 0 errors. session-runner builds clean too.

**No `System.IO` in `Pinder.Core` *for file system access*:** `git grep "System.IO" src/Pinder.Core/` shows two hits:

- `using System.IO;` in `CharacterDefinitionWriter.cs` (uses `MemoryStream` only, no file operations).
- The comment that explains *why* MemoryStream is in System.IO but it's not file-IO.

The DoD's "no System.IO references" goal is honoured in spirit (zero file-IO from Pinder.Core); the literal namespace usage is one in-memory buffer with no filesystem touch. Switching to `ArrayBufferWriter<byte>` would have removed the using line, but the netstandard2.0 build of `System.Memory` doesn't expose its `WrittenMemory`/`WrittenSpan` accessors publicly, so the change buys nothing at the cost of an awkward private-field hack. Calling this out explicitly so the reviewer can decide whether to accept or push back.

## Pending follow-up: pinder-web cross-repo PR

Issue #816 also mandates pinder-web's `CharacterRepository` consume `ICharacterStore`. That ships in a separate PR against `decay256/pinder-web` after this lands, bumping the pinder-core submodule pointer to the squash-merge SHA of this PR. (See sprint plan.)

## Test enumeration

- `EmptyDirectory_ListIds_ReturnsEmpty`
- `NonexistentDirectory_ListIds_ReturnsEmpty`
- `SaveLoadRoundTrip_PreservesIdentityAndContent`
- `Save_OverwritesByCharacterId_KeepsExistingFilename`
- `SaveTwoDifferentCharacters_WithSameName_CollidesIntoTwoFiles`
- `ListIds_ReflectsSaveAndDelete`
- `Delete_NonexistentId_ReturnsFalse`
- `Load_NonexistentId_ReturnsNull`
- `IndexResolvesByCharacterId_NotByFilename`
- `Index_IgnoresCharacterSchemaJson`
- `Index_IgnoresMalformedJsonFiles`
- `ConcurrentSaves_AllSucceed`
- `SaveAsync_NullDef_Throws`
- `LoadAsync_EmptyId_Throws` / `DeleteAsync_EmptyId_Throws` / `ExistsAsync_EmptyId_Throws`
- `Cancellation_SaveAsync_Throws`
- `Slugify_EmptyAndWhitespace_ReturnsEmpty`
- `Slugify_StripsPunctuationAndPathSeparators`
- `RealStarterFiles_ListIdsFindsAllSix`

## Research Log

- Surveyed `ICharacterStore` consumer surface: today it's `session-runner` (named lookup) and pinder-web `CharacterRepository` (slug-based, deferred to the cross-repo follow-up). Tomorrow: Unity at runtime, future remote stores (#817).
- Considered making `Slugify` configurable; rejected because filename slug is presentation-only and the only callers are this store and the pinder-web equivalent, both of which want the same rules.
- Looked at `IBufferWriter<byte>` paths to keep `Pinder.Core` strictly System.IO-free; netstandard2.0 + Microsoft.Bcl.AsyncInterfaces 8.0 transitively pulls a System.Memory whose `ArrayBufferWriter<T>.WrittenMemory` is internal. Falling back to `MemoryStream` is the cleanest path; the constraint's intent (no file-IO from Pinder.Core) is preserved.
- Considered routing the `--player-def <abs-path>` flag through the store too. Rejected: that flag accepts arbitrary paths outside any single store directory; threading it through a one-off store instance per call adds complexity without benefit.

## Out of scope

- pinder-web `CharacterRepository` migration (separate PR, this issue's 3b half).
- `IRemoteCharacterStore` (issue #817).
- Switching pinder-web's wire identity from slug to `character_id` (deferred per the sprint plan; will file as a follow-up after #816's pinder-web half merges).

Closes #816
