### PR TITLE
fix(prompts): drop 1-3 sentence cap from OpponentResponseInstruction (#830)

### DIFF
--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -204,7 +204,7 @@ Generate your next message.
 - React authentically to what was just said
 - If Interest dropped: show cooling without being melodramatic
 - If Interest rose: show warming without being gushing
-- Keep it to 1–3 sentences. Match the register.
+- Match the register exactly as established in your system prompt above. Length follows your character's texting style — one word, one sentence, several short fragments, or one long run-on thought, whichever your texting-style block calls for.
 
 Output format:
 Output your actual message text directly. Do not wrap it in quotes or [RESPONSE] tags.


### PR DESCRIPTION
Closes #830

Replace the generic 1-3 sentence ceiling on `OpponentResponseInstruction` with 'length follows your character's texting style'. The cap contradicted per-character texting-style fragments \u2014 one-word-archetype characters and run-on-archetype characters were forced to violate their voice prompt to comply with the generic constraint.

## DoD Evidence

- [x] Sentence-count ceiling removed from `OpponentResponseInstruction` (`src/Pinder.LlmAdapters/PromptTemplates.cs:207`).
- [x] Replacement text defers length to the character's texting-style block, per ticket's locked decision.
- [x] No tests asserted on the '1-3 sentences' substring; `grep -rn` in `tests/` returns 0 hits for any opponent-response sentence-count assertion.
- [x] `dotnet build Pinder.Core.sln` clean (0 errors).
- [x] `dotnet test --filter 'FullyQualifiedName~Opponent'`: **112 passed, 0 failed.**
- [x] Filtered `PromptTemplate` tests: 5/188 fails reproduce identically on plain `origin/main` (pre-existing, unrelated to this change \u2014 they look for substrings 'OPPONENT PROFILE' / 'sharpen-not-expand' which were never in this prompt).

## Research Log

1. Read the ticket. Surgical edit to `PromptTemplates.cs:207`.
2. Located the line, replaced with ticket's recommended text (verbatim from the ticket's 'After' block).
3. Grepped tests for assertions on `1-3 sentences`, `Keep it to`, opponent-response sentence counts. None found.
4. Verified the 5 pre-existing test failures in `Pinder.LlmAdapters.Tests` reproduce on plain `origin/main` \u2014 pre-existing, unrelated.

## Drive-by changes

None. Single-line edit.

## Sprint reference

Drain run prompt-quality + setup-trim 2026-05-09, ticket C.1 of 10. Phase C (prompt-quality cluster) opening shot.