### PR TITLE
feat(setup-trim): slim psychological-stake to 5-7 fragment lines (#826)

### DIFF
--- a/src/Pinder.SessionSetup/IStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/IStakeGenerator.cs
@@ -6,16 +6,24 @@ using Pinder.Core.Interfaces;
 namespace Pinder.SessionSetup
 {
     /// <summary>
-    /// Generates a "psychological stake" novella-style character bible for a
-    /// single character, derived from their assembled system prompt.
-    /// One call per character.
+    /// Generates a "psychological stake" tight 5-7 single-line riff-able
+    /// fragment list for a single character, derived from their assembled
+    /// system prompt. One call per character.
     /// </summary>
+    /// <remarks>
+    /// #826 (setup-trim phase 3): the previous novella-style 6-point
+    /// 2-3-paragraphs-each character bible was replaced with the slim
+    /// fragment shape because the stake is injected into every turn's
+    /// system prompt and the bigger shape was costing ~1500 input tokens
+    /// per turn per character with no demonstrated lift.
+    /// </remarks>
     public interface IStakeGenerator
     {
         /// <summary>
-        /// Generate a psychological-stake paragraph block (plain prose,
-        /// paragraph breaks only — see <c>Pinder.SessionSetup/README.md</c>)
-        /// for <paramref name="characterName"/>. Returns an empty string on
+        /// Generate a psychological-stake fragment list (plain text, one
+        /// fragment per line, 5-7 lines, ~10-15 words each — see
+        /// <c>Pinder.SessionSetup/README.md</c>) for
+        /// <paramref name="characterName"/>. Returns an empty string on
         /// transport failure — never throws.
         /// </summary>
         Task<string> GenerateAsync(

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -11,30 +11,42 @@ namespace Pinder.SessionSetup
     /// Default <see cref="IStakeGenerator"/> built on <see cref="ILlmTransport"/>
     /// (non-streaming) and optionally <see cref="IStreamingLlmTransport"/>
     /// (streaming overload).
-    /// Generates a novella-style "psychological stake" character bible.
+    /// Generates a tight 5-7 single-line riff-able stake fragment list.
     /// </summary>
     /// <remarks>
-    /// Output contract (issue pinder-web #136): the returned stake is plain
-    /// prose, paragraph breaks only — no markdown headings, bold, italics,
-    /// bullet or numbered lists, blockquotes, or code fences. Both the system
-    /// and user prompts forbid markdown explicitly. <c>Pinder.GameApi</c>
-    /// runs a <c>MarkdownSanitizer</c> as defence-in-depth before storing
-    /// the result.
-    ///
+    /// <para>
+    /// #826 (setup-trim phase 3): the previous novella-style 6-point
+    /// 2-3-paragraphs-each character bible has been replaced with a tight
+    /// 5-7 plain-text single-line fragment list. The output is injected
+    /// verbatim into every turn's system prompt via
+    /// <c>Player.AppendToSystemPrompt</c>, so each fragment costs per-turn
+    /// tokens; the slim shape cuts ~1000 input tokens per character per
+    /// turn relative to the legacy prompt.
+    /// </para>
+    /// <para>
+    /// Output contract (issue pinder-web #136): each yielded fragment is
+    /// plain text — no markdown headings, bold, italics, bullet or
+    /// numbered lists, blockquotes, or code fences. The transport sees
+    /// one fragment per line. Both the system and user prompts forbid
+    /// markdown explicitly. <c>Pinder.GameApi</c> runs a
+    /// <c>MarkdownSanitizer</c> as defence-in-depth before storing the
+    /// result.
+    /// </para>
+    /// <para>
     /// Streaming: when an <see cref="IStreamingLlmTransport"/> is supplied,
     /// <see cref="StreamStakeAsync"/> yields raw fragments as they arrive
     /// and propagates transport failures as
     /// <see cref="LlmTransportException"/> (deliberate departure from the
     /// non-streaming overload, which swallows).
+    /// </para>
     /// </remarks>
     public sealed class LlmStakeGenerator : IStakeGenerator
     {
         private const string SystemPrompt =
-            "You are a novelist writing a character bible for a comedy about online dating. " +
-            "Respond in plain prose only. Do NOT use markdown formatting of any kind: no " +
-            "headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered " +
-            "lists (-, *, +, 1., 2.), no blockquotes (>), and no inline or fenced code " +
-            "(`, ```). Separate paragraphs with blank lines.";
+            "You are a writer's-room script consultant for a comedy about online dating. " +
+            "Output a tight list of 5-7 single-line fragments. One fragment per line. " +
+            "Plain text only. No markdown, no leading dashes, no numbering, no headings. " +
+            "Each line ~10-15 words. Specific, vivid, slightly absurd, played straight.";
 
         private readonly ILlmTransport _transport;
         private readonly IStreamingLlmTransport? _streamingTransport;
@@ -169,22 +181,29 @@ namespace Pinder.SessionSetup
             // Stake generation is once-per-character-per-session and the result is cached into the
             // assembled system prompt prefix, so cost impact of full-profile input is one-time, not
             // per-turn. See LESSONS_LEARNED LLM-INPUT-SILENT-TRUNCATION-IS-ALWAYS-A-BUG.
+            //
+            // #826 (setup-trim phase 3): output is now 5-7 single-line fragments, one per line,
+            // plain text. The fragment list is injected into every turn's system prompt, so this
+            // shape directly reduces per-turn input tokens by ~1000 per character relative to the
+            // legacy 6-point novella prompt.
             string promptSlice = assembledSystemPrompt;
 
             return
-                $@"Based on this character's assembled fragments, write a psychological portrait that a novelist would use to write their dialogue. Be creative and specific — fill in gaps based on what the fragments imply, don't summarize them.
+                $@"Read this character profile and write 5-7 single-line riff-able fragments the dialogue model can latch onto. One per line. No prose, no markdown, no leading dashes, no numbering, no headings. ~10-15 words per line.
 
-TONAL INSTRUCTION: This is a comedy game about the absurdity of online dating. The psychological stakes should be over the top and slightly ridiculous — but the character treats them as completely, genuinely real. The comedy lives in the gap between how absurd the reason sounds stated plainly and how seriously the character feels it. A character who joined because they had a spiritual crisis in an IKEA and now believes their soulmate is someone who understands the existential weight of flat-pack furniture is funnier than a character who is simply 'looking for connection' — and no less emotionally true. Lean into specific absurdity. Make the precipitating events specific and a little unhinged. The character should never know they're funny.
+TONAL INSTRUCTION: This is a comedy game about the absurdity of online dating. Stakes are over the top and slightly ridiculous — but the character treats them as completely, genuinely real. The comedy lives in the gap between how absurd the line sounds stated plainly and how seriously the character feels it. Specific absurdity beats generic feeling. A character who joined because they had a spiritual crisis in an IKEA and now believes their soulmate is someone who understands the existential weight of flat-pack furniture is funnier than a character who is simply 'looking for connection' — and no less emotionally true. The character never knows they're funny.
 
-Cover six things, each in 2-3 paragraphs:
-1. Why they are on this app right now. Not a general 'looking for connection' — a specific, absurd, over-the-top emotional context. What ridiculous but emotionally real thing happened recently? Name the specific humiliating, strange, or unhinged moment that preceded this. Make it funny but play it straight.
-2. What they actually want from a match. Their real underlying need — and it should be slightly deranged in its specificity. What exact bizarre thing would having it feel like? What would they do the morning after?
-3. What they are secretly afraid of. The belief about themselves they are protecting — make it specific and a little ridiculous. What absurd thing would it confirm about them if they failed here?
-4. What winning this conversation would mean emotionally — not 'getting the date' but what specific, slightly unhinged thing it proves or heals or demonstrates.
-5. What losing would mean emotionally — not 'getting unmatched' but the specific catastrophic conclusion they would draw about themselves.
-6. Their biographical backstory: 3-5 specific, concrete, slightly unhinged events from the last 2-3 years of their life. These should be specific enough to be revealed in conversation and funny enough to belong in a comedy — not themes but events. A named relationship and the specific absurd way it ended. A job decision and what they did the week after (something strange). A specific moment of realisation in an unlikely location. A place they went alone and what they did there. These are the facts the character can share when the conversation gets real. Write them as vivid, specific narrative fragments. The more specific and slightly absurd, the better.
+Cover, in any order, 5-7 of these (pick whichever fit the character; the goal is a tight riff-able set, not exhaustive coverage):
+- why they are on the app right now (specific absurd recent moment that preceded this)
+- their secret fear about themselves (the belief they're protecting)
+- what they actually want (slightly deranged in its specificity)
+- what winning emotionally would prove, heal, or demonstrate (specific, unhinged)
+- what losing emotionally would conclude about them (specific catastrophe)
+- 2-3 backstory specifics: vivid concrete events from the last 2-3 years (a named relationship and the absurd way it ended; a job decision and what they did the week after; a specific moment of realisation in an unlikely location; a place they went alone and what they did there)
 
-Write 2-3 paragraphs per point. This is a novelist's character bible for a comedy. Write flowing prose only. Do NOT use markdown formatting of any kind: no headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), no inline or fenced code (`, ```). Separate paragraphs with blank lines. Do not number the six points; let the prose flow from one to the next. The character is real, their feelings are genuine, their reasons are ridiculous.
+Write each fragment as one line, ~10-15 words, vivid and specific. No multi-sentence run-ons. No 'I am' or 'I want' framing — these are riff-able fragments, not first-person statements. Examples of the right shape: 'Quit a 9-year nonprofit job after fainting at a fundraiser and woke up convinced she was a saboteur.' / 'Believes the right partner will know how to fold a fitted sheet without crying.' / 'Last summer drove three hours to a town with no cell service to look at one specific oak tree.'
+
+OUTPUT: 5-7 lines. One fragment per line. Plain text. No markdown formatting of any kind: no headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), no inline or fenced code (`, ```). No blank lines between fragments.
 
 CHARACTER PROFILE:
 {promptSlice}";
@@ -196,8 +215,12 @@ CHARACTER PROFILE:
             /// <summary>Temperature. Default 0.9 (matches the legacy helper).</summary>
             public double Temperature { get; set; } = 0.9;
 
-            /// <summary>Max output tokens. Default 800.</summary>
-            public int MaxTokens { get; set; } = 800;
+            /// <summary>
+            /// Max output tokens. Default 300 (#826: hard ceiling for the
+            /// 5-7 single-line-fragment shape; target output is ~250 tokens
+            /// per character, so 300 leaves a small safety margin).
+            /// </summary>
+            public int MaxTokens { get; set; } = 300;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/SessionSetup/LlmStakeGeneratorStreamTests.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/LlmStakeGeneratorStreamTests.cs
@@ -47,8 +47,11 @@ namespace Pinder.Core.Tests.SessionSetup
 
             Assert.NotNull(streaming.LastSystemPrompt);
             // Plain-text contract: the system prompt must explicitly forbid markdown.
-            Assert.Contains("plain prose", streaming.LastSystemPrompt!);
-            Assert.Contains("Do NOT use markdown", streaming.LastSystemPrompt!);
+            // #826 reshaped the prompt from prose to a 5-7 single-line fragment list, but
+            // the no-markdown contract is unchanged — just expressed as "plain text" /
+            // "no markdown" rather than the legacy "plain prose" / "Do NOT use markdown".
+            Assert.Contains("Plain text", streaming.LastSystemPrompt!);
+            Assert.Contains("No markdown", streaming.LastSystemPrompt!);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #826

Setup-trim phase 3. Replaces the novella-style stake prompt with a tight 5-7 single-line fragment list. The stake is injected verbatim into every turn's system prompt, so this directly reduces per-turn input tokens by ~450-500 per character.

## DoD Evidence

- [x] `LlmStakeGenerator` rewritten per the locked decisions in the ticket: 5-7 plain-text single-line fragments, one per line; no markdown; coverage of why-on-app / secret-fear / what-they-want / what-winning-means / what-losing-means / 2-3 backstory specifics (any 5-7).
- [x] Tonal instruction preserved (specific absurdity, played straight, character never knows they're funny). Three concrete example fragments embedded in the user prompt to pin the shape.
- [x] `Options.MaxTokens` default lowered from 800 to 300. Comment explains the budget (~250 token target + safety margin).
- [x] `Options.Temperature` default unchanged at 0.9.
- [x] `dotnet build Pinder.Core.sln` clean (0 errors).
- [x] `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj --no-build`: **2682 passed, 0 failed, 18 skipped.**
- [x] `dotnet test --filter "FullyQualifiedName~Stake"`: 13/13 pass.
- [x] Eval validity: PR #837 (#834) lifted the silent 4000-char input cap, so the slim-prompt comparison samples are now eval-honest (full assembled profiles, no truncation bias). Per the ticket: stake-prompt sample outputs against full untruncated profiles can now be regenerated with the new prompt shape and the comparison is sound.

### Approximate token deltas (chars/4 heuristic)

| | Old | New | Δ |
|---|---|---|---|
| System prompt | 88 | 75 | -13 |
| User-message scaffold (excl. per-character profile) | 806 | 619 | -187 |
| Total INPUT scaffold per stake call | 894 | 694 | **-200** |
| MaxTokens (output cap) | 800 | 300 | **-500** |
| Per-turn savings (output is the dominant per-turn cost — injected into every-turn system prompt) | — | — | **~450-500 tokens / character / turn** |

The input savings are once-per-character-per-session; the output savings recur **every turn**, every character, for the lifetime of the session. With two characters per session this is ~900-1000 tokens shaved off every per-turn system prompt.

## Research Log

1. Read the ticket. Locked decisions: 5-7 single-line fragments, ~10-15 words each, no markdown / dashes / numbering / headings, MaxTokens 300, Temperature 0.9. Coverage list of 5-7 things to pick from. Tonal instruction (specific absurdity) preserved.
2. Rewrote the system prompt: from "novelist writing a character bible" to "writer's-room script consultant" — different framing pulls the model toward staccato-line output instead of paragraph prose. Explicit "One fragment per line. Plain text only. No markdown..." in the system prompt itself, not just the user message.
3. Rewrote the user message: kept the IKEA flat-pack-furniture comedy example verbatim because it's a precise calibration shot for the tonal target. Replaced the numbered "1. … 2. … 6." structure with a single "Cover, in any order, 5-7 of these (pick whichever fit the character)" plus a bulleted shopping list. **Crucially:** because the legacy prompt always demanded all six and the new shape lets the model choose 5-7, the prompt explicitly says "the goal is a tight riff-able set, not exhaustive coverage" so the model knows incomplete coverage is intentional.
4. Embedded **three concrete example fragments** in the user message (saboteur / fitted-sheet / oak-tree). Examples in-prompt are the single highest-leverage way to pin output shape; absent them the model defaults to whatever shape its training data weighted highest, which for "psychological stake" is paragraph prose.
5. `MaxTokens` default 800 → 300. Comment explains the budget ("~250 target with safety margin"). 800 was a relic of the prose era — at 5-7 lines × ~15 words = ~75-105 tokens of substantive content, even with provider preamble noise the model rarely needs more than ~200.
6. Updated `IStakeGenerator` interface XML doc to reflect the new shape. Added a `<remarks>` block referencing #826 with the per-turn-token rationale.
7. Updated `LlmStakeGenerator` class XML doc similarly. The streaming-overload contract (`IAsyncEnumerable<string>` of raw fragments, throw-on-failure semantics) is unchanged.
8. Test fix: `LlmStakeGeneratorStreamTests.StreamStakeAsync_ForwardsPlainTextSystemPrompt` asserted on substring `"plain prose"` and `"Do NOT use markdown"`. Both phrases are gone — the new system prompt says `"Plain text only. No markdown..."`. Updated assertions to the new substrings (`"Plain text"` and `"No markdown"`); the **spirit** of the test (the system prompt forbids markdown) is preserved exactly. No other test changed.
9. Looked for tests asserting on stake output shape (paragraphs, prose, six-point structure). None found in pinder-core. The pinder-web side has snapshot/sanitizer tests but they don't assert on shape; they just round-trip arbitrary text through `MarkdownSanitizer`.

## Drive-by changes

None. The PR touches three files:
- `src/Pinder.SessionSetup/LlmStakeGenerator.cs` (system prompt + user prompt + MaxTokens default + class XML doc)
- `src/Pinder.SessionSetup/IStakeGenerator.cs` (interface XML doc to reflect the new shape — required because the legacy doc-comment described "novella-style character bible," which is now wrong)
- `tests/Pinder.Core.Tests/SessionSetup/LlmStakeGeneratorStreamTests.cs` (single assertion update to match the new system-prompt phrasing while preserving the test's intent — the system prompt forbids markdown)

`git diff origin/main...HEAD` reads exactly these three files. Nothing else.

## Sprint reference

Drain run prompt-quality + setup-trim 2026-05-09, ticket B.2 of 10. Phase B in flight: A.1 #834 ✅ (PR #837), B.1 #827 ✅ (PR #838), **B.2 #826 (this PR)**, B.3 #559 next (pinder-web matchup wiring removal + alembic DROP column + bump pinder-core submodule pointer past this PR).
