### PR TITLE
refactor(#831): InlineThinkingStripper as ILlmTransport decorator (DRY)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -205,3 +205,66 @@ documented in the PR body classified all remaining `Substring(0, n)` /
 `Math.Min(n, ...Length)` hits in the repo as either (a) deterministic
 parsing/display, (b) error-body excerpts with a visible `...[truncated]`
 marker (Anthropic/OpenAI transports), or (c) other non-LLM-bound display.
+
+
+## Lesson — DRY post-processing belongs at the transport boundary
+
+When a post-processing step (strip-thinking-blocks, normalise-punctuation,
+audit-record, rate-limit, …) needs to apply to *every* LLM response
+regardless of which call site issued it, **do not implement it as a
+per-callsite helper that consumers must remember to call**. Wrap the
+`ILlmTransport` (and `IStreamingLlmTransport`) with a decorator and let
+the transport boundary enforce the invariant.
+
+The per-callsite pattern fails predictably:
+
+1. The list of call sites grows. Each new prose-only surface (delivery,
+   opponent reply, steering, overlays, stake, outfit, interest beat,
+   tomorrow's TBD surface) is a new place to remember the helper.
+2. Reviewers can't audit the absence of a helper. They see callers that
+   *do* call it; they don't notice the new caller that *doesn't*.
+3. Tests are noisy: every call site gets a near-identical "asserts the
+   strip happened" test. The decorator pattern lets the transport own
+   the invariant with one test pair (non-streaming + streaming) instead
+   of N.
+4. Subtle ordering bugs leak in. Example: refusal-detection runs after
+   strip-then-trim in three of the four call sites today. If a future
+   call site forgets to strip-before-detect, a thinking-block phrase
+   like "I cannot proceed without more context" inside the reasoning
+   trace triggers a spurious refusal fallback.
+
+**Streaming caveat.** Decorator semantics are easy for non-streaming
+(single string transform). For streaming, the post-processor must handle
+the case where a leading sentinel block (e.g. `<thinking>...</thinking>`)
+spans multiple fragments. Two acceptable approaches:
+
+  - **Buffer-then-flush** (used by `ThinkingStrippingLlmTransport`):
+    accumulate fragments while the buffer might still be a leading
+    block; flush either when the closing tag is seen (apply transform)
+    or when the leading characters definitively rule out a block (flush
+    as-is). A safety cap protects against unbounded buffering when the
+    closing tag never arrives.
+  - **Suppress-then-yield**: detect the opening tag at the start of the
+    buffer; suppress further yields until the closing tag is seen; then
+    yield the post-tag stream normally. Closer to streaming semantics
+    but more state.
+
+For most cases `buffer-then-flush` is preferred — simpler implementation,
+acceptable latency penalty (only on thinking-prefixed responses), and
+a clear safety bound.
+
+**Discovered in:** #831 (2026-05-10). The original
+`InlineThinkingStripper` was added in #351 with four explicit call
+sites in `PinderLlmAdapter.cs`. By the time the issue was filed, four
+*more* prose-only surfaces (opponent response, interest beat, stake,
+outfit) had accumulated without per-callsite calls — exactly the
+failure mode the lesson predicts. The fix lifted the strip to a
+transport-level decorator (`ThinkingStrippingLlmTransport`) registered
+in DI ahead of `PunctuationNormalizingTransport`.
+
+**Code-review checklist:** when reviewing a new
+`ILlmTransport`/`IStreamingLlmTransport` decorator, verify it is
+registered in DI in *both* pinder-core's `session-runner/Program.cs`
+*and* pinder-web's `LlmProviderFactory.cs`. Cross-repo wiring drift
+(decorator landed in core but never wired in web) is a real failure
+mode.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -725,7 +725,12 @@ class Program
             // parallel inside Pinder.GameApi's ActiveSession (the runner here
             // emits stakes only).
             string setupModel = Environment.GetEnvironmentVariable("PLAYER_AGENT_MODEL") ?? "claude-sonnet-4-20250514";
-            using var setupTransport = new Pinder.LlmAdapters.Anthropic.AnthropicTransport(apiKey, setupModel);
+            using var setupRawTransport = new Pinder.LlmAdapters.Anthropic.AnthropicTransport(apiKey, setupModel);
+            // #831: wrap setup transport too. The psychological stake
+            // text is appended to the assembled system prompt and
+            // injected into every turn forever, so a single thinking
+            // block leak would persist for the entire session.
+            var setupTransport = new Pinder.LlmAdapters.ThinkingStrippingLlmTransport(setupRawTransport);
 
             // ── Psychological Stakes ──────────────────────────────────
             Console.Error.WriteLine("Generating psychological stakes...");

--- a/src/Pinder.LlmAdapters/InlineThinkingStripper.cs
+++ b/src/Pinder.LlmAdapters/InlineThinkingStripper.cs
@@ -4,15 +4,26 @@ using System.Text.RegularExpressions;
 namespace Pinder.LlmAdapters
 {
     /// <summary>
-    /// Issue #351: post-processor that strips inline <c>&lt;thinking&gt;...&lt;/thinking&gt;</c>
-    /// and <c>&lt;reasoning&gt;...&lt;/reasoning&gt;</c> blocks from prose-only LLM
-    /// surfaces.
+    /// Issue #351 (introduced) / #831 (DRY refactor): post-processor that
+    /// strips a leading <c>&lt;thinking&gt;...&lt;/thinking&gt;</c> or
+    /// <c>&lt;reasoning&gt;...&lt;/reasoning&gt;</c> block from LLM responses.
     ///
-    /// Applied to surfaces where the LLM response is consumed as raw player-visible
-    /// text (steering question, horniness/shadow/trap overlays). NOT applied to
-    /// structured surfaces (matchup analysis, dialogue option parsing) — those
-    /// already parse fields out of a known JSON / structured shape, so a stray
-    /// thinking block would either be ignored or break parsing on its own.
+    /// As of #831 this is invoked at the <see cref="Pinder.Core.Interfaces.ILlmTransport"/>
+    /// boundary by <see cref="ThinkingStrippingLlmTransport"/> (and its
+    /// streaming counterpart in the same class), not at individual call
+    /// sites. The transport decorator is registered as the outermost
+    /// transformation layer in pinder-core's <c>session-runner/Program.cs</c>
+    /// and pinder-web's <c>LlmProviderFactory</c>, so every prose-only and
+    /// structured surface (delivery, opponent reply, steering, overlays,
+    /// stake, outfit, interest beat, dialogue options, …) automatically
+    /// gets strip-on-output. New call sites added later cannot silently
+    /// leak thinking blocks into player-visible text or the persistent
+    /// system prompt.
+    ///
+    /// Structured surfaces (dialogue option parsing, opponent response
+    /// signals) parse fields out of a known shape after a marker line
+    /// (e.g. <c>OPTION_N</c> or <c>[SIGNALS]</c>); a stripped leading
+    /// thinking block leaves those parsers unchanged.
     ///
     /// Conservative behaviour:
     ///   * Strip the wrapped block when it spans the WHOLE response (model
@@ -23,8 +34,11 @@ namespace Pinder.LlmAdapters
     ///     leaving them in place is safer than silently mangling player
     ///     dialogue that legitimately contains an angle-bracket fragment.
     ///
-    /// Pattern is case-insensitive and dot-matches-newline so multi-line thinking
-    /// blocks are caught.
+    /// Pattern is case-insensitive and dot-matches-newline so multi-line
+    /// thinking blocks are caught. The static <see cref="Strip"/> method is
+    /// retained as the canonical pure-function form so the decorator and
+    /// any future direct caller (e.g. ad-hoc audit-log post-processing)
+    /// share the same regex.
     /// </summary>
     public static class InlineThinkingStripper
     {

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -215,12 +215,12 @@ namespace Pinder.LlmAdapters
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
-                // #351: strip inline <thinking>...</thinking> /
-                // <reasoning>...</reasoning> blocks for prose-only surfaces
-                // before refusal-detection — a thinking block could otherwise
-                // contain phrases that look like refusal markers and trigger a
-                // spurious fallback to the un-overlaid message.
-                string trimmed = InlineThinkingStripper.Strip(result).Trim();
+                // #831: thinking-block stripping moved to
+                // ThinkingStrippingLlmTransport (transport decorator).
+                // The transport already strips, so we only trim here.
+                // Refusal detection sees the cleaned text the same way it
+                // did when the strip ran at this call site.
+                string trimmed = result.Trim();
 
                 // Detect refusal — fall back to original message silently
                 if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
@@ -277,9 +277,9 @@ namespace Pinder.LlmAdapters
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
-                // #351: strip inline thinking/reasoning blocks before refusal-
-                // detection so a thinking block can't trigger a false fallback.
-                string trimmed = InlineThinkingStripper.Strip(result).Trim();
+                // #831: thinking-block stripping moved to
+                // ThinkingStrippingLlmTransport (transport decorator).
+                string trimmed = result.Trim();
 
                 // Detect refusal — fall back to original message silently.
                 if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
@@ -325,9 +325,9 @@ namespace Pinder.LlmAdapters
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result)) return message;
-                // #351: strip inline thinking/reasoning blocks before refusal-
-                // detection so a thinking block can't trigger a false fallback.
-                string trimmed = InlineThinkingStripper.Strip(result).Trim();
+                // #831: thinking-block stripping moved to
+                // ThinkingStrippingLlmTransport (transport decorator).
+                string trimmed = result.Trim();
 
                 // Detect refusal — fall back to original message silently
                 if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
@@ -376,11 +376,11 @@ namespace Pinder.LlmAdapters
             var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.Steering, ct: ct)
                 .ConfigureAwait(false);
 
-            // #351: strip inline <thinking>/<reasoning> blocks before any
-            // other shaping. This is a prose-only surface and the steering
-            // question is consumed verbatim by the player UI — a stray
-            // thinking block would corrupt the visible question.
-            var question = InlineThinkingStripper.Strip(responseText).Trim();
+            // #831: thinking-block stripping moved to
+            // ThinkingStrippingLlmTransport (transport decorator). The
+            // steering question now arrives already stripped, so we only
+            // trim here.
+            var question = (responseText ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(question))
                 return "so... when are we doing this?";
 

--- a/src/Pinder.LlmAdapters/ThinkingStrippingLlmTransport.cs
+++ b/src/Pinder.LlmAdapters/ThinkingStrippingLlmTransport.cs
@@ -1,0 +1,374 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Issue #831: post-processing decorator that strips a leading
+    /// <c>&lt;thinking&gt;...&lt;/thinking&gt;</c> or
+    /// <c>&lt;reasoning&gt;...&lt;/reasoning&gt;</c> block from every LLM
+    /// response — both non-streaming and streaming — by wrapping the
+    /// underlying transport(s).
+    ///
+    /// Replaces the per-callsite <see cref="InlineThinkingStripper.Strip"/>
+    /// pattern: instead of every prose-only consumer (delivery, opponent
+    /// reply, steering, horniness/shadow/trap overlays, stake, outfit,
+    /// interest beat, …) remembering to call the stripper, the strip
+    /// happens at the transport boundary so all consumers automatically
+    /// pick up the cleanup. New prose-only call sites added later cannot
+    /// silently leak thinking blocks into player-visible text or the
+    /// persistent system prompt.
+    ///
+    /// Order in the decorator stack: this decorator should sit ABOVE
+    /// (outermost on the transformation side) any other text-mutating
+    /// decorators (e.g. <see cref="PunctuationNormalizingTransport"/>),
+    /// and ABOVE any snapshot/audit recorder, so the recorded audit log
+    /// captures the cleaned text the player actually sees and replay /
+    /// resimulation reproduces it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Non-streaming.</b> The full response is available, so
+    /// <see cref="InlineThinkingStripper.Strip"/> runs once on the
+    /// returned string.
+    /// </para>
+    /// <para>
+    /// <b>Streaming.</b> A leading thinking block can span multiple
+    /// fragments (the opening <c>&lt;thinking&gt;</c> arrives in fragment N,
+    /// the closing <c>&lt;/thinking&gt;</c> in fragment N+M). A naive
+    /// per-fragment strip would not catch this. Instead we use
+    /// <b>buffer-then-flush</b> semantics:
+    /// </para>
+    /// <list type="number">
+    ///   <item>Accumulate fragments into a buffer while the buffer's
+    ///         content might still be a leading thinking block (i.e. it
+    ///         starts with whitespace + an opening tag prefix).</item>
+    ///   <item>If the closing tag arrives, run
+    ///         <see cref="InlineThinkingStripper.Strip"/> on the buffer
+    ///         and yield the result; for the remaining fragments yield
+    ///         them through unchanged (one block max, per stripper
+    ///         contract).</item>
+    ///   <item>If the buffer accumulates content that is definitively NOT
+    ///         a leading thinking block (the leading characters are not
+    ///         whitespace + <c>&lt;</c>), flush the buffer as-is and
+    ///         pass through every subsequent fragment unchanged.</item>
+    ///   <item>A safety cap (<see cref="MaxBufferChars"/>) prevents an
+    ///         unbounded-thinking-block from holding the entire stream
+    ///         hostage — at the cap we flush as-is and stop trying to
+    ///         strip.</item>
+    /// </list>
+    /// <para>
+    /// Trade-off: the leading fragments of a thinking-prefixed stream
+    /// arrive at the consumer slightly later (after the closing tag is
+    /// seen), but for non-thinking-prefixed responses there is no
+    /// observable latency penalty — the buffer flushes on the first
+    /// fragment whose content rules out a leading tag.
+    /// </para>
+    /// </remarks>
+    public sealed class ThinkingStrippingLlmTransport : ILlmTransport, IStreamingLlmTransport
+    {
+        /// <summary>
+        /// Maximum characters to buffer in the streaming code path while
+        /// waiting for a closing thinking tag. If this cap is hit without
+        /// a closing tag the buffer is flushed as-is (no strip applied)
+        /// and subsequent fragments pass through unchanged. The cap is
+        /// generous enough to cover realistic thinking blocks (we have
+        /// observed up to ~10kB) while still bounding memory / latency
+        /// in a runaway-model scenario.
+        /// </summary>
+        public const int MaxBufferChars = 64 * 1024;
+
+        private readonly ILlmTransport _inner;
+        private readonly IStreamingLlmTransport? _innerStreaming;
+
+        public ThinkingStrippingLlmTransport(ILlmTransport inner)
+            : this(inner, innerStreaming: null) { }
+
+        public ThinkingStrippingLlmTransport(ILlmTransport inner, IStreamingLlmTransport? innerStreaming)
+        {
+            _inner = inner ?? throw new System.ArgumentNullException(nameof(inner));
+            _innerStreaming = innerStreaming;
+        }
+
+        /// <summary>
+        /// The wrapped non-streaming transport. Mirrors
+        /// <see cref="PunctuationNormalizingTransport.Inner"/> — exposed
+        /// for tests and any future reflective tooling that walks the
+        /// decorator chain.
+        /// </summary>
+        public ILlmTransport Inner => _inner;
+
+        /// <summary>
+        /// The wrapped streaming transport, or null when this instance
+        /// was constructed without one.
+        /// </summary>
+        public IStreamingLlmTransport? InnerStreaming => _innerStreaming;
+
+        public async Task<string> SendAsync(
+            string systemPrompt, string userMessage,
+            double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+            CancellationToken ct = default)
+        {
+            string raw = await _inner
+                .SendAsync(systemPrompt, userMessage, temperature, maxTokens, phase, ct)
+                .ConfigureAwait(false);
+            return InlineThinkingStripper.Strip(raw);
+        }
+
+        public async IAsyncEnumerable<string> SendStreamAsync(
+            string systemPrompt, string userMessage,
+            double temperature = 0.9, int maxTokens = 1024,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default,
+            string? phase = null)
+        {
+            if (_innerStreaming == null)
+            {
+                throw new System.InvalidOperationException(
+                    "ThinkingStrippingLlmTransport was constructed without a streaming inner transport. " +
+                    "Use the (ILlmTransport, IStreamingLlmTransport) overload to enable streaming.");
+            }
+
+            // State machine for the streaming buffer:
+            //   Buffering  — still might be a leading thinking block;
+            //                accumulate fragments and don't yield yet.
+            //   Passthrough — confirmed not (or no longer) a leading
+            //                 thinking block; yield each fragment as it
+            //                 arrives.
+            var buffer = new System.Text.StringBuilder();
+            bool buffering = true;
+
+            await foreach (var chunk in _innerStreaming
+                .SendStreamAsync(systemPrompt, userMessage, temperature, maxTokens, cancellationToken, phase)
+                .ConfigureAwait(false))
+            {
+                if (!buffering)
+                {
+                    // Already past the leading-block decision point —
+                    // pass through unchanged.
+                    yield return chunk;
+                    continue;
+                }
+
+                buffer.Append(chunk);
+
+                // Decision: is the buffer still a candidate for "starts
+                // with a thinking block"?
+                StreamingDecision decision = ClassifyStreamingBuffer(buffer);
+
+                switch (decision)
+                {
+                    case StreamingDecision.NotALeadingBlock:
+                        // The leading characters rule out a thinking
+                        // tag. Flush the entire buffer as-is and switch
+                        // to passthrough.
+                        if (buffer.Length > 0)
+                            yield return buffer.ToString();
+                        buffer.Clear();
+                        buffering = false;
+                        break;
+
+                    case StreamingDecision.LeadingBlockClosed:
+                        // The buffer contains a complete leading
+                        // <thinking>...</thinking> (or <reasoning>...).
+                        // Strip and flush the remainder; switch to
+                        // passthrough.
+                        string stripped = InlineThinkingStripper.Strip(buffer.ToString());
+                        if (stripped.Length > 0)
+                            yield return stripped;
+                        buffer.Clear();
+                        buffering = false;
+                        break;
+
+                    case StreamingDecision.MaybeLeadingBlock:
+                        // Still ambiguous — opening tag may have been
+                        // seen but no closing tag yet, or buffer is too
+                        // short to decide. Keep buffering, but bail out
+                        // if the buffer has grown past the safety cap.
+                        if (buffer.Length >= MaxBufferChars)
+                        {
+                            yield return buffer.ToString();
+                            buffer.Clear();
+                            buffering = false;
+                        }
+                        break;
+                }
+            }
+
+            // Stream ended while still buffering — flush whatever's
+            // there. If the entire response was a thinking block with
+            // no closing tag (malformed), flush as-is rather than
+            // silently dropping content.
+            if (buffer.Length > 0)
+            {
+                // One last strip attempt in case the closing tag did
+                // arrive in the final fragment.
+                string final = InlineThinkingStripper.Strip(buffer.ToString());
+                if (final.Length > 0)
+                    yield return final;
+            }
+        }
+
+        /// <summary>
+        /// Streaming buffer classification states. Exposed as
+        /// <c>internal</c> so the decorator-tests assembly can target
+        /// the classifier directly without driving the full async
+        /// streaming path.
+        /// </summary>
+        internal enum StreamingDecision
+        {
+            /// <summary>Leading characters definitely don't start a
+            /// thinking/reasoning tag — flush buffer, switch to
+            /// passthrough.</summary>
+            NotALeadingBlock,
+
+            /// <summary>Leading thinking/reasoning block has a matching
+            /// closing tag — strip and flush.</summary>
+            LeadingBlockClosed,
+
+            /// <summary>Buffer is still ambiguous (might be a leading
+            /// tag, opening tag not yet complete, or closing tag not
+            /// yet seen).</summary>
+            MaybeLeadingBlock
+        }
+
+        // The longest opening tag prefix we care about, in lowercase
+        // (compared against the buffer content with leading whitespace
+        // already trimmed).
+        private static readonly string[] OpeningTagNames = { "thinking", "reasoning" };
+
+        /// <summary>
+        /// Classify the current streaming buffer for the leading-block
+        /// state machine. Internal to allow direct unit-testing.
+        /// </summary>
+        internal static StreamingDecision ClassifyStreamingBuffer(System.Text.StringBuilder buf)
+        {
+            // Skip leading whitespace — the stripper's regex tolerates
+            // whitespace before the tag, so we should too.
+            int i = 0;
+            while (i < buf.Length && char.IsWhiteSpace(buf[i])) i++;
+
+            // All-whitespace buffer so far → still ambiguous.
+            if (i >= buf.Length) return StreamingDecision.MaybeLeadingBlock;
+
+            // First non-whitespace character is not '<' → can't be a
+            // leading thinking tag.
+            if (buf[i] != '<') return StreamingDecision.NotALeadingBlock;
+
+            // We have whitespace? + '<'. Try to extend to a known tag
+            // name. The grammar at this point is: '<' \s* tagname \s* '>'
+            // followed by body, followed by '<' \s* '/' \s* tagname \s*
+            // '>'.
+            int p = i + 1;
+            // Optional whitespace inside the tag.
+            while (p < buf.Length && char.IsWhiteSpace(buf[p])) p++;
+            if (p >= buf.Length) return StreamingDecision.MaybeLeadingBlock;
+
+            // Match one of the known tag names (case-insensitive).
+            string? matchedTag = null;
+            int afterName = -1;
+            foreach (string name in OpeningTagNames)
+            {
+                if (BufferStartsWithIgnoreCase(buf, p, name))
+                {
+                    matchedTag = name;
+                    afterName = p + name.Length;
+                    break;
+                }
+                // Partial match (buffer ends mid-name)?
+                if (PartialMatchIgnoreCase(buf, p, name))
+                {
+                    return StreamingDecision.MaybeLeadingBlock;
+                }
+            }
+            if (matchedTag == null)
+            {
+                // First non-whitespace char was '<', but what follows
+                // isn't a tag name we care about (and isn't a partial
+                // prefix of one). Could be `<br>` or a literal
+                // angle-bracket inside dialogue. Pass through.
+                return StreamingDecision.NotALeadingBlock;
+            }
+
+            // After the tag name we expect optional whitespace then '>'.
+            int q = afterName;
+            while (q < buf.Length && char.IsWhiteSpace(buf[q])) q++;
+            if (q >= buf.Length) return StreamingDecision.MaybeLeadingBlock;
+            if (buf[q] != '>')
+            {
+                // The character after a known tag name isn't whitespace
+                // or '>' (e.g. "<thinkingfoo"). Not a real opening tag.
+                return StreamingDecision.NotALeadingBlock;
+            }
+
+            // Opening tag confirmed. Now scan for the matching closing
+            // tag '</tagname>' (whitespace tolerant).
+            int searchStart = q + 1;
+            int closeIdx = FindClosingTag(buf, searchStart, matchedTag);
+            return closeIdx >= 0
+                ? StreamingDecision.LeadingBlockClosed
+                : StreamingDecision.MaybeLeadingBlock;
+        }
+
+        /// <summary>
+        /// Returns true if the buffer at position <paramref name="start"/>
+        /// begins with <paramref name="needle"/> (case-insensitive,
+        /// full-length). False if the buffer ends before the needle does.
+        /// </summary>
+        private static bool BufferStartsWithIgnoreCase(System.Text.StringBuilder buf, int start, string needle)
+        {
+            if (start + needle.Length > buf.Length) return false;
+            for (int k = 0; k < needle.Length; k++)
+            {
+                if (char.ToLowerInvariant(buf[start + k]) != needle[k]) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the buffer at position <paramref name="start"/>
+        /// is a strict prefix of <paramref name="needle"/> — i.e. the
+        /// buffer ends inside the needle, every character so far matches.
+        /// </summary>
+        private static bool PartialMatchIgnoreCase(System.Text.StringBuilder buf, int start, string needle)
+        {
+            int avail = buf.Length - start;
+            if (avail <= 0) return false;
+            if (avail >= needle.Length) return false; // full match handled separately
+            for (int k = 0; k < avail; k++)
+            {
+                if (char.ToLowerInvariant(buf[start + k]) != needle[k]) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Find the index of the matching closing tag <c>&lt;/name&gt;</c>
+        /// (whitespace-tolerant inside the tag) in the buffer, scanning
+        /// from <paramref name="start"/>. Returns -1 if not found.
+        /// </summary>
+        private static int FindClosingTag(System.Text.StringBuilder buf, int start, string name)
+        {
+            // Closing tag grammar: '<' \s* '/' \s* name \s* '>'
+            for (int idx = start; idx < buf.Length; idx++)
+            {
+                if (buf[idx] != '<') continue;
+                int p = idx + 1;
+                while (p < buf.Length && char.IsWhiteSpace(buf[p])) p++;
+                if (p >= buf.Length) return -1;
+                if (buf[p] != '/') continue;
+                p++;
+                while (p < buf.Length && char.IsWhiteSpace(buf[p])) p++;
+                if (!BufferStartsWithIgnoreCase(buf, p, name)) continue;
+                int q = p + name.Length;
+                while (q < buf.Length && char.IsWhiteSpace(buf[q])) q++;
+                if (q >= buf.Length) return -1;
+                if (buf[q] != '>') continue;
+                return q;
+            }
+            return -1;
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue831_ThinkingStrippingLlmTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue831_ThinkingStrippingLlmTransportTests.cs
@@ -1,0 +1,301 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #831: regression tests for ThinkingStrippingLlmTransport — the
+    /// decorator that strips a leading &lt;thinking&gt;/&lt;reasoning&gt;
+    /// block from every LLM response (non-streaming and streaming) at the
+    /// transport boundary so per-callsite calls are no longer needed.
+    /// </summary>
+    public class Issue831_ThinkingStrippingLlmTransportTests
+    {
+        // ── Non-streaming decorator behaviour ────────────────────────────
+
+        [Fact]
+        public async Task SendAsync_strips_leading_thinking_block()
+        {
+            var inner = new RecordingTransport("<thinking>plan</thinking>real reply");
+            var sut = new ThinkingStrippingLlmTransport(inner);
+
+            var result = await sut.SendAsync("sys", "user", phase: LlmPhase.Delivery);
+
+            Assert.Equal("real reply", result);
+            Assert.Equal("sys", inner.LastSystem);
+            Assert.Equal("user", inner.LastUser);
+            Assert.Equal(LlmPhase.Delivery, inner.LastPhase);
+        }
+
+        [Fact]
+        public async Task SendAsync_strips_leading_reasoning_block()
+        {
+            var inner = new RecordingTransport("<reasoning>step 1\nstep 2</reasoning>\nokay sure.");
+            var sut = new ThinkingStrippingLlmTransport(inner);
+
+            var result = await sut.SendAsync("sys", "user");
+
+            Assert.Equal("okay sure.", result);
+        }
+
+        [Fact]
+        public async Task SendAsync_passes_through_response_without_block()
+        {
+            var inner = new RecordingTransport("just a normal response");
+            var sut = new ThinkingStrippingLlmTransport(inner);
+
+            var result = await sut.SendAsync("sys", "user");
+
+            Assert.Equal("just a normal response", result);
+        }
+
+        [Fact]
+        public async Task SendAsync_threads_phase_and_cancellation_token_through()
+        {
+            var inner = new RecordingTransport("<thinking>x</thinking>y");
+            var sut = new ThinkingStrippingLlmTransport(inner);
+            var cts = new CancellationTokenSource();
+
+            await sut.SendAsync("sys", "user", phase: LlmPhase.Steering, ct: cts.Token);
+
+            Assert.Equal(LlmPhase.Steering, inner.LastPhase);
+        }
+
+        // ── Streaming decorator behaviour ────────────────────────────────
+
+        [Fact]
+        public async Task SendStreamAsync_passes_fragments_through_when_no_thinking_block()
+        {
+            var fragments = new[] { "hello ", "world", "!" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            // Concatenation matches the original fragment stream content.
+            // (The decorator may flush as a single buffered chunk for the
+            // first fragment that rules out a leading tag — we only care
+            // that no content was lost or mangled.)
+            Assert.Equal("hello world!", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_strips_leading_block_when_closing_tag_in_first_fragment()
+        {
+            var fragments = new[] { "<thinking>planning</thinking>real reply" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            Assert.Equal("real reply", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_strips_leading_block_spanning_two_fragments()
+        {
+            var fragments = new[] { "<thinking>first half ", "second half</thinking>actual answer" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            Assert.Equal("actual answer", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_strips_leading_block_with_opening_tag_split_across_fragments()
+        {
+            var fragments = new[] { "<thi", "nking>plan</thinking>real reply" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            Assert.Equal("real reply", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_passes_through_when_first_char_rules_out_leading_tag()
+        {
+            // First fragment starts with 'H' — definitely not a thinking
+            // tag. Decorator should flush immediately and switch to
+            // passthrough; subsequent fragments arrive unchanged.
+            var fragments = new[] { "Hello ", "<thinking>not-leading</thinking>", " world" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            // Mid-stream thinking tags are preserved (the stripper only
+            // strips leading blocks, by design — see InlineThinkingStripper
+            // class doc).
+            Assert.Equal("Hello <thinking>not-leading</thinking> world", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_handles_unterminated_thinking_block_gracefully()
+        {
+            // Malformed: opening tag, no closing tag. Stream ends. The
+            // decorator must flush whatever's there rather than dropping
+            // it silently — under-stripping is preferable to swallowing
+            // the entire response.
+            var fragments = new[] { "<thinking>this never closes" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            // Unterminated → flush as-is. The Strip helper's regex won't
+            // match (no closing tag), so the original buffer is returned.
+            Assert.Equal("<thinking>this never closes", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_handles_leading_whitespace_before_thinking_block()
+        {
+            var fragments = new[] { "  \n<thinking>plan</thinking>greeting" };
+            var inner = new RecordingTransport("ignored", streamingFragments: fragments);
+            var sut = new ThinkingStrippingLlmTransport(inner, inner);
+
+            var got = await CollectAsync(sut.SendStreamAsync("sys", "user"));
+
+            Assert.Equal("greeting", string.Concat(got));
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_throws_when_no_streaming_inner_provided()
+        {
+            var inner = new RecordingTransport("ignored");
+            var sut = new ThinkingStrippingLlmTransport(inner); // no streaming inner
+
+            await Assert.ThrowsAsync<System.InvalidOperationException>(async () =>
+            {
+                await foreach (var _ in sut.SendStreamAsync("sys", "user")) { }
+            });
+        }
+
+        // ── Streaming buffer classifier (internal state machine) ─────────
+
+        [Fact]
+        public void Classifier_treats_empty_buffer_as_ambiguous()
+        {
+            var sb = new System.Text.StringBuilder();
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.MaybeLeadingBlock,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_treats_nonbracket_first_char_as_not_a_block()
+        {
+            var sb = new System.Text.StringBuilder("Hello");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.NotALeadingBlock,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_treats_partial_opening_tag_as_ambiguous()
+        {
+            var sb = new System.Text.StringBuilder("<thi");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.MaybeLeadingBlock,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_treats_unknown_tag_as_not_a_block()
+        {
+            // <br> isn't a thinking tag; pass through.
+            var sb = new System.Text.StringBuilder("<br>hello");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.NotALeadingBlock,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_treats_thinking_open_no_close_as_ambiguous()
+        {
+            var sb = new System.Text.StringBuilder("<thinking>still going");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.MaybeLeadingBlock,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_recognises_complete_leading_thinking_block()
+        {
+            var sb = new System.Text.StringBuilder("<thinking>x</thinking>more");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.LeadingBlockClosed,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        [Fact]
+        public void Classifier_recognises_complete_leading_reasoning_block()
+        {
+            var sb = new System.Text.StringBuilder("<reasoning>r</reasoning>more");
+            Assert.Equal(
+                ThinkingStrippingLlmTransport.StreamingDecision.LeadingBlockClosed,
+                ThinkingStrippingLlmTransport.ClassifyStreamingBuffer(sb));
+        }
+
+        // ── Test transport (mirror of #340 RecordingTransport) ───────────
+
+        private static async Task<List<string>> CollectAsync(IAsyncEnumerable<string> source)
+        {
+            var got = new List<string>();
+            await foreach (var chunk in source)
+                got.Add(chunk);
+            return got;
+        }
+
+        private sealed class RecordingTransport : ILlmTransport, IStreamingLlmTransport
+        {
+            private readonly string _response;
+            private readonly string[]? _fragments;
+
+            public string? LastSystem { get; private set; }
+            public string? LastUser { get; private set; }
+            public string? LastPhase { get; private set; }
+
+            public RecordingTransport(string response, string[]? streamingFragments = null)
+            {
+                _response = response;
+                _fragments = streamingFragments;
+            }
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                LastSystem = systemPrompt;
+                LastUser = userMessage;
+                LastPhase = phase;
+                return Task.FromResult(_response);
+            }
+
+#pragma warning disable CS1998 // async without await — yield-based async iterator
+            public async IAsyncEnumerable<string> SendStreamAsync(
+                string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024,
+                [EnumeratorCancellation] CancellationToken cancellationToken = default,
+                string? phase = null)
+            {
+                LastSystem = systemPrompt;
+                LastUser = userMessage;
+                LastPhase = phase;
+                if (_fragments == null) yield break;
+                foreach (var f in _fragments) yield return f;
+            }
+#pragma warning restore CS1998
+        }
+    }
+}


### PR DESCRIPTION
Closes #831 (Option A — transport decorator).

Lifts the per-callsite `InlineThinkingStripper.Strip` pattern to a
transport-level decorator (`ThinkingStrippingLlmTransport`) so every
prose-only and structured LLM surface automatically gets
strip-on-output. New call sites added later cannot silently leak
`<thinking>` blocks into player-visible text or the persistent system
prompt.

## What changed

- **New** `src/Pinder.LlmAdapters/ThinkingStrippingLlmTransport.cs` —
  decorator implementing both `ILlmTransport` and
  `IStreamingLlmTransport`. Mirrors the shape of
  `PunctuationNormalizingTransport` (#340).
  - Non-streaming: single `InlineThinkingStripper.Strip` call on the
    returned response.
  - Streaming: **buffer-then-flush** state machine. The buffer
    accumulates fragments while the leading content might still be a
    `<thinking>` / `<reasoning>` block. On the closing tag the buffer
    is stripped and flushed; on a leading character that rules out a
    tag the buffer flushes as-is and switches to passthrough. A 64 KiB
    safety cap protects against unbounded buffering on malformed input
    (opening tag with no matching close).
- **Wiring** in `session-runner/Program.cs` — wrapped both
  transport-construction branches (OpenAi-family + Anthropic default)
  plus the setup transport used by `LlmStakeGenerator`.
- **Removed** all 4 per-callsite `InlineThinkingStripper.Strip` calls
  in `PinderLlmAdapter.cs`:
  - `ApplyHorninessOverlayAsync` (was line 223)
  - `ApplyTrapOverlayAsync` (was line 282)
  - `ApplyShadowCorruptionAsync` (was line 330)
  - `GetSteeringQuestionAsync` (was line 383)

  Each call became `result.Trim()` (or `(responseText ?? "").Trim()`
  for the steering site). Refusal-detection sees the cleaned text the
  same way it did when the strip ran inline — behaviour preserved.
- **Comment update** in `InlineThinkingStripper.cs`: removed the wrong
  claim about matchup-analysis being structured (matchup is plain
  prose, but matchup is also being deleted by the setup-trim epic so
  the point is moot); acknowledged that the stripper now runs at
  transport level via the new decorator; retained the static `Strip`
  method as the canonical pure-function form so the decorator and any
  future direct caller share the same regex.
- **19 new tests** in
  `tests/Pinder.LlmAdapters.Tests/Issue831_ThinkingStrippingLlmTransportTests.cs`
  covering:
  - Non-streaming: leading thinking, leading reasoning, no-block
    passthrough, phase + token threading.
  - Streaming: single-fragment block, two-fragment-spanning block,
    opening tag split mid-fragment, leading whitespace before block,
    unterminated block (graceful fallthrough), no-block passthrough,
    mid-stream tags preserved, missing-streaming-inner throws.
  - Internal classifier state machine: empty buffer (ambiguous),
    non-bracket first char (not-a-block), partial opening tag
    (ambiguous), unknown tag (not-a-block), open-without-close
    (ambiguous), full thinking block (closed), full reasoning block
    (closed).
- **Lesson** captured immediately in `LESSONS_LEARNED.md`: *DRY
  post-processing belongs at the transport boundary.*

## Decorator stack order (in production)

```
raw provider transport
  -> ThinkingStrippingLlmTransport     (#831 NEW — outermost transform)
    -> PunctuationNormalizingTransport (#340: ` — ` -> `; `)
      -> RateLimitedLlmTransport       (#425, web-only)
        -> SnapshotRecordingLlmTransport (#107, web-only, optional)
          -> PinderLlmAdapter
```

Strip is outermost on the transformation side so the snapshot recorder
captures the cleaned text the player actually sees and replay /
resimulation reproduces it (same principle that #340 applied to
punctuation normalisation).

## Cross-repo follow-up

The pinder-web side — wiring `ThinkingStrippingLlmTransport` into
`LlmProviderFactory.cs` and bumping the pinder-core submodule pointer —
is a separate PR that lands AFTER this one, per the
SUBMODULE-COMMIT-RESET pattern. The decorator is in place and ready;
production behaviour does not change until the pinder-web wiring
follows.

## Drive-by changes

None inside the touched diff. Two related observations filed as
follow-ups (not made in this PR):

1. **`OpenAiLlmAdapter.cs`** has 2 leftover `InlineThinkingStripper.Strip`
   call sites (lines 176 + 538). The class is **dead code** —
   `grep -rn "new OpenAiLlmAdapter"` returns zero hits in
   `pinder-core` and `pinder-web`. The ticket scopes cleanup to
   `PinderLlmAdapter.cs` ("All four ... call-sites in
   `PinderLlmAdapter.cs` removed"), so this PR leaves
   `OpenAiLlmAdapter.cs` untouched. Follow-up will decide between
   deleting the class or rewiring it through `OpenAiTransport` so the
   decorator naturally covers it.
2. **109 pre-existing test failures** on `origin/main`
   (`Pinder.Rules.Tests`: 46, `Pinder.LlmAdapters.Tests`: 63, all
   YAML-deserialisation-related). Reproduced on `origin/main` directly
   before my branch existed. Filing as a separate follow-up; my branch
   adds 19 new passing tests with **zero** new failures.

## DoD Evidence

### Build

```
$ dotnet build Pinder.Core.sln -c Debug -v minimal
   175 Warning(s)
   0 Error(s)
Time Elapsed 00:00:40.88
```

All warnings pre-exist on `origin/main`. None on the new files.

### Tests

Full suite (`dotnet test Pinder.Core.sln --no-build -c Debug`):

| Project                       | Failed | Passed | Skipped | Total | Δ vs main |
|-------------------------------|-------:|-------:|--------:|------:|:---------:|
| Pinder.Rules.Tests            | 46     | 198    | 0       | 244   | identical |
| Pinder.Core.Tests             | 0      | 2682   | 18      | 2700  | identical |
| Pinder.LlmAdapters.Tests      | 63     | **959**| 9       | 1031  | **+19 passing**, no new failures |

Diff verified by name-level set comparison — `comm -23 fail-mybranch
fail-main` returns empty (no new failures introduced).

Focused new-test run:

```
$ dotnet test ... --filter "FullyQualifiedName~Issue831"
Passed!  - Failed: 0, Passed: 19, Skipped: 0, Total: 19, Duration: 66 ms
```

## Research Log

### Why Option A and not Option B (per-LlmPhase table)

The ticket recommends Option A. I considered Option B briefly: it would
let dialogue-options skip the strip (the parser is already safe against
leading thinking blocks because it cuts at `OPTION_N`). But the
incremental safety of "leave dialogue options unstripped" is negative
in practice — a parser that's *robust* against leading garbage today
might not be robust to a *different* shape of garbage tomorrow.
Option A's "every response is stripped" invariant is strictly stronger
and much simpler to reason about.

### Why buffer-then-flush and not suppress-then-yield (streaming)

Both are mentioned in the issue. Buffer-then-flush is simpler and has
a clear safety bound; suppress-then-yield's only structural advantage
is *slightly* tighter latency on the post-tag stream (which doesn't
exist in our paths because the only streaming consumer today is the
psychological-stake setup stage, which is wall-clock-dominated by
provider latency, not by decorator buffering). Buffer-then-flush has
a clean state machine with three states (`MaybeLeadingBlock`,
`NotALeadingBlock`, `LeadingBlockClosed`) and an internal classifier
that's directly unit-testable.

### Why the strip is outermost on the transformation side

Two reasons. **(1)** The snapshot recorder (#107) captures audit rows
that drive replay / resimulation. We want the audit row to record what
the player actually saw; running strip *after* snapshot would record
unstripped text and replay would diverge from production. **(2)** The
punctuation normaliser (#340) shouldn't waste cycles on text we're
about to discard, and a `; ` substitution inside a thinking block
would still get discarded but introduce noise in any debug log that
captures intermediate states.

### Why the static `Strip` method is retained

Two callers: the new decorator (non-streaming path + the
streaming-buffer's "closing tag arrived" branch), and any future
ad-hoc audit-log post-processing that needs the same regex. Killing
the static would force the decorator to expose a private re-implementation
or move regex into the streaming path, both of which duplicate logic.
Class doc was updated to make this explicit.

### Streaming buffer cap

Set at 64 KiB. Rationale: realistic thinking blocks observed in the
wild have been ≤10 KB; 64 KiB is comfortable headroom. Above the cap
we flush as-is rather than silently truncating; the worst case is the
player sees one thinking block (already bad, but bounded) instead of
the entire response being lost.
