### PR TITLE
refactor(#832): assembled prompt emits ACTIVE ARCHETYPE block, not ranked list

### DIFF
--- a/src/Pinder.Core/Prompts/PromptBuilder.cs
+++ b/src/Pinder.Core/Prompts/PromptBuilder.cs
@@ -74,12 +74,32 @@ namespace Pinder.Core.Prompts
                 fragments.TextingStyleSources, characterIdSeed));
             sb.AppendLine();
 
-            // ARCHETYPES
-            sb.AppendLine("ARCHETYPES (tendency order — most to least dominant)");
-            for (int i = 0; i < fragments.RankedArchetypes.Count; i++)
+            // ACTIVE ARCHETYPE (#832): emit only the level-eligible top-ranked
+            // archetype with its full behavior text. The ranked-list of every
+            // archetype the character has any tendency vote for was noise —
+            // the LLM had no way to tell which were level-eligible vs.
+            // pre-cap or post-cap, and the bare names without behavior text
+            // forced the model to use training-data priors. The active
+            // archetype's behavior block (sourced from
+            // ArchetypeCatalog._behaviors / archetypes-enriched.yaml §2) is
+            // rich, load-bearing, and includes sample lines — exactly the
+            // texture the dialogue model needs.
+            //
+            // Fallback: when ResolveActiveArchetype returns null (legacy /
+            // under-leveled / no archetype votes), emit a single-line
+            // marker so the prompt stays well-formed and downstream parsers
+            // (e.g. system-prompt-shape tests) still find the section.
+            sb.AppendLine("ACTIVE ARCHETYPE");
+            if (fragments.ActiveArchetype != null)
             {
-                var (archetype, count) = fragments.RankedArchetypes[i];
-                sb.AppendLine($"{i + 1}. {archetype} (x{count})");
+                var aa = fragments.ActiveArchetype;
+                sb.AppendLine($"- {aa.Name} ({aa.InterferenceLevel})");
+                if (!string.IsNullOrWhiteSpace(aa.Behavior))
+                    sb.AppendLine(aa.Behavior);
+            }
+            else
+            {
+                sb.AppendLine("(none resolved)");
             }
             sb.AppendLine();
 

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -353,7 +353,9 @@ namespace Pinder.Core.Tests
             Assert.Contains("he/him", profile.AssembledSystemPrompt);
             Assert.Contains("BACKSTORY", profile.AssembledSystemPrompt);
             Assert.Contains("TEXTING STYLE", profile.AssembledSystemPrompt);
-            Assert.Contains("ARCHETYPES", profile.AssembledSystemPrompt);
+            // #832: ARCHETYPES (tendency-order ranked list) replaced by
+            // ACTIVE ARCHETYPE (the level-eligible top-ranked archetype).
+            Assert.Contains("ACTIVE ARCHETYPE", profile.AssembledSystemPrompt);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/CharacterSystemTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterSystemTests.cs
@@ -176,7 +176,10 @@ namespace Pinder.Core.Tests
             Assert.Contains("PERSONALITY", prompt);
             Assert.Contains("BACKSTORY", prompt);
             Assert.Contains("TEXTING STYLE", prompt);
-            Assert.Contains("ARCHETYPES", prompt);
+            // #832: ARCHETYPES (tendency-order ranked list) replaced by
+            // ACTIVE ARCHETYPE (the level-eligible top-ranked archetype).
+            Assert.Contains("ACTIVE ARCHETYPE", prompt);
+            Assert.DoesNotContain("ARCHETYPES (tendency order", prompt);
             Assert.Contains("EFFECTIVE STATS", prompt);
             Assert.Contains("TestChar", prompt);
             Assert.Contains("she/her", prompt);

--- a/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
+++ b/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Prompts;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #832: the assembled system prompt's archetype section is now
+    /// "ACTIVE ARCHETYPE" (the level-eligible top-ranked archetype with
+    /// its full behavior text), not "ARCHETYPES (tendency order — ...)"
+    /// (a numbered list of every archetype name with vote counts).
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class Issue832_ActiveArchetypePromptTests
+    {
+        private static readonly Dictionary<StatType, int> ZeroBaseStats =
+            new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 0 }, { StatType.Rizz, 0 },
+                { StatType.Honesty, 0 }, { StatType.Chaos, 0 },
+                { StatType.Wit, 0 }, { StatType.SelfAwareness, 0 },
+            };
+
+        private static readonly Dictionary<ShadowStatType, int> ZeroShadow =
+            new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            };
+
+        // ── Section structure ────────────────────────────────────────────
+
+        [Fact]
+        public void BuildSystemPrompt_EmitsActiveArchetypeSection()
+        {
+            var fragments = BuildFragmentsWithActiveArchetype(
+                name: "The Peacock",
+                behavior: "Loud, expensive flex. Sample lines: \"check my watch\" \u00b7 \"weekend trip booked\"",
+                count: 4, totalCount: 5);
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+
+            Assert.Contains("ACTIVE ARCHETYPE", prompt);
+        }
+
+        [Fact]
+        public void BuildSystemPrompt_DoesNotEmitRankedTendencyList()
+        {
+            // #832: the old ranked list is gone. A new system prompt MUST
+            // NOT contain the old header ("ARCHETYPES (tendency order ...")
+            // and MUST NOT contain the numbered-list pattern (e.g. "1.").
+            var fragments = BuildFragmentsWithActiveArchetype(
+                name: "The Peacock", behavior: "behavior", count: 4, totalCount: 5,
+                rankedNonActives: new[] { ("The Wall of Text", 2), ("The Hey Opener", 1) });
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+
+            Assert.DoesNotContain("ARCHETYPES (tendency order", prompt);
+            // The non-active archetypes must NOT appear in the prompt.
+            Assert.DoesNotContain("The Wall of Text", prompt);
+            Assert.DoesNotContain("The Hey Opener", prompt);
+        }
+
+        // ── Active-archetype content ─────────────────────────────────────
+
+        [Fact]
+        public void BuildSystemPrompt_IncludesActiveArchetypeNameInterferenceAndBehavior()
+        {
+            // 4 of 5 votes \u2192 ratio 0.80 \u2192 "dominant" interference level.
+            var fragments = BuildFragmentsWithActiveArchetype(
+                name: "The Peacock",
+                behavior: "Loud, expensive flex.\n*Sample lines:* \"check my watch\" \u00b7 \"weekend trip booked\"",
+                count: 4, totalCount: 5);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+
+            // Name + interference level on a labelled bullet so a parser
+            // can split them out cleanly.
+            Assert.Contains("- The Peacock (dominant)", prompt);
+            // Full behavior text (including sample-lines fragment).
+            Assert.Contains("Loud, expensive flex.", prompt);
+            Assert.Contains("*Sample lines:*", prompt);
+        }
+
+        [Fact]
+        public void BuildSystemPrompt_RendersClearInterferenceLevel_ForSplitVotes()
+        {
+            // 2 of 4 = 0.5 \u2192 "clear" (per ActiveArchetype.InterferenceLevel).
+            var fragments = BuildFragmentsWithActiveArchetype(
+                name: "The Peacock", behavior: "b", count: 2, totalCount: 4);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", null, fragments, new TrapState());
+
+            Assert.Contains("- The Peacock (clear)", prompt);
+        }
+
+        [Fact]
+        public void BuildSystemPrompt_RendersSlightInterferenceLevel_ForMinorityVotes()
+        {
+            // 1 of 5 = 0.2 \u2192 "slight".
+            var fragments = BuildFragmentsWithActiveArchetype(
+                name: "The Peacock", behavior: "b", count: 1, totalCount: 5);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", null, fragments, new TrapState());
+
+            Assert.Contains("- The Peacock (slight)", prompt);
+        }
+
+        // ── Fallback path ────────────────────────────────────────────────
+
+        [Fact]
+        public void BuildSystemPrompt_NullActiveArchetype_EmitsNoneResolvedFallback()
+        {
+            // No active archetype (legacy / under-leveled / no votes).
+            var fragments = new FragmentCollection(
+                personalityFragments: new List<string> { "x" },
+                backstoryFragments:   new List<string> { "y" },
+                textingStyleFragments: new List<string> { "z" },
+                rankedArchetypes:     new List<(string, int)>(),
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(ZeroBaseStats, ZeroShadow),
+                activeArchetype: null);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", null, fragments, new TrapState());
+
+            Assert.Contains("ACTIVE ARCHETYPE", prompt);
+            Assert.Contains("(none resolved)", prompt);
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private static FragmentCollection BuildFragmentsWithActiveArchetype(
+            string name,
+            string behavior,
+            int count,
+            int totalCount,
+            IEnumerable<(string Name, int Count)>? rankedNonActives = null)
+        {
+            var ranked = new List<(string, int)> { (name, count) };
+            if (rankedNonActives != null) ranked.AddRange(rankedNonActives);
+
+            var active = new ActiveArchetype(name, behavior, count, totalCount);
+
+            return new FragmentCollection(
+                personalityFragments:  new List<string> { "p" },
+                backstoryFragments:    new List<string> { "b" },
+                textingStyleFragments: new List<string> { "t" },
+                rankedArchetypes:      ranked,
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(ZeroBaseStats, ZeroShadow),
+                activeArchetype: active);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue836_TextingStylePlaceholderAggregationTests.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStylePlaceholderAggregationTests.cs
@@ -260,7 +260,9 @@ namespace Pinder.Core.Tests
             // Slice out the TEXTING STYLE section so we don't accidentally
             // hit anatomy strings that legitimately appear in PERSONALITY
             // or BACKSTORY.
-            string section = ExtractSection(prompt, "TEXTING STYLE", "ARCHETYPES");
+            // #832: ARCHETYPES (tendency-order ranked list) replaced by
+            // ACTIVE ARCHETYPE; use the new header as the boundary.
+            string section = ExtractSection(prompt, "TEXTING STYLE", "ACTIVE ARCHETYPE");
 
             // Anatomy texting-style fragments must NOT appear here.
             var anatomyTexting = fragments.TextingStyleSources


### PR DESCRIPTION
Closes #832.

The system prompt's archetype section was a numbered list of every archetype the character had any tendency vote for, sorted by count (`1. The Bio Responder (x4)\n2. The Wall of Text (x2)\n...`). The engine already computes the canonical answer in `CharacterAssembler.ResolveActiveArchetype` (the level-eligible top-ranked archetype) and exposes it as `FragmentCollection.ActiveArchetype` — but the prompt was emitting a noisy ranked list instead, AND none of those names came with their behavior text.

This PR replaces the ranked list with a single `ACTIVE ARCHETYPE` block carrying the active archetype's name, interference level, and full behavior text (the latter sourced from `ArchetypeCatalog._behaviors` / `archetypes-enriched.yaml`).

## What changed

- **`src/Pinder.Core/Prompts/PromptBuilder.cs`** — old:
  ```
  ARCHETYPES (tendency order — most to least dominant)
  1. The Bio Responder (x4)
  2. The Wall of Text (x2)
  3. The Hey Opener (x1)
  ```
  new:
  ```
  ACTIVE ARCHETYPE
  - The Bio Responder (clear)
  Reads everything. Believes that referencing something specific from the bio is the unlock...
  *Sample lines:* "hey stranger 👋" · "omg I was literally just thinking about you" · ...
  ```
  Fallback when `fragments.ActiveArchetype` is null (legacy / under-leveled / no votes): emit `(none resolved)` so the prompt stays well-formed and downstream parsers still find the section.

- **New `tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs`** — 5 tests:
  - `BuildSystemPrompt_EmitsActiveArchetypeSection` — header present.
  - `BuildSystemPrompt_DoesNotEmitRankedTendencyList` — old `ARCHETYPES (tendency order` header gone, AND non-active archetype names don't appear anywhere in the prompt.
  - `BuildSystemPrompt_IncludesActiveArchetypeNameInterferenceAndBehavior` — the bullet line is `- {Name} ({InterferenceLevel})` and the full behavior text (incl. `*Sample lines:*` block) is present.
  - `BuildSystemPrompt_RendersClearInterferenceLevel_ForSplitVotes` — 2/4 votes → `clear`.
  - `BuildSystemPrompt_RendersSlightInterferenceLevel_ForMinorityVotes` — 1/5 votes → `slight`.
  - `BuildSystemPrompt_NullActiveArchetype_EmitsNoneResolvedFallback` — fallback path.

- **3 existing tests updated** — they asserted on the old `ARCHETYPES` substring:
  - `CharacterSystemTests.BuildSystemPrompt_ContainsRequiredSections` — now asserts `ACTIVE ARCHETYPE` + tendency list absent.
  - `CharacterDefinitionLoaderTests.Parse_SystemPrompt_BuiltFromFragments` — now asserts `ACTIVE ARCHETYPE`.
  - `Issue836_TextingStylePlaceholderAggregationTests` — its `ExtractSection(prompt, "TEXTING STYLE", "ARCHETYPES")` boundary marker would otherwise walk past the new header into the next section. Updated to `"ACTIVE ARCHETYPE"`.

## Per-call directive injection (Option B)

Per the ticket's recommendation: this PR lands the system-prompt side ONLY. The per-call `activeArchetypeDirective` injections in `GameSession.cs` (lines 819, 841, 1379, 1398, 1448, 1491, 1560, 1672, 1692) are intentionally **left in place** so the prompt-side change can be A/B-observed before pulling the per-call prop. Will file as a follow-up.

## Drive-by changes

None.

## Note on interference-level labels

The ticket text uses `"dominant" / "primary" / "secondary"` but `ActiveArchetype.InterferenceLevel` actually produces `"dominant" / "clear" / "slight"` (per #375 acceptance tests, ratios 0.7+/0.4+/below). Implementation is the source of truth; this PR uses the actual labels — tests + spec text in the assembled prompt match the existing `Directive` formatter.

## DoD Evidence

### Build

```
$ dotnet build Pinder.Core.sln -c Debug -v minimal
   176 Warning(s)
   0 Error(s)
```

All warnings pre-exist on `origin/main`.

### Tests

Full suite (`dotnet test Pinder.Core.sln -c Debug`):

| Project                       | Failed | Passed | Skipped | Total | Δ vs main |
|-------------------------------|-------:|-------:|--------:|------:|:---------:|
| Pinder.Rules.Tests            | 46     | 198    | 0       | 244   | identical |
| Pinder.Core.Tests             | **0**  | **2688** | 18    | 2706  | **+6 passing** (1 new file × 5 tests + 1 existing test reactivated by test update) |
| Pinder.LlmAdapters.Tests      | 63     | 959    | 9       | 1031  | identical (pre-existing 63 failures on main, unrelated) |

Focused new-test run (`--filter "FullyQualifiedName~Issue832"`):
```
Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5
```

End-to-end verification (loaded three real character JSONs, assembled their system prompts, dumped the new section):

```
=========== reuben (Reuben_404) ===========
ACTIVE ARCHETYPE
- The Philosopher (slight)
Opens with "what do you think the meaning of life is?" or a would-you-rather about horse-duck size ratios. Intellectualising as a defence mechanism — if the conversation stays in the realm of ideas, rejection feels less personal. Uses philosophy as both genuine engagement and armour.
[has old ranked list? False]

=========== sable (Sable_xo) ===========
ACTIVE ARCHETYPE
- The Love Bomber (clear)
Overwhelming affection, attention, and declarations on the fastest possible timeline. "I feel like I've known you forever" after two days. Future-faking at scale. May be genuine anxiety presenting as intensity. May be a control tactic. Can't read that this is alarming rather than romantic.
[has old ranked list? False]

=========== brick (Brick_haus) ===========
ACTIVE ARCHETYPE
- The Sniper (slight)
Doesn't waste swipes. Selective. Considered. When they message, it's deliberate and specific. Every message is a risk they've calculated, which means they can freeze on the edge of a send. The counterpart to the Copy-Paste Machine in every way.

*Sample lines:* "I've been on here for three months and I've matched with seventeen people. I swiped on you specifically because of [reason]."
[has old ranked list? False]
```

Pre-flight: verified all 20 archetypes registered in `ArchetypeCatalog._byName` have a non-empty entry in `_behaviors` (no missing behavior text).

## Research Log

### Why Option B (system-prompt only) and not Option A (atomic — also drop per-call injections)

The ticket explicitly recommends Option B: "Don't let 'clean it all up' produce a regression. Verify the new system prompt does the work first." The per-call injections are belt-and-suspenders right now; pulling them before observing the system-prompt-only behaviour would make a regression hard to attribute. Filing the per-call cleanup as a follow-up (#TBD).

### Why "(none resolved)" for the fallback rather than dropping the section entirely

A well-formed prompt with consistent section markers makes downstream parsing (system-prompt-shape tests, debug surfaces, future analytics) cheaper. Dropping the section conditionally would force every consumer to handle the absence; emitting a single-line marker keeps the contract regular at near-zero token cost.

### Why the `Directive` property of `ActiveArchetype` wasn't reused as-is

`ActiveArchetype.Directive` returns `"ACTIVE ARCHETYPE: {Name} ({InterferenceLevel})\n{Behavior}"` — a single label line followed by the behavior. That's the per-call user-message injection format (designed to drop into the body of a turn-specific user message). For the system-prompt section I want a header + bulleted-name-line + behavior-on-its-own-line, which makes the section visually consistent with PERSONALITY / BACKSTORY / TEXTING STYLE / EFFECTIVE STATS. Hard-duplicating the format string is two lines of code; reusing `Directive` would force a parse-and-reflow that's ugly and fragile.

### Why not lift `_behaviors` keys back into `ActiveArchetype` constructor for "missing-behavior alarm"

Considered: have the constructor throw if `behavior` is null/whitespace, so a future archetype added to `_byName` without a matching `_behaviors` entry would fail loudly. Decided against in this PR — the assembler already silently passes whatever `ArchetypeCatalog.GetBehavior(name)` returns (which falls back to empty for unknown names) and adding throw-on-construct here would be a behaviour change beyond the ticket's scope. Filing the missing-behavior detection as a separate concern; the pre-flight verification in this PR's DoD covers today's state.
