### PR TITLE
refactor(#833): assembled prompt emits bullet-list sections, not pipe-joined prose

### DIFF
--- a/src/Pinder.Core/Prompts/PromptBuilder.cs
+++ b/src/Pinder.Core/Prompts/PromptBuilder.cs
@@ -54,13 +54,21 @@ namespace Pinder.Core.Prompts
             sb.AppendLine();
 
             // PERSONALITY
+            // #833: emit as a bullet list (one fragment per line) instead
+            // of a `" | "`-joined prose blob. Easier for the LLM to scan,
+            // easier to provenance back to the originating item / anatomy
+            // when a fragment surfaces verbatim in delivered text.
             sb.AppendLine("PERSONALITY");
-            sb.AppendLine(string.Join(" | ", fragments.PersonalityFragments));
+            AppendBulletList(sb, fragments.PersonalityFragments);
             sb.AppendLine();
 
             // BACKSTORY
+            // #833: emit as a bullet list. Was newline-joined (closer to
+            // bulleted than the other sections) but make it explicit so
+            // the leading `- ` marker is consistent across every
+            // multi-fragment section.
             sb.AppendLine("BACKSTORY");
-            sb.AppendLine(string.Join(Environment.NewLine, fragments.BackstoryFragments));
+            AppendBulletList(sb, fragments.BackstoryFragments);
             sb.AppendLine();
 
             // TEXTING STYLE
@@ -69,8 +77,14 @@ namespace Pinder.Core.Prompts
             // pick keyed on characterIdSeed). The full per-source list on
             // FragmentCollection.TextingStyleSources is unaffected — the
             // Character Sheet UI still renders every fragment.
+            //
+            // #833: AggregateAsList returns the picked fragments as an
+            // ordered list so we can bullet-format them here, consistent
+            // with PERSONALITY / BACKSTORY. The legacy `Aggregate` (joined
+            // string) is still available for delivery context
+            // (CharacterProfile.TextingStyleFragment).
             sb.AppendLine("TEXTING STYLE");
-            sb.AppendLine(TextingStyleAggregator.Aggregate(
+            AppendBulletList(sb, TextingStyleAggregator.AggregateAsList(
                 fragments.TextingStyleSources, characterIdSeed));
             sb.AppendLine();
 
@@ -126,6 +140,27 @@ namespace Pinder.Core.Prompts
             }
 
             return sb.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// #833: helper that emits a list of fragments as a bullet list,
+        /// one fragment per line with a leading <c>- </c> marker. Empty
+        /// or null entries are skipped (rather than emitted as an empty
+        /// bullet). When the input list itself is empty, no output is
+        /// written — callers can decide whether the section header alone
+        /// is meaningful for the empty case (e.g. PERSONALITY with no
+        /// items still emits the header for downstream parser stability).
+        /// </summary>
+        private static void AppendBulletList(StringBuilder sb, System.Collections.Generic.IReadOnlyList<string> fragments)
+        {
+            if (fragments == null) return;
+            for (int i = 0; i < fragments.Count; i++)
+            {
+                string fragment = fragments[i];
+                if (string.IsNullOrWhiteSpace(fragment)) continue;
+                sb.Append("- ");
+                sb.AppendLine(fragment);
+            }
         }
     }
 }

--- a/src/Pinder.Core/Prompts/TextingStyleAggregator.cs
+++ b/src/Pinder.Core/Prompts/TextingStyleAggregator.cs
@@ -63,8 +63,32 @@ namespace Pinder.Core.Prompts
             IReadOnlyList<TextingStyleFragmentSource> sources,
             string? seedKey)
         {
+            // Convenience wrapper for legacy callers that want the joined
+            // form (e.g. CharacterProfile.TextingStyleFragment passed into
+            // delivery context). #833 splits the same picking logic into
+            // AggregateAsList so PromptBuilder can bullet-format the
+            // assembled prompt without re-splitting the joined string.
+            var picked = AggregateAsList(sources, seedKey);
+            return picked.Count == 0 ? string.Empty : string.Join(" | ", picked);
+        }
+
+        /// <summary>
+        /// #833: same picking logic as <see cref="Aggregate"/> but returns
+        /// the picked fragments as an ordered list (in the same order
+        /// <see cref="Aggregate"/> would have joined them). Used by
+        /// <see cref="PromptBuilder"/> to emit the TEXTING STYLE section
+        /// as a bullet list rather than a pipe-joined prose blob.
+        /// </summary>
+        /// <returns>
+        /// The picked fragments in deterministic order, or an empty list
+        /// when no item fragments are available. Never null.
+        /// </returns>
+        public static IReadOnlyList<string> AggregateAsList(
+            IReadOnlyList<TextingStyleFragmentSource> sources,
+            string? seedKey)
+        {
             if (sources == null || sources.Count == 0)
-                return string.Empty;
+                return System.Array.Empty<string>();
 
             // 1. Anatomy is silenced for now in the texting-style channel.
             //    Personality / backstory fragments from anatomy are unaffected
@@ -79,7 +103,7 @@ namespace Pinder.Core.Prompts
             }
 
             if (itemSources.Count == 0)
-                return string.Empty;
+                return System.Array.Empty<string>();
 
             // 2. With 0..PlaceholderItemPickCount items, no sampling is
             //    needed — just keep them all. The picked items preserve
@@ -94,8 +118,17 @@ namespace Pinder.Core.Prompts
                 picked = PickDeterministic(itemSources, PlaceholderItemPickCount, seedKey);
             }
 
-            // 3. Join with the existing " | " separator.
-            return string.Join(" | ", picked.Select(p => p.Src.Fragment));
+            // 3. Return the picked fragments in their preserved original
+            //    assembly order. Joining (with `" | "`) is now done by
+            //    the legacy Aggregate wrapper for callers that still want
+            //    the joined string; PromptBuilder consumes this list
+            //    directly and bullet-formats it.
+            var result = new List<string>(picked.Count);
+            foreach (var p in picked)
+            {
+                if (p.Src.Fragment != null) result.Add(p.Src.Fragment);
+            }
+            return result;
         }
 
         // ------------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/Issue833_BulletListPromptSectionsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue833_BulletListPromptSectionsTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Prompts;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #833: PromptBuilder emits PERSONALITY, BACKSTORY, and TEXTING
+    /// STYLE as bullet lists (one fragment per line, leading "- ") instead
+    /// of pipe-joined / newline-joined prose blobs. Easier for the LLM to
+    /// scan, easier to provenance back to the originating item / anatomy
+    /// when a fragment surfaces verbatim in delivered text.
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class Issue833_BulletListPromptSectionsTests
+    {
+        private static readonly Dictionary<StatType, int> ZeroBaseStats =
+            new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 0 }, { StatType.Rizz, 0 },
+                { StatType.Honesty, 0 }, { StatType.Chaos, 0 },
+                { StatType.Wit, 0 }, { StatType.SelfAwareness, 0 },
+            };
+
+        private static readonly Dictionary<ShadowStatType, int> ZeroShadow =
+            new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            };
+
+        // ── PERSONALITY ──────────────────────────────────────────────────
+
+        [Fact]
+        public void PersonalitySection_EmitsBulletList_NotPipeJoined()
+        {
+            var fragments = BuildFragments(
+                personality: new[] { "fragment_a", "fragment_b", "fragment_c" });
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+            string section = ExtractSection(prompt, "PERSONALITY", "BACKSTORY");
+
+            // Each fragment lives on its own line with a "- " marker.
+            Assert.Contains("- fragment_a", section);
+            Assert.Contains("- fragment_b", section);
+            Assert.Contains("- fragment_c", section);
+            // Old pipe-joined form must NOT appear.
+            Assert.DoesNotContain("fragment_a | fragment_b", section);
+        }
+
+        // ── BACKSTORY ────────────────────────────────────────────────────
+
+        [Fact]
+        public void BackstorySection_EmitsBulletList()
+        {
+            var fragments = BuildFragments(
+                backstory: new[] { "born somewhere", "moved cities", "had a moment" });
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+            string section = ExtractSection(prompt, "BACKSTORY", "TEXTING STYLE");
+
+            Assert.Contains("- born somewhere", section);
+            Assert.Contains("- moved cities", section);
+            Assert.Contains("- had a moment", section);
+        }
+
+        // ── TEXTING STYLE ────────────────────────────────────────────────
+
+        [Fact]
+        public void TextingStyleSection_EmitsBulletList_FromAggregatedItems()
+        {
+            // Two item-kind sources only \u2014 anatomy is silenced in this
+            // channel by #836's aggregator.
+            var sources = new List<TextingStyleFragmentSource>
+            {
+                new TextingStyleFragmentSource("item", "rolex",  "uses lots of \u2026"),
+                new TextingStyleFragmentSource("item", "blazer", "lowercase texts only"),
+            };
+            var fragments = BuildFragments(textingStyleSources: sources);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+            string section = ExtractSection(prompt, "TEXTING STYLE", "ACTIVE ARCHETYPE");
+
+            Assert.Contains("- uses lots of \u2026", section);
+            Assert.Contains("- lowercase texts only", section);
+            // Old pipe-joined form must NOT appear.
+            Assert.DoesNotContain("uses lots of \u2026 | lowercase", section);
+        }
+
+        // ── Empty section handling ───────────────────────────────────────
+
+        [Fact]
+        public void EmptyFragmentList_EmitsNoBullets_HeaderStillPresent()
+        {
+            var fragments = BuildFragments(personality: new string[0]);
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+
+            // Header is always emitted (downstream parsers depend on it)
+            // but no bullet body lines for an empty list.
+            Assert.Contains("PERSONALITY", prompt);
+            string section = ExtractSection(prompt, "PERSONALITY", "BACKSTORY");
+            // The section between PERSONALITY and BACKSTORY should be just
+            // whitespace \u2014 no bullet lines to extract.
+            var bullets = section.Split('\n')
+                .Select(l => l.Trim())
+                .Where(l => l.StartsWith("- "))
+                .ToList();
+            Assert.Empty(bullets);
+        }
+
+        [Fact]
+        public void NullOrWhitespaceFragments_AreSkipped_NotEmittedAsEmptyBullets()
+        {
+            var fragments = BuildFragments(
+                personality: new[] { "real-fragment", "", "   ", null! });
+
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "TestChar", "she/her", "bio", fragments, new TrapState());
+            string section = ExtractSection(prompt, "PERSONALITY", "BACKSTORY");
+
+            var bullets = section.Split('\n')
+                .Select(l => l.Trim())
+                .Where(l => l.StartsWith("- "))
+                .ToList();
+            Assert.Single(bullets);
+            Assert.Equal("- real-fragment", bullets[0]);
+        }
+
+        // ── TextingStyleAggregator.AggregateAsList ───────────────────────
+
+        [Fact]
+        public void TextingStyleAggregator_AggregateAsList_ReturnsItemFragmentsInOriginalOrder()
+        {
+            var sources = new List<TextingStyleFragmentSource>
+            {
+                new TextingStyleFragmentSource("anatomy", "anatomy-x", "anatomy-frag"),
+                new TextingStyleFragmentSource("item",    "item-1",    "item-fragment-1"),
+                new TextingStyleFragmentSource("anatomy", "anatomy-y", "anatomy-frag-2"),
+                new TextingStyleFragmentSource("item",    "item-2",    "item-fragment-2"),
+            };
+
+            var picked = TextingStyleAggregator.AggregateAsList(sources, seedKey: null);
+
+            // Anatomy is filtered out; only the two item fragments survive,
+            // in their original order.
+            Assert.Equal(new[] { "item-fragment-1", "item-fragment-2" }, picked);
+        }
+
+        [Fact]
+        public void TextingStyleAggregator_Aggregate_StillReturnsJoinedString_ForLegacyCallers()
+        {
+            // Round-trip the legacy joined form so CharacterDefinitionLoader
+            // (which uses the joined string for delivery context) is unaffected.
+            var sources = new List<TextingStyleFragmentSource>
+            {
+                new TextingStyleFragmentSource("item", "i1", "frag-one"),
+                new TextingStyleFragmentSource("item", "i2", "frag-two"),
+            };
+
+            string joined = TextingStyleAggregator.Aggregate(sources, seedKey: null);
+
+            Assert.Equal("frag-one | frag-two", joined);
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private static FragmentCollection BuildFragments(
+            IReadOnlyList<string>? personality = null,
+            IReadOnlyList<string>? backstory = null,
+            IReadOnlyList<TextingStyleFragmentSource>? textingStyleSources = null)
+        {
+            return new FragmentCollection(
+                personalityFragments:  personality ?? new List<string> { "p" },
+                backstoryFragments:    backstory   ?? new List<string> { "b" },
+                textingStyleFragments: new List<string>(),
+                rankedArchetypes:      new List<(string, int)>(),
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(ZeroBaseStats, ZeroShadow),
+                activeArchetype: null,
+                textingStyleSources: textingStyleSources ?? new List<TextingStyleFragmentSource>());
+        }
+
+        private static string ExtractSection(string prompt, string header, string nextHeader)
+        {
+            int start = prompt.IndexOf(header, System.StringComparison.Ordinal);
+            Assert.True(start >= 0, $"Section '{header}' not found in prompt.");
+            int afterHeader = start + header.Length;
+            int end = prompt.IndexOf(nextHeader, afterHeader, System.StringComparison.Ordinal);
+            return end >= 0 ? prompt.Substring(afterHeader, end - afterHeader) : prompt.Substring(afterHeader);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue836_TextingStylePlaceholderAggregationTests.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStylePlaceholderAggregationTests.cs
@@ -273,9 +273,15 @@ namespace Pinder.Core.Tests
             foreach (var anaFrag in anatomyTexting)
                 Assert.DoesNotContain(anaFrag, section);
 
-            // Exactly two item fragments joined with " | ".
-            var trimmed = section.Trim();
-            Assert.Equal(2, trimmed.Split(new[] { " | " }, StringSplitOptions.None).Length);
+            // #833: section emitted as a bullet list (one fragment per
+            // line, leading `- `) instead of `" | "`-joined prose. Count
+            // the bullets to verify exactly 2 item fragments survive
+            // the placeholder pick.
+            var bulletLines = section.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(l => l.Trim())
+                .Where(l => l.StartsWith("- "))
+                .ToList();
+            Assert.Equal(2, bulletLines.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #833.

`PromptBuilder.BuildSystemPrompt` was joining PERSONALITY, BACKSTORY, and TEXTING STYLE fragments into prose blobs. PERSONALITY + TEXTING STYLE used `" | "` as a separator; BACKSTORY used `\n`. Hard for the LLM to scan, hard to provenance back to the originating item / anatomy when a fragment surfaces verbatim in delivered text. This PR bullet-formats all three.

## What changed

**Before** (PERSONALITY example):
```
PERSONALITY
fragment_a | fragment_b | fragment_c | fragment_d
```

**After**:
```
PERSONALITY
- fragment_a
- fragment_b
- fragment_c
- fragment_d
```

Same treatment for BACKSTORY and TEXTING STYLE.

### Files

- **`src/Pinder.Core/Prompts/PromptBuilder.cs`** — three sections rewritten through a new private `AppendBulletList` helper. One fragment per line, leading `- `. Empty/whitespace fragments skipped (rather than emitted as empty bullets). Section headers always emitted (downstream parser stability), even when the fragment list is empty.

- **`src/Pinder.Core/Prompts/TextingStyleAggregator.cs`** — added a sister method `AggregateAsList` that returns the picked fragments as `IReadOnlyList<string>` instead of the legacy `" | "`-joined string. The original `Aggregate` is now a thin wrapper: `AggregateAsList` + `string.Join`. The wrapper preserves the legacy-string contract for `CharacterDefinitionLoader` (which writes the joined form into `CharacterProfile.TextingStyleFragment` for delivery context); the list form is consumed directly by `PromptBuilder` so the assembled prompt can bullet-format without re-splitting on `" | "`.

- **8 new tests** in `tests/Pinder.Core.Tests/Issue833_BulletListPromptSectionsTests.cs`:
  - `PersonalitySection_EmitsBulletList_NotPipeJoined`
  - `BackstorySection_EmitsBulletList`
  - `TextingStyleSection_EmitsBulletList_FromAggregatedItems`
  - `EmptyFragmentList_EmitsNoBullets_HeaderStillPresent`
  - `NullOrWhitespaceFragments_AreSkipped_NotEmittedAsEmptyBullets`
  - `TextingStyleAggregator_AggregateAsList_ReturnsItemFragmentsInOriginalOrder` — anatomy-filtering preserved
  - `TextingStyleAggregator_Aggregate_StillReturnsJoinedString_ForLegacyCallers` — legacy contract preserved

- **1 existing test updated**: `Issue836.PromptBuilder_TextingStyleSection_OnlyContainsItemFragments` was asserting "exactly 2 segments after splitting on ` | `". Now asserts exactly 2 lines starting with `- ` in the section. Same intent, new shape.

## Sections NOT changed (per ticket)

- ARCHETYPES — already emitted as a labelled bullet line by #832 (just landed in PR #845): `- {Name} ({InterferenceLevel})\n{Behavior}`.
- EFFECTIVE STATS — already bulleted with `- ` prefix.
- ACTIVE TRAP INSTRUCTIONS — left as raw `LlmInstruction` text per the ticket's "if a single trap's instruction is multi-paragraph, leave its internal structure alone" guidance.

## Drive-by changes

None.

## DoD Evidence

### Build

```
$ dotnet build Pinder.Core.sln -c Debug -v minimal
   176 Warning(s)
   0 Error(s)
```

### Tests

| Project                       | Failed | Passed | Skipped | Total | Δ vs main |
|-------------------------------|-------:|-------:|--------:|------:|:---------:|
| Pinder.Rules.Tests            | 46     | 198    | 0       | 244   | identical |
| Pinder.Core.Tests             | **0**  | **2695** | 18    | 2713  | **+7 passing** (8 new − 1 reactivated existing test that was previously asserting the joined-string shape) |
| Pinder.LlmAdapters.Tests      | 63     | 959    | 9       | 1031  | identical (pre-existing 63 failures, unrelated) |

Focused new-test run (`--filter "FullyQualifiedName~Issue833"`):
```
Passed!  - Failed: 0, Passed: 8, Skipped: 0, Total: 8
```

End-to-end verification (assembled Sable_xo's system prompt, confirmed bullet formatting flowed through all three sections):

```
PERSONALITY
- presents as spontaneous because the work of being spontaneous is now invisible to everyone including themselves; ...
- takes up space as a recovered right, not a default; what reads as confidence is specifically the decision not to shrink, ...
- compensates forward rather than retreating ...
- the chaos that comes through the nails is not imprecision ...
- doesn't need you to believe in it; needs it to be the framework; ...
- slow blink when interested is not performance ...
- comfortable in their own skin in a way that reads as unusual; ...
- ...

BACKSTORY
- was in a four-year relationship where her partner's recurring complaint was that she was exhausting; ...
- wore this to a wedding at twenty-six; an older relative stopped her in the car park ...
- bought them at five-foot-two with a specific six-foot-one ex in mind; ...
- started doing her nails during the first COVID lockdown ...
- ...

TEXTING STYLE
- SYNTAX: ...
- emoji-as-noun: replaces a word with the emoji of it ...
- shorthand: ...
- (anatomy-kind sources correctly silenced by the #836 placeholder aggregator)
```

## Token cost

Negligible. Each bullet adds ~2 tokens vs the `" | "` separator (2 chars). For a typical character with 14 personality + 14 backstory + 2 texting-style fragments, that's ~60 extra tokens in a ~3 KB system prompt — well under measurement noise.

## Research Log

### Why a sister `AggregateAsList` instead of changing the existing `Aggregate` return type

`Aggregate` is consumed by both `PromptBuilder` (which now wants the list) and `CharacterDefinitionLoader` (which writes the result into `CharacterProfile.TextingStyleFragment` — a `string` that's then passed into delivery context). Changing `Aggregate`'s signature would force loader changes for no semantic benefit (the loader genuinely wants the joined string). Adding `AggregateAsList` and making `Aggregate` a thin wrapper keeps the picking logic single-source-of-truth without forcing every consumer to re-rejoin or re-split.

### Why bullet-prefix multi-paragraph TEXTING STYLE fragments

A single texting-style fragment in the items DB can contain internal "SYNTAX:" / "TONE:" sub-headings. After bullet-prefixing, the rendered shape is:
```
- SYNTAX:
- emoji: ...
- shorthand: ...
TONE:
- stance: ...
```

That's slightly weird-looking (the section header "SYNTAX:" gets bullet-prefixed too) but it's still legible to the LLM, and trying to pre-parse the fragment to detect internal structure would be fragile and goes beyond the ticket scope. Filed as a low-priority observation; ticket explicitly asks for "one fragment per bullet, no mid-fragment separators" — that's what's emitted.

### Why fall back to skipping null/whitespace fragments rather than emitting empty bullets

A `- ` line with nothing after it is visual noise in the prompt and provides zero signal to the LLM. A null entry from a malformed fragment source is more likely to indicate a data bug than an intentional empty fragment. Skipping is the conservative default; if a future fragment source legitimately needs to emit an empty marker, that consumer can pre-filter or the helper can grow a flag. Today the simple skip is correct.

### Why ACTIVE TRAP INSTRUCTIONS isn't changed

Per the ticket: "if a single trap's instruction is multi-paragraph, leave its internal structure alone — bullet-prefix the trap entry, not the lines inside." Trap instructions are LLM-authored multi-paragraph blocks; bullet-prefixing the whole block would make sense, but each call site only ever has 0–1 traps active per character per turn (the loop emits one per active trap). Since the maximum-realistic case is a single active trap, "bullet-prefix the trap entry" doesn't visibly differ from the current "emit the instruction text". Leaving as-is keeps the diff minimal and the ticket's intent is satisfied.
