### PR TITLE
feat(#817): IRemoteCharacterStore interface + query/filter contract

### DIFF
--- a/src/Pinder.Core/Characters/CharacterAssetMetadata.cs
+++ b/src/Pinder.Core/Characters/CharacterAssetMetadata.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Server-supplied metadata accompanying a remote character. Opaque to
+    /// the engine: Pinder commits to the field names + types + semantics,
+    /// the asset backend (e.g. Eigencore — gated #819) commits to indexing
+    /// + querying + round-trip preservation.
+    ///
+    /// The full attribute vocabulary (legal tag prefixes, length limits,
+    /// canonical timestamps) is specified in issue #818. This type is
+    /// intentionally only the *shape* of the contract.
+    /// </summary>
+    public sealed class CharacterAssetMetadata
+    {
+        /// <summary>Asset kind discriminator. Today always "character/v1".</summary>
+        public const string AssetKindCharacterV1 = "character/v1";
+
+        /// <summary>UUIDv4 identity of the underlying <see cref="CharacterDefinition"/>.</summary>
+        public string CharacterId { get; }
+
+        /// <summary>
+        /// Owner identity as understood by the asset backend. Format and
+        /// semantics are the backend's contract; the engine treats it as an
+        /// opaque string. Empty string is permitted for ownerless assets
+        /// (e.g. official packs uploaded by a service identity).
+        /// </summary>
+        public string OwnerId { get; }
+
+        /// <summary>
+        /// Author-supplied tags. ALL tags must match in
+        /// <see cref="CharacterAssetQuery.Tags"/> filters. The legal vocabulary
+        /// (reserved prefixes, length / charset limits) is specified in
+        /// issue #818.
+        /// </summary>
+        public IReadOnlyList<string> Tags { get; }
+
+        /// <summary>Whether the asset is publicly discoverable.</summary>
+        public bool IsPublic { get; }
+
+        /// <summary>Server-assigned creation timestamp (UTC).</summary>
+        public DateTimeOffset CreatedAt { get; }
+
+        /// <summary>Server-assigned last-modified timestamp (UTC).</summary>
+        public DateTimeOffset UpdatedAt { get; }
+
+        /// <summary>
+        /// Asset kind discriminator, always
+        /// <see cref="AssetKindCharacterV1"/> ("character/v1") for v1.
+        /// Future kinds (item packs, anatomy packs) reuse the same metadata
+        /// envelope with a different value.
+        /// </summary>
+        public string AssetKind { get; }
+
+        public CharacterAssetMetadata(
+            string characterId,
+            string ownerId,
+            IReadOnlyList<string> tags,
+            bool isPublic,
+            DateTimeOffset createdAt,
+            DateTimeOffset updatedAt,
+            string assetKind = AssetKindCharacterV1)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            CharacterId = characterId;
+            OwnerId = ownerId ?? string.Empty;
+            Tags = tags ?? throw new ArgumentNullException(nameof(tags));
+            IsPublic = isPublic;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            AssetKind = string.IsNullOrWhiteSpace(assetKind) ? AssetKindCharacterV1 : assetKind;
+        }
+    }
+}

--- a/src/Pinder.Core/Characters/CharacterAssetPage.cs
+++ b/src/Pinder.Core/Characters/CharacterAssetPage.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Single page of metadata returned by
+    /// <see cref="IRemoteCharacterStore.QueryAsync"/>. Metadata only — the
+    /// caller fetches each character's payload via
+    /// <see cref="ICharacterStore.LoadAsync"/> on demand.
+    /// </summary>
+    public sealed class CharacterAssetPage
+    {
+        /// <summary>Items in this page, in server-defined order.</summary>
+        public IReadOnlyList<CharacterAssetMetadata> Items { get; }
+
+        /// <summary>
+        /// Pagination cursor for the next page, or <c>null</c> when this is
+        /// the last page. Pass back unchanged in
+        /// <see cref="CharacterAssetQuery.Cursor"/>.
+        /// </summary>
+        public string? NextCursor { get; }
+
+        public CharacterAssetPage(IReadOnlyList<CharacterAssetMetadata> items, string? nextCursor)
+        {
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+            NextCursor = nextCursor;
+        }
+    }
+}

--- a/src/Pinder.Core/Characters/CharacterAssetQuery.cs
+++ b/src/Pinder.Core/Characters/CharacterAssetQuery.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Filter / pagination input for <see cref="IRemoteCharacterStore.QueryAsync"/>.
+    /// All filter properties are AND'd together. Within
+    /// <see cref="Tags"/>, every entry must match (intersection semantics, not
+    /// union).
+    ///
+    /// Defaults: no filters (returns the most recently updated public assets
+    /// the caller has access to), <see cref="Limit"/> = 50.
+    /// </summary>
+    public sealed class CharacterAssetQuery
+    {
+        /// <summary>Maximum legal value of <see cref="Limit"/>.</summary>
+        public const int MaxLimit = 500;
+
+        /// <summary>Default value of <see cref="Limit"/> if the caller omits it.</summary>
+        public const int DefaultLimit = 50;
+
+        /// <summary>
+        /// Filter to assets owned by this owner identity. <c>null</c> means
+        /// "any owner". Empty string is reserved for the explicit
+        /// "ownerless / service-owned" filter.
+        /// </summary>
+        public string? OwnerId { get; }
+
+        /// <summary>
+        /// Required tags. Every tag in this list must appear on the asset's
+        /// <see cref="CharacterAssetMetadata.Tags"/>. <c>null</c> or empty
+        /// means "no tag filter".
+        /// </summary>
+        public IReadOnlyList<string>? Tags { get; }
+
+        /// <summary>
+        /// Filter to public-only or private-only assets. <c>null</c> means
+        /// "no visibility filter" (server may further restrict by auth).
+        /// </summary>
+        public bool? IsPublic { get; }
+
+        /// <summary>
+        /// Maximum number of results to return in this page. 1..<see cref="MaxLimit"/>;
+        /// values outside the range are clamped at construction time.
+        /// </summary>
+        public int Limit { get; }
+
+        /// <summary>
+        /// Opaque pagination cursor returned by a previous
+        /// <see cref="CharacterAssetPage.NextCursor"/>. <c>null</c> requests
+        /// the first page.
+        /// </summary>
+        public string? Cursor { get; }
+
+        public CharacterAssetQuery(
+            string? ownerId = null,
+            IReadOnlyList<string>? tags = null,
+            bool? isPublic = null,
+            int limit = DefaultLimit,
+            string? cursor = null)
+        {
+            OwnerId = ownerId;
+            Tags = tags;
+            IsPublic = isPublic;
+            Limit = ClampLimit(limit);
+            Cursor = cursor;
+        }
+
+        private static int ClampLimit(int requested)
+        {
+            if (requested < 1) return 1;
+            if (requested > MaxLimit) return MaxLimit;
+            return requested;
+        }
+    }
+}

--- a/src/Pinder.Core/Characters/IRemoteCharacterStore.cs
+++ b/src/Pinder.Core/Characters/IRemoteCharacterStore.cs
@@ -1,0 +1,55 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Network-backed character store. Extends <see cref="ICharacterStore"/>
+    /// with server-side discovery (<see cref="QueryAsync"/>), per-asset
+    /// metadata access, and a publish flow that stamps server-controlled
+    /// fields (timestamps, owner identity).
+    ///
+    /// Implementations live outside this repo (the first one is gated under
+    /// issue #819). This interface intentionally has no HTTP / auth /
+    /// network types — those are the implementation's concern.
+    ///
+    /// Drop-in compatibility: a caller that already takes an
+    /// <see cref="ICharacterStore"/> can be handed an
+    /// <see cref="IRemoteCharacterStore"/> and continues to work; the
+    /// remote-specific methods are additive.
+    /// </summary>
+    public interface IRemoteCharacterStore : ICharacterStore
+    {
+        /// <summary>
+        /// Returns one page of metadata matching the given query. Metadata
+        /// only — the caller follows up with
+        /// <see cref="ICharacterStore.LoadAsync"/> for each
+        /// <see cref="CharacterAssetMetadata.CharacterId"/> it actually wants
+        /// to instantiate.
+        /// </summary>
+        Task<CharacterAssetPage> QueryAsync(CharacterAssetQuery query, CancellationToken ct = default);
+
+        /// <summary>
+        /// Returns the metadata for a single character, or <c>null</c> when
+        /// no character with that id is in the store (or is not visible to
+        /// the calling identity).
+        /// </summary>
+        Task<CharacterAssetMetadata?> GetMetadataAsync(string characterId, CancellationToken ct = default);
+
+        /// <summary>
+        /// Publishes a character to the remote store. The server may
+        /// overwrite <see cref="CharacterAssetMetadata.CharacterId"/>,
+        /// <see cref="CharacterAssetMetadata.OwnerId"/>,
+        /// <see cref="CharacterAssetMetadata.CreatedAt"/>,
+        /// <see cref="CharacterAssetMetadata.UpdatedAt"/> on the returned
+        /// metadata; client-supplied <see cref="CharacterAssetMetadata.Tags"/>
+        /// and <see cref="CharacterAssetMetadata.IsPublic"/> flow through
+        /// unchanged on a successful publish.
+        /// </summary>
+        /// <returns>The server's view of the published asset's metadata.</returns>
+        Task<CharacterAssetMetadata> PublishAsync(
+            CharacterDefinition def,
+            CharacterAssetMetadata metadata,
+            CancellationToken ct = default);
+    }
+}

--- a/tests/Pinder.Core.Tests/Characters/IRemoteCharacterStoreContractTests.cs
+++ b/tests/Pinder.Core.Tests/Characters/IRemoteCharacterStoreContractTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Characters
+{
+    /// <summary>
+    /// Contract tests for <see cref="IRemoteCharacterStore"/> exercised
+    /// against the in-memory fake. These also verify that
+    /// <see cref="IRemoteCharacterStore"/> is a drop-in
+    /// <see cref="ICharacterStore"/> per issue #817.
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class IRemoteCharacterStoreContractTests
+    {
+        private static CharacterDefinition NewDef(string idHex, string name = "Tester")
+        {
+            var spent = new Dictionary<StatType, int>
+            {
+                [StatType.Charm] = 1, [StatType.Rizz] = 1, [StatType.Honesty] = 1,
+                [StatType.Chaos] = 1, [StatType.Wit] = 1, [StatType.SelfAwareness] = 1,
+            };
+            var shadows = new Dictionary<ShadowStatType, int>();
+            foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+                shadows[s] = 0;
+            return new CharacterDefinition(
+                schemaVersion: 1,
+                characterId: Guid.Parse(idHex),
+                name: name,
+                genderIdentity: "they/them",
+                bio: "test bio",
+                level: 1,
+                items: Array.Empty<string>(),
+                anatomy: new Dictionary<string, string>(),
+                allocation: new AllocationBlock(spent, 0, shadows));
+        }
+
+        private static CharacterAssetMetadata NewMeta(
+            string idHex,
+            IReadOnlyList<string>? tags = null,
+            bool isPublic = true,
+            string ownerId = "owner:test")
+        {
+            return new CharacterAssetMetadata(
+                characterId: idHex,
+                ownerId: ownerId,
+                tags: tags ?? Array.Empty<string>(),
+                isPublic: isPublic,
+                createdAt: DateTimeOffset.MinValue,
+                updatedAt: DateTimeOffset.MinValue);
+        }
+
+        [Fact]
+        public void IRemoteCharacterStore_IsAlsoAnICharacterStore()
+        {
+            // Drop-in compatibility: a caller that already takes an
+            // ICharacterStore must compile when handed an
+            // IRemoteCharacterStore. Issue #817 treats this as a contract.
+            IRemoteCharacterStore remote = new InMemoryRemoteCharacterStore();
+            ICharacterStore baseShape = remote;
+            Assert.NotNull(baseShape);
+            Assert.True(typeof(ICharacterStore).IsAssignableFrom(typeof(IRemoteCharacterStore)));
+        }
+
+        [Fact]
+        public async Task PublishAsync_ThenLoadAsync_RoundTripsTheDefinition()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            var def = NewDef("11111111-1111-4111-8111-111111111111", name: "Round_Trip");
+
+            var stamped = await store.PublishAsync(def, NewMeta("11111111-1111-4111-8111-111111111111"));
+            Assert.NotEqual(DateTimeOffset.MinValue, stamped.CreatedAt);
+
+            var loaded = await store.LoadAsync(def.CharacterId.ToString("D"));
+            Assert.NotNull(loaded);
+            Assert.Equal(def.CharacterId, loaded!.CharacterId);
+            Assert.Equal("Round_Trip", loaded.Name);
+        }
+
+        [Fact]
+        public async Task PublishAsync_StampsCreatedAtAndUpdatedAt_ServerSide()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            var def = NewDef("11111111-1111-4111-8111-111111111111");
+
+            // Client supplies MinValue; server replaces.
+            var clientMeta = NewMeta("11111111-1111-4111-8111-111111111111");
+            Assert.Equal(DateTimeOffset.MinValue, clientMeta.CreatedAt);
+            Assert.Equal(DateTimeOffset.MinValue, clientMeta.UpdatedAt);
+
+            var stamped = await store.PublishAsync(def, clientMeta);
+
+            Assert.NotEqual(DateTimeOffset.MinValue, stamped.CreatedAt);
+            Assert.NotEqual(DateTimeOffset.MinValue, stamped.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task PublishAsync_PreservesTagsAndVisibilityFromClient()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            var def = NewDef("11111111-1111-4111-8111-111111111111");
+            var meta = NewMeta(
+                "11111111-1111-4111-8111-111111111111",
+                tags: new[] { "official-pack", "starter" },
+                isPublic: true);
+
+            var stamped = await store.PublishAsync(def, meta);
+
+            Assert.Equal(new[] { "official-pack", "starter" }, stamped.Tags.ToArray());
+            Assert.True(stamped.IsPublic);
+        }
+
+        [Fact]
+        public async Task PublishAsync_ReplacesOwnerId_WithServerIdentity()
+        {
+            // The server uses its authenticated identity; the client cannot
+            // claim arbitrary owner ids. Verified by stamping the OwnerId
+            // via SimulatedServiceOwnerId in the fake.
+            var store = new InMemoryRemoteCharacterStore { SimulatedServiceOwnerId = "service:authoritative" };
+            var def = NewDef("11111111-1111-4111-8111-111111111111");
+            var meta = NewMeta("11111111-1111-4111-8111-111111111111", ownerId: "client:lying");
+
+            var stamped = await store.PublishAsync(def, meta);
+
+            Assert.Equal("service:authoritative", stamped.OwnerId);
+        }
+
+        [Fact]
+        public async Task QueryAsync_FiltersByTags_AllMustMatch()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            await store.PublishAsync(
+                NewDef("11111111-1111-4111-8111-111111111111", "A"),
+                NewMeta("11111111-1111-4111-8111-111111111111", tags: new[] { "official-pack" }));
+            await store.PublishAsync(
+                NewDef("22222222-2222-4222-8222-222222222222", "B"),
+                NewMeta("22222222-2222-4222-8222-222222222222", tags: new[] { "official-pack", "starter" }));
+            await store.PublishAsync(
+                NewDef("33333333-3333-4333-8333-333333333333", "C"),
+                NewMeta("33333333-3333-4333-8333-333333333333", tags: new[] { "community" }));
+
+            // Single tag filter
+            var pageOfficial = await store.QueryAsync(
+                new CharacterAssetQuery(tags: new[] { "official-pack" }));
+            Assert.Equal(2, pageOfficial.Items.Count);
+
+            // Two-tag filter — only B has both.
+            var pageBoth = await store.QueryAsync(
+                new CharacterAssetQuery(tags: new[] { "official-pack", "starter" }));
+            Assert.Single(pageBoth.Items);
+            Assert.Equal("22222222-2222-4222-8222-222222222222", pageBoth.Items[0].CharacterId);
+
+            // No-match tag.
+            var pageNone = await store.QueryAsync(
+                new CharacterAssetQuery(tags: new[] { "nonexistent" }));
+            Assert.Empty(pageNone.Items);
+        }
+
+        [Fact]
+        public async Task QueryAsync_FiltersByIsPublic()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            await store.PublishAsync(
+                NewDef("11111111-1111-4111-8111-111111111111"),
+                NewMeta("11111111-1111-4111-8111-111111111111", isPublic: true));
+            await store.PublishAsync(
+                NewDef("22222222-2222-4222-8222-222222222222"),
+                NewMeta("22222222-2222-4222-8222-222222222222", isPublic: false));
+
+            var publicPage = await store.QueryAsync(new CharacterAssetQuery(isPublic: true));
+            Assert.Single(publicPage.Items);
+            Assert.True(publicPage.Items[0].IsPublic);
+
+            var privatePage = await store.QueryAsync(new CharacterAssetQuery(isPublic: false));
+            Assert.Single(privatePage.Items);
+            Assert.False(privatePage.Items[0].IsPublic);
+
+            var allPage = await store.QueryAsync(new CharacterAssetQuery());
+            Assert.Equal(2, allPage.Items.Count);
+        }
+
+        [Fact]
+        public async Task QueryAsync_PaginationViaCursor_DrainsAllResults()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            for (int i = 0; i < 7; i++)
+            {
+                string id = $"{i:x8}-aaaa-4aaa-8aaa-000000000000";
+                await store.PublishAsync(NewDef(id, name: "Char-" + i), NewMeta(id));
+            }
+
+            var seenIds = new List<string>();
+            string? cursor = null;
+            do
+            {
+                var page = await store.QueryAsync(new CharacterAssetQuery(limit: 3, cursor: cursor));
+                seenIds.AddRange(page.Items.Select(m => m.CharacterId));
+                cursor = page.NextCursor;
+                Assert.True(page.Items.Count <= 3);
+            } while (cursor != null);
+
+            Assert.Equal(7, seenIds.Count);
+            Assert.Equal(7, seenIds.Distinct().Count());
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_ReturnsNullForUnknownId()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            var got = await store.GetMetadataAsync("00000000-0000-4000-8000-000000000000");
+            Assert.Null(got);
+        }
+
+        [Fact]
+        public async Task GetMetadataAsync_AfterPublish_ReturnsStampedMetadata()
+        {
+            var store = new InMemoryRemoteCharacterStore();
+            var def = NewDef("11111111-1111-4111-8111-111111111111");
+            var stamped = await store.PublishAsync(def, NewMeta("11111111-1111-4111-8111-111111111111"));
+
+            var got = await store.GetMetadataAsync(def.CharacterId.ToString("D"));
+            Assert.NotNull(got);
+            Assert.Equal(stamped.CharacterId, got!.CharacterId);
+            Assert.Equal(stamped.UpdatedAt, got.UpdatedAt);
+        }
+
+        [Fact]
+        public void CharacterAssetQuery_LimitClampsToRange()
+        {
+            Assert.Equal(1, new CharacterAssetQuery(limit: 0).Limit);
+            Assert.Equal(1, new CharacterAssetQuery(limit: -5).Limit);
+            Assert.Equal(CharacterAssetQuery.MaxLimit,
+                new CharacterAssetQuery(limit: CharacterAssetQuery.MaxLimit + 99).Limit);
+            Assert.Equal(CharacterAssetQuery.DefaultLimit, new CharacterAssetQuery().Limit);
+        }
+
+        [Fact]
+        public void CharacterAssetMetadata_RejectsBlankCharacterId()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CharacterAssetMetadata(
+                    characterId: "",
+                    ownerId: "owner",
+                    tags: Array.Empty<string>(),
+                    isPublic: false,
+                    createdAt: DateTimeOffset.UtcNow,
+                    updatedAt: DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public void CharacterAssetMetadata_RequiresTags()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CharacterAssetMetadata(
+                    characterId: "11111111-1111-4111-8111-111111111111",
+                    ownerId: "owner",
+                    tags: null!,
+                    isPublic: false,
+                    createdAt: DateTimeOffset.UtcNow,
+                    updatedAt: DateTimeOffset.UtcNow));
+        }
+
+        [Fact]
+        public void CharacterAssetMetadata_DefaultAssetKindIsCharacterV1()
+        {
+            var meta = NewMeta("11111111-1111-4111-8111-111111111111");
+            Assert.Equal("character/v1", meta.AssetKind);
+            Assert.Equal(CharacterAssetMetadata.AssetKindCharacterV1, meta.AssetKind);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Characters/InMemoryRemoteCharacterStore.cs
+++ b/tests/Pinder.Core.Tests/Characters/InMemoryRemoteCharacterStore.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+
+namespace Pinder.Core.Tests.Characters
+{
+    /// <summary>
+    /// Test-only in-memory implementation of <see cref="IRemoteCharacterStore"/>.
+    /// Validates the interface shape works for at least one impl and gives
+    /// IRemoteCharacterStore-consuming tests something to inject.
+    ///
+    /// Lives in the test project intentionally — issue #817 does not ship
+    /// any production impl (gated #819).
+    /// </summary>
+    public sealed class InMemoryRemoteCharacterStore : IRemoteCharacterStore
+    {
+        private readonly object _gate = new object();
+        private readonly Dictionary<string, CharacterDefinition> _payloads =
+            new Dictionary<string, CharacterDefinition>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, CharacterAssetMetadata> _metas =
+            new Dictionary<string, CharacterAssetMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        // Sequence counter the fake uses to generate deterministic
+        // server-stamped CreatedAt / UpdatedAt timestamps.
+        private long _seq;
+
+        public string SimulatedServiceOwnerId { get; set; } = "service:test";
+
+        // --- ICharacterStore ------------------------------------------------
+
+        public Task<IReadOnlyList<string>> ListIdsAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                IReadOnlyList<string> ids = _payloads.Keys.ToList();
+                return Task.FromResult(ids);
+            }
+        }
+
+        public Task<CharacterDefinition?> LoadAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                _payloads.TryGetValue(characterId, out var def);
+                return Task.FromResult<CharacterDefinition?>(def);
+            }
+        }
+
+        public Task SaveAsync(CharacterDefinition def, CancellationToken ct = default)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            ct.ThrowIfCancellationRequested();
+            string id = def.CharacterId.ToString("D");
+            lock (_gate)
+            {
+                _payloads[id] = def;
+                if (!_metas.ContainsKey(id))
+                {
+                    _metas[id] = StampServerSide(new CharacterAssetMetadata(
+                        characterId: id,
+                        ownerId: SimulatedServiceOwnerId,
+                        tags: Array.Empty<string>(),
+                        isPublic: false,
+                        createdAt: DateTimeOffset.MinValue,
+                        updatedAt: DateTimeOffset.MinValue),
+                        existing: null);
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                bool removed = _payloads.Remove(characterId);
+                _metas.Remove(characterId);
+                return Task.FromResult(removed);
+            }
+        }
+
+        public Task<bool> ExistsAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                return Task.FromResult(_payloads.ContainsKey(characterId));
+            }
+        }
+
+        // --- IRemoteCharacterStore ------------------------------------------
+
+        public Task<CharacterAssetPage> QueryAsync(CharacterAssetQuery query, CancellationToken ct = default)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+            ct.ThrowIfCancellationRequested();
+
+            lock (_gate)
+            {
+                IEnumerable<CharacterAssetMetadata> results = _metas.Values
+                    .OrderBy(m => m.UpdatedAt)
+                    .ThenBy(m => m.CharacterId, StringComparer.Ordinal);
+
+                if (!string.IsNullOrEmpty(query.OwnerId))
+                    results = results.Where(m => m.OwnerId == query.OwnerId);
+                if (query.IsPublic.HasValue)
+                    results = results.Where(m => m.IsPublic == query.IsPublic.Value);
+                if (query.Tags != null && query.Tags.Count > 0)
+                    results = results.Where(m => query.Tags.All(t =>
+                        m.Tags.Contains(t, StringComparer.Ordinal)));
+
+                var ordered = results.ToList();
+
+                int offset = 0;
+                if (!string.IsNullOrEmpty(query.Cursor) && int.TryParse(query.Cursor, out var parsed))
+                    offset = Math.Max(0, parsed);
+
+                var page = ordered.Skip(offset).Take(query.Limit).ToList();
+                int nextOffset = offset + page.Count;
+                string? nextCursor = nextOffset < ordered.Count
+                    ? nextOffset.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : null;
+
+                return Task.FromResult(new CharacterAssetPage(page, nextCursor));
+            }
+        }
+
+        public Task<CharacterAssetMetadata?> GetMetadataAsync(string characterId, CancellationToken ct = default)
+        {
+            if (string.IsNullOrWhiteSpace(characterId))
+                throw new ArgumentException("characterId must be non-empty.", nameof(characterId));
+            ct.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                _metas.TryGetValue(characterId, out var meta);
+                return Task.FromResult<CharacterAssetMetadata?>(meta);
+            }
+        }
+
+        public Task<CharacterAssetMetadata> PublishAsync(
+            CharacterDefinition def,
+            CharacterAssetMetadata metadata,
+            CancellationToken ct = default)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            if (metadata == null) throw new ArgumentNullException(nameof(metadata));
+            ct.ThrowIfCancellationRequested();
+
+            string id = def.CharacterId.ToString("D");
+
+            lock (_gate)
+            {
+                _payloads[id] = def;
+
+                _metas.TryGetValue(id, out var existing);
+                var stamped = StampServerSide(
+                    new CharacterAssetMetadata(
+                        characterId: id,
+                        ownerId: existing?.OwnerId ?? SimulatedServiceOwnerId,
+                        tags: metadata.Tags,
+                        isPublic: metadata.IsPublic,
+                        createdAt: DateTimeOffset.MinValue, // overwritten below
+                        updatedAt: DateTimeOffset.MinValue,
+                        assetKind: metadata.AssetKind),
+                    existing);
+                _metas[id] = stamped;
+                return Task.FromResult(stamped);
+            }
+        }
+
+        // --- helpers --------------------------------------------------------
+
+        private CharacterAssetMetadata StampServerSide(
+            CharacterAssetMetadata client,
+            CharacterAssetMetadata? existing)
+        {
+            long seq = System.Threading.Interlocked.Increment(ref _seq);
+            // Use a fixed epoch + the sequence to keep tests deterministic
+            // without dragging IClock through the test fake.
+            var epoch = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var stamp = epoch.AddSeconds(seq);
+            return new CharacterAssetMetadata(
+                characterId: client.CharacterId,
+                ownerId: existing?.OwnerId ?? SimulatedServiceOwnerId,
+                tags: client.Tags,
+                isPublic: client.IsPublic,
+                createdAt: existing?.CreatedAt ?? stamp,
+                updatedAt: stamp,
+                assetKind: client.AssetKind);
+        }
+    }
+}


### PR DESCRIPTION
Pure interface + types. No production implementation; #819 is gated.

## What

- `IRemoteCharacterStore : ICharacterStore` — adds `QueryAsync`, `GetMetadataAsync`, `PublishAsync`.
- `CharacterAssetMetadata` — opaque-to-engine asset metadata. Fields per the issue: `CharacterId`, `OwnerId`, `Tags`, `IsPublic`, `CreatedAt`, `UpdatedAt`, `AssetKind = "character/v1"`.
- `CharacterAssetQuery` — filter/pagination input. `OwnerId?`, `Tags?` (all-must-match), `IsPublic?`, `Limit` (clamped to 1..500, default 50), `Cursor`.
- `CharacterAssetPage` — `Items` + `NextCursor` return shape.
- `tests/.../Characters/InMemoryRemoteCharacterStore` (test-project-only fake) + 14 contract tests.

## Drop-in compatibility (locked by test)

`IRemoteCharacterStore_IsAlsoAnICharacterStore` asserts both static type assignability and that an `IRemoteCharacterStore` instance is reachable through `ICharacterStore`. Per the issue: a caller that already takes an `ICharacterStore` keeps working when handed a remote store.

## Server-side authority pinned by tests

`PublishAsync` is treated as "client proposes, server disposes" for owner identity and timestamps:

- `PublishAsync_StampsCreatedAtAndUpdatedAt_ServerSide` — client supplies `MinValue`, server replaces.
- `PublishAsync_ReplacesOwnerId_WithServerIdentity` — client lies about owner; server overwrites with its authenticated identity.
- `PublishAsync_PreservesTagsAndVisibilityFromClient` — `Tags` and `IsPublic` are client-controlled, flow through unchanged.

These are contract pins, not implementation details — the gated #819 wrapper has to honour the same shape.

## Limit clamping

`CharacterAssetQuery_LimitClampsToRange` confirms `<1` clamps to 1 and `>MaxLimit` clamps to 500. Server impls don't need defensive clamping again because the client-side type already does it.

## DoD Evidence

```
$ dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --filter "Category=Characters"
Passed!  - Failed:     0, Passed:   248, Skipped:     0, Total:   248
```

(Baseline pre-#817: 234 in Characters category. +14 from this PR's contract tests.)

**No HTTP / network code:** `git grep -E "System.Net|HttpClient" src/Pinder.Core/Characters tests/Pinder.Core.Tests/Characters` returns nothing.

**Build:** `dotnet build Pinder.Core.sln` clean.

## Test enumeration

- `IRemoteCharacterStore_IsAlsoAnICharacterStore` — drop-in compat.
- `PublishAsync_ThenLoadAsync_RoundTripsTheDefinition`.
- `PublishAsync_StampsCreatedAtAndUpdatedAt_ServerSide`.
- `PublishAsync_PreservesTagsAndVisibilityFromClient`.
- `PublishAsync_ReplacesOwnerId_WithServerIdentity`.
- `QueryAsync_FiltersByTags_AllMustMatch` (single-tag, two-tag, no-match).
- `QueryAsync_FiltersByIsPublic`.
- `QueryAsync_PaginationViaCursor_DrainsAllResults` (7 items, limit 3, cursor walks).
- `GetMetadataAsync_ReturnsNullForUnknownId` / `GetMetadataAsync_AfterPublish_ReturnsStampedMetadata`.
- `CharacterAssetQuery_LimitClampsToRange`.
- `CharacterAssetMetadata_RejectsBlankCharacterId` / `_RequiresTags` / `_DefaultAssetKindIsCharacterV1`.

## Out of scope

- Eigencore wrapper impl (#819 — gated, do-not-start).
- The full attribute vocabulary (legal tag prefixes, length limits, canonical timestamps) — that's #818 and ships in this same sprint right after.

## Research Log

- Considered making `CharacterAssetMetadata` a `record`. Rejected: `LangVersion=8.0` is pinned across pinder-core (see existing `ConversationIndexing` doc-comment); records require C# 9. Used the same sealed/immutable-by-construction pattern as `CharacterDefinition`.
- Considered putting the in-memory fake in `Pinder.Core` proper (so consumers across projects could share it). Rejected: it's a test fixture, doesn't belong in the production assembly.
- Cursor format is implementation-defined (the in-memory fake uses an integer offset). The interface contract treats the cursor as opaque — the server's wrapper can encode whatever it wants there.

Closes #817
