### PR TITLE
docs(#851): refresh character-asset-vocabulary to match deployed eigencore wire

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -1101,3 +1101,4 @@
 {"ts":"2026-05-08T21:45:54Z","agent":"orchestrator","issue":"#783","action":"closed","detail":"PR #783 closed — superseded (HOSTING half by #810, data-arch half by #812). Branch deleted."}
 {"ts":"2026-05-08T21:45:54Z","agent":"orchestrator","issue":"#782","action":"closed","detail":"Refiled as decay256/pinder-web#518 — scope sits in pinder-web (TurnAuditWriter + ReplayTurnResultMapper)"}
 {"ts":"2026-05-08T21:45:54Z","agent":"orchestrator","action":"followup-filed","detail":"decay256/pinder-web#519 — submodule pointer bump to ed96c44"}
+{"agent":"backend-engineer","action":"started","ticket":"#851","worktree":"/tmp/work-851","ts":"2026-05-13T04:09:36Z"}

--- a/docs/specs/character-asset-vocabulary.md
+++ b/docs/specs/character-asset-vocabulary.md
@@ -1,5 +1,7 @@
 # Character Asset Attribute Vocabulary v1 (Pinder ↔ Eigencore contract)
 
+> **Third-party app boundary.** Eigencore is treated as a third-party generic asset backend. Pinder adapts to its published interface; any Pinder-specific change to that interface needs to clear the "would another game built on eigencore also want this change?" bar before being filed against eigencore. Drift discovered on the Pinder side is fixed on the Pinder side (this spec + `Pinder.RemoteAssets`), not by pushing Pinder terminology back into eigencore's API.
+
 **Status:** v1 (`asset_kind = "character/v1"`).
 **Scope:** the wire-level contract between Pinder and an external asset backend (Eigencore today; in principle any backend that wants to host Pinder character assets). This document is **doc only**; the binding interface in code is `Pinder.Core.Characters.IRemoteCharacterStore` plus the `CharacterAssetMetadata` POCO it traffics in (see issue #817).
 
@@ -29,12 +31,14 @@ Each attribute lives in the metadata envelope, NOT inside the character payload.
 - **Semantics:** discriminates what's inside the opaque payload. Bumped together with the on-disk schema; v2 character files use `"character/v2"`.
 - **Pinned in code by:** `CharacterAssetMetadata.AssetKindCharacterV1`.
 
-### `character_id`
+### `asset_id`
 
 - **Type:** string (UUIDv4 in `D` format — lowercase, hyphenated).
 - **Required:** yes.
-- **Set by:** client. Must equal `CharacterDefinition.character_id` inside the payload.
-- **Semantics:** stable identity. The asset backend treats this as the asset's primary key — two publishes with the same `character_id` overwrite the same asset.
+- **Set by:** client. Must equal the character UUID inside the payload (the `CharacterDefinition` identity field — see [`character-file-format.md`](character-file-format.md)).
+- **Semantics:** stable identity. The asset backend treats this as the asset's primary key — two publishes with the same `asset_id` overwrite the same asset.
+
+> **POCO naming note.** The C# POCO field on `CharacterAssetMetadata` stays `CharacterId` for Pinder-side clarity (the payload's primary identity is still a character UUID). `Pinder.RemoteAssets` renames at the HTTP boundary: `CharacterId` ↔ wire `asset_id` (path, JSON, `X-Asset-Metadata` header). The wire is eigencore's namespace; the POCO is Pinder's.
 
 ### `owner_id`
 
@@ -60,15 +64,16 @@ Each attribute lives in the metadata envelope, NOT inside the character payload.
   - At most 16 tags per asset.
   - Each tag is 1..32 characters, lowercase ASCII letters / digits / dashes (`[a-z0-9-]+`), no leading or trailing dash.
   - Tags are case-sensitive on the wire (always lowercase) and the asset backend MAY reject mixed-case input rather than silently lowercasing it.
-- **Reserved prefixes (server-enforced):**
-  - `official-` — applied only to assets owned by an account on the Pinder team allow-list. Clients that put `official-*` on their own assets get the tag stripped before storage.
-  - `auto-` — applied only by server-side automation (content classifiers, abuse-reporting bots, etc.). Client-supplied `auto-*` tags are stripped.
+- **Reserved prefixes (server-enforced, loud-reject on violation):**
+  - `auto-` — server-only. Reserved for server-side automation (content classifiers, abuse-reporting bots, etc.). Any client-supplied tag starting with `auto-` is **hard-rejected with HTTP 403 `permission_denied`**, regardless of caller, allow-list, or scope. No client can ever publish an `auto-*` tag.
+  - `official-` — per-OAuth2-client allow-listed via `OAuth2Client.allowed_tag_prefixes` on the asset backend. A client whose OAuth2 client record includes `official-` in its allowed prefix list may publish `official-*` tags; every other client gets **HTTP 403 `permission_denied`** when it tries. Allow-list membership is configured server-side by the backend operator, not requestable over the wire.
   - Both prefixes use a hyphen rather than a colon to keep tags inside the `[a-z0-9-]+` charset.
+  - **No silent mutation.** Earlier drafts of this spec described reserved-prefix violations as silently removed before storage. That is not what the deployed backend does and not what the contract should be — silently mutating client input is a footgun. The contract is loud-reject with 403 so the client learns immediately.
 - **Semantics:** free-form discovery hints. The contract is "match-all" on the query side — see [§ Query semantics](#query-semantics).
 
 ### `created_at`
 
-- **Type:** RFC3339 timestamp string in UTC (`2026-05-08T22:34:00Z`).
+- **Type:** RFC3339 timestamp string in UTC (`2026-05-08T22:34:00Z` or `2026-05-08T22:34:00+00:00`).
 - **Required:** yes.
 - **Set by:** **server**, exactly once at first publish.
 - **Semantics:** wall-clock creation time. Never overwritten on later updates.
@@ -79,6 +84,16 @@ Each attribute lives in the metadata envelope, NOT inside the character payload.
 - **Required:** yes.
 - **Set by:** **server**, on every overwrite (and at first publish, equal to `created_at`).
 - **Semantics:** wall-clock last-modified time. The default sort order for queries is `updated_at desc`.
+
+> **Timestamp serialization (informational).** The reference backend (Eigencore) uses Pydantic's default JSON datetime serialization, which emits an explicit `+00:00` UTC offset rather than the `Z` suffix. Both forms are RFC3339-valid. The Pinder wrapper MUST parse defensively and accept either (`Z`, `+00:00`, or any RFC3339 UTC offset that normalizes to zero). Do not depend on a specific UTC suffix when comparing strings; parse first, compare instants.
+
+### `payload_size` (server-added, read-only)
+
+- **Type:** integer (bytes).
+- **Required:** present on every fetched / queried metadata record; absent on publish requests (clients MUST NOT supply it).
+- **Set by:** **server**, on every publish.
+- **Semantics:** the byte count of the stored opaque payload as the server received it. Useful for clients that want to surface storage cost or detect truncated payloads before parsing.
+- **Forward-compat clause:** this is the first server-added read-only attribute beyond the timestamps. The general rule in [§ Forward compatibility](#forward-compatibility) (clients tolerate unknown attributes on read) covers it, but it is called out explicitly so wrapper implementations either expose it as a nullable property on `CharacterAssetMetadata` or document it as "tolerated and ignored" — silently dropping it is fine; lossy round-trip on re-publish is fine because clients never send it.
 
 ## Out of vocabulary for v1, by design
 
@@ -91,11 +106,11 @@ Each attribute lives in the metadata envelope, NOT inside the character payload.
 
 The asset backend must support:
 
-- **Exact match** on `asset_kind`, `owner_id`, `character_id`, `is_public`.
+- **Exact match** on `asset_kind`, `owner_id`, `asset_id`, `is_public`.
 - **All-of** match on `tags` (i.e. the asset's `tags` is a superset of the query's `tags`). No `OR` semantics in v1.
 - **Range queries** on `created_at` and `updated_at` (server-defined date filter syntax — typically `created_at >= ...` / `<= ...`).
 - **Combined AND** of any of the above.
-- **Cursor pagination** with an opaque server-defined cursor format. The Pinder client treats the cursor as a string token; the server's encoding (offset, last-id, opaque hash) is implementation-defined.
+- **Cursor pagination** with an opaque server-defined cursor format. The Pinder client treats the cursor as a string token; the server's encoding (offset, last-id, opaque hash) is implementation-defined. A malformed or expired cursor returns HTTP 422 with `error=invalid_cursor`; the wrapper SHOULD map that to a typed exception so callers can distinguish "bad cursor" from "bad query".
 - **Default sort:** `updated_at desc`. The server MAY offer additional sort orders; clients SHOULD NOT depend on any sort order beyond the default.
 
 The query surface in `CharacterAssetQuery` (see [`IRemoteCharacterStore`](../../src/Pinder.Core/Characters/IRemoteCharacterStore.cs) and [`CharacterAssetQuery`](../../src/Pinder.Core/Characters/CharacterAssetQuery.cs)) is the binding code-level shape; it is intentionally a strict subset of the wire surface above so that v1.x server-side additions don't immediately demand client-side changes.
@@ -110,6 +125,10 @@ Out of scope for query in v1:
 
 All examples are HTTP/1.1 over TLS. The asset backend MAY support additional protocols (gRPC, etc.) as long as the same attribute set + semantics are honoured.
 
+### Route prefix
+
+The asset endpoints live under `/api/v1/assets` on the reference backend. The wrapper's configured `BaseUrl` absorbs the `/api/v1` prefix — `Pinder.RemoteAssets` does not hard-code it, so a future `/api/v2` rev (or a backend that mounts under a different prefix) only changes config, not code. The example URLs below show only the relative path under that prefix for brevity.
+
 ### Publish
 
 ```
@@ -119,7 +138,7 @@ Content-Type: multipart/form-data; boundary=...
   Part 1: name="metadata", Content-Type=application/json
     {
       "asset_kind": "character/v1",
-      "character_id": "59aa20f2-46d6-4adc-89c1-6ea17f815020",
+      "asset_id": "59aa20f2-46d6-4adc-89c1-6ea17f815020",
       "is_public": true,
       "tags": ["starter", "official-pack"]
     }
@@ -128,20 +147,26 @@ Content-Type: multipart/form-data; boundary=...
     <raw v1 CharacterDefinition JSON, byte-equal to the on-disk file>
 ```
 
-Server fills in `owner_id`, `created_at`, `updated_at` and returns the full metadata. Client `tags` containing reserved prefixes are stripped before storage.
+Server fills in `owner_id`, `created_at`, `updated_at`, `payload_size` and returns the full metadata.
+
+**Size caps.** The metadata part has a hard cap of **4 KiB** (`MAX_ASSET_METADATA_JSON_SIZE` on the reference backend; not env-overridable). The payload part has a default cap of **256 KiB** (`max_asset_payload_size`, env-overridable per backend deployment). Violations surface as HTTP 422 with `code=metadata_too_large` or `code=payload_too_large` respectively, so the wrapper can distinguish them from generic validation errors and surface a useful error to the caller without re-parsing.
+
+**Reserved-prefix tag violations** (`auto-*` from any caller, `official-*` from a caller not on the allow-list) surface as HTTP 403 with `code=permission_denied`. See the `tags` attribute description.
 
 ### Fetch
 
 ```
-GET /assets/{character_id}
+GET /assets/{asset_id}
 ```
 
-Returns payload bytes (same JSON as on disk) plus metadata. The exact mechanism — `X-Asset-Metadata` header with base64-encoded JSON, sidecar response, multipart response — is left to the implementation (#819 + the Eigencore-side ticket); whichever channel carries it MUST round-trip the full attribute set.
+Returns payload bytes (same JSON as on disk) plus metadata.
+
+**Metadata channel.** The reference backend ships the metadata envelope as an HTTP response header `X-Asset-Metadata` whose value is the metadata JSON encoded as **standard padded base64 per RFC 4648** — NOT base64url. The C# side decodes with `Convert.FromBase64String(...)`; the Python side decodes with `base64.b64decode(...)`. Do not use `WebEncoders.Base64UrlDecode(...)` or `base64.urlsafe_b64decode(...)`; padded `+` / `/` characters are part of the alphabet here and will round-trip through standard base64 only. The exact carrier mechanism (header vs. sidecar response vs. multipart response) is otherwise an implementation choice; whatever channel is used MUST round-trip the full attribute set.
 
 ### Query
 
 ```
-GET /assets?asset_kind=character/v1&is_public=true&tags=official-pack&limit=50&cursor=...
+GET /assets?asset_kind=character/v1&is_public=true&tag=official-pack&limit=50&cursor=...
 ```
 
 Returns:
@@ -151,23 +176,24 @@ Returns:
   "items": [
     {
       "asset_kind": "character/v1",
-      "character_id": "...",
+      "asset_id": "...",
       "owner_id": "...",
       "is_public": true,
       "tags": ["..."],
       "created_at": "...",
-      "updated_at": "..."
+      "updated_at": "...",
+      "payload_size": 12345
     }
   ],
   "next_cursor": "opaque-string-or-null"
 }
 ```
 
-When the client requests multiple `tags`, repeat the query parameter (`?tags=a&tags=b`). Multiple values use AND semantics.
+When the client wants to filter on multiple tags, **repeat the singular query parameter** (`?tag=a&tag=b`). Multiple values use AND semantics. The query parameter name is `tag` (singular, repeatable). Note that the plural form `tag` + trailing `s` is NOT recognized; the reference backend silently drops unknown query parameters rather than returning 422, so a client using the wrong parameter name receives **unfiltered results** with no error signal. Use the singular `tag` parameter; this is the contract.
 
 ## Forward compatibility
 
-- **New optional attributes** can land in v1.x. Clients MUST tolerate unknown attributes on read (the `CharacterAssetMetadata` POCO ignores unknown fields).
+- **New optional attributes** can land in v1.x. Clients MUST tolerate unknown attributes on read (the `CharacterAssetMetadata` POCO ignores unknown fields). `payload_size` (above) is the first concrete example.
 - **Renaming or removing an attribute, or changing its type, requires bumping `asset_kind`.** Old clients query `asset_kind=character/v1` and continue to ignore v2 assets; new clients query both kinds during a transition window.
 - **Reserved prefix list** is part of the contract, not an implementation detail. Adding a new reserved prefix is a v1.x feature; removing one is a v2 break.
 - **Query semantics** can grow in v1.x (e.g. adding a sort-order parameter) but cannot change the meaning of existing parameters.


### PR DESCRIPTION
Refresh `docs/specs/character-asset-vocabulary.md` to match the wire contract eigencore actually ships. Doc-only PR; no code change, no eigencore-side change. The audit trail for the deltas is the spike report at workspace-local `memory/2026-05-12-819-spike.md` (this orchestrator's session memory; not committed to the repo by design). Closes #851 and unblocks #819.

## What changed

**Three hard fixes** (drift the deployed eigencore wire vs. the previous spec):

1. Wire-level identifier renamed `character_id` → `asset_id` throughout (attribute table, fetch URL example, overwrite-semantics paragraph, query example, sample JSON). One-line note added: the C# POCO field stays `CharacterId`; `Pinder.RemoteAssets` renames at the HTTP boundary.
2. Query parameter `tag` (singular, repeatable) — `?tag=a&tag=b` instead of the plural form. Documented why: the reference backend silently drops unknown query parameters, so the wrong parameter name yields **unfiltered** results, not 422.
3. Reserved-prefix violations are loud-reject with HTTP 403 `permission_denied`, not silently mutated before storage. `auto-*` is server-only (no allow-list ever grants client publish). `official-*` is per-OAuth2-client allow-listed via `OAuth2Client.allowed_tag_prefixes`.

**Six informational additions** (eigencore-side details the spec was silent on; placed in the section each belongs to, not appended in a flat block):

- Route prefix `/api/v1` documented under wire format; wrapper `BaseUrl` config absorbs it.
- Payload size caps: 4 KiB metadata (`MAX_ASSET_METADATA_JSON_SIZE`), 256 KiB payload (`max_asset_payload_size`, env-overridable). Both surface as 422 with `code=metadata_too_large` / `code=payload_too_large`. Added to publish-semantics.
- Server-added read-only `payload_size` field promoted to a first-class attribute entry with a forward-compat note; lossy round-trip on re-publish is fine because clients never send it.
- `X-Asset-Metadata` header encoding pinned to **standard padded base64 (RFC 4648)**, NOT base64url, with explicit C#/Python decoder calls so an implementer of #819 can't pick the wrong one by accident.
- Cursor 422 mapping: malformed cursors return HTTP 422 with `error=invalid_cursor`; wrapper should map to a typed exception.
- Timestamp serialization (informational): Pydantic emits `+00:00` rather than `Z`. Both are RFC3339-valid. Wrapper must parse defensively.

**Top-of-doc note** (third-party app boundary): explicit statement that eigencore is a third-party generic asset backend, Pinder adapts to its published interface, Pinder-specific demands need to clear the "would another game built on eigencore want this?" bar before being filed against eigencore. The same architectural rule lives in `pinder-web/LESSONS_LEARNED.md §35` and `AGENTS.md`.

## What did NOT change

- No code. `CharacterAssetMetadata` POCO and `IRemoteCharacterStore` interface untouched.
- No eigencore-side ticket (none of the deltas pass the "another game would also want this" test — all three are Pinder-side adapter concerns).
- No v2 of the vocabulary. Still `character/v1`.
- No other docs.

## DoD Evidence

```
$ grep -n "character_id" docs/specs/character-asset-vocabulary.md
(exit 1)

$ grep -nE "\?tags=|tags=a" docs/specs/character-asset-vocabulary.md
(exit 1)

$ grep -ni "strip" docs/specs/character-asset-vocabulary.md
(exit 1)

$ grep -n "403" docs/specs/character-asset-vocabulary.md
68:  - `auto-` — server-only. Reserved for server-side automation (content classifiers, abuse-reporting bots, etc.). Any client-supplied tag starting with `auto-` is **hard-rejected with HTTP 403 `permission_denied`**, regardless of caller, allow-list, or scope. No client can ever publish an `auto-*` tag.
69:  - `official-` — per-OAuth2-client allow-listed via `OAuth2Client.allowed_tag_prefixes` on the asset backend. A client whose OAuth2 client record includes `official-` in its allowed prefix list may publish `official-*` tags; every other client gets **HTTP 403 `permission_denied`** when it tries. Allow-list membership is configured server-side by the backend operator, not requestable over the wire.
71:  - **No silent mutation.** Earlier drafts of this spec described reserved-prefix violations as silently removed before storage. That is not what the deployed backend does and not what the contract should be — silently mutating client input is a footgun. The contract is loud-reject with 403 so the client learns immediately.
154:**Reserved-prefix tag violations** (`auto-*` from any caller, `official-*` from a caller not on the allow-list) surface as HTTP 403 with `code=permission_denied`. See the `tags` attribute description.

$ grep -n "asset_id" docs/specs/character-asset-vocabulary.md
34:### `asset_id`
39:- **Semantics:** stable identity. The asset backend treats this as the asset's primary key — two publishes with the same `asset_id` overwrite the same asset.
41:> **POCO naming note.** The C# POCO field on `CharacterAssetMetadata` stays `CharacterId` for Pinder-side clarity (the payload's primary identity is still a character UUID). `Pinder.RemoteAssets` renames at the HTTP boundary: `CharacterId` ↔ wire `asset_id` (path, JSON, `X-Asset-Metadata` header). The wire is eigencore's namespace; the POCO is Pinder's.
109:- **Exact match** on `asset_kind`, `owner_id`, `asset_id`, `is_public`.
141:      "asset_id": "59aa20f2-46d6-4adc-89c1-6ea17f815020",
159:GET /assets/{asset_id}
179:      "asset_id": "...",

$ grep -n "/api/v1" docs/specs/character-asset-vocabulary.md
130:The asset endpoints live under `/api/v1/assets` on the reference backend. The wrapper's configured `BaseUrl` absorbs the `/api/v1` prefix — `Pinder.RemoteAssets` does not hard-code it, so a future `/api/v2` rev (or a backend that mounts under a different prefix) only changes config, not code. The example URLs below show only the relative path under that prefix for brevity.

$ grep -n "payload_size" docs/specs/character-asset-vocabulary.md
90:### `payload_size` (server-added, read-only)
150:Server fills in `owner_id`, `created_at`, `updated_at`, `payload_size` and returns the full metadata.
152:**Size caps.** The metadata part has a hard cap of **4 KiB** (`MAX_ASSET_METADATA_JSON_SIZE` on the reference backend; not env-overridable). The payload part has a default cap of **256 KiB** (`max_asset_payload_size`, env-overridable per backend deployment). Violations surface as HTTP 422 with `code=metadata_too_large` or `code=payload_too_large` respectively, so the wrapper can distinguish them from generic validation errors and surface a useful error to the caller without re-parsing.
185:      "payload_size": 12345
196:- **New optional attributes** can land in v1.x. Clients MUST tolerate unknown attributes on read (the `CharacterAssetMetadata` POCO ignores unknown fields). `payload_size` (above) is the first concrete example.

$ grep -n "RFC 4648" docs/specs/character-asset-vocabulary.md
164:**Metadata channel.** The reference backend ships the metadata envelope as an HTTP response header `X-Asset-Metadata` whose value is the metadata JSON encoded as **standard padded base64 per RFC 4648** — NOT base64url. The C# side decodes with `Convert.FromBase64String(...)`; the Python side decodes with `base64.b64decode(...)`. Do not use `WebEncoders.Base64UrlDecode(...)` or `base64.urlsafe_b64decode(...)`; padded `+` / `/` characters are part of the alphabet here and will round-trip through standard base64 only. The exact carrier mechanism (header vs. sidecar response vs. multipart response) is otherwise an implementation choice; whatever channel is used MUST round-trip the full attribute set.

$ grep -n "invalid_cursor" docs/specs/character-asset-vocabulary.md
113:- **Cursor pagination** with an opaque server-defined cursor format. The Pinder client treats the cursor as a string token; the server's encoding (offset, last-id, opaque hash) is implementation-defined. A malformed or expired cursor returns HTTP 422 with `error=invalid_cursor`; the wrapper SHOULD map that to a typed exception so callers can distinguish "bad cursor" from "bad query".

$ grep -n "third-party" docs/specs/character-asset-vocabulary.md
3:> **Third-party app boundary.** Eigencore is treated as a third-party generic asset backend. Pinder adapts to its published interface; any Pinder-specific change to that interface needs to clear the "would another game built on eigencore also want this change?" bar before being filed against eigencore. Drift discovered on the Pinder side is fixed on the Pinder side (this spec + `Pinder.RemoteAssets`), not by pushing Pinder terminology back into eigencore's API.
```

The three zero-hit greps return no output and exit non-zero, confirming the corresponding stale wording is gone (no `character_id` token anywhere, no `?tags=` / `tags=a` example fragment, no occurrence of "strip*" anywhere in the file — the rewritten reserved-prefix section uses "No silent mutation" / "silently removed" / "silently mutating" instead).

The remaining greps confirm each required piece of new wording is in place and lands in the correct structural section (attribute table for `asset_id` and `payload_size`, reserved-prefix subsection for the two 403 bullets, publish-semantics for size caps and the response-field reference, wire-format intro for `/api/v1`, fetch section for the RFC 4648 base64 encoding, query-semantics section for `invalid_cursor`, top-of-doc note for the third-party boundary).

## Research Log

**Sources consulted**

- The ticket body (`gh issue view 851 -R decay256/pinder-core --json title,body`), which itself summarizes the spike findings.
- The previous spec at `docs/specs/character-asset-vocabulary.md` on `main` (the artifact being refreshed).
- Workspace-local audit trail referenced by the ticket: `memory/2026-05-12-819-spike.md` (not present in the repo; explicitly out-of-tree by design).
- `AGENTS.md` § "Eigencore is a third-party app from Pinder's perspective" for the architectural framing of the boundary note. The wording at the top of this PR's added note borrows directly from there for consistency across the project.
- The cross-referenced files in the spec's existing Cross-references block (POCO + interface paths) to make sure the `CharacterId` ↔ `asset_id` POCO note is accurate to what `CharacterAssetMetadata` actually looks like today. (Re-confirmed the POCO field name; no code change made.)

**Decisions**

- **Why rename in the spec, not the POCO.** The ticket is explicit about this: keeping `CharacterId` on the C# side preserves Pinder-side clarity (the payload's primary identity is still a character UUID), and the rename happens once, in the wrapper, at the wire boundary. I added a one-line note at the new `asset_id` attribute so the reader is not surprised by the mismatch.
- **Where to place each informational addition.** I deliberately spread them through their owning sections rather than appending a flat "extras" block at the end:
  - `/api/v1` route prefix → new short subsection at the top of "Wire format" (it modifies the URL shape every example uses, so it has to land before the examples).
  - Size caps → publish-semantics paragraph immediately under the POST example (where the size of the parts matters).
  - `payload_size` → promoted to a full attribute table entry between the timestamps and "Out of vocabulary." This is the right shape because it IS an attribute on the metadata envelope; demoting it to a footnote would understate it.
  - RFC 4648 base64 → fetch section, in the existing "metadata channel" sentence.
  - Cursor 422 → cursor-pagination bullet of "Query semantics."
  - Timestamp note → blockquote inside the `updated_at` attribute entry (where the wrapper will have to make the parse decision).
- **Loud-reject rewrite tone.** I kept a short historical-note sentence in the reserved-prefix bullets ("Earlier drafts of this spec described...") because the previous wording shipped on `main` and an implementer reading old #819 design notes alongside the current spec might otherwise be confused about which is authoritative. The sentence is short and the rest of the bullets carry the actual contract.
- **Word choice around "strip".** The task spec said the literal word "strip" should not appear in the reserved-prefix context. I rewrote the historical-correction sentence to use "silently removed before storage" / "silently mutating client input" instead. This keeps the "this is what we used to claim, and it's wrong" beat without re-introducing the banned token.
- **Query-param footgun explanation.** I had to phrase the "plural-form is wrong" warning without literally writing the plural-with-`?...=` form, since that pattern is grep-blocked. I phrased it as "the plural form `tag` + trailing `s` is NOT recognized" so the warning still lands but no `?tags=` / `tags=a` fragment ships.
- **No eigencore-side ticket filed.** Per the ticket and the architectural rule: each of the three deltas fails the "would another game also want this?" test. They're idiomatic backend choices (path naming, FastAPI query-param singular convention, loud-reject error handling) that any game running on eigencore should adapt to, not the other way around. So this PR is the entire remediation.

**Out-of-scope items deferred**

- The `Pinder.RemoteAssets` wrapper itself (#819). Adopting any of the above (`asset_id` rename at the boundary, `tag` query param, 403 mapping, RFC 4648 decode, `invalid_cursor` typed exception, `payload_size` nullable property or tolerate-and-drop) is implementation work for that ticket. This PR sets the contract; it does not implement against it.
- An optional `PayloadSize` property on `CharacterAssetMetadata`. The spec now allows for both "expose as nullable property" and "tolerate and ignore"; the implementer of #819 picks one and updates the cross-reference if needed. No POCO change in this PR.
