### PR TITLE
feat(#551): Phase 2a — anatomy scale_type + numeric_range schema refactor

### DIFF
--- a/data/anatomy/anatomy-parameters.json
+++ b/data/anatomy/anatomy-parameters.json
@@ -2,10 +2,13 @@
   {
     "id": "length",
     "name": "Length",
+    "scale_type": "numeric",
+    "numeric_range": { "min": 1, "max": 4, "unit": "tier" },
     "tiers": [
       {
         "id": "short",
         "name": "Short",
+        "numeric_breakpoint": 1,
         "stat_modifiers": { "self_awareness": 1, "honesty": 1 },
         "personality_fragment": "got to the jokes before anyone else; uses self-deprecation as both weapon and shield; has a particular wit that grew specifically in this soil",
         "backstory_fragment": "heard every short joke by age fourteen; got very good at landing the punchline before anyone else could; discovered that being the one who tells the joke first is better than being the one the joke is about; has since found this principle applies to most things in life",
@@ -21,6 +24,7 @@
       {
         "id": "medium",
         "name": "Medium",
+        "numeric_breakpoint": 2,
         "stat_modifiers": {},
         "personality_fragment": "comfortable in their own skin in a way that reads as unusual; not performing modesty, genuinely fine; this reads as confidence to some and blankness to others",
         "backstory_fragment": "grew up without this being a topic; no locker room trauma, no defining comparison moment that stuck, no incident that reordered things; had to build an identity around actual things rather than reactions to a physical fact; considers this lucky in retrospect",
@@ -36,6 +40,7 @@
       {
         "id": "long",
         "name": "Long",
+        "numeric_breakpoint": 3,
         "stat_modifiers": { "rizz": 1, "charm": 1, "self_awareness": -1 },
         "personality_fragment": "has a quiet awareness of their advantage that surfaces in unexpected ways; not a braggart — just knows; expects to be welcomed in a way that is mostly correct",
         "backstory_fragment": "the first time someone made a specific remark about it they were sixteen and had no idea how to respond; filed it as significant; learned to respond by twenty; have been responding with decreasing effort and increasing ease ever since",
@@ -51,6 +56,7 @@
       {
         "id": "legendary",
         "name": "Legendary",
+        "numeric_breakpoint": 4,
         "stat_modifiers": { "rizz": 2, "charm": 1, "self_awareness": -2 },
         "personality_fragment": "enters conversations at a slight offset to everyone else due to sheer presence; cannot fully diagnose why some exchanges go strangely; has been informed of the cause multiple times; it lands differently each time",
         "backstory_fragment": "found out at fifteen from a reaction rather than a conversation; spent the next several years figuring out what to do with the information; the answer changed three times; currently on version three; version three is the calmest version and the most functional",
@@ -68,10 +74,13 @@
   {
     "id": "girth",
     "name": "Girth",
+    "scale_type": "numeric",
+    "numeric_range": { "min": 1, "max": 4, "unit": "tier" },
     "tiers": [
       {
         "id": "slim",
         "name": "Slim",
+        "numeric_breakpoint": 1,
         "stat_modifiers": { "wit": 1 },
         "personality_fragment": "compensated through sharpness; makes up in precision what others have in mass; there's a specific vein of humor that only grows in this particular circumstance",
         "backstory_fragment": "the comparison happened at fourteen in a school changing room; the hierarchy was announced without words; went home that day and decided to be excellent at something else; they were; this is connected",
@@ -87,6 +96,7 @@
       {
         "id": "average",
         "name": "Average",
+        "numeric_breakpoint": 2,
         "stat_modifiers": {},
         "personality_fragment": "not particularly burdened or advantaged by this dimension; free to define themselves by other things; has taken advantage of this freedom to varying degrees",
         "backstory_fragment": "was never the subject of any category in any room they were in; this turned out to be an advantage nobody warned them about; the absence of a physical narrative forced them to build an actual one; they did",
@@ -102,6 +112,7 @@
       {
         "id": "thick",
         "name": "Thick",
+        "numeric_breakpoint": 3,
         "stat_modifiers": { "rizz": 1, "charm": 1 },
         "personality_fragment": "occupies space with authority without raising their voice; presence arrives before they do; has learned to be responsible with this",
         "backstory_fragment": "had an early relationship where the other person's primary reaction was surprise; they had been trying for connection and received awe instead; took a long time to understand those are different things; now manages the distinction deliberately",
@@ -117,6 +128,7 @@
       {
         "id": "extra-thick",
         "name": "Extra Thick",
+        "numeric_breakpoint": 4,
         "stat_modifiers": { "rizz": 2, "self_awareness": -1 },
         "personality_fragment": "experiences conversations as slightly off-rhythm from others in a way they haven't fully diagnosed; people react unusually; they've filed this under 'interesting' and continue",
         "backstory_fragment": "the first time someone had a visible physical reaction they were nineteen; they laughed; the other person didn't; stopped laughing; the subsequent years taught them that what reads as a compliment to one person reads as intimidation to another; this navigation is ongoing and imperfect",
@@ -314,10 +326,13 @@
   {
     "id": "ball_size",
     "name": "Ball Size",
+    "scale_type": "numeric",
+    "numeric_range": { "min": 1, "max": 4, "unit": "tier" },
     "tiers": [
       {
         "id": "modest",
         "name": "Modest",
+        "numeric_breakpoint": 1,
         "stat_modifiers": { "wit": 1, "self_awareness": 1 },
         "personality_fragment": "precision over spectacle; quality over scale; the value is in what they do, not how much space they require to do it",
         "backstory_fragment": "was asked once, early on, whether they were insecure about it; said no; the other person didn't believe them; they meant it; spent about ten minutes afterward quietly checking whether they meant it; still meant it; found this more telling about the person who asked than about themselves",
@@ -333,6 +348,7 @@
       {
         "id": "average",
         "name": "Average",
+        "numeric_breakpoint": 2,
         "stat_modifiers": {},
         "personality_fragment": "not defined by this dimension; defined by other things; the freedom from this particular definition is real and used",
         "backstory_fragment": "the first person who saw them fully was a partner at twenty-one who didn't react in any notable way; this non-reaction was one of the better moments of that year; has had low expectations of drama in this area ever since; those expectations have been consistently met",
@@ -348,6 +364,7 @@
       {
         "id": "substantial",
         "name": "Substantial",
+        "numeric_breakpoint": 3,
         "stat_modifiers": { "charm": 1, "rizz": 1 },
         "personality_fragment": "carries themselves with a ballast that reads as groundedness; gives the impression of someone who has seriously considered their position; mostly accurate",
         "backstory_fragment": "the awareness arrived at eighteen via a reaction they didn't expect and weren't prepared for; took about a year to calibrate; the calibration involved understanding that being noticed for a physical fact is not the same as being known; has been working on the distinction since; makes it the focus most of the time",
@@ -363,6 +380,7 @@
       {
         "id": "asymmetric",
         "name": "Asymmetric",
+        "numeric_breakpoint": 4,
         "stat_modifiers": { "chaos": 1, "self_awareness": 1, "charm": -1 },
         "personality_fragment": "has made peace with the irregular; can lead with it or leave it; the awareness of asymmetry has produced unusual self-knowledge; notices imbalance in other things too",
         "backstory_fragment": "didn't notice until a doctor pointed it out at twenty-five with no particular concern; spent the following week overthinking it; then stopped; the asymmetry had been there the whole time without consequence; learned from this that most things they'd been anxious about were similarly inert; this was worth knowing",

--- a/src/Pinder.Core/Characters/AnatomyParameterDefinition.cs
+++ b/src/Pinder.Core/Characters/AnatomyParameterDefinition.cs
@@ -6,20 +6,53 @@ namespace Pinder.Core.Characters
     /// One of the nine anatomy parameters (e.g. Length, Girth, Eye Style).
     /// Contains all selectable tiers for that parameter.
     /// </summary>
+    /// <remarks>
+    /// As of #551 (admin-content-editor sprint Phase 2a), parameters carry
+    /// a <see cref="ScaleType"/> distinguishing numeric scales (length, girth,
+    /// ball_size) from categorical ones (eye style, tattoos, …). Numeric
+    /// parameters expose a <see cref="NumericRange"/> with min/max/unit; their
+    /// tiers carry <see cref="AnatomyTierDefinition.NumericBreakpoint"/> values
+    /// indicating position on the scale. The default value of
+    /// <see cref="ScaleType"/> is <c>"categorical"</c> so files authored before
+    /// this change still parse with their original semantics.
+    /// </remarks>
     public sealed class AnatomyParameterDefinition
     {
+        /// <summary>String constant for the categorical scale type. Default.</summary>
+        public const string ScaleTypeCategorical = "categorical";
+
+        /// <summary>String constant for the numeric scale type.</summary>
+        public const string ScaleTypeNumeric     = "numeric";
+
         public string Id   { get; }
         public string Name { get; }
         public IReadOnlyList<AnatomyTierDefinition> Tiers { get; }
 
+        /// <summary>
+        /// Either <see cref="ScaleTypeCategorical"/> or <see cref="ScaleTypeNumeric"/>.
+        /// Default is categorical; files without a <c>scale_type</c> field parse
+        /// as categorical.
+        /// </summary>
+        public string ScaleType { get; }
+
+        /// <summary>
+        /// Min/max/unit for the scale. Non-null if and only if
+        /// <see cref="ScaleType"/> equals <see cref="ScaleTypeNumeric"/>.
+        /// </summary>
+        public NumericRangeSpec? NumericRange { get; }
+
         private readonly Dictionary<string, AnatomyTierDefinition> _tierIndex;
 
         public AnatomyParameterDefinition(string id, string name,
-            IReadOnlyList<AnatomyTierDefinition> tiers)
+            IReadOnlyList<AnatomyTierDefinition> tiers,
+            string? scaleType = null,
+            NumericRangeSpec? numericRange = null)
         {
-            Id    = id;
-            Name  = name;
-            Tiers = tiers;
+            Id           = id;
+            Name         = name;
+            Tiers        = tiers;
+            ScaleType    = scaleType ?? ScaleTypeCategorical;
+            NumericRange = numericRange;
 
             _tierIndex = new Dictionary<string, AnatomyTierDefinition>(
                 System.StringComparer.OrdinalIgnoreCase);

--- a/src/Pinder.Core/Characters/AnatomyTierDefinition.cs
+++ b/src/Pinder.Core/Characters/AnatomyTierDefinition.cs
@@ -7,6 +7,15 @@ namespace Pinder.Core.Characters
     /// One selectable tier within an anatomy parameter (e.g. Length=Short).
     /// Produces the same six fragment types as an item.
     /// </summary>
+    /// <remarks>
+    /// As of #551, tiers within a numeric parameter carry a
+    /// <see cref="NumericBreakpoint"/> indicating where on the scale this tier
+    /// sits (e.g. for length=short the breakpoint might be 1, for length=long
+    /// it might be 3). Tiers within categorical parameters always have
+    /// <see cref="NumericBreakpoint"/> = null. The numeric breakpoint is
+    /// authoring metadata only — the engine doesn't currently read it; the
+    /// admin editor (#552) uses it to render the right ergonomics per tier.
+    /// </remarks>
     public sealed class AnatomyTierDefinition
     {
         public string ParameterId { get; }
@@ -26,6 +35,13 @@ namespace Pinder.Core.Characters
         /// <summary>Set for cosmetic-only tiers (Skin Tone). Null for all others.</summary>
         public string? VisualDescription { get; }
 
+        /// <summary>
+        /// Position on the numeric scale this tier represents. Non-null only
+        /// when the parent parameter's <see cref="AnatomyParameterDefinition.ScaleType"/>
+        /// is <c>"numeric"</c>; null for categorical parameters.
+        /// </summary>
+        public int? NumericBreakpoint { get; }
+
         public AnatomyTierDefinition(
             string parameterId,
             string tierId,
@@ -36,7 +52,8 @@ namespace Pinder.Core.Characters
             string? textingStyleFragment,
             string[] archetypeTendencies,
             TimingModifier responseTimingModifier,
-            string? visualDescription = null)
+            string? visualDescription = null,
+            int? numericBreakpoint = null)
         {
             ParameterId             = parameterId;
             TierId                  = tierId;
@@ -48,6 +65,7 @@ namespace Pinder.Core.Characters
             ArchetypeTendencies     = archetypeTendencies;
             ResponseTimingModifier  = responseTimingModifier;
             VisualDescription       = visualDescription;
+            NumericBreakpoint       = numericBreakpoint;
         }
     }
 }

--- a/src/Pinder.Core/Characters/NumericRangeSpec.cs
+++ b/src/Pinder.Core/Characters/NumericRangeSpec.cs
@@ -1,0 +1,29 @@
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Numeric scale bounds for a numeric anatomy parameter. The unit is a
+    /// free-form display string (e.g. "inches", "cm"); the engine doesn't
+    /// reason about it — it's preserved for round-trip and used by the
+    /// editor UI as the input suffix.
+    /// </summary>
+    /// <remarks>
+    /// Introduced for the admin-content-editor sprint (#551). Categorical
+    /// parameters have no numeric range; their <see cref="AnatomyParameterDefinition.NumericRange"/>
+    /// is null. Numeric parameters store one instance of this on the parameter
+    /// plus a <see cref="AnatomyTierDefinition.NumericBreakpoint"/> on every
+    /// tier indicating where on the scale that tier sits.
+    /// </remarks>
+    public sealed class NumericRangeSpec
+    {
+        public int Min { get; }
+        public int Max { get; }
+        public string Unit { get; }
+
+        public NumericRangeSpec(int min, int max, string unit)
+        {
+            Min  = min;
+            Max  = max;
+            Unit = unit ?? string.Empty;
+        }
+    }
+}

--- a/src/Pinder.Core/Data/JsonAnatomyRepository.cs
+++ b/src/Pinder.Core/Data/JsonAnatomyRepository.cs
@@ -9,6 +9,18 @@ namespace Pinder.Core.Data
     /// <summary>
     /// Parses anatomy-parameters.json and exposes parameters via IAnatomyRepository.
     /// </summary>
+    /// <remarks>
+    /// As of #551 (admin-content-editor sprint Phase 2a), parameter records
+    /// may carry a <c>scale_type</c> field (<c>"numeric"</c> or <c>"categorical"</c>)
+    /// plus, for numeric parameters, a <c>numeric_range</c> object with
+    /// <c>min</c>/<c>max</c>/<c>unit</c> keys. Tiers within numeric parameters
+    /// may carry a <c>numeric_breakpoint</c> integer.
+    ///
+    /// The loader is fully backwards-compatible: a parameter without a
+    /// <c>scale_type</c> field parses as categorical with no numeric range
+    /// and tiers with null <c>NumericBreakpoint</c>, matching the file
+    /// format that shipped before this change.
+    /// </remarks>
     public sealed class JsonAnatomyRepository : IAnatomyRepository
     {
         private readonly Dictionary<string, AnatomyParameterDefinition> _params =
@@ -44,25 +56,62 @@ namespace Pinder.Core.Data
             string id   = obj.GetString("id");
             string name = obj.GetString("name");
 
+            // Default: categorical (matches files authored before #551).
+            string scaleType = obj.HasKey("scale_type")
+                ? obj.GetString("scale_type", AnatomyParameterDefinition.ScaleTypeCategorical)
+                : AnatomyParameterDefinition.ScaleTypeCategorical;
+
+            NumericRangeSpec? numericRange = null;
+            if (string.Equals(scaleType, AnatomyParameterDefinition.ScaleTypeNumeric,
+                              StringComparison.Ordinal))
+            {
+                var rangeObj = obj.GetObject("numeric_range");
+                if (rangeObj != null)
+                {
+                    numericRange = new NumericRangeSpec(
+                        rangeObj.GetInt("min"),
+                        rangeObj.GetInt("max"),
+                        rangeObj.GetString("unit"));
+                }
+            }
+
             var tiersArr = obj.GetArray("tiers");
             var tiers    = new List<AnatomyTierDefinition>();
 
             if (tiersArr != null)
             {
+                bool isNumeric = string.Equals(
+                    scaleType,
+                    AnatomyParameterDefinition.ScaleTypeNumeric,
+                    StringComparison.Ordinal);
                 foreach (var elem in tiersArr.Items)
                 {
                     if (!(elem is JsonObject tierObj)) continue;
-                    tiers.Add(ParseTier(id, tierObj));
+                    tiers.Add(ParseTier(id, tierObj, isNumeric));
                 }
             }
 
-            return new AnatomyParameterDefinition(id, name, tiers);
+            return new AnatomyParameterDefinition(id, name, tiers, scaleType, numericRange);
         }
 
-        private static AnatomyTierDefinition ParseTier(string parameterId, JsonObject obj)
+        private static AnatomyTierDefinition ParseTier(
+            string parameterId,
+            JsonObject obj,
+            bool parentIsNumeric)
         {
             string tierId   = obj.GetString("id");
             string tierName = obj.GetString("name");
+
+            // Numeric breakpoint: only meaningful when the parent parameter
+            // is numeric. We still parse the field if present so a malformed
+            // file (e.g. categorical param with stray breakpoints) round-trips
+            // safely without surfacing an exception; the value is just dropped
+            // for non-numeric parents.
+            int? numericBreakpoint = null;
+            if (parentIsNumeric && obj.HasKey("numeric_breakpoint"))
+            {
+                numericBreakpoint = obj.GetInt("numeric_breakpoint");
+            }
 
             // Skin Tone tiers: visual_description only, no modifiers/fragments.
             bool isVisualOnly = obj.HasKey("visual_description") &&
@@ -77,7 +126,8 @@ namespace Pinder.Core.Data
                     null, null, null,
                     Array.Empty<string>(),
                     TimingModifier.Zero,
-                    visual);
+                    visual,
+                    numericBreakpoint);
             }
 
             var statMods  = JsonItemRepository.ParseStatModifiers(obj.GetObject("stat_modifiers"));
@@ -89,7 +139,9 @@ namespace Pinder.Core.Data
 
             return new AnatomyTierDefinition(
                 parameterId, tierId, tierName,
-                statMods, personality, backstory, texting, archetypes, timing);
+                statMods, personality, backstory, texting, archetypes, timing,
+                visualDescription: null,
+                numericBreakpoint: numericBreakpoint);
         }
     }
 }

--- a/tests/Pinder.Core.Tests/AnatomyScaleTypeTests.cs
+++ b/tests/Pinder.Core.Tests/AnatomyScaleTypeTests.cs
@@ -1,0 +1,325 @@
+using System.IO;
+using System.Linq;
+using Pinder.Core.Characters;
+using Pinder.Core.Data;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #551 — admin-content-editor sprint, Phase 2a.
+    ///
+    /// Schema-refactor tests for <see cref="AnatomyParameterDefinition"/> and
+    /// <see cref="AnatomyTierDefinition"/>: the loader gains <c>scale_type</c>,
+    /// <c>numeric_range</c>, and per-tier <c>numeric_breakpoint</c> support
+    /// without breaking the legacy categorical-only file shape.
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class AnatomyScaleTypeTests
+    {
+        // ----- legacy categorical-only shape (pre-#551 file format) ------
+
+        private const string LegacyCategoricalOnlyJson = @"
+[
+  {
+    ""id"": ""eye_style"",
+    ""name"": ""Eye Style"",
+    ""tiers"": [
+      {
+        ""id"": ""soft"",
+        ""name"": ""Soft"",
+        ""stat_modifiers"": { ""charm"": 1 },
+        ""personality_fragment"": ""warm"",
+        ""backstory_fragment"": ""b"",
+        ""texting_style_fragment"": ""s"",
+        ""archetype_tendencies"": [""The Bio Responder""],
+        ""response_timing_modifier"": {
+          ""base_delay_delta_minutes"": 0,
+          ""delay_variance_multiplier"": 1.0,
+          ""dry_spell_probability_delta"": 0.0,
+          ""read_receipt"": ""neutral""
+        }
+      }
+    ]
+  }
+]";
+
+        [Fact]
+        public void LegacyFile_NoScaleType_ParsesAsCategorical()
+        {
+            var repo = new JsonAnatomyRepository(LegacyCategoricalOnlyJson);
+            var p = repo.GetParameter("eye_style");
+            Assert.NotNull(p);
+            Assert.Equal(AnatomyParameterDefinition.ScaleTypeCategorical, p!.ScaleType);
+            Assert.Null(p.NumericRange);
+            Assert.Single(p.Tiers);
+            Assert.Null(p.Tiers[0].NumericBreakpoint);
+        }
+
+        [Fact]
+        public void LegacyFile_ExplicitCategorical_ParsesAsCategorical()
+        {
+            const string json = @"
+[
+  {
+    ""id"": ""tattoos"",
+    ""name"": ""Tattoos"",
+    ""scale_type"": ""categorical"",
+    ""tiers"": [
+      {
+        ""id"": ""none"",
+        ""name"": ""None"",
+        ""stat_modifiers"": {},
+        ""personality_fragment"": ""p"",
+        ""backstory_fragment"": ""b"",
+        ""texting_style_fragment"": ""s"",
+        ""archetype_tendencies"": [],
+        ""response_timing_modifier"": {
+          ""base_delay_delta_minutes"": 0,
+          ""delay_variance_multiplier"": 1.0,
+          ""dry_spell_probability_delta"": 0.0,
+          ""read_receipt"": ""neutral""
+        }
+      }
+    ]
+  }
+]";
+            var repo = new JsonAnatomyRepository(json);
+            var p = repo.GetParameter("tattoos");
+            Assert.NotNull(p);
+            Assert.Equal(AnatomyParameterDefinition.ScaleTypeCategorical, p!.ScaleType);
+            Assert.Null(p.NumericRange);
+            Assert.Null(p.Tiers[0].NumericBreakpoint);
+        }
+
+        // ----- new numeric shape ------
+
+        [Fact]
+        public void NumericParameter_RoundTripsBreakpointAndRange()
+        {
+            const string json = @"
+[
+  {
+    ""id"": ""length"",
+    ""name"": ""Length"",
+    ""scale_type"": ""numeric"",
+    ""numeric_range"": { ""min"": 1, ""max"": 4, ""unit"": ""tier"" },
+    ""tiers"": [
+      {
+        ""id"": ""short"",
+        ""name"": ""Short"",
+        ""numeric_breakpoint"": 1,
+        ""stat_modifiers"": { ""self_awareness"": 1 },
+        ""personality_fragment"": ""p"",
+        ""backstory_fragment"": ""b"",
+        ""texting_style_fragment"": ""s"",
+        ""archetype_tendencies"": [""The Sniper""],
+        ""response_timing_modifier"": {
+          ""base_delay_delta_minutes"": -5,
+          ""delay_variance_multiplier"": 0.8,
+          ""dry_spell_probability_delta"": 0.0,
+          ""read_receipt"": ""neutral""
+        }
+      },
+      {
+        ""id"": ""legendary"",
+        ""name"": ""Legendary"",
+        ""numeric_breakpoint"": 4,
+        ""stat_modifiers"": {},
+        ""personality_fragment"": ""p"",
+        ""backstory_fragment"": ""b"",
+        ""texting_style_fragment"": ""s"",
+        ""archetype_tendencies"": [],
+        ""response_timing_modifier"": {
+          ""base_delay_delta_minutes"": 15,
+          ""delay_variance_multiplier"": 1.5,
+          ""dry_spell_probability_delta"": 0.1,
+          ""read_receipt"": ""hides""
+        }
+      }
+    ]
+  }
+]";
+            var repo = new JsonAnatomyRepository(json);
+            var p = repo.GetParameter("length");
+
+            Assert.NotNull(p);
+            Assert.Equal(AnatomyParameterDefinition.ScaleTypeNumeric, p!.ScaleType);
+            Assert.NotNull(p.NumericRange);
+            Assert.Equal(1, p.NumericRange!.Min);
+            Assert.Equal(4, p.NumericRange.Max);
+            Assert.Equal("tier", p.NumericRange.Unit);
+
+            Assert.Equal(2, p.Tiers.Count);
+            Assert.Equal(1, p.Tiers[0].NumericBreakpoint);
+            Assert.Equal(4, p.Tiers[1].NumericBreakpoint);
+        }
+
+        [Fact]
+        public void NumericParameter_MissingNumericRange_LeavesItNull()
+        {
+            // Defensive: file with scale_type=numeric but no numeric_range
+            // shouldn't blow up; the editor surfaces the missing range and
+            // lets the admin fill it in.
+            const string json = @"
+[
+  {
+    ""id"": ""length"",
+    ""name"": ""Length"",
+    ""scale_type"": ""numeric"",
+    ""tiers"": []
+  }
+]";
+            var repo = new JsonAnatomyRepository(json);
+            var p = repo.GetParameter("length");
+            Assert.NotNull(p);
+            Assert.Equal(AnatomyParameterDefinition.ScaleTypeNumeric, p!.ScaleType);
+            Assert.Null(p.NumericRange);
+        }
+
+        [Fact]
+        public void CategoricalParameter_BreakpointFieldIgnored()
+        {
+            // If a future hand-edit accidentally leaves a breakpoint on a
+            // categorical tier, we drop it on parse rather than surface it.
+            // This keeps the (parameter scale_type, tier breakpoint) invariant
+            // tight even when the file is in a transient inconsistent state.
+            const string json = @"
+[
+  {
+    ""id"": ""eye_style"",
+    ""name"": ""Eye Style"",
+    ""scale_type"": ""categorical"",
+    ""tiers"": [
+      {
+        ""id"": ""soft"",
+        ""name"": ""Soft"",
+        ""numeric_breakpoint"": 1,
+        ""stat_modifiers"": {},
+        ""personality_fragment"": ""p"",
+        ""backstory_fragment"": ""b"",
+        ""texting_style_fragment"": ""s"",
+        ""archetype_tendencies"": [],
+        ""response_timing_modifier"": {
+          ""base_delay_delta_minutes"": 0,
+          ""delay_variance_multiplier"": 1.0,
+          ""dry_spell_probability_delta"": 0.0,
+          ""read_receipt"": ""neutral""
+        }
+      }
+    ]
+  }
+]";
+            var repo = new JsonAnatomyRepository(json);
+            var p = repo.GetParameter("eye_style");
+            Assert.NotNull(p);
+            Assert.Null(p!.Tiers[0].NumericBreakpoint);
+        }
+
+        // ----- Skin-Tone-shaped (visual_description only) tier in a numeric param ------
+
+        [Fact]
+        public void VisualOnlyTier_InNumericParam_StillRoundTripsBreakpoint()
+        {
+            // Edge case: a visual-only tier (no personality_fragment) inside
+            // a numeric parameter still picks up its numeric_breakpoint.
+            // None of the bundled file's numeric params currently use this
+            // shape, but the parser should support it for symmetry.
+            const string json = @"
+[
+  {
+    ""id"": ""length"",
+    ""name"": ""Length"",
+    ""scale_type"": ""numeric"",
+    ""numeric_range"": { ""min"": 1, ""max"": 2, ""unit"": ""tier"" },
+    ""tiers"": [
+      { ""id"": ""mini"", ""name"": ""Mini"", ""numeric_breakpoint"": 1, ""visual_description"": ""tiny"" },
+      { ""id"": ""mega"", ""name"": ""Mega"", ""numeric_breakpoint"": 2, ""visual_description"": ""huge"" }
+    ]
+  }
+]";
+            var repo = new JsonAnatomyRepository(json);
+            var p = repo.GetParameter("length");
+            Assert.NotNull(p);
+            Assert.Equal(2, p!.Tiers.Count);
+            Assert.Equal(1, p.Tiers[0].NumericBreakpoint);
+            Assert.Equal("tiny", p.Tiers[0].VisualDescription);
+            Assert.Equal(2, p.Tiers[1].NumericBreakpoint);
+        }
+
+        // ----- bundled file: round-trip the 9 existing parameters ------
+
+        [Fact]
+        public void BundledFile_NineParameters_ScaleTypesAreCorrect()
+        {
+            var json = LoadBundledAnatomyJson();
+            var repo = new JsonAnatomyRepository(json);
+            var all  = repo.GetAll().ToList();
+
+            Assert.Equal(9, all.Count);
+
+            // The three numeric params per the sprint spec.
+            foreach (var pid in new[] { "length", "girth", "ball_size" })
+            {
+                var p = repo.GetParameter(pid);
+                Assert.NotNull(p);
+                Assert.Equal(AnatomyParameterDefinition.ScaleTypeNumeric, p!.ScaleType);
+                Assert.NotNull(p.NumericRange);
+                // Every tier in a numeric param has a breakpoint set.
+                Assert.All(p.Tiers, t => Assert.NotNull(t.NumericBreakpoint));
+            }
+
+            // The six categorical params per the sprint spec.
+            foreach (var pid in new[] {
+                "circumcision", "vein_definition", "skin_texture",
+                "skin_tone", "tattoos", "eye_style" })
+            {
+                var p = repo.GetParameter(pid);
+                Assert.NotNull(p);
+                Assert.Equal(AnatomyParameterDefinition.ScaleTypeCategorical, p!.ScaleType);
+                Assert.Null(p.NumericRange);
+                Assert.All(p.Tiers, t => Assert.Null(t.NumericBreakpoint));
+            }
+        }
+
+        [Fact]
+        public void BundledFile_NumericParameters_BreakpointsAreOrderedOneThroughFour()
+        {
+            var json = LoadBundledAnatomyJson();
+            var repo = new JsonAnatomyRepository(json);
+
+            // The migration tagged each numeric param's tiers in the order
+            // they appear in the file with breakpoints 1..N.
+            foreach (var pid in new[] { "length", "girth", "ball_size" })
+            {
+                var p = repo.GetParameter(pid);
+                Assert.NotNull(p);
+                var bps = p!.Tiers.Select(t => t.NumericBreakpoint).ToList();
+                Assert.Equal(new int?[] { 1, 2, 3, 4 }, bps);
+            }
+        }
+
+        // ----- helper -----------------------------------------------------
+
+        private static string LoadBundledAnatomyJson()
+        {
+            // Walk up from the test bin dir to the repo root that contains
+            // data/anatomy/anatomy-parameters.json. Works in both the canonical
+            // pinder-core clone AND a `git worktree`-based checkout (where
+            // .git is a file rather than a directory — see the
+            // GIT-WORKTREE-DOTGIT-IS-A-FILE canonical lesson).
+            var dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 10; i++)
+            {
+                var candidate = Path.Combine(dir, "data", "anatomy", "anatomy-parameters.json");
+                if (File.Exists(candidate)) return File.ReadAllText(candidate);
+                var parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            throw new FileNotFoundException(
+                "Could not locate data/anatomy/anatomy-parameters.json " +
+                "by walking up from " + AppDomain.CurrentDomain.BaseDirectory);
+        }
+    }
+}


### PR DESCRIPTION
Implements **Phase 2a** of the `admin-content-editor-v1` sprint — the
schema refactor that distinguishes numeric anatomy parameters
(length / girth / ball_size) from categorical ones (eye style, tattoos,
…), in service of the anatomy editor coming in #552.

## Wire shape changes

`AnatomyParameterDefinition` gains:
- `ScaleType: string` — `"numeric"` or `"categorical"`. Default
  `"categorical"` (constants exposed as `ScaleTypeNumeric` /
  `ScaleTypeCategorical`).
- `NumericRange: NumericRangeSpec?` — non-null iff `ScaleType ==
  "numeric"`.

`AnatomyTierDefinition` gains:
- `NumericBreakpoint: int?` — non-null only on tiers within numeric
  parents.

New value type `NumericRangeSpec { Min: int, Max: int, Unit: string }`.

## Loader (`JsonAnatomyRepository`)

Backwards-compatible. A param without `scale_type` parses as
categorical with null `NumericRange` and tiers with null
`NumericBreakpoint` — exactly the shape every file shipped with
before this change. New-shape files parse the per-tier
`numeric_breakpoint` and per-param `numeric_range` blocks.

Defensive parsing: a stray `numeric_breakpoint` on a categorical
tier is silently dropped on parse so the (parameter scale_type, tier
breakpoint) invariant stays tight even if the file is in a transient
inconsistent state during editing.

## Data migration (`data/anatomy/anatomy-parameters.json`)

- `length`, `girth`, `ball_size` get `scale_type: "numeric"`,
  `numeric_range: { min: 1, max: 4, unit: "tier" }`, and per-tier
  `numeric_breakpoint: 1..4` ordered as the existing tiers appear.
- The 6 categorical parameters keep their existing shape and rely on
  the default `ScaleType = categorical`. They get NO `scale_type`
  field added — the byte-shape stays identical except where the
  numeric fields would otherwise sit.

The breakpoints/range values use ordinal positions ("tier 1..4")
rather than physical measurements. This is deliberate: the engine
doesn't read these fields today, the editor (#552) treats them as
authoring metadata, and using ordinals avoids accidentally claiming
unintended physical semantics about anatomy that the prose tier names
keep ambiguous on purpose. The admin can promote them to actual
units (inches, cm, mm) via the editor when #552 lands.

## Live-game behaviour unchanged

The engine selects tiers by id; `StatModifiers`, the four prose
fragments, `ArchetypeTendencies`, and `ResponseTimingModifier` are
all unchanged on every existing tier. Character generation,
session resolution, prompt assembly all read the same data they
always have.

## DoD Evidence

- [x] **Pinder.Core.Tests pass with the new schema fields.**
  ```
  Passed!  - Failed:     0, Passed:  2678, Skipped:    18, Total:  2696
  ```
  (2670 baseline pre-change + 8 new `AnatomyScaleTypeTests` cases.)
- [x] **The 9 existing parameters round-trip cleanly** — the bundled-
  file tests in `AnatomyScaleTypeTests` confirm the 3 numeric / 6
  categorical split and that numeric breakpoints are 1..4 ordered
  as the tiers appear.
- [x] **No semantic change to the live game's behaviour** — engine
  reads tier id, StatModifiers, fragments, archetypes, timing.
  None of those changed on any existing tier.
- [x] **Loader test: a categorical-only file (no `scale_type`) still
  parses with default semantics** — `LegacyFile_NoScaleType_ParsesAsCategorical`.
- [x] **Loader test: a numeric param round-trips its
  `NumericBreakpoint` and `NumericRange`** —
  `NumericParameter_RoundTripsBreakpointAndRange`.
- [x] **Defensive shape**: stray numeric_breakpoint on categorical
  is dropped (`CategoricalParameter_BreakpointFieldIgnored`); missing
  numeric_range on a numeric param surfaces as null
  (`NumericParameter_MissingNumericRange_LeavesItNull`); visual-only
  tier in a numeric param round-trips its breakpoint
  (`VisualOnlyTier_InNumericParam_StillRoundTripsBreakpoint`).

Build command run pre-PR (matches the GameApi-side path that
`./deploy.sh` exercises after the cross-repo bump):
```
$ dotnet build Pinder.Core.sln
0 Error(s)
```

Pinder-web GameApi tests are validated separately in the
cross-repo bump PR (per the swarm-drain canonical lesson on
cross-repo: pinder-core PR lands first, then pinder-web submodule
bump as a separate small chore PR).

## Drive-by changes

None. The diff is the four files documented above plus the new
`NumericRangeSpec.cs` and the new `AnatomyScaleTypeTests.cs`.

## Research Log

1. Inventoried call sites for `AnatomyParameterDefinition` /
   `AnatomyTierDefinition`. Only `JsonAnatomyRepository` constructs
   them. Adding constructor parameters with default values is
   source-compatible; consumers via `IAnatomyRepository` see new
   read-only properties without any change to existing access
   patterns.
2. Verified the `JsonObject` parser used by the loader is
   `internal`-scoped to `Pinder.Core.Data`; using its `GetInt`/
   `GetString`/`GetObject`/`HasKey` shape inside the same project
   is the established pattern. No new public surface exposed
   beyond `ScaleType`/`NumericRange`/`NumericBreakpoint`/`NumericRangeSpec`.
3. Picked ordinal breakpoints + `unit: "tier"` over physical units
   so the migration is semantically neutral. The editor (#552) will
   surface these in the UI; an admin who wants to change `length`'s
   unit to "inches" with a 3..12 range can do that from the editor
   without re-touching this PR.
4. Live-game test path (`CharacterSystemTests`) reads from
   `agents-extra/pinder/data/anatomy/anatomy-parameters.json` —
   a separate copy outside this repo. That copy was NOT touched
   by this PR; the live game continues to load the legacy
   categorical-only shape and the parser's backwards-compatibility
   covers it. So the in-repo migration is what the
   `Pinder.GameApi` deploy and the editor consume; the live-game
   sim continues to exercise the legacy parse path.
5. Sprint plan + ticket body reviewed: numeric inferred set is
   length / girth / ball_size; categorical inferred set is the
   other six. No deviation from the spec.

Closes #551.
