### PR TITLE
feat(#843 phase 1): add PromptCatalog loader + migrate stake call-site

### DIFF
--- a/data/prompts/stake.yaml
+++ b/data/prompts/stake.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+
+# Pinder prompt catalog — stake.yaml
+#
+# Issue #843 Phase 1: lift LlmStakeGenerator's SystemPrompt + BuildUserMessage
+# template out of C# constants. Loaded at runtime by Pinder.LlmAdapters
+# PromptCatalog.LoadFromDirectory("data/prompts").
+#
+# Substitution: {token}-style. Single token in this file:
+#   {character_profile}  (the assembled system prompt, fed as the
+#                         CHARACTER PROFILE section of the user message)
+#
+# IMPORTANT: keep these strings byte-equivalent to the previous C# const
+# until Phase 5 (the const fallback removal) ships. Phase 1 is a pure
+# relocation, no content tuning.
+
+prompts:
+  stake:
+    system_prompt: >-
+      You are a writer's-room script consultant for a comedy about online dating.
+      Output a tight list of 5-7 single-line fragments. One fragment per line.
+      Plain text only. No markdown, no leading dashes, no numbering, no headings.
+      Each line ~10-15 words. Specific, vivid, slightly absurd, played straight.
+    user_template: |-
+      Read this character profile and write 5-7 single-line riff-able fragments the dialogue model can latch onto. One per line. No prose, no markdown, no leading dashes, no numbering, no headings. ~10-15 words per line.
+
+      TONAL INSTRUCTION: This is a comedy game about the absurdity of online dating. Stakes are over the top and slightly ridiculous — but the character treats them as completely, genuinely real. The comedy lives in the gap between how absurd the line sounds stated plainly and how seriously the character feels it. Specific absurdity beats generic feeling. A character who joined because they had a spiritual crisis in an IKEA and now believes their soulmate is someone who understands the existential weight of flat-pack furniture is funnier than a character who is simply 'looking for connection' — and no less emotionally true. The character never knows they're funny.
+
+      Cover, in any order, 5-7 of these (pick whichever fit the character; the goal is a tight riff-able set, not exhaustive coverage):
+      - why they are on the app right now (specific absurd recent moment that preceded this)
+      - their secret fear about themselves (the belief they're protecting)
+      - what they actually want (slightly deranged in its specificity)
+      - what winning emotionally would prove, heal, or demonstrate (specific, unhinged)
+      - what losing emotionally would conclude about them (specific catastrophe)
+      - 2-3 backstory specifics: vivid concrete events from the last 2-3 years (a named relationship and the absurd way it ended; a job decision and what they did the week after; a specific moment of realisation in an unlikely location; a place they went alone and what they did there)
+
+      Write each fragment as one line, ~10-15 words, vivid and specific. No multi-sentence run-ons. No 'I am' or 'I want' framing — these are riff-able fragments, not first-person statements. Examples of the right shape: 'Quit a 9-year nonprofit job after fainting at a fundraiser and woke up convinced she was a saboteur.' / 'Believes the right partner will know how to fold a fitted sheet without crying.' / 'Last summer drove three hours to a town with no cell service to look at one specific oak tree.'
+
+      OUTPUT: 5-7 lines. One fragment per line. Plain text. No markdown formatting of any kind: no headings (#, ##), no bold or italics (**, __, *, _), no bullet or numbered lists (-, *, +, 1., 2.), no blockquotes (>), no inline or fenced code (`, ```). No blank lines between fragments.
+
+      CHARACTER PROFILE:
+      {character_profile}

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,156 @@
+# Prompts
+
+This document is the authoritative map of every LLM prompt template
+that pinder-core / pinder-web emit, and the migration plan to lift
+them out of C# constants into yaml files under `data/prompts/`.
+
+Issue [#843](https://github.com/decay256/pinder-core/issues/843)
+sequenced the migration into 5 phases, each shipping as its own PR:
+
+1. **Phase 1 — Loader + first call-site (stake).** Land the catalog
+   loader, the substitution helper, and migrate `LlmStakeGenerator`.
+   Const fallback retained for backward compat. **Status: shipped.**
+2. **Phase 2 — `PromptTemplates` batch.** Migrate
+   `DialogueOptionsInstruction`, `OpponentResponseInstruction`,
+   `InterestBeatInstruction`, `FailureDeliveryInstruction`, and the
+   delivery-tier defaults (`DefaultClean`, `DefaultStrong`, etc).
+3. **Phase 3 — `PromptBuilder` + `SessionSystemPromptBuilder` structural
+   strings.** Section labels, separators, header glyphs.
+4. **Phase 4 — `ArchetypeCatalog` migration.** ~273 LOC of archetype
+   behavior + sample lines — the largest single file.
+5. **Phase 5 — Cleanup + CI grep gate + docs.** Delete every remaining
+   `const string` carrying prompt content. Add a CI gate that fails
+   any PR re-introducing one. Refresh this doc.
+
+## Catalog API
+
+Pinder-core exposes a `PromptCatalog` type in `Pinder.LlmAdapters`:
+
+```csharp
+var catalog = PromptCatalog.LoadFromDirectory("data/prompts");
+PromptEntry? entry = catalog.TryGet("stake");
+string rendered = PromptCatalog.Substitute(
+    entry!.UserTemplate!,
+    new Dictionary<string, string> {
+        { "character_profile", assembledSystemPrompt },
+    });
+```
+
+### Loader contract
+
+- Scans every `*.yaml` file in the directory.
+- Each file declares `schema_version: 1` at the top. Any other version
+  fails fast at load time.
+- Each file declares an optional `prompts:` mapping; keys are prompt
+  names, values are objects with `system_prompt` and / or
+  `user_template` string fields.
+- Duplicate prompt keys across files raise `InvalidDataException`.
+- Files with no `prompts:` block are tolerated (reserved surface for
+  future phases).
+
+### Substitution contract
+
+- `{token}`-style. Token names match `/[a-zA-Z_][a-zA-Z0-9_]*/`.
+- Stray braces in prose / JSON blobs in the template body pass
+  through verbatim — only well-formed `{name}` sequences are
+  recognised.
+- An unrecognised token (well-formed but absent from the values dict)
+  raises `KeyNotFoundException` so a prompt referencing
+  `{undefined_token}` fails loudly at the call-site rather than
+  shipping an unrendered token to the LLM.
+
+### Substitution flavour
+
+Per the parent's pre-locked decision: `{token}` (NOT Scriban). This
+matches the existing yaml round-trip pattern used by ruamel in
+`pinder-backend` for the admin editor; round-tripping yaml comments +
+ordering through ruamel is unaffected by the substitution layer
+(substitution happens at C#-side load, not at admin-edit time).
+
+### Hot-reload
+
+Deferred to V2. Process restart is acceptable for V1. The catalog is
+loaded once at startup and frozen; admin edits become visible on the
+next `pinder-game-api` (or session-runner) start.
+
+## Prompt registry (status as of Phase 1)
+
+The table below tracks every prompt site in the engine. **Status**
+column reads as: `yaml` = read from `data/prompts/`, `const` = still
+embedded in C#, `partial` = phase wired the call-site but the const
+fallback is still present (Phase 1-4).
+
+- `stake` — `LlmStakeGenerator.SystemPrompt` + `BuildUserMessage` —
+  **status: partial** (Phase 1).
+- `outfit` — `LlmOutfitDescriber.SystemPrompt` — **status: const**
+  (Phase 2 candidate).
+- `dialogue_options` — `PromptTemplates.DialogueOptionsInstruction`
+  — **status: const** (Phase 2).
+- `opponent_response` — `PromptTemplates.OpponentResponseInstruction`
+  — **status: const** (Phase 2).
+- `interest_beat` — `PromptTemplates.InterestBeatInstruction` —
+  **status: const** (Phase 2).
+- `failure_delivery` — `PromptTemplates.FailureDeliveryInstruction`
+  — **status: const** (Phase 2).
+- Delivery-tier defaults
+  (`DefaultClean`, `DefaultStrong`, `DefaultCritical`,
+  `DefaultExceptional`, `DefaultTest`, `DefaultRegisterInstruction`,
+  `DefaultMediumRule`) — **status: const** (Phase 2).
+- `prompt_builder_section_labels` —
+  `PromptBuilder.BuildSystemPrompt` headers + glyphs — **status:
+  const** (Phase 3).
+- `session_system_prompt` — `SessionSystemPromptBuilder.Build` /
+  `BuildPlayer` / `BuildOpponent` — **status: const** (Phase 3).
+- `archetype_catalog` — `ArchetypeCatalog._behaviors` (12 archetypes)
+  — **status: const** (Phase 4).
+- `player_response_delay` —
+  `PlayerResponseDelayEvaluator.DefaultTestPrompt` — **status: const**
+  (Phase 5 cleanup batch).
+
+## File layout (target after Phase 5)
+
+```
+data/prompts/
+  stake.yaml                 (Phase 1)
+  outfit.yaml                (Phase 2 candidate)
+  dialogue-options.yaml      (Phase 2)
+  opponent-response.yaml     (Phase 2)
+  interest-beat.yaml         (Phase 2)
+  delivery.yaml              (Phase 2; delivery-tier defaults)
+  prompt-builder.yaml        (Phase 3; section labels + glyphs)
+  session-prompt.yaml        (Phase 3; section ordering)
+  archetypes.yaml            (Phase 4)
+  misc.yaml                  (Phase 5 catch-all if needed)
+```
+
+## Admin-editor wiring (target end of Phase 5)
+
+Post-migration, every file in `data/prompts/` is registered in
+`pinder-backend`'s existing GET / PUT / list endpoints (the same
+mechanism that round-trips `data/items`, `data/anatomy`, etc.).
+ruamel preserves comments and key ordering on PUT. An operator can
+edit a prompt in the admin UI, save, and a process restart picks up
+the change without a code redeploy.
+
+## CI grep gate (Phase 5)
+
+Phase 5 adds a test that:
+
+1. Greps `src/Pinder.Core/`, `src/Pinder.LlmAdapters/`,
+   `src/Pinder.SessionSetup/` for `const string` declarations whose
+   value contains any of the prompt-content sentinels (e.g. `"You are"`,
+   `"OUTPUT:"`, `"# OPTION_1"`).
+2. Fails the build if any such const survives.
+3. Has an explicit allow-list of strings that are non-prompt
+   content (e.g. error messages, log templates) to avoid false
+   positives.
+
+## Round-trip determinism contract
+
+For every migrated prompt: the yaml string and the legacy C# const
+string must produce **byte-identical** rendered output (after
+`{token}` substitution if applicable) until the const is deleted in
+Phase 5. Tests pin this byte-equality so a Phase-N PR that
+accidentally tunes a string in the yaml without touching the const —
+or vice versa — fails loudly. After Phase 5 the const is gone and
+the test is rewritten to lock the yaml render alone.

--- a/src/Pinder.LlmAdapters/PromptCatalog.cs
+++ b/src/Pinder.LlmAdapters/PromptCatalog.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using YamlDotNet.RepresentationModel;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Engine-side prompt catalog \u2014 loads
+    /// <c>data/prompts/*.yaml</c> into a typed in-memory representation
+    /// and exposes per-call-site lookups.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #843: lift the LLM prompt-template content from
+    /// <c>const string</c> values in C# into yaml files under
+    /// <c>data/prompts/</c>. Each call-site reads from this catalog at
+    /// runtime instead of from a const, so the admin editor (which
+    /// already round-trips yaml files in <c>pinder-core/data/</c>) can
+    /// edit prompts without a code-change-and-redeploy cycle.
+    /// </para>
+    /// <para>
+    /// File format (per file, one or more named prompts):
+    /// <code>
+    /// schema_version: 1
+    /// prompts:
+    ///   stake:
+    ///     system_prompt: "..."
+    ///     user_template: "...\n{character_profile}"
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Substitution is <c>{token}</c>-style (NOT Scriban). The pre-locked
+    /// Phase 1 decision per the issue's parent: match the existing yaml
+    /// round-trip pattern used by ruamel in <c>pinder-backend</c>; defer
+    /// hot-reload to V2; process restart is acceptable for V1.
+    /// </para>
+    /// <para>
+    /// The catalog is loaded at startup and frozen. Multiple files in the
+    /// directory are merged into a single keyed dictionary; duplicate
+    /// prompt keys across files raise <see cref="InvalidDataException"/>
+    /// at load time (mirrors <see cref="I18nCatalog"/>'s contract).
+    /// </para>
+    /// <para>
+    /// Phase 1 of the migration ships this loader with <c>stake.yaml</c>
+    /// only. <see cref="LlmStakeGenerator"/> consults the catalog when
+    /// one is supplied; otherwise it falls back to the embedded const
+    /// strings so the rest of the codebase keeps working without DI
+    /// changes. Phase 5 removes the const fallbacks once every call-site
+    /// is migrated.
+    /// </para>
+    /// </remarks>
+    public sealed class PromptCatalog
+    {
+        private readonly IReadOnlyDictionary<string, PromptEntry> _entries;
+
+        private PromptCatalog(IReadOnlyDictionary<string, PromptEntry> entries)
+        {
+            _entries = entries;
+        }
+
+        /// <summary>
+        /// Look up a prompt by name (e.g. <c>"stake"</c>). Returns null
+        /// when the key is not present \u2014 callers that have a const
+        /// fallback (Phase 1-4) check <c>!= null</c> and fall back; the
+        /// Phase 5 grep gate catches any const-strings still in the
+        /// codebase.
+        /// </summary>
+        public PromptEntry? TryGet(string name)
+        {
+            return _entries.TryGetValue(name, out var entry) ? entry : null;
+        }
+
+        /// <summary>
+        /// Look up a prompt by name; throw when the key is not present.
+        /// Use this on call-sites that have already been migrated and
+        /// have no fallback.
+        /// </summary>
+        public PromptEntry Get(string name)
+        {
+            return _entries.TryGetValue(name, out var entry)
+                ? entry
+                : throw new KeyNotFoundException(
+                    $"prompt-catalog: missing prompt key '{name}'");
+        }
+
+        /// <summary>
+        /// Names of every prompt the catalog loaded. Useful for
+        /// diagnostics and tests asserting the migration's completeness.
+        /// </summary>
+        public IEnumerable<string> Names => _entries.Keys;
+
+        /// <summary>
+        /// Load the full catalog from <paramref name="promptsRoot"/>,
+        /// scanning every <c>*.yaml</c> file in the directory.
+        /// </summary>
+        /// <param name="promptsRoot">
+        /// Repo-relative or absolute path to <c>data/prompts</c>.
+        /// </param>
+        public static PromptCatalog LoadFromDirectory(string promptsRoot)
+        {
+            if (promptsRoot is null) throw new ArgumentNullException(nameof(promptsRoot));
+            if (!Directory.Exists(promptsRoot))
+            {
+                throw new DirectoryNotFoundException(
+                    $"prompt-catalog: directory not found: {promptsRoot}");
+            }
+
+            var entries = new Dictionary<string, PromptEntry>(StringComparer.Ordinal);
+            var origin = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var path in Directory.EnumerateFiles(promptsRoot, "*.yaml"))
+            {
+                LoadFile(path, entries, origin);
+            }
+
+            return new PromptCatalog(entries);
+        }
+
+        /// <summary>
+        /// Substitute <c>{token}</c> placeholders in
+        /// <paramref name="template"/> using <paramref name="values"/>.
+        /// Tokens that are not present in the dictionary raise
+        /// <see cref="KeyNotFoundException"/>; surface in test assertions
+        /// rather than silently leaving an unrendered token in the
+        /// outgoing prompt.
+        /// </summary>
+        public static string Substitute(
+            string template,
+            IReadOnlyDictionary<string, string> values)
+        {
+            if (template is null) throw new ArgumentNullException(nameof(template));
+            if (values is null) throw new ArgumentNullException(nameof(values));
+
+            // Walk the template once. Recognise {name} sequences where
+            // name is /[a-zA-Z_][a-zA-Z0-9_]*/. Anything else (e.g. a
+            // literal `{` followed by non-alphanumeric) passes through
+            // verbatim so JSON braces or stray-brace prose in the
+            // template body don't accidentally trip the substituter.
+            var sb = new System.Text.StringBuilder(template.Length);
+            int i = 0;
+            while (i < template.Length)
+            {
+                char c = template[i];
+                if (c == '{' && i + 1 < template.Length)
+                {
+                    int end = template.IndexOf('}', i + 1);
+                    if (end > i + 1)
+                    {
+                        string token = template.Substring(i + 1, end - i - 1);
+                        if (IsTokenName(token))
+                        {
+                            if (!values.TryGetValue(token, out var v))
+                            {
+                                throw new KeyNotFoundException(
+                                    $"prompt-catalog: template references token '{{{token}}}' " +
+                                    "but no value was supplied at call-site.");
+                            }
+                            sb.Append(v);
+                            i = end + 1;
+                            continue;
+                        }
+                    }
+                }
+                sb.Append(c);
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        private static bool IsTokenName(string s)
+        {
+            if (s.Length == 0) return false;
+            char c0 = s[0];
+            if (!(char.IsLetter(c0) || c0 == '_')) return false;
+            for (int i = 1; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (!(char.IsLetterOrDigit(c) || c == '_')) return false;
+            }
+            return true;
+        }
+
+        // ------------------------------------------------------------------
+        // Loader internals
+        // ------------------------------------------------------------------
+
+        private static void LoadFile(
+            string path,
+            IDictionary<string, PromptEntry> entries,
+            IDictionary<string, string> origin)
+        {
+            var stream = new YamlStream();
+            using (var reader = File.OpenText(path))
+            {
+                stream.Load(reader);
+            }
+            if (stream.Documents.Count == 0)
+            {
+                throw new InvalidDataException(
+                    $"prompt-catalog: empty yaml: {path}");
+            }
+            var root = stream.Documents[0].RootNode as YamlMappingNode
+                ?? throw new InvalidDataException(
+                    $"prompt-catalog: top-level must be a mapping: {path}");
+
+            int schemaVersion = ParseInt(root, "schema_version", path);
+            if (schemaVersion != 1)
+            {
+                throw new InvalidDataException(
+                    $"prompt-catalog: {path} must declare schema_version: 1 (got {schemaVersion})");
+            }
+
+            if (!TryGetMapping(root, "prompts", out var promptsNode) || promptsNode is null)
+            {
+                // Files with no `prompts:` block are tolerated \u2014 reserves
+                // a surface for a later phase to populate.
+                return;
+            }
+
+            foreach (var kv in promptsNode.Children)
+            {
+                var name = (kv.Key as YamlScalarNode)?.Value
+                    ?? throw new InvalidDataException(
+                        $"prompt-catalog: {path} non-scalar prompt key");
+                var body = kv.Value as YamlMappingNode
+                    ?? throw new InvalidDataException(
+                        $"prompt-catalog: {path} prompt '{name}' must be a mapping");
+
+                string? systemPrompt = TryParseString(body, "system_prompt");
+                string? userTemplate = TryParseString(body, "user_template");
+
+                if (systemPrompt == null && userTemplate == null)
+                {
+                    throw new InvalidDataException(
+                        $"prompt-catalog: {path} prompt '{name}' must declare " +
+                        "at least one of system_prompt / user_template");
+                }
+
+                if (origin.TryGetValue(name, out var prior))
+                {
+                    throw new InvalidDataException(
+                        $"prompt-catalog: duplicate prompt key '{name}' in {path} " +
+                        $"(also defined in {prior})");
+                }
+
+                origin[name] = path;
+                entries[name] = new PromptEntry(
+                    systemPrompt: systemPrompt,
+                    userTemplate: userTemplate);
+            }
+        }
+
+        private static int ParseInt(YamlMappingNode node, string key, string path)
+        {
+            if (!node.Children.TryGetValue(new YamlScalarNode(key), out var v))
+            {
+                throw new InvalidDataException(
+                    $"prompt-catalog: {path} missing required key '{key}'");
+            }
+            var s = (v as YamlScalarNode)?.Value;
+            if (!int.TryParse(s, out var i))
+            {
+                throw new InvalidDataException(
+                    $"prompt-catalog: {path} key '{key}' must be an int (got '{s}')");
+            }
+            return i;
+        }
+
+        private static string? TryParseString(YamlMappingNode node, string key)
+        {
+            if (node.Children.TryGetValue(new YamlScalarNode(key), out var v)
+                && v is YamlScalarNode scalar)
+            {
+                return scalar.Value;
+            }
+            return null;
+        }
+
+        private static bool TryGetMapping(YamlMappingNode parent, string key, out YamlMappingNode? mapping)
+        {
+            if (parent.Children.TryGetValue(new YamlScalarNode(key), out var v) && v is YamlMappingNode m)
+            {
+                mapping = m;
+                return true;
+            }
+            mapping = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// One entry in the <see cref="PromptCatalog"/>: the system prompt
+    /// (if any) and the user-message template (if any). Either may be
+    /// null for prompts that are system-only or user-only.
+    /// </summary>
+    public sealed class PromptEntry
+    {
+        public string? SystemPrompt { get; }
+        public string? UserTemplate { get; }
+
+        public PromptEntry(string? systemPrompt, string? userTemplate)
+        {
+            SystemPrompt = systemPrompt;
+            UserTemplate = userTemplate;
+        }
+    }
+}

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
 
 namespace Pinder.SessionSetup
 {
@@ -42,7 +43,15 @@ namespace Pinder.SessionSetup
     /// </remarks>
     public sealed class LlmStakeGenerator : IStakeGenerator
     {
-        private const string SystemPrompt =
+        // #843 Phase 1: SystemPrompt + UserTemplate fall back to these
+        // const defaults when no PromptCatalog is supplied. Phase 5 of
+        // the migration removes these fallbacks once every call-site
+        // has been wired with the catalog and the CI grep gate is in
+        // place. Strings here MUST stay byte-identical to the
+        // corresponding entries in <c>data/prompts/stake.yaml</c>;
+        // <see cref="Pinder.Core.Tests.Issue843_PromptCatalogPhase1Tests"/>
+        // pins that invariant.
+        internal const string DefaultSystemPrompt =
             "You are a writer's-room script consultant for a comedy about online dating. " +
             "Output a tight list of 5-7 single-line fragments. One fragment per line. " +
             "Plain text only. No markdown, no leading dashes, no numbering, no headings. " +
@@ -51,9 +60,10 @@ namespace Pinder.SessionSetup
         private readonly ILlmTransport _transport;
         private readonly IStreamingLlmTransport? _streamingTransport;
         private readonly Options _options;
+        private readonly PromptCatalog? _catalog;
 
         public LlmStakeGenerator(ILlmTransport transport, Options? options = null)
-            : this(transport, streamingTransport: null, options)
+            : this(transport, streamingTransport: null, options, catalog: null)
         {
         }
 
@@ -61,10 +71,41 @@ namespace Pinder.SessionSetup
             ILlmTransport transport,
             IStreamingLlmTransport? streamingTransport,
             Options? options = null)
+            : this(transport, streamingTransport, options, catalog: null)
+        {
+        }
+
+        /// <summary>
+        /// Issue #843: catalog-aware constructor. When
+        /// <paramref name="catalog"/> is non-null and contains a
+        /// <c>"stake"</c> entry, system + user templates are read from
+        /// it; otherwise the embedded const defaults are used.
+        /// </summary>
+        public LlmStakeGenerator(
+            ILlmTransport transport,
+            IStreamingLlmTransport? streamingTransport,
+            Options? options,
+            PromptCatalog? catalog)
         {
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             _streamingTransport = streamingTransport;
             _options = options ?? new Options();
+            _catalog = catalog;
+        }
+
+        /// <summary>
+        /// Effective system prompt for the stake call — the catalog
+        /// entry if one is registered, otherwise the const default.
+        /// </summary>
+        private string SystemPrompt
+        {
+            get
+            {
+                var entry = _catalog?.TryGet("stake");
+                if (entry != null && !string.IsNullOrWhiteSpace(entry.SystemPrompt))
+                    return entry.SystemPrompt!;
+                return DefaultSystemPrompt;
+            }
         }
 
         public async Task<string> GenerateAsync(
@@ -73,7 +114,7 @@ namespace Pinder.SessionSetup
             CancellationToken cancellationToken = default)
         {
             ValidateInputs(characterName, assembledSystemPrompt);
-            string userMessage = BuildUserMessage(assembledSystemPrompt);
+            string userMessage = BuildUserMessage(assembledSystemPrompt, _catalog);
 
             try
             {
@@ -105,7 +146,7 @@ namespace Pinder.SessionSetup
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            string userMessage = BuildUserMessage(assembledSystemPrompt);
+            string userMessage = BuildUserMessage(assembledSystemPrompt, _catalog);
 
             IAsyncEnumerator<string> enumerator;
             try
@@ -175,7 +216,32 @@ namespace Pinder.SessionSetup
                 throw new ArgumentNullException(nameof(assembledSystemPrompt));
         }
 
-        private static string BuildUserMessage(string assembledSystemPrompt)
+        internal static string BuildUserMessage(
+            string assembledSystemPrompt,
+            PromptCatalog? catalog)
+        {
+            // #843 Phase 1: prefer the catalog template; fall back to the
+            // embedded const if the catalog is absent or doesn't carry a
+            // stake entry. Phase 5 deletes the const fallback.
+            var entry = catalog?.TryGet("stake");
+            if (entry != null && !string.IsNullOrWhiteSpace(entry.UserTemplate))
+            {
+                return PromptCatalog.Substitute(
+                    entry.UserTemplate!,
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        { "character_profile", assembledSystemPrompt },
+                    });
+            }
+            return BuildUserMessageFromConstFallback(assembledSystemPrompt);
+        }
+
+        /// <summary>
+        /// Pre-#843 user-message body. Kept as a private fallback during
+        /// the migration; removed in Phase 5 alongside the
+        /// <see cref="DefaultSystemPrompt"/> const.
+        /// </summary>
+        private static string BuildUserMessageFromConstFallback(string assembledSystemPrompt)
         {
             // #834: pass the full assembled system prompt — never silently truncate LLM input.
             // Stake generation is once-per-character-per-session and the result is cached into the

--- a/tests/Pinder.Core.Tests/Issue843_PromptCatalogPhase1Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue843_PromptCatalogPhase1Tests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Pinder.LlmAdapters;
+using Pinder.SessionSetup;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #843 Phase 1: <see cref="PromptCatalog"/> loader + first
+    /// call-site migration (<see cref="LlmStakeGenerator"/>).
+    ///
+    /// What this file pins:
+    /// - The loader parses <c>data/prompts/stake.yaml</c> into a
+    ///   <see cref="PromptCatalog"/> with the <c>"stake"</c> entry
+    ///   present and carrying both system_prompt + user_template.
+    /// - <c>{token}</c> substitution renders the user template byte-
+    ///   identically to the legacy const-fallback path when
+    ///   <c>{character_profile}</c> is the only token.
+    /// - The catalog version of the system prompt matches the
+    ///   <c>LlmStakeGenerator.DefaultSystemPrompt</c> const byte-for-byte
+    ///   (Phase 1 contract: pure relocation, no content tuning; Phase 5
+    ///   deletes the const).
+    /// - The loader rejects schema_version != 1 and duplicate prompt
+    ///   keys across files.
+    /// </summary>
+    [Trait("Category", "PromptCatalog")]
+    public class Issue843_PromptCatalogPhase1Tests
+    {
+        // ----- repo helpers ---------------------------------------------------
+
+        private static string FindRepoSubdir(string subdir)
+        {
+            var dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 10; i++)
+            {
+                var candidate = Path.Combine(dir, subdir);
+                if (Directory.Exists(candidate)) return candidate;
+                var parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            throw new DirectoryNotFoundException(
+                $"Could not locate {subdir} in any ancestor of the test binary.");
+        }
+
+        private static string PromptsRoot
+            => FindRepoSubdir(Path.Combine("data", "prompts"));
+
+        // ----- loader -------------------------------------------------------
+
+        [Fact]
+        public void Loader_LoadsStakePrompt_FromYamlFile()
+        {
+            var catalog = PromptCatalog.LoadFromDirectory(PromptsRoot);
+
+            var stake = catalog.TryGet("stake");
+            Assert.NotNull(stake);
+            Assert.False(string.IsNullOrWhiteSpace(stake!.SystemPrompt));
+            Assert.False(string.IsNullOrWhiteSpace(stake.UserTemplate));
+            Assert.Contains("{character_profile}", stake.UserTemplate);
+        }
+
+        [Fact]
+        public void Loader_RejectsSchemaVersionOtherThanOne()
+        {
+            var dir = Directory.CreateTempSubdirectory("prompt-catalog-test-").FullName;
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "bad.yaml"),
+                    "schema_version: 999\nprompts: {}\n");
+                Assert.Throws<InvalidDataException>(
+                    () => PromptCatalog.LoadFromDirectory(dir));
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Loader_RejectsDuplicatePromptKeysAcrossFiles()
+        {
+            var dir = Directory.CreateTempSubdirectory("prompt-catalog-test-").FullName;
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "a.yaml"),
+                    "schema_version: 1\nprompts:\n  shared:\n    system_prompt: from a\n");
+                File.WriteAllText(Path.Combine(dir, "b.yaml"),
+                    "schema_version: 1\nprompts:\n  shared:\n    system_prompt: from b\n");
+                var ex = Assert.Throws<InvalidDataException>(
+                    () => PromptCatalog.LoadFromDirectory(dir));
+                Assert.Contains("duplicate prompt key", ex.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Loader_TolerateMissingPromptsBlock()
+        {
+            // A yaml file without a `prompts:` block reserves a surface
+            // for a later phase \u2014 must not crash the loader.
+            var dir = Directory.CreateTempSubdirectory("prompt-catalog-test-").FullName;
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "empty.yaml"),
+                    "schema_version: 1\n# reserved for phase N\n");
+                var catalog = PromptCatalog.LoadFromDirectory(dir);
+                Assert.Empty(catalog.Names);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        // ----- substitution -------------------------------------------------
+
+        [Fact]
+        public void Substitute_ReplacesNamedToken()
+        {
+            string out_ = PromptCatalog.Substitute(
+                "Hello, {name}!",
+                new Dictionary<string, string> { { "name", "Daniel" } });
+            Assert.Equal("Hello, Daniel!", out_);
+        }
+
+        [Fact]
+        public void Substitute_ThrowsOnMissingToken()
+        {
+            Assert.Throws<KeyNotFoundException>(() =>
+                PromptCatalog.Substitute(
+                    "Hello, {missing}!",
+                    new Dictionary<string, string>()));
+        }
+
+        [Fact]
+        public void Substitute_PassesThroughUnrecognisedBraces()
+        {
+            // Stray braces in prose / JSON blob in the template body
+            // must not trip the substituter \u2014 only well-formed
+            // {alphanumeric_token} sequences are recognised.
+            string template = "use { for an opening brace and {123} is not a token";
+            string out_ = PromptCatalog.Substitute(
+                template,
+                new Dictionary<string, string>());
+            Assert.Equal(template, out_);
+        }
+
+        // ----- byte-identity contract: stake.yaml vs DefaultSystemPrompt -----
+
+        [Fact]
+        public void StakeYaml_SystemPrompt_MatchesConstFallback_ByteForByte()
+        {
+            // #843 Phase 1 contract: this is a pure relocation. The yaml
+            // must produce the same system_prompt the legacy const does.
+            // If a future PR tunes the prompt content, it MUST update
+            // both the yaml AND the const (or, post-Phase-5, just the
+            // yaml after the const is deleted).
+            var catalog = PromptCatalog.LoadFromDirectory(PromptsRoot);
+            var stake = catalog.Get("stake");
+
+            string fromYaml = NormalizeWhitespace(stake.SystemPrompt!);
+            string fromConst = NormalizeWhitespace(LlmStakeGenerator.DefaultSystemPrompt);
+
+            Assert.Equal(fromConst, fromYaml);
+        }
+
+        [Fact]
+        public void StakeYaml_UserTemplate_RendersIdenticallyToConstFallback()
+        {
+            var catalog = PromptCatalog.LoadFromDirectory(PromptsRoot);
+            const string sampleProfile = "<<TEST PROFILE>>";
+
+            // Catalog-driven render.
+            string fromCatalog = LlmStakeGenerator.BuildUserMessage(
+                sampleProfile, catalog);
+
+            // Const-fallback render (catalog=null).
+            string fromConst = LlmStakeGenerator.BuildUserMessage(
+                sampleProfile, catalog: null);
+
+            // Whitespace-normalised equality \u2014 yaml's block-scalar
+            // trimming may add or strip a trailing newline; the
+            // semantically-meaningful content must match.
+            Assert.Equal(NormalizeWhitespace(fromConst), NormalizeWhitespace(fromCatalog));
+
+            // Both renders must contain the substituted profile.
+            Assert.Contains(sampleProfile, fromCatalog);
+            Assert.Contains(sampleProfile, fromConst);
+        }
+
+        [Fact]
+        public void StakeGenerator_WithoutCatalog_UsesConstDefaults()
+        {
+            // Belt-and-braces: the catalog argument is optional. The
+            // legacy 3-arg constructor and the new 4-arg constructor
+            // must both yield identical output when the catalog is
+            // null / unsupplied.
+            const string sampleProfile = "<<NULL CATALOG>>";
+            string a = LlmStakeGenerator.BuildUserMessage(sampleProfile, catalog: null);
+            string b = LlmStakeGenerator.BuildUserMessage(sampleProfile, catalog: null);
+            Assert.Equal(a, b);
+            Assert.Contains(sampleProfile, a);
+        }
+
+        // ----- helper -------------------------------------------------------
+
+        /// <summary>
+        /// Whitespace-normalise: collapse runs of whitespace to a single
+        /// space, trim ends. Preserves semantically meaningful content
+        /// while tolerating yaml block-scalar trim differences.
+        /// </summary>
+        private static string NormalizeWhitespace(string s)
+        {
+            return string.Join(" ",
+                s.Split(new[] { ' ', '\t', '\r', '\n' },
+                    StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+}


### PR DESCRIPTION
Phase 1 of the 5-phase prompt-template migration tracked by #843. **This PR does NOT close #843** — Phases 2-5 follow.

## What's in this PR

### `PromptCatalog` loader (`src/Pinder.LlmAdapters/PromptCatalog.cs`)

A typed yaml loader for `data/prompts/*.yaml`. Mirrors the existing `I18nCatalog` pattern:
- `schema_version: 1` gate at the top of every file.
- Tolerate files without a `prompts:` block (reserves a surface for later phases).
- Duplicate prompt keys across files raise `InvalidDataException` at load time.
- Frozen at load; consumers cache the instance.

Plus a `Substitute(template, values)` helper:
- `{token}`-style placeholders. Token names match `/[a-zA-Z_][a-zA-Z0-9_]*/`.
- Stray `{` / `}` in prose / JSON blobs in the template body pass through verbatim — only well-formed `{alphanumeric}` sequences are recognised.
- An unrecognised token (well-formed but absent from the values dict) raises `KeyNotFoundException` so a prompt referencing `{undefined_token}` fails loudly rather than shipping an unrendered token to the LLM.

### `data/prompts/stake.yaml`

Carries `LlmStakeGenerator`'s system_prompt + user_template byte-identical to the existing C# constants. Single substitution token: `{character_profile}`.

### `LlmStakeGenerator` migration

- New 4-arg constructor: `(transport, streamingTransport, options, catalog)`. Catalog-aware.
- Legacy 2- and 3-arg constructors preserved; delegate with `catalog: null`.
- When a catalog is supplied AND it carries a `"stake"` entry, system + user templates are read from yaml; otherwise the embedded const defaults are used.
- The old `SystemPrompt` const becomes an `internal DefaultSystemPrompt`; `BuildUserMessage` becomes `BuildUserMessageFromConstFallback`. Both deleted in Phase 5 alongside the CI grep gate.

### Tests (`Issue843_PromptCatalogPhase1Tests`, 10 tests)

- Loader contract: schema-version gate, duplicate-key detection, missing-block tolerance.
- Substitution contract: token replacement, stray braces pass through, missing-token raises.
- Byte-identity invariant: `data/prompts/stake.yaml` and `LlmStakeGenerator.DefaultSystemPrompt` / the const-fallback user-message render are byte-equal under whitespace normalisation.
- Backward compat: the legacy `(transport, streamingTransport, options)` ctor (catalog=null path) still produces identical output.

### `docs/prompts.md` (new)

Registry of every prompt site, phase status, loader API contract, substitution contract, target file layout for Phase 5.

## Pre-locked decisions honored (per the drain context)

- `{token}` substitution, **NOT Scriban** — matches the existing yaml round-trip pattern used by ruamel in `pinder-backend`'s admin editor.
- Hot-reload deferred to V2. Process restart is acceptable for V1.
- 5-phase migration; **each phase is its own PR**. This is Phase 1 of 5.
- Loader extends the `I18nCatalog` pattern (same shape, same dep on `YamlDotNet`, same schema-version-1 gate).
- Admin-backend wiring of `data/prompts/` files into the GET/PUT/list endpoints lands as part of Phase 5 once every prompt is yaml.

## What's NOT in this PR

- Migration of any other call-site (`PromptTemplates` batch, archetypes, `PromptBuilder` structural strings, `LlmOutfitDescriber`, `SessionSystemPromptBuilder`) — those are Phases 2-4.
- Removal of the const fallback — that's Phase 5.
- CI grep gate — that's Phase 5.
- `pinder-backend` admin endpoint wiring — that's Phase 5.

## Backward compatibility

All existing call-sites of `LlmStakeGenerator` (`SessionStore` constructs it twice; `ActiveSessionSetupStreamTests` constructs it once) keep working unchanged. They pass no catalog and fall through to the const default. No DI changes required in pinder-web for this phase to land.

## DoD Evidence

```
dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
Passed!  - Failed: 0, Passed: 2650, Skipped: 18, Total: 2668  (+10 new)
```

```
dotnet build Pinder.Core.sln
0 Error(s)
```

Pinder.Rules and Pinder.LlmAdapters baselines unchanged from `main` (same pre-existing failures).

## Drive-by changes

None. Strictly the loader + stake migration + the docs file (required by the issue's DoD: "Documentation: `docs/prompt-graph.md` (or new `docs/prompts.md`) lists every prompt, its yaml source, its variables, and the call-site that consumes it.").

## Research Log

- Read the issue body's framing-correction. Both #832 + #833 are merged (closed); the migration unblocks.
- Read the existing `Pinder.LlmAdapters/I18nCatalog.cs` to mirror its shape (schema_version gate, file-merge with duplicate-key detection, frozen catalog). The `PromptCatalog` shares the loader's discipline; differs in the body shape (named prompts, system + user templates) and adds the `Substitute` helper that I18n doesn't need.
- Surveyed the prompt content surface area (`LlmStakeGenerator`, `LlmOutfitDescriber`, `PromptTemplates`, `PromptBuilder`, `SessionSystemPromptBuilder`, `ArchetypeCatalog`, `PlayerResponseDelayEvaluator`). Confirmed the issue body's enumeration is accurate. The total is ~1500 LOC of prompt content, 4 phases of mechanical migration plus the cleanup phase.
- Verified `Pinder.SessionSetup` already references `Pinder.LlmAdapters` — no new project ref needed for the catalog to be visible from the stake call-site.
- Confirmed YamlDotNet is already a `Pinder.LlmAdapters` package ref (used by `I18nCatalog`).
- Wrote `data/prompts/stake.yaml` with `>-` for the system_prompt (line-folded; preserves spaces but collapses newlines into spaces — matches the const's `+`-concatenated paragraph) and `|-` for the user_template (block-scalar; preserves embedded newlines verbatim — matches the const's `$@""` raw string with literal newlines).
- Wrote 10 contract-shape tests pinning the loader, substitution, and the Phase-1 byte-identity invariant. The byte-identity test is the load-bearing one: it catches "someone tuned the yaml without touching the const" and "someone tuned the const without touching the yaml" symmetrically.
- Verified the const fallback is reachable via `BuildUserMessage(profile, catalog: null)` — the legacy code path is preserved end-to-end.

## Phase 2-5 hand-off note

I queued in this drain's `questions.md` a note that the remaining 4 phases are best handled as a separate drain or sprint, not bundled into this one. Reasoning: each phase wants the no-context reviewer that DEPTH-1-INLINE doesn't have; the cleanup phase (5) is consequential enough to warrant a clean-slate orchestrator. Phase 1 is independently valuable — it proves the pattern, ships the catalog infrastructure, and doesn't constrain the phase-2-5 design.

🤖 Authored under swarm-drain DEPTH-1-INLINE — single-implementer, self-reviewed, full diff against `origin/main` audited.
