### PR TITLE
feat(#474): collect events on TurnSnapshot + populate event_interpretation

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -606,6 +606,32 @@ class Program
         // Load real trap definitions — fallback to NullTrapRegistry if file missing/corrupt
         ITrapRegistry trapRegistry = TrapRegistryLoader.Load(AppContext.BaseDirectory, Console.Error);
 
+        // Issue #474: load the i18n catalog so per-turn snapshots can
+        // embed deterministic interpretation strings on each event.
+        // Best-effort: if data/i18n is missing the simulator still runs
+        // but Events[].EventInterpretation is left empty (the kind
+        // strings still land, so a later pass with a fresh catalog can
+        // re-render). FindRepoRoot uses Directory.Exists checks (not
+        // .git probes) so it works correctly inside a git worktree.
+        Pinder.LlmAdapters.I18nCatalog? snapshotI18nCatalog = null;
+        try
+        {
+            string? repoRoot = DataFileLocator.FindRepoRoot(AppContext.BaseDirectory);
+            if (repoRoot != null)
+            {
+                string i18nDir = Path.Combine(repoRoot, "data", "i18n");
+                if (Directory.Exists(i18nDir))
+                {
+                    snapshotI18nCatalog = Pinder.LlmAdapters.I18nCatalog.LoadFromDirectory(i18nDir, "en");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[WARN] Failed to load i18n catalog for event interpretations: {ex.Message}");
+            snapshotI18nCatalog = null;
+        }
+
         // Shadow tracking — wrap player's StatBlock so GameSession can track shadow growth
         var sableShadows = new SessionShadowTracker(sableStats);
 
@@ -1350,7 +1376,8 @@ class Program
                     tellSnap,
                     perTurnTextDiffs,
                     session.OpponentHistory,
-                    playerSender: player1);
+                    playerSender: player1,
+                    i18nCatalog: snapshotI18nCatalog);
 
                 string turnSnapPath = Path.Combine(playtestDir, $"{sessionSlug}.turn-{turn:D2}.snap.json");
                 File.WriteAllText(turnSnapPath, JsonSerializer.Serialize(turnSnap, new JsonSerializerOptions { WriteIndented = true }));
@@ -1651,7 +1678,8 @@ class Program
         TellSnapshot? activeTell,
         List<List<TextDiffSnapshot>>? perTurnTextDiffs = null,
         IReadOnlyList<Pinder.Core.Conversation.ConversationMessage>? opponentHistory = null,
-        string? playerSender = null)
+        string? playerSender = null,
+        Pinder.LlmAdapters.I18nCatalog? i18nCatalog = null)
     {
         var state = result.StateAfter;
 
@@ -1725,6 +1753,13 @@ class Program
             .Select(m => new OpponentHistoryEntry { Role = m.Role, Content = m.Content })
             .ToList();
 
+        // Issue #474: detect canonical event kinds fired this turn and
+        // resolve their interpretation strings via the (optional) i18n
+        // catalog. Empty list when no event-class condition was met,
+        // or when the catalog is null (sim runs without data/i18n).
+        var eventKinds = TurnEventDetector.DetectEventKinds(result);
+        var events = TurnEventInterpreter.Build(eventKinds, turnNumber, i18nCatalog);
+
         return new TurnSnapshot
         {
             TurnNumber = turnNumber,
@@ -1744,6 +1779,7 @@ class Program
             RizzCumulativeFailureCount = rizzCumulativeFailureCount,
             ConversationHistory = convEntries,
             OpponentHistory = opponentHistoryEntries,
+            Events = events,
         };
     }
 

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -73,6 +73,19 @@ namespace Pinder.SessionRunner.Snapshot
     ///     same-turn callback phrases were stripped from the delivered message.
     ///   </description></item>
     ///   <item><description>
+    ///     <c>Events</c> (issue #474, deferred from i18n Phase 1.5
+    ///     #436): per-turn list of <see cref="EventSnapshot"/> entries
+    ///     covering <c>combo_hit</c>, <c>tell_read</c>, <c>callback_hit</c>,
+    ///     <c>nat_20</c>, <c>nat_1</c>, <c>miss_by_N</c>,
+    ///     <c>horniness_fail</c>, <c>shadow_tick_*</c>, <c>trap_activated</c>.
+    ///     Each entry carries the canonical kind, the turn number, and the
+    ///     human-readable interpretation string picked deterministically
+    ///     (FNV-1a-32 over <c>(kind, turn_number)</c>) from the
+    ///     <c>data/i18n/&lt;locale&gt;/events.yaml</c> catalog — byte-for-byte
+    ///     identical to the frontend's variantIndex, so engine-emit and
+    ///     web-render agree.
+    ///   </description></item>
+    ///   <item><description>
     ///     <c>OpponentHistory</c> (issue #788): engine-owned opponent-LLM
     ///     conversation history. Each entry carries <c>Role</c>
     ///     (<c>"user"</c> or <c>"assistant"</c>) and <c>Content</c>. Survives
@@ -126,6 +139,44 @@ namespace Pinder.SessionRunner.Snapshot
         /// have resolved yet.
         /// </summary>
         public List<OpponentHistoryEntry> OpponentHistory { get; set; } = new List<OpponentHistoryEntry>();
+
+        /// <summary>
+        /// Issue #474: events fired on this turn, with their deterministic
+        /// human-readable interpretation strings from the i18n catalog.
+        /// Empty list when no event-class condition was met (a fully
+        /// neutral turn). Order is the engine's emission order:
+        ///
+        /// <list type="number">
+        ///   <item><description>roll-class first (nat_20 / nat_1 / miss_by_N)</description></item>
+        ///   <item><description>combo / tell / callback bonuses</description></item>
+        ///   <item><description>horniness_fail</description></item>
+        ///   <item><description>shadow_tick_* (one per shadow that grew)</description></item>
+        ///   <item><description>trap_activated</description></item>
+        /// </list>
+        ///
+        /// <para>Pre-#474 snapshots persist without this field; replay
+        /// tooling treats it as optional. No data migration needed.</para>
+        /// </summary>
+        public List<EventSnapshot> Events { get; set; } = new List<EventSnapshot>();
+    }
+
+    /// <summary>
+    /// Issue #474: one event fired on a turn, with its deterministic
+    /// human-readable interpretation. <see cref="Kind"/> is the canonical
+    /// event kind (<c>combo_hit</c>, <c>nat_20</c>, etc. — the keys in
+    /// <c>data/i18n/&lt;locale&gt;/events.yaml</c>);
+    /// <see cref="EventInterpretation"/> is the chosen variant string,
+    /// picked deterministically by
+    /// <see cref="Pinder.Core.I18n.VariantPicker.PickIndex"/> on
+    /// <c>(Kind, TurnNumber)</c>. Empty interpretation when the catalog
+    /// has no entry for the kind (defensive fallback for forward
+    /// compatibility with new event kinds added engine-side before yaml).
+    /// </summary>
+    public sealed class EventSnapshot
+    {
+        public string Kind { get; set; } = string.Empty;
+        public int TurnNumber { get; set; }
+        public string EventInterpretation { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/session-runner/Snapshot/TurnEventDetector.cs
+++ b/session-runner/Snapshot/TurnEventDetector.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+
+namespace Pinder.SessionRunner.Snapshot
+{
+    /// <summary>
+    /// Issue #474: derive the canonical per-turn event kinds from a
+    /// <see cref="TurnResult"/>. Each detected kind matches an entry in
+    /// <c>data/i18n/&lt;locale&gt;/events.yaml</c> so the snapshot
+    /// writer can populate <see cref="EventSnapshot.EventInterpretation"/>
+    /// via <c>I18nCatalog.TVariant(kind, turnNumber)</c>.
+    ///
+    /// <para>
+    /// This detector is the source of truth for which engine signals
+    /// rise to "event". Adding a new kind requires three coordinated
+    /// changes (mirroring the i18n Phase 1.5 / Phase 2 contract):
+    /// <list type="number">
+    ///   <item><description>Yaml entry under <c>events:</c> with N
+    ///   <c>summary_variants</c> (locked convention: 5).</description></item>
+    ///   <item><description>Detection rule here \u2014 an additional
+    ///   <c>events.Add(...)</c> call gated on the engine signal.</description></item>
+    ///   <item><description>Frontend renderer mapping in
+    ///   <c>frontend/src/i18n/useText.ts</c> (the picker is a port of
+    ///   <see cref="Pinder.Core.I18n.VariantPicker"/>).</description></item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// Pure: no IO, no allocation beyond the result list. Safe to call
+    /// inside hot paths.
+    /// </para>
+    /// </summary>
+    internal static class TurnEventDetector
+    {
+        /// <summary>
+        /// Derive the ordered list of event kinds fired on this turn.
+        /// Order is the engine's emission order \u2014 see
+        /// <see cref="TurnSnapshot.Events"/> for the canonical order.
+        /// Returns an empty list when no event-class condition was met.
+        /// </summary>
+        public static List<string> DetectEventKinds(TurnResult result)
+        {
+            if (result is null) throw new ArgumentNullException(nameof(result));
+
+            var kinds = new List<string>();
+
+            // 1. Roll-class events. nat_20 / nat_1 are exclusive of each
+            //    other and of the miss_by_N family (a nat_1 always
+            //    misses but is its own category and the variant copy
+            //    leans on the "automatic worst-case" framing).
+            if (result.Roll.IsNatTwenty)
+            {
+                kinds.Add("nat_20");
+            }
+            else if (result.Roll.IsNatOne)
+            {
+                kinds.Add("nat_1");
+            }
+            else if (!result.Roll.IsSuccess && result.Roll.MissMargin > 0)
+            {
+                // miss_by_<exact margin>. The events.yaml ships
+                // catalog entries for miss_by_1, miss_by_3, miss_by_5;
+                // other margins emit the kind anyway and the snapshot
+                // writer falls back to an empty interpretation for
+                // forward compatibility (see TurnEventInterpreter).
+                kinds.Add("miss_by_" + result.Roll.MissMargin);
+            }
+
+            // 2. Combo / tell / callback bonuses. Independent of roll
+            //    class \u2014 you can land a nat_20 that also triggered a
+            //    combo, and both events emit.
+            if (!string.IsNullOrEmpty(result.ComboTriggered))
+            {
+                kinds.Add("combo_hit");
+            }
+            if (result.TellReadBonus > 0)
+            {
+                kinds.Add("tell_read");
+            }
+            if (result.CallbackBonusApplied > 0)
+            {
+                kinds.Add("callback_hit");
+            }
+
+            // 3. Horniness corruption. Emit when the per-turn check
+            //    missed AND the overlay actually fired \u2014 a missed check
+            //    that produced no overlay (e.g. no shadows present) is
+            //    not a player-visible event from the events-yaml
+            //    framing's perspective.
+            if (result.HorninessCheck.IsMiss && result.HorninessCheck.OverlayApplied)
+            {
+                kinds.Add("horniness_fail");
+            }
+
+            // 4. Shadow ticks. ShadowGrowthEvents is a list of strings
+            //    of the form "<ShadowStatType> +N (<reason>)" emitted
+            //    by SessionShadowTracker.ApplyGrowth. We parse the
+            //    leading shadow name and route to
+            //    shadow_tick_<lowercase_name>. Multiple shadows can
+            //    grow on a single turn (one entry per growth).
+            foreach (string growth in result.ShadowGrowthEvents)
+            {
+                string? name = ParseShadowName(growth);
+                if (name is null) continue;
+                kinds.Add("shadow_tick_" + name.ToLowerInvariant());
+            }
+
+            // 5. Trap activation. The roll's ActivatedTrap is set when
+            //    the player stepped into a trope-trap THIS turn (not
+            //    when one was already active and ticking down).
+            if (result.Roll.ActivatedTrap != null)
+            {
+                kinds.Add("trap_activated");
+            }
+
+            // crit_save is a class of event the engine doesn't surface
+            // distinctly today \u2014 it would require pre-roll DC vs.
+            // post-bonus comparison the TurnResult doesn't carry. Add
+            // here when the engine-side signal lands; the events-yaml
+            // entry is already in place.
+
+            return kinds;
+        }
+
+        /// <summary>
+        /// Parse the leading shadow stat name from a growth-event
+        /// string. Returns null when the prefix doesn't match the
+        /// "<c>&lt;Name&gt; +&lt;digits&gt;</c>" shape \u2014 defence in
+        /// depth against future growth-event format drift.
+        /// </summary>
+        internal static string? ParseShadowName(string growth)
+        {
+            if (string.IsNullOrEmpty(growth)) return null;
+            int sp = growth.IndexOf(' ');
+            if (sp <= 0) return null;
+            string head = growth.Substring(0, sp);
+            // Be defensive: only accept all-letter names. Stops trash
+            // strings (e.g. "+5 something") from forming bad kind ids.
+            for (int i = 0; i < head.Length; i++)
+            {
+                if (!char.IsLetter(head[i])) return null;
+            }
+            // The next non-space char must be '+' for the tracker's
+            // canonical shape; if not, treat as drift and skip.
+            if (sp + 1 >= growth.Length || growth[sp + 1] != '+') return null;
+            return head;
+        }
+    }
+}

--- a/session-runner/Snapshot/TurnEventInterpreter.cs
+++ b/session-runner/Snapshot/TurnEventInterpreter.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Pinder.LlmAdapters;
+
+namespace Pinder.SessionRunner.Snapshot
+{
+    /// <summary>
+    /// Issue #474: thin wrapper around <see cref="I18nCatalog.TVariant"/>
+    /// that catches the missing-kind case (the catalog throws on
+    /// unknown kinds; we want graceful fallback for forward compat
+    /// with new event kinds that the engine emits before the yaml
+    /// catches up).
+    /// </summary>
+    internal static class TurnEventInterpreter
+    {
+        /// <summary>
+        /// Build the per-event interpretation block. <paramref name="catalog"/>
+        /// may be null \u2014 the simulator runs in environments where the
+        /// data/i18n directory isn't available (CI fixtures, ad-hoc
+        /// repros); we degrade to empty interpretations rather than
+        /// crashing the snapshot write.
+        /// </summary>
+        public static List<EventSnapshot> Build(
+            IReadOnlyList<string> kinds, int turnNumber, I18nCatalog? catalog)
+        {
+            var events = new List<EventSnapshot>(kinds.Count);
+            foreach (string kind in kinds)
+            {
+                string interpretation = string.Empty;
+                if (catalog != null)
+                {
+                    try
+                    {
+                        interpretation = catalog.TVariant(kind, turnNumber);
+                    }
+                    catch (KeyNotFoundException)
+                    {
+                        // Unknown kind in this locale \u2014 leave empty.
+                        // Engine + yaml are intentionally allowed to
+                        // drift in either direction during sprints; the
+                        // snapshot still records the kind so a later
+                        // pass can re-render with a fresh catalog.
+                    }
+                }
+                events.Add(new EventSnapshot
+                {
+                    Kind = kind,
+                    TurnNumber = turnNumber,
+                    EventInterpretation = interpretation,
+                });
+            }
+            return events;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue474SnapshotEventsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue474SnapshotEventsTests.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner.Snapshot;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #474: per-turn <c>Events</c> array on <see cref="TurnSnapshot"/>,
+    /// populated from <see cref="TurnResult"/> via
+    /// <see cref="TurnEventDetector.DetectEventKinds"/> and rendered to
+    /// human-readable interpretation strings via
+    /// <see cref="Pinder.LlmAdapters.I18nCatalog.TVariant"/>.
+    ///
+    /// <para>
+    /// This fixture covers:
+    /// <list type="bullet">
+    ///   <item>Per-event-kind detection from a fully-saturated TurnResult.</item>
+    ///   <item>Mutual exclusion between roll-class events (nat_20 / nat_1
+    ///   / miss_by_N).</item>
+    ///   <item>Multiple shadow ticks on the same turn each emit their own
+    ///   <c>shadow_tick_*</c> kind.</item>
+    ///   <item>Ordering matches the engine emission order
+    ///   (roll \u2192 combo/tell/callback \u2192 horniness \u2192 shadows \u2192 trap).</item>
+    ///   <item>Forward compat: new event kinds with no yaml entry
+    ///   surface in <c>Events</c> with empty interpretation rather than
+    ///   throwing.</item>
+    ///   <item>Schema-discipline: <c>BuildTurnSnapshot</c> populates
+    ///   <c>Events</c> on every snapshot.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    [Trait("Category", "SessionRunner")]
+    public class Issue474SnapshotEventsTests
+    {
+        // ── Detector unit tests ──────────────────────────────────────────
+
+        [Fact]
+        public void Detector_NeutralTurn_EmitsNoEvents()
+        {
+            // Plain success, no overlays, no growth, no traps. The
+            // events.yaml framing reserves the kinds for moments
+            // worth explaining to the player; a clean Charm 12 vs DC 10
+            // is just "you nailed the line" with no annotation.
+            var result = MakeResult(roll: MakeSuccessRoll());
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Empty(kinds);
+        }
+
+        [Fact]
+        public void Detector_Nat20_EmitsNat20()
+        {
+            var roll = new RollResult(20, null, 20, StatType.Charm, 2, 0, 13, FailureTier.None);
+            var result = MakeResult(roll: roll);
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Equal(new[] { "nat_20" }, kinds);
+        }
+
+        [Fact]
+        public void Detector_Nat1_EmitsNat1_NotMissByN()
+        {
+            // RollResult constructor sets is_nat_one and miss_margin
+            // both \u2014 the detector must classify nat_1 first and skip
+            // the miss_by_N branch (mutual exclusion).
+            var roll = new RollResult(1, null, 1, StatType.Charm, 2, 0, 13, FailureTier.Catastrophe);
+            var result = MakeResult(roll: roll);
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Equal(new[] { "nat_1" }, kinds);
+            Assert.DoesNotContain(kinds, k => k.StartsWith("miss_by_"));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(7)]
+        public void Detector_MissByN_EmitsExactMargin(int margin)
+        {
+            // Miss_by_<exact margin>. Catalog ships entries for 1/3/5
+            // but the detector emits the exact margin regardless \u2014
+            // forward compat with future fine-grained variants.
+            int dieRoll = 13 - margin;
+            var roll = new RollResult(dieRoll, null, dieRoll, StatType.Charm, 0, 0, 13, FailureTier.Misfire);
+            // RollResult computes IsSuccess + MissMargin internally.
+            Assert.False(roll.IsSuccess);
+            var result = MakeResult(roll: roll);
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Equal(new[] { "miss_by_" + margin }, kinds);
+        }
+
+        [Fact]
+        public void Detector_ComboTellCallback_AllThreeEmit()
+        {
+            // A turn that triggered a combo, read a tell, and applied
+            // a callback bonus emits all three kinds in canonical order
+            // alongside the roll's nat_20.
+            var roll = new RollResult(20, null, 20, StatType.Charm, 2, 0, 13, FailureTier.None);
+            var result = MakeResult(
+                roll: roll,
+                comboTriggered: "ice-breaker",
+                tellReadBonus: 2,
+                callbackBonusApplied: 3);
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Equal(new[]
+            {
+                "nat_20",
+                "combo_hit",
+                "tell_read",
+                "callback_hit",
+            }, kinds);
+        }
+
+        [Fact]
+        public void Detector_HorninessFail_EmitsOnlyWhenOverlayApplied()
+        {
+            // A horniness check that missed but produced no overlay
+            // (e.g. no shadows present) is not the player-visible
+            // event the yaml framing covers \u2014 the framing is "desire
+            // overran your read", which only makes sense when the
+            // overlay actually corrupted the message.
+            var roll = MakeSuccessRoll();
+            var hornMissNoOverlay = new HorninessCheckResult(
+                roll: 5, modifier: 1, total: 6, dc: 12,
+                isMiss: true, tier: FailureTier.Misfire,
+                overlayApplied: false);
+            var hornMissOverlay = new HorninessCheckResult(
+                roll: 5, modifier: 1, total: 6, dc: 12,
+                isMiss: true, tier: FailureTier.Misfire,
+                overlayApplied: true);
+
+            Assert.Empty(TurnEventDetector.DetectEventKinds(
+                MakeResult(roll: roll, horniness: hornMissNoOverlay)));
+            Assert.Equal(new[] { "horniness_fail" },
+                TurnEventDetector.DetectEventKinds(MakeResult(roll: roll, horniness: hornMissOverlay)));
+        }
+
+        [Fact]
+        public void Detector_MultipleShadowTicks_EachEmitOwnKind()
+        {
+            // Two shadows can grow on the same turn (e.g. a Charm Nat 1
+            // grows Madness AND triggers a Despair tick). Each emits
+            // its own shadow_tick_<name> kind.
+            var roll = MakeSuccessRoll();
+            var result = MakeResult(
+                roll: roll,
+                shadowGrowth: new[]
+                {
+                    "Madness +1 (Charm Nat 1)",
+                    "Despair +2 (RIZZ TropeTrap failure)",
+                });
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            Assert.Equal(new[]
+            {
+                "shadow_tick_madness",
+                "shadow_tick_despair",
+            }, kinds);
+        }
+
+        [Fact]
+        public void Detector_TrapActivation_EmitsTrapActivated()
+        {
+            var trap = new Pinder.Core.Traps.TrapDefinition(
+                id: "cringe",
+                stat: StatType.Honesty,
+                effect: Pinder.Core.Traps.TrapEffect.Disadvantage,
+                effectValue: 0,
+                durationTurns: 3,
+                llmInstruction: "",
+                clearMethod: "Pick an Honesty option.",
+                nat1Bonus: "",
+                displayName: "Cringe",
+                summary: "You're aware of how you're coming across.");
+            var roll = new RollResult(8, null, 8, StatType.Charm, 0, 0, 13, FailureTier.Misfire,
+                activatedTrap: trap);
+            var result = MakeResult(roll: roll);
+            var kinds = TurnEventDetector.DetectEventKinds(result);
+            // miss_by_5 (DC 13, total 8) AND trap_activated; ordering:
+            // roll-class first, trap last.
+            Assert.Equal(new[] { "miss_by_5", "trap_activated" }, kinds);
+        }
+
+        [Theory]
+        [InlineData("Madness +1 (Charm Nat 1)", "Madness")]
+        [InlineData("Despair +2 (RIZZ TropeTrap failure)", "Despair")]
+        [InlineData("Overthinking +1 (3 SA in a row)", "Overthinking")]
+        public void ParseShadowName_HappyPaths(string growth, string expected)
+        {
+            Assert.Equal(expected, TurnEventDetector.ParseShadowName(growth));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("garbage")]
+        [InlineData("madness +1 (lowercase)")]   // lower-case still letters; OK
+        [InlineData("Madness")]                  // no space
+        [InlineData("Madness 1")]                // no '+'
+        [InlineData("3 short reads")]            // leading digits
+        public void ParseShadowName_DefensiveFormatDrift(string growth)
+        {
+            // The lowercase entry IS valid (all letters), so it
+            // round-trips. We assert via a separate path:
+            if (growth == "madness +1 (lowercase)")
+            {
+                Assert.Equal("madness", TurnEventDetector.ParseShadowName(growth));
+            }
+            else
+            {
+                Assert.Null(TurnEventDetector.ParseShadowName(growth));
+            }
+        }
+
+        // ── BuildTurnSnapshot integration ────────────────────────────────
+
+        [Fact]
+        public void BuildTurnSnapshot_PopulatesEventsArray_OnEveryTurn()
+        {
+            // Schema discipline: every TurnSnapshot built going forward
+            // carries the Events array (possibly empty) so replay
+            // tooling can rely on it.
+            var roll = new RollResult(20, null, 20, StatType.Charm, 2, 0, 13, FailureTier.None);
+            var result = new TurnResult(
+                roll: roll, deliveredMessage: "msg", opponentMessage: "...",
+                narrativeBeat: null, interestDelta: 1,
+                stateAfter: new GameStateSnapshot(
+                    10, InterestState.Interested, 0, Array.Empty<string>(), 1),
+                isGameOver: false, outcome: null,
+                shadowGrowthEvents: Array.Empty<string>(),
+                comboTriggered: "ice-breaker");
+
+            var conversationHistory = new List<(string Sender, string Text)>
+            {
+                ("P1", "p1 turn 1"), ("P2", "p2 turn 1"),
+            };
+
+            var snap = global::Program.BuildTurnSnapshot(
+                turnNumber: 1,
+                result: result,
+                shadows: new SessionShadowTracker(MakeStats()),
+                statsUsedHistory: new List<StatType>(),
+                highestPctHistory: new List<bool>(),
+                charmUsageCount: 0,
+                charmMadnessTriggered: false,
+                saUsageCount: 0,
+                saOverthinkingTriggered: false,
+                rizzCumulativeFailureCount: 0,
+                conversationHistory: conversationHistory,
+                comboHistory: new List<(StatType Stat, bool Succeeded)>(),
+                activeTell: null,
+                perTurnTextDiffs: null,
+                opponentHistory: null,
+                playerSender: "P1",
+                i18nCatalog: null);
+
+            // Events list is non-null and contains exactly the kinds
+            // the detector reports. The interpretation is empty because
+            // we passed null catalog \u2014 the writer degraded gracefully
+            // (same path the simulator takes when data/i18n is
+            // unavailable).
+            Assert.NotNull(snap.Events);
+            Assert.Equal(2, snap.Events.Count);
+            Assert.Equal("nat_20", snap.Events[0].Kind);
+            Assert.Equal(1, snap.Events[0].TurnNumber);
+            Assert.Equal(string.Empty, snap.Events[0].EventInterpretation);
+            Assert.Equal("combo_hit", snap.Events[1].Kind);
+        }
+
+        [Fact]
+        public void BuildTurnSnapshot_WithI18nCatalog_PopulatesInterpretationStrings()
+        {
+            // End-to-end: load the real seeded events.yaml, pass it to
+            // BuildTurnSnapshot, verify each event has a non-empty
+            // interpretation drawn deterministically from the variant
+            // catalog.
+            var catalog = LoadCatalog();
+            var roll = new RollResult(20, null, 20, StatType.Charm, 2, 0, 13, FailureTier.None);
+            var result = new TurnResult(
+                roll: roll, deliveredMessage: "msg", opponentMessage: "...",
+                narrativeBeat: null, interestDelta: 1,
+                stateAfter: new GameStateSnapshot(
+                    10, InterestState.Interested, 0, Array.Empty<string>(), 7),
+                isGameOver: false, outcome: null,
+                shadowGrowthEvents: Array.Empty<string>(),
+                comboTriggered: "ice-breaker");
+
+            var snap = global::Program.BuildTurnSnapshot(
+                turnNumber: 7,
+                result: result,
+                shadows: new SessionShadowTracker(MakeStats()),
+                statsUsedHistory: new List<StatType>(),
+                highestPctHistory: new List<bool>(),
+                charmUsageCount: 0,
+                charmMadnessTriggered: false,
+                saUsageCount: 0,
+                saOverthinkingTriggered: false,
+                rizzCumulativeFailureCount: 0,
+                conversationHistory: new List<(string Sender, string Text)> { ("P1","x"), ("P2","y") },
+                comboHistory: new List<(StatType Stat, bool Succeeded)>(),
+                activeTell: null,
+                perTurnTextDiffs: null,
+                opponentHistory: null,
+                playerSender: "P1",
+                i18nCatalog: catalog);
+
+            Assert.Equal(2, snap.Events.Count);
+            Assert.False(string.IsNullOrEmpty(snap.Events[0].EventInterpretation),
+                "nat_20 must have a non-empty interpretation from events.yaml");
+            Assert.False(string.IsNullOrEmpty(snap.Events[1].EventInterpretation),
+                "combo_hit must have a non-empty interpretation from events.yaml");
+
+            // Determinism: re-pick at the same turn yields the same
+            // string \u2014 critical for cross-language parity with
+            // frontend variantIndex.
+            var snap2 = global::Program.BuildTurnSnapshot(
+                turnNumber: 7,
+                result: result,
+                shadows: new SessionShadowTracker(MakeStats()),
+                statsUsedHistory: new List<StatType>(),
+                highestPctHistory: new List<bool>(),
+                charmUsageCount: 0,
+                charmMadnessTriggered: false,
+                saUsageCount: 0,
+                saOverthinkingTriggered: false,
+                rizzCumulativeFailureCount: 0,
+                conversationHistory: new List<(string Sender, string Text)> { ("P1","x"), ("P2","y") },
+                comboHistory: new List<(StatType Stat, bool Succeeded)>(),
+                activeTell: null,
+                perTurnTextDiffs: null,
+                opponentHistory: null,
+                playerSender: "P1",
+                i18nCatalog: catalog);
+            Assert.Equal(snap.Events[0].EventInterpretation, snap2.Events[0].EventInterpretation);
+            Assert.Equal(snap.Events[1].EventInterpretation, snap2.Events[1].EventInterpretation);
+        }
+
+        [Fact]
+        public void OnDiskSnapshot_SerializesEventsArrayWithCanonicalShape()
+        {
+            // Issue #474 acceptance criterion: "run a sim, inspect a
+            // .turn-NN.snap.json file, confirm the Events array is
+            // present and each entry has a non-empty
+            // EventInterpretation". This test simulates the exact
+            // serialization path session-runner takes (System.Text.Json
+            // with WriteIndented = true) and asserts the disk shape is
+            // what replay tooling will see.
+            var catalog = LoadCatalog();
+            var roll = new RollResult(20, null, 20, StatType.Charm, 2, 0, 13, FailureTier.None);
+            var result = new TurnResult(
+                roll: roll, deliveredMessage: "msg", opponentMessage: "...",
+                narrativeBeat: null, interestDelta: 1,
+                stateAfter: new GameStateSnapshot(
+                    10, InterestState.Interested, 0, Array.Empty<string>(), 4),
+                isGameOver: false, outcome: null,
+                shadowGrowthEvents: new[] { "Madness +1 (Charm Nat 1)" },
+                comboTriggered: "ice-breaker",
+                tellReadBonus: 2);
+
+            var snap = global::Program.BuildTurnSnapshot(
+                turnNumber: 4,
+                result: result,
+                shadows: new SessionShadowTracker(MakeStats()),
+                statsUsedHistory: new List<StatType>(),
+                highestPctHistory: new List<bool>(),
+                charmUsageCount: 0,
+                charmMadnessTriggered: false,
+                saUsageCount: 0,
+                saOverthinkingTriggered: false,
+                rizzCumulativeFailureCount: 0,
+                conversationHistory: new List<(string Sender, string Text)> { ("P1","x"), ("P2","y") },
+                comboHistory: new List<(StatType Stat, bool Succeeded)>(),
+                activeTell: null,
+                perTurnTextDiffs: null,
+                opponentHistory: null,
+                playerSender: "P1",
+                i18nCatalog: catalog);
+
+            // Match the simulator's serializer settings.
+            string json = System.Text.Json.JsonSerializer.Serialize(snap,
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+
+            // The on-disk JSON contains the Events array with the
+            // canonical key names (PascalCase by default — the
+            // simulator doesn't pin a JsonNamingPolicy on this path,
+            // so the shape matches what replay tools today already
+            // parse off the disk for the rest of the snapshot).
+            Assert.Contains("\"Events\":", json);
+            Assert.Contains("\"Kind\":", json);
+            Assert.Contains("\"TurnNumber\":", json);
+            Assert.Contains("\"EventInterpretation\":", json);
+
+            // Each of the three detected kinds (nat_20, combo_hit,
+            // tell_read, shadow_tick_madness) appears in the
+            // serialized output with a non-empty interpretation.
+            Assert.Contains("\"nat_20\"", json);
+            Assert.Contains("\"combo_hit\"", json);
+            Assert.Contains("\"tell_read\"", json);
+            Assert.Contains("\"shadow_tick_madness\"", json);
+
+            // No empty interpretation strings on the live catalog
+            // path — a missing variant set is a yaml gap that should
+            // surface (every kind we detect has yaml entries today).
+            foreach (var ev in snap.Events)
+            {
+                Assert.False(string.IsNullOrEmpty(ev.EventInterpretation),
+                    $"event {ev.Kind} has empty interpretation — events.yaml is missing the kind");
+            }
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────
+
+        private static StatBlock MakeStats() => new StatBlock(
+            new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 3 }, { StatType.Rizz, 2 },
+                { StatType.Honesty, 1 }, { StatType.Chaos, 0 },
+                { StatType.Wit, 4 }, { StatType.SelfAwareness, 2 },
+            },
+            new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            });
+
+        private static RollResult MakeSuccessRoll() =>
+            new RollResult(15, null, 15, StatType.Charm, 2, 0, 13, FailureTier.None);
+
+        private static TurnResult MakeResult(
+            RollResult? roll = null,
+            string? comboTriggered = null,
+            int tellReadBonus = 0,
+            int callbackBonusApplied = 0,
+            HorninessCheckResult? horniness = null,
+            IReadOnlyList<string>? shadowGrowth = null)
+        {
+            return new TurnResult(
+                roll: roll ?? MakeSuccessRoll(),
+                deliveredMessage: "msg",
+                opponentMessage: "...",
+                narrativeBeat: null,
+                interestDelta: 1,
+                stateAfter: new GameStateSnapshot(
+                    10, InterestState.Interested, 0, Array.Empty<string>(), 1),
+                isGameOver: false,
+                outcome: null,
+                shadowGrowthEvents: shadowGrowth,
+                comboTriggered: comboTriggered,
+                callbackBonusApplied: callbackBonusApplied,
+                tellReadBonus: tellReadBonus,
+                horninessCheck: horniness);
+        }
+
+        private static Pinder.LlmAdapters.I18nCatalog LoadCatalog()
+        {
+            // Walk up from the current directory looking for data/i18n.
+            // Mirrors the I18nCatalogTests pattern (works in normal
+            // checkouts AND inside git worktrees \u2014 no .git probe).
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                string candidate = System.IO.Path.Combine(dir, "data", "i18n");
+                if (System.IO.Directory.Exists(candidate))
+                {
+                    return Pinder.LlmAdapters.I18nCatalog.LoadFromDirectory(candidate, "en");
+                }
+                var parent = System.IO.Directory.GetParent(dir);
+                if (parent == null) break;
+                dir = parent.FullName;
+            }
+            throw new System.IO.DirectoryNotFoundException(
+                "could not find data/i18n above test base dir");
+        }
+    }
+}


### PR DESCRIPTION
Closes decay256/pinder-web#474

(Tracking issue lives in pinder-web; the file changes are here in pinder-core because `session-runner/Snapshot/SessionSnapshot.cs` is engine-side.)

## Summary

Phase 1.5 (pinder-web#436) added the engine-side `I18nCatalog` and `VariantPicker` (FNV-1a-32 mirror of the frontend port). The remaining piece — `TurnSnapshot` gains an `event_interpretation` field per event — was deferred because the snapshot didn't collect events at all. This PR closes that gap end-to-end.

## Changes

- **`session-runner/Snapshot/SessionSnapshot.cs`**: add `Events: List<EventSnapshot>` to `TurnSnapshot`. `EventSnapshot { Kind, TurnNumber, EventInterpretation }`. Updated the comment block at the top of the file per AGENTS.md Snapshot Schema Discipline rule.
- **`session-runner/Snapshot/TurnEventDetector.cs`** (new): pure helper. Walks a `TurnResult` and returns the canonical kind list — `combo_hit`, `tell_read`, `callback_hit`, `nat_20`, `nat_1`, `miss_by_<exact>`, `horniness_fail`, `shadow_tick_<name>`, `trap_activated`. Order matches the canonical engine emission order so replay tooling can index into the same sequence the live UI renders.
- **`session-runner/Snapshot/TurnEventInterpreter.cs`** (new): thin wrapper around `I18nCatalog.TVariant` that catches missing-kind exceptions and degrades to empty interpretation. Forward-compat for new event kinds emitted before yaml catches up; degraded path also covers ad-hoc sim runs without `data/i18n` available.
- **`session-runner/Program.cs`**: `BuildTurnSnapshot` accepts an optional `i18nCatalog` parameter, detects events from the resolved `TurnResult`, and emits the `Events` array on every snapshot. Main loop loads the catalog once via `DataFileLocator.FindRepoRoot` — uses `Directory.Exists` not `.git` probes, so it works correctly inside a git worktree (GIT-WORKTREE-DOTGIT-IS-A-FILE lesson).
- **`Issue474SnapshotEventsTests`** (new, 23 cases): per-kind detection, mutual exclusion (nat_1 vs miss_by_N), multi-shadow-tick parallel emission, ordering invariant, missing-yaml graceful fallback, end-to-end `Build → JSON-serialize` verification of the on-disk shape with the real seeded `events.yaml`.

## Drive-by changes

None. Diff bounded to `session-runner/Snapshot/*` (one schema update + two new files), `session-runner/Program.cs` (catalog load + BuildTurnSnapshot signature + new helper invocation), and one new test file.

## Verification (acceptance criterion 4 of the ticket)

The ticket asks: "run a sim, inspect a `.turn-NN.snap.json` file, confirm the Events array is present and each entry has a non-empty `EventInterpretation`."

In lieu of a live sim run that hits real LLMs (the simulator requires API keys for character delivery), `OnDiskSnapshot_SerializesEventsArrayWithCanonicalShape` exercises the exact serialization path the simulator takes (`System.Text.Json.JsonSerializer.Serialize(snap, new JsonSerializerOptions { WriteIndented = true })`) and asserts:

- `"Events":` key present in the on-disk JSON.
- Each event entry has the `Kind` / `TurnNumber` / `EventInterpretation` keys.
- Every detected kind on a representative turn (nat_20 + combo_hit + tell_read + shadow_tick_madness) has a non-empty interpretation drawn deterministically from the live catalog.

The test loads the same `data/i18n/en/events.yaml` shipped in this repo, so a yaml-side gap (missing kind, empty `summary_variants`) would surface as an empty interpretation and fail the test.

## Backwards compat

Pre-#474 snapshots persist without the `Events` field; replay tooling treats it as optional. No data migration needed.

## Note: `crit_save`

The yaml ships an entry for `crit_save` but the engine doesn't currently surface a "critical save" signal distinctly from a plain success — it would require pre-roll DC vs. post-bonus comparison the `TurnResult` doesn't carry. Documented as a one-line TODO in `TurnEventDetector` next to the existing detection rules; the wiring will land when the engine signal does.

## DoD Evidence

- **Self-review against `origin/main`**: full diff read, no scope creep, no untouched files altered.
- **Build (`dotnet build Pinder.Core.sln`)**: 0 errors. Pre-existing nullability warnings in `Pinder.LlmAdapters` unchanged.
- **Tests**:
  - `Pinder.Core.Tests` (full suite): **2669 passed, 0 failed, 18 skipped**, ~8s. Pre-existing failures in `Pinder.Rules.Tests` (46) and `Pinder.LlmAdapters.Tests` (63) confirmed identical on `origin/main` (canonical clone) — both are pre-existing YamlDotNet/integration-test failures unrelated to this PR. Verified by running each individually on `/root/projects/pinder-core` HEAD.
  - Issue474-specific: **23 passed, 0 failed**.

## Research Log

| Topic | Source | Finding |
|---|---|---|
| Existing schema-discipline pattern | `session-runner/Snapshot/SessionSnapshot.cs:50-83` (the comment block) | Per AGENTS.md rule, every player-visible game-state field must appear in the comment block AND in TurnSnapshot. New `Events` field added to both. |
| Engine event signals | `src/Pinder.Core/Conversation/TurnResult.cs` | All required signals are available off `TurnResult` (Roll.IsNatTwenty/IsNatOne/MissMargin, ComboTriggered, TellReadBonus, CallbackBonusApplied, HorninessCheck, ShadowGrowthEvents, Roll.ActivatedTrap). |
| Shadow growth event format | `src/Pinder.Core/Stats/SessionShadowTracker.cs:46` | `"<ShadowStatType> +<amount> (<reason>)"`. Detector parses the leading word, route to `shadow_tick_<lowercase>`. Defensive parse rejects malformed shapes (returns null) so future format drift doesn't bleed into kind ids. |
| Variant catalog | `src/Pinder.LlmAdapters/I18nCatalog.cs` (TVariant); `src/Pinder.Core/I18n/VariantPicker.cs` (FNV-1a-32) | Both are public; the simulator consumes them directly in `BuildTurnSnapshot` via the new `i18nCatalog` param. |
| Yaml inventory | `data/i18n/en/events.yaml` | Catalog has 14 kinds: nat_20, nat_1, miss_by_{1,3,5}, combo_hit, tell_read, callback_hit, crit_save, horniness_fail, shadow_tick_{madness,despair,denial,dread,overthinking}, trap_activated. The detector emits the same kinds (minus crit_save and `shadow_tick_fixation`, both engine-signal gaps). |
| Worktree compatibility | `session-runner/DataFileLocator.cs:50` (FindRepoRoot) | Uses `Directory.Exists("data") && Directory.Exists("src")` checks, never probes `.git`. Safe in worktrees. |