### PR TITLE
fix(stake): remove silent 4000-char truncation in LlmStakeGenerator (#834)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -153,7 +153,10 @@ letting it leak in via probing.
 Six tests in `CharacterLoaderSpecTests` were spuriously failing in the
 worktree until `FindPromptDir()` was taught to accept the file form.
 
-### NEVER-SILENTLY-TRUNCATE-LLM-INPUTS
+### LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG
+
+*(also known as NEVER-SILENTLY-TRUNCATE-LLM-INPUTS — the canonical name as of #834.)*
+
 
 **Symptom:** Stake-generation samples for #826 were compared head-to-head
 between prompt variants for weeks before anyone noticed the prompts were
@@ -195,4 +198,10 @@ which of the five rules above applies. PRs that quietly add such a slice
 without the comment block must be sent back.
 
 **Discovered in:** #834 audit, prompted by #826 stake-prompt re-spec
-discussion in the pinder Discord (2026-05-09).
+discussion in the pinder Discord (2026-05-09). Fix landed in PR for #834 —
+removed the 4000-char cap in `LlmStakeGenerator.BuildUserMessage` and the
+500-char cap in `LlmPlayerAgent.BuildSystemMessage` (sim-tool path); audit
+documented in the PR body classified all remaining `Substring(0, n)` /
+`Math.Min(n, ...Length)` hits in the repo as either (a) deterministic
+parsing/display, (b) error-body excerpts with a visible `...[truncated]`
+marker (Anthropic/OpenAI transports), or (c) other non-LLM-bound display.

--- a/session-runner/LlmPlayerAgent.cs
+++ b/session-runner/LlmPlayerAgent.cs
@@ -225,13 +225,15 @@ namespace Pinder.SessionRunner
 
             if (!string.IsNullOrEmpty(context.PlayerSystemPrompt))
             {
-                // Extract brief personality traits (first 500 chars to keep prompt lean)
-                string personality = context.PlayerSystemPrompt.Length > 500
-                    ? context.PlayerSystemPrompt.Substring(0, 500) + "..."
-                    : context.PlayerSystemPrompt;
+                // #834: pass the full assembled player system prompt. The previous 500-char
+                // "keep prompt lean" cap silently truncated the character's personality block,
+                // dropping anatomy/aesthetic/backstory fragments past the 500-char mark. Sim
+                // strategic reasoning is fine with the full character bible — this is a sim-tool,
+                // not a per-turn budget hotspot. See LESSONS_LEARNED
+                // LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG.
                 sb.AppendLine();
                 sb.AppendLine();
-                sb.Append($"Character personality (for voice, not strategy):\n{personality}");
+                sb.Append($"Character personality (for voice, not strategy):\n{context.PlayerSystemPrompt}");
             }
 
             return sb.ToString();

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -165,8 +165,11 @@ namespace Pinder.SessionSetup
 
         private static string BuildUserMessage(string assembledSystemPrompt)
         {
-            int promptWindow = Math.Min(4000, assembledSystemPrompt.Length);
-            string promptSlice = assembledSystemPrompt.Substring(0, promptWindow);
+            // #834: pass the full assembled system prompt — never silently truncate LLM input.
+            // Stake generation is once-per-character-per-session and the result is cached into the
+            // assembled system prompt prefix, so cost impact of full-profile input is one-time, not
+            // per-turn. See LESSONS_LEARNED LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG.
+            string promptSlice = assembledSystemPrompt;
 
             return
                 $@"Based on this character's assembled fragments, write a psychological portrait that a novelist would use to write their dialogue. Be creative and specific — fill in gaps based on what the fragments imply, don't summarize them.


### PR DESCRIPTION
Closes #834

Removes the silent 4000-char truncation in `LlmStakeGenerator.BuildUserMessage` (the named instance in the bug body) and audits all remaining `Substring(0, n)` / `Math.Min(n, ...Length)` slices in pinder-core. One additional silent LLM-input slice was found (`session-runner/LlmPlayerAgent.cs:230`) and removed; everything else is either deterministic parsing/display or visible-marker error-body excerpts.

## DoD Evidence

- [x] `LlmStakeGenerator.BuildUserMessage` no longer truncates `assembledSystemPrompt`. Full profile passed through. (`src/Pinder.SessionSetup/LlmStakeGenerator.cs`, line 168 → comment + full passthrough.)
- [x] Full audit completed (see classification table below).
- [x] New rule in `LESSONS_LEARNED.md` named `LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG` (existing pre-emptive entry was named `NEVER-SILENTLY-TRUNCATE-LLM-INPUTS`; renamed to the canonical name from #834 and kept the alias). Body reused unchanged plus a "Discovered in" footer pointing at this PR.
- [x] Code-review checklist item lives inside that lesson (the "Code-review checklist:" paragraph at the bottom). Reviewers grep new diffs for `Substring(0, ` on prompt-bound strings and reject without a justification comment block.
- [x] `dotnet build Pinder.Core.sln` clean (0 errors, pre-existing warnings only).
- [x] `dotnet test Pinder.Core.sln --no-build` filtered to `Stake|PlayerAgent`: 168 passed, 0 failed.

### Audit table — every `Substring(0, n)` / `Math.Min(n, ...Length)` in pinder-core

| File:Line | Pattern | Category | Action |
|---|---|---|---|
| `src/Pinder.SessionSetup/LlmStakeGenerator.cs:168-169` | 4000-char silent cap on assembled system prompt | (b) silent truncation of LLM-bound input | **REMOVED** |
| `session-runner/LlmPlayerAgent.cs:230` | 500-char silent slice on PlayerSystemPrompt before injecting into sim-player system prompt | (b) silent truncation of LLM-bound input | **REMOVED** |
| `src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs:194` | error body excerpt with `…[truncated]` marker for exception message | (c) display/audit truncation with visible marker | keep |
| `src/Pinder.LlmAdapters/Anthropic/AnthropicClient.cs:97,105` | 200-byte error body slice for log/throw | (c) display/error truncation | keep |
| `src/Pinder.LlmAdapters/OpenAi/OpenAiClient.cs:87` | 200-byte error body slice | (c) | keep |
| `src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs:162,325` | 500/200-byte error body slice | (c) | keep |
| `src/Pinder.LlmAdapters/Anthropic/OpponentResponseParsers.cs:45` | extract message text up to `[SIGNALS]` marker | (a) deterministic parsing, not truncation | keep |
| `src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs:352` | same parser pattern (cuts at signal index) | (a) deterministic parsing | keep |
| `src/Pinder.SessionSetup/DirectoryCharacterStore.cs:220` | 8-char shortId from GUID hex | (a) deterministic display id | keep |
| `src/Pinder.SessionSetup/LlmMatchupAnalyzer.cs:287` | 8-char shortId from hex | (a) deterministic display id | keep — note: file deleted by #827 in next ticket of this drain |
| `session-runner/CharacterLoader.cs:74,120,133,194,270` | filename/colon/dash/comma splitting in YAML/text parsers | (a) deterministic parsing | keep |
| `session-runner/PlaytestFormatter.cs:233` | string-formatting an event display line | (a) display | keep |
| `session-runner/Snapshot/TurnEventDetector.cs:137` | parse a growth marker prefix | (a) deterministic parsing | keep |
| `session-runner/Program.cs:1532` | `WrapText` line-break helper for terminal output | (a) display | keep |
| `session-runner/Program.cs:1827` | parse session number from slug | (a) deterministic parsing | keep |

No `[..N]`, `Take(N)`, `\.Take` slice patterns, or other tokeniser-based caps were found in pinder-core that hit prompt-bound strings. The single 4000-magic-number elsewhere (`src/Pinder.Core/Progression/LevelTable.cs:21`) is XP table data, unrelated.

### Note on the cross-repo audit (pinder-web)

Per ticket: cross-repo audit on pinder-web is to be done **after merge**, with any findings filed as **follow-up tickets**, not patched in this PR. That work runs immediately after this merges and any findings will be filed before B.1 (#827) starts, per the standing-order envelope.

A pre-look has already surfaced one known visible (with marker) slice — `pinder-web/src/Pinder.GameApi/Services/Snapshot/LlmExchange.cs:83-86` `TruncateAndSanitise` 64 KB cap with a `...[truncated]` marker. Visible, but means snapshot resims of any >64 KB exchange diverge from prod. That's category (c) on the visible side; whether to raise/drop the cap is an independent design decision and is being filed as a follow-up rather than rolled into this PR.

## Research Log

1. Re-read the bug body. The named instance is `LlmStakeGenerator.BuildUserMessage` line 166-187. `Math.Min(4000, ...Length)` then `Substring(0, promptWindow)` — no log, no marker, no metric. Stake is injected into every turn's system prompt forever via `Player.AppendToSystemPrompt`, so any drop of post-4000 content (anatomy / backstory / texting style depending on character order) silently biases stakes for the entire session.
2. Audited every `Substring(0, ` and `Math.Min(<num>, ...Length)` in `src/`, `session-runner/`, and `tests/` of pinder-core. Classification per ticket schema (a)/(b)/(c) shown in the table above.
3. The audit surfaced one previously-uncalled-out instance: `session-runner/LlmPlayerAgent.cs:230` slices `PlayerSystemPrompt` to 500 chars and feeds the slice into the sim-player's system prompt with a "..." suffix. The old comment ("first 500 chars to keep prompt lean") doesn't justify the silent loss for a strategic-reasoning agent — and the ticket explicitly calls this site out as "Display-only, but reinforce-or-remove for clarity." Removed the cap, replaced the comment with a #834 reference.
4. No tests assert on the 4000-char cap or the 500-char cap. Filtered test run (`Stake|PlayerAgent`): 168 passed, 0 failed.
5. `LESSONS_LEARNED.md` already contained an entry titled `NEVER-SILENTLY-TRUNCATE-LLM-INPUTS` (added pre-emptively). Renamed to the canonical name from the ticket (`LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG`) with the old name kept as an alias line so existing references don't break. Appended the "Discovered in" footer with this PR's specific fix details.

### Test discipline (per project AGENTS.md)

```
dotnet build Pinder.Core.sln > /tmp/build-834.txt 2>&1 ; tail -5
# 0 errors, 175 pre-existing warnings.
dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --no-build --filter "FullyQualifiedName~Stake|FullyQualifiedName~PlayerAgent"
# Passed: 168, Failed: 0.
```

The full-suite run also ran (`dotnet test Pinder.Core.sln --no-build`) and produced 46 failures in `Pinder.Rules.Tests` and 63 in `Pinder.LlmAdapters.Tests`. Verified these are **pre-existing on plain `origin/main`** before any of this PR's changes were applied — `YamlDotNet` `DefaultObjectFactory.Create(System.String)` deserialization failures, an environmental flake unrelated to this PR. They reproduce identically on the unchanged baseline. Not a merge blocker; surfacing here so the next person who runs the full suite isn't surprised.

## Drive-by changes

- `LESSONS_LEARNED.md` heading rename `NEVER-SILENTLY-TRUNCATE-LLM-INPUTS` → `LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG`, alias line preserved. (Per ticket; not a behaviour change.)
- "Discovered in" footer in the same lesson body now references this PR with the specific files touched.

No other untracked changes. `git diff origin/main...HEAD` reads exactly the three intended files.

## Sprint reference

Drain run prompt-quality + setup-trim 2026-05-09, ticket A.1 of 10. Phase A blocker — must land before #826 (slim-stake re-spec) so stake-prompt comparison samples are eval-honest.
