### PR TITLE
i18n: add topnav.admin string for admin-editor nav link

### DIFF
--- a/data/i18n/en/ui.yaml
+++ b/data/i18n/en/ui.yaml
@@ -9,6 +9,7 @@ strings:
   topnav.aria_primary: "Primary"
   topnav.play: "Play"
   topnav.sessions: "Sessions"
+  topnav.admin: "Admin"
 
   # ── Common (#439) ─────────────────────────────────────────────────
   common.loading: "Loading…"


### PR DESCRIPTION
Tiny string addition. Adds `topnav.admin: "Admin"` to `data/i18n/en/ui.yaml` so pinder-web's TopNav can render a conditional Admin link for users with `is_admin: true` (admin-content-editor-v1 follow-up).

## DoD Evidence

- One-line addition to ui.yaml.
- No new schema fields, no behavioural change to the engine.

## Research Log

Pinder-web TopNav uses `t('topnav.admin')` to render the new conditional Admin link. The i18n source-of-truth lives in pinder-core's data dir (`pinder-core/data/i18n/en/ui.yaml`); pinder-web's frontend bundles it via `scripts/build-i18n.mjs` at build time. Hence the string lives here.