### PR TITLE
feat(#854): Pinder.RemoteAssets sub-PR 2/3 — query + paging path

### DIFF
--- a/src/Pinder.Core/Characters/CharacterAssetQuery.cs
+++ b/src/Pinder.Core/Characters/CharacterAssetQuery.cs
@@ -53,18 +53,62 @@ namespace Pinder.Core.Characters
         /// </summary>
         public string? Cursor { get; }
 
+        /// <summary>
+        /// Filter by asset-kind discriminator (e.g.
+        /// <see cref="CharacterAssetMetadata.AssetKindCharacterV1"/>).
+        /// <c>null</c> means "no asset-kind filter". The wrapper
+        /// implementation URL-encodes the value, so the canonical
+        /// <c>character/v1</c> ends up as <c>character%2Fv1</c> on the
+        /// wire.
+        /// </summary>
+        public string? AssetKind { get; }
+
+        /// <summary>
+        /// Half-open lower bound on <see cref="CharacterAssetMetadata.CreatedAt"/>
+        /// (inclusive). <c>null</c> means "no lower bound".
+        /// </summary>
+        public DateTimeOffset? CreatedAfter { get; }
+
+        /// <summary>
+        /// Half-open upper bound on <see cref="CharacterAssetMetadata.CreatedAt"/>
+        /// (exclusive). <c>null</c> means "no upper bound".
+        /// </summary>
+        public DateTimeOffset? CreatedBefore { get; }
+
+        /// <summary>
+        /// Half-open lower bound on <see cref="CharacterAssetMetadata.UpdatedAt"/>
+        /// (inclusive). <c>null</c> means "no lower bound".
+        /// </summary>
+        public DateTimeOffset? UpdatedAfter { get; }
+
+        /// <summary>
+        /// Half-open upper bound on <see cref="CharacterAssetMetadata.UpdatedAt"/>
+        /// (exclusive). <c>null</c> means "no upper bound".
+        /// </summary>
+        public DateTimeOffset? UpdatedBefore { get; }
+
         public CharacterAssetQuery(
             string? ownerId = null,
             IReadOnlyList<string>? tags = null,
             bool? isPublic = null,
             int limit = DefaultLimit,
-            string? cursor = null)
+            string? cursor = null,
+            string? assetKind = null,
+            DateTimeOffset? createdAfter = null,
+            DateTimeOffset? createdBefore = null,
+            DateTimeOffset? updatedAfter = null,
+            DateTimeOffset? updatedBefore = null)
         {
             OwnerId = ownerId;
             Tags = tags;
             IsPublic = isPublic;
             Limit = ClampLimit(limit);
             Cursor = cursor;
+            AssetKind = assetKind;
+            CreatedAfter = createdAfter;
+            CreatedBefore = createdBefore;
+            UpdatedAfter = updatedAfter;
+            UpdatedBefore = updatedBefore;
         }
 
         private static int ClampLimit(int requested)

--- a/src/Pinder.RemoteAssets/EigencoreCharacterStore.cs
+++ b/src/Pinder.RemoteAssets/EigencoreCharacterStore.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
@@ -22,10 +24,12 @@ namespace Pinder.RemoteAssets
     /// ("Eigencore is a THIRD-PARTY APP from Pinder's perspective") and
     /// lesson §35 of pinder-web/LESSONS_LEARNED.md.
     ///
-    /// Sub-PR scope (#853): read path only — <see cref="LoadAsync"/>,
-    /// <see cref="GetMetadataAsync"/>, <see cref="ExistsAsync"/>. The
-    /// other interface members throw <see cref="NotSupportedException"/>
-    /// until sub-PRs #854 (query) and #855 (publish/save/delete) wire
+    /// Sub-PR scope:
+    /// #853 — read path (<see cref="LoadAsync"/>, <see cref="GetMetadataAsync"/>,
+    ///        <see cref="ExistsAsync"/>).
+    /// #854 — query / paging path (<see cref="QueryAsync"/>).
+    /// The remaining members (Save / Publish / Delete / ListIds) still
+    /// throw <see cref="NotSupportedException"/> until sub-PR #855 wires
     /// them up.
     /// </summary>
     public sealed class EigencoreCharacterStore : IRemoteCharacterStore
@@ -122,8 +126,122 @@ namespace Pinder.RemoteAssets
         public Task<bool> DeleteAsync(string characterId, CancellationToken ct = default) =>
             throw new NotSupportedException("DeleteAsync is reserved for sub-PR #855 (write path).");
 
-        public Task<CharacterAssetPage> QueryAsync(CharacterAssetQuery query, CancellationToken ct = default) =>
-            throw new NotSupportedException("QueryAsync is reserved for sub-PR #854 (query path).");
+        // ---- IRemoteCharacterStore query path (#854) ---------------------
+
+        /// <summary>
+        /// <c>GET {baseUrl}/assets?&lt;encoded filters&gt;</c>. Returns one
+        /// page of metadata matching <paramref name="query"/>. The wrapper
+        /// does NOT auto-paginate; the caller drives by passing the
+        /// returned <see cref="CharacterAssetPage.NextCursor"/> back in a
+        /// subsequent <see cref="CharacterAssetQuery.Cursor"/> until it
+        /// comes back null.
+        ///
+        /// Wire contract: see <c>docs/specs/character-asset-vocabulary.md</c>
+        /// § Query semantics + § Wire format / Query. Key invariants:
+        /// <list type="bullet">
+        ///   <item>Tag filter param is <c>tag</c> (singular, repeatable),
+        ///         NOT <c>tags</c>. The reference backend silently drops
+        ///         unknown params, so getting this wrong returns
+        ///         unfiltered results with no error signal.</item>
+        ///   <item><c>asset_kind=character/v1</c> URL-encodes the slash
+        ///         to <c>character%2Fv1</c>.</item>
+        ///   <item>Cursor is opaque pass-through. 422 with
+        ///         <c>error=invalid_cursor</c> in the body throws
+        ///         <see cref="RemoteAssetInvalidCursorException"/>.</item>
+        ///   <item>Date filters are RFC3339 UTC. Wire response timestamps
+        ///         are parsed defensively (both <c>Z</c> and
+        ///         <c>+00:00</c> suffixes accepted) via the shared
+        ///         <see cref="CharacterAssetMetadataParser"/>.</item>
+        /// </list>
+        /// </summary>
+        public async Task<CharacterAssetPage> QueryAsync(CharacterAssetQuery query, CancellationToken ct = default)
+        {
+            if (query == null) throw new ArgumentNullException(nameof(query));
+
+            bool retried = false;
+
+            while (true)
+            {
+                using (var req = new HttpRequestMessage(HttpMethod.Get, BuildQueryUri(query)))
+                {
+                    await AttachAuthAsync(req, ct).ConfigureAwait(false);
+
+                    HttpResponseMessage resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                        .ConfigureAwait(false);
+                    try
+                    {
+                        int status = (int)resp.StatusCode;
+
+                        if (status == 200)
+                        {
+                            byte[] body = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                            return ParseQueryResponse(body);
+                        }
+
+                        if (status == 401)
+                        {
+                            string body401 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetAuthException(
+                                "Eigencore returned 401 for GET assets query.",
+                                responseBody: body401);
+                        }
+
+                        if (status == 422)
+                        {
+                            string body422 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            (string? errorCode, IReadOnlyList<string> errors) = ParseValidationBody(body422);
+                            if (string.Equals(errorCode, "invalid_cursor", StringComparison.Ordinal))
+                            {
+                                throw new RemoteAssetInvalidCursorException(
+                                    "Eigencore returned 422 invalid_cursor for GET assets query.",
+                                    responseBody: body422);
+                            }
+                            throw new RemoteAssetValidationException(
+                                "Eigencore returned 422 for GET assets query.",
+                                errors: errors,
+                                responseBody: body422);
+                        }
+
+                        if (status == 429)
+                        {
+                            TimeSpan delay = ParseRetryAfter(resp) ?? _config.DefaultRetryAfter;
+                            string body429 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            if (retried)
+                            {
+                                throw new RemoteAssetRateLimitException(
+                                    "Eigencore returned 429 for GET assets query after one retry.",
+                                    retryAfter: delay,
+                                    responseBody: body429);
+                            }
+                            retried = true;
+                            resp.Dispose();
+                            if (delay > TimeSpan.Zero)
+                                await Task.Delay(delay, ct).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        if (status >= 500 && status <= 599)
+                        {
+                            string body5xx = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetServerException(
+                                $"Eigencore returned {status} for GET assets query.",
+                                statusCode: status,
+                                responseBody: body5xx);
+                        }
+
+                        string bodyOther = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                        throw new RemoteAssetServerException(
+                            $"Eigencore returned unexpected status {status} for GET assets query.",
+                            statusCode: status,
+                            responseBody: bodyOther);
+                    }
+                    finally
+                    {
+                        resp.Dispose();
+                    }
+                }
+            }
+        }
 
         public Task<CharacterAssetMetadata> PublishAsync(
             CharacterDefinition def,
@@ -241,6 +359,198 @@ namespace Pinder.RemoteAssets
             // Relative path; HttpClient.BaseAddress is set to BaseUrl + "/"
             // in the ctor.
             return new Uri($"assets/{Uri.EscapeDataString(characterId)}", UriKind.Relative);
+        }
+
+        /// <summary>
+        /// Build the relative <c>assets?...</c> URI for a query. Each
+        /// scalar filter contributes at most one <c>key=value</c> pair;
+        /// <c>tag</c> is emitted as a repeated <c>tag=...</c> param
+        /// (one per value, AND semantics). Values are URL-encoded with
+        /// <see cref="Uri.EscapeDataString"/>, which encodes <c>/</c>
+        /// to <c>%2F</c> as required for <c>asset_kind=character/v1</c>.
+        /// </summary>
+        private static Uri BuildQueryUri(CharacterAssetQuery query)
+        {
+            // Pre-built so the implementation reads top-to-bottom.
+            var sb = new StringBuilder("assets");
+            bool first = true;
+
+            void Append(string key, string value)
+            {
+                sb.Append(first ? '?' : '&');
+                first = false;
+                sb.Append(key);
+                sb.Append('=');
+                sb.Append(Uri.EscapeDataString(value));
+            }
+
+            if (!string.IsNullOrEmpty(query.AssetKind))
+                Append("asset_kind", query.AssetKind!);
+
+            // OwnerId distinguishes null ("any owner") from empty
+            // string ("explicit ownerless / service-owned"); the spec
+            // calls this out. Empty string is a legitimate filter value.
+            if (query.OwnerId != null)
+                Append("owner_id", query.OwnerId);
+
+            if (query.IsPublic.HasValue)
+                Append("is_public", query.IsPublic.Value ? "true" : "false");
+
+            // tag (singular, repeatable). Emitting `tags=a,b` or
+            // `tags=a` is the canonical bug this PR pins against; the
+            // backend silently drops `tags=` and returns unfiltered
+            // results. Code-review + the regression grep both watchdog
+            // this.
+            if (query.Tags != null)
+            {
+                foreach (var t in query.Tags)
+                {
+                    if (!string.IsNullOrEmpty(t))
+                        Append("tag", t);
+                }
+            }
+
+            // Limit always emitted — the wire contract gives the server
+            // freedom to choose a different default, and CharacterAssetQuery
+            // already clamps to a sensible client default.
+            Append("limit", query.Limit.ToString(CultureInfo.InvariantCulture));
+
+            if (!string.IsNullOrEmpty(query.Cursor))
+                Append("cursor", query.Cursor!);
+
+            if (query.CreatedAfter.HasValue)
+                Append("created_after", FormatRfc3339Utc(query.CreatedAfter.Value));
+            if (query.CreatedBefore.HasValue)
+                Append("created_before", FormatRfc3339Utc(query.CreatedBefore.Value));
+            if (query.UpdatedAfter.HasValue)
+                Append("updated_after", FormatRfc3339Utc(query.UpdatedAfter.Value));
+            if (query.UpdatedBefore.HasValue)
+                Append("updated_before", FormatRfc3339Utc(query.UpdatedBefore.Value));
+
+            return new Uri(sb.ToString(), UriKind.Relative);
+        }
+
+        /// <summary>
+        /// Format a <see cref="DateTimeOffset"/> as RFC3339 UTC with the
+        /// <c>Z</c> zone suffix. The wire contract is UTC; we normalize
+        /// to UTC here and emit the canonical <c>Z</c> form regardless of
+        /// the caller's original offset. Sub-second precision is
+        /// preserved at the .NET DateTime default (100ns ticks).
+        /// </summary>
+        private static string FormatRfc3339Utc(DateTimeOffset ts)
+        {
+            // "o" round-trip yields "2026-01-02T03:04:05.0000000+00:00" for
+            // a UTC offset; switching to UTC and using the explicit "Z"
+            // form keeps the wire string compact and matches what
+            // RFC3339-strict parsers expect.
+            return ts.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse the <c>{"items":[...], "next_cursor":"..."}</c> response
+        /// envelope into a <see cref="CharacterAssetPage"/>. Each item is
+        /// the same shape as the read-path <c>X-Asset-Metadata</c>
+        /// payload, so we delegate per-item parsing to
+        /// <see cref="CharacterAssetMetadataParser.ParseElement"/> for
+        /// consistency.
+        /// </summary>
+        private static CharacterAssetPage ParseQueryResponse(byte[] body)
+        {
+            if (body == null || body.Length == 0)
+                throw new RemoteAssetMalformedMetadataException(
+                    "Query response body is empty.");
+
+            try
+            {
+                using (var doc = JsonDocument.Parse(body))
+                {
+                    var root = doc.RootElement;
+                    if (root.ValueKind != JsonValueKind.Object)
+                        throw new RemoteAssetMalformedMetadataException(
+                            "Query response root must be a JSON object.");
+
+                    var items = new List<CharacterAssetMetadata>();
+                    if (root.TryGetProperty("items", out var itemsEl))
+                    {
+                        if (itemsEl.ValueKind != JsonValueKind.Array)
+                            throw new RemoteAssetMalformedMetadataException(
+                                "Query response 'items' must be a JSON array.");
+                        foreach (var item in itemsEl.EnumerateArray())
+                        {
+                            items.Add(CharacterAssetMetadataParser.ParseElement(item));
+                        }
+                    }
+                    // Spec is explicit: items is always present. Treat a
+                    // missing items key the same as an empty array on
+                    // forward-compat grounds (don't throw on a server
+                    // that returns {"next_cursor": null} alone).
+
+                    string? nextCursor = null;
+                    if (root.TryGetProperty("next_cursor", out var ncEl)
+                        && ncEl.ValueKind == JsonValueKind.String)
+                    {
+                        nextCursor = ncEl.GetString();
+                    }
+                    // JsonValueKind.Null falls through → nextCursor stays
+                    // null, which is the contract for "last page".
+
+                    return new CharacterAssetPage(items, nextCursor);
+                }
+            }
+            catch (JsonException ex)
+            {
+                throw new RemoteAssetMalformedMetadataException(
+                    "Query response is not valid JSON.", ex);
+            }
+        }
+
+        /// <summary>
+        /// Best-effort parse of a 422 body to extract the <c>error</c>
+        /// discriminator and any per-field <c>errors</c> array. The wire
+        /// shape is loosely specified — Pydantic v2 commonly emits
+        /// <c>{"detail": [...]}</c>, the asset-backend spec calls for
+        /// <c>{"error": "invalid_cursor", ...}</c>. We accept either and
+        /// return <c>(null, [])</c> when the body is not parseable as
+        /// JSON or doesn't carry the expected fields.
+        /// </summary>
+        private static (string? errorCode, IReadOnlyList<string> errors) ParseValidationBody(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return (null, Array.Empty<string>());
+
+            try
+            {
+                using (var doc = JsonDocument.Parse(body))
+                {
+                    var root = doc.RootElement;
+                    if (root.ValueKind != JsonValueKind.Object)
+                        return (null, Array.Empty<string>());
+
+                    string? code = null;
+                    if (root.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String)
+                        code = errEl.GetString();
+                    else if (root.TryGetProperty("code", out var codeEl) && codeEl.ValueKind == JsonValueKind.String)
+                        code = codeEl.GetString();
+
+                    var errors = new List<string>();
+                    if (root.TryGetProperty("errors", out var errsEl) && errsEl.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var e in errsEl.EnumerateArray())
+                        {
+                            if (e.ValueKind == JsonValueKind.String)
+                            {
+                                var s = e.GetString();
+                                if (s != null) errors.Add(s);
+                            }
+                        }
+                    }
+                    return (code, errors);
+                }
+            }
+            catch (JsonException)
+            {
+                return (null, Array.Empty<string>());
+            }
         }
 
         private async Task AttachAuthAsync(HttpRequestMessage req, CancellationToken ct)

--- a/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreQueryTests.cs
+++ b/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreQueryTests.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Stats;
+using Pinder.RemoteAssets;
+using Pinder.RemoteAssets.Exceptions;
+using Xunit;
+
+namespace Pinder.RemoteAssets.Tests
+{
+    /// <summary>
+    /// Query-path tests for <see cref="EigencoreCharacterStore"/> (issue
+    /// #854). Each test pins a single bullet from the ticket's "Tests
+    /// required" list. The first test (<see
+    /// cref="QueryAsync_MultipleTags_Emits_Singular_Tag_Param_Never_Plural"/>)
+    /// is the #1 regression guard called out by the ticket: it asserts
+    /// that the wrapper emits <c>tag=foo&amp;tag=bar</c>, NOT
+    /// <c>tags=...</c>. FastAPI silently drops unknown query params, so
+    /// the wrong spelling returns unfiltered results with no error
+    /// signal in production.
+    /// </summary>
+    public class EigencoreCharacterStoreQueryTests
+    {
+        private const string AssetIdA = "59aa20f2-46d6-4adc-89c1-6ea17f815020";
+        private const string AssetIdB = "8d6b4f5a-9a8e-4e2a-9b1c-1d3e4f5a6b7c";
+        private const string AssetIdC = "12345678-1234-1234-1234-123456789abc";
+
+        // -- helpers -----------------------------------------------------
+
+        /// <summary>
+        /// Build an items-array element matching the wire shape from
+        /// <c>docs/specs/character-asset-vocabulary.md</c> § Query.
+        /// Timestamps are emitted with the literal string passed in so
+        /// callers can pin the <c>Z</c> vs <c>+00:00</c> defensive-parse
+        /// test.
+        /// </summary>
+        private static void WriteItem(
+            Utf8JsonWriter w,
+            string assetId,
+            string assetKind = "character/v1",
+            string ownerId = "user:test",
+            bool isPublic = true,
+            string[]? tags = null,
+            string createdAt = "2026-01-02T03:04:05+00:00",
+            string updatedAt = "2026-01-02T03:04:06+00:00")
+        {
+            w.WriteStartObject();
+            w.WriteString("asset_kind", assetKind);
+            w.WriteString("asset_id", assetId);
+            w.WriteString("owner_id", ownerId);
+            w.WriteBoolean("is_public", isPublic);
+            w.WriteStartArray("tags");
+            foreach (var t in tags ?? Array.Empty<string>()) w.WriteStringValue(t);
+            w.WriteEndArray();
+            w.WriteString("created_at", createdAt);
+            w.WriteString("updated_at", updatedAt);
+            w.WriteEndObject();
+        }
+
+        private static byte[] BuildPage(string? nextCursor, Action<Utf8JsonWriter> writeItems)
+        {
+            using var ms = new MemoryStream();
+            using (var w = new Utf8JsonWriter(ms))
+            {
+                w.WriteStartObject();
+                w.WriteStartArray("items");
+                writeItems(w);
+                w.WriteEndArray();
+                if (nextCursor == null) w.WriteNull("next_cursor");
+                else w.WriteString("next_cursor", nextCursor);
+                w.WriteEndObject();
+            }
+            return ms.ToArray();
+        }
+
+        private static CharacterDefinition StubParse(byte[] _)
+        {
+            // Query path doesn't invoke the parser, but Configuration
+            // requires it to be non-null. Return a minimal stub.
+            return new CharacterDefinition(
+                schemaVersion: 1,
+                characterId: Guid.Parse(AssetIdA),
+                name: "Stub",
+                genderIdentity: "they/them",
+                bio: "stub",
+                level: 1,
+                items: Array.Empty<string>(),
+                anatomy: new Dictionary<string, string>(),
+                allocation: new AllocationBlock(
+                    new Dictionary<StatType, int>(),
+                    0,
+                    new Dictionary<ShadowStatType, int>()));
+        }
+
+        private static (EigencoreCharacterStore store, FakeHttpMessageHandler handler) Make(
+            Func<CancellationToken, Task<string>>? authProvider = null,
+            TimeSpan? defaultRetryAfter = null)
+        {
+            var handler = new FakeHttpMessageHandler();
+            var config = new Configuration(
+                baseUrl: new Uri("https://eigencore.test/api/v1"),
+                httpMessageHandler: handler,
+                authTokenProvider: authProvider ?? (ct => Task.FromResult("test-token")),
+                payloadParser: StubParse,
+                defaultRetryAfter: defaultRetryAfter ?? TimeSpan.FromMilliseconds(1));
+            return (new EigencoreCharacterStore(config), handler);
+        }
+
+        private static HttpResponseMessage OkJson(byte[] body) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+
+        // -- tests -------------------------------------------------------
+
+        /// <summary>
+        /// #1 regression test from the ticket. Multi-tag filter MUST emit
+        /// <c>tag=foo&amp;tag=bar</c> (singular, repeatable). The
+        /// reference backend silently drops unknown query params, so an
+        /// implementation that accidentally emits <c>tags=foo</c> returns
+        /// unfiltered results with no error signal. This is the most
+        /// likely failure mode for this PR and is asserted first.
+        /// </summary>
+        [Fact]
+        public async Task QueryAsync_MultipleTags_Emits_Singular_Tag_Param_Never_Plural()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            var query = new CharacterAssetQuery(tags: new[] { "foo", "bar" });
+            await store.QueryAsync(query);
+
+            string url = handler.Requests[0].RequestUri!.ToString();
+            Assert.Contains("tag=foo", url);
+            Assert.Contains("tag=bar", url);
+            // The two appearances of `tag=` must be the singular form.
+            // Any `tags=` substring is a regression.
+            Assert.DoesNotContain("tags=", url);
+        }
+
+        [Fact]
+        public async Task QueryAsync_EmptyResult_Returns_Empty_Page_With_Null_Cursor()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            var page = await store.QueryAsync(new CharacterAssetQuery());
+
+            Assert.Empty(page.Items);
+            Assert.Null(page.NextCursor);
+        }
+
+        [Fact]
+        public async Task QueryAsync_SinglePage_Returns_Items_And_Null_Cursor()
+        {
+            var (store, handler) = Make();
+            byte[] body = BuildPage(null, w =>
+            {
+                WriteItem(w, AssetIdA);
+                WriteItem(w, AssetIdB);
+                WriteItem(w, AssetIdC);
+            });
+            handler.Enqueue(OkJson(body));
+
+            var page = await store.QueryAsync(new CharacterAssetQuery());
+
+            Assert.Equal(3, page.Items.Count);
+            Assert.Null(page.NextCursor);
+            Assert.Equal(AssetIdA, page.Items[0].CharacterId);
+            Assert.Equal(AssetIdB, page.Items[1].CharacterId);
+            Assert.Equal(AssetIdC, page.Items[2].CharacterId);
+        }
+
+        /// <summary>
+        /// Multi-page sanity: wrapper does NOT auto-paginate. Caller
+        /// drives by passing <c>NextCursor</c> back into a second
+        /// <c>QueryAsync</c> call. Assertion: TWO separate HTTP calls,
+        /// not one wrapper-internal loop.
+        /// </summary>
+        [Fact]
+        public async Task QueryAsync_MultiPage_Does_Not_AutoPaginate_Caller_Drives()
+        {
+            var (store, handler) = Make();
+            byte[] page1 = BuildPage("abc", w =>
+            {
+                WriteItem(w, AssetIdA);
+            });
+            byte[] page2 = BuildPage(null, w =>
+            {
+                WriteItem(w, AssetIdB);
+                WriteItem(w, AssetIdC);
+            });
+            handler.Enqueue(OkJson(page1));
+            handler.Enqueue(OkJson(page2));
+
+            // First call returns NextCursor="abc"; wrapper stops there.
+            var first = await store.QueryAsync(new CharacterAssetQuery());
+            Assert.Single(first.Items);
+            Assert.Equal("abc", first.NextCursor);
+            Assert.Single(handler.Requests); // exactly one call so far
+
+            // Caller drives the second page.
+            var second = await store.QueryAsync(new CharacterAssetQuery(cursor: "abc"));
+            Assert.Equal(2, second.Items.Count);
+            Assert.Null(second.NextCursor);
+            Assert.Equal(2, handler.Requests.Count); // two calls total
+            // Second request URL carries the cursor.
+            Assert.Contains("cursor=abc", handler.Requests[1].RequestUri!.ToString());
+        }
+
+        [Fact]
+        public async Task QueryAsync_AssetKind_With_Slash_Is_UrlEncoded()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            await store.QueryAsync(new CharacterAssetQuery(assetKind: "character/v1"));
+
+            string url = handler.Requests[0].RequestUri!.ToString();
+            Assert.Contains("asset_kind=character%2Fv1", url);
+            // Defensive: the raw slash form must NOT appear in the
+            // query-string portion. Splitting on '?' guards against the
+            // base path's slashes confusing the assertion.
+            string queryString = url.Substring(url.IndexOf('?'));
+            Assert.DoesNotContain("asset_kind=character/v1", queryString);
+        }
+
+        [Fact]
+        public async Task QueryAsync_IsPublic_True_Emits_Literal_True()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            await store.QueryAsync(new CharacterAssetQuery(isPublic: true));
+
+            string url = handler.Requests[0].RequestUri!.ToString();
+            Assert.Contains("is_public=true", url);
+        }
+
+        [Fact]
+        public async Task QueryAsync_OwnerId_Appears_Verbatim_In_Url()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            const string owner = "user:1234";
+            await store.QueryAsync(new CharacterAssetQuery(ownerId: owner));
+
+            string url = handler.Requests[0].RequestUri!.ToString();
+            // The colon round-trips through Uri.EscapeDataString as %3A
+            // — but the original literal characters must be recoverable.
+            // We assert both the encoded and decoded forms to keep the
+            // test resilient to future encoding-strictness tweaks.
+            string queryString = url.Substring(url.IndexOf('?'));
+            string decoded = Uri.UnescapeDataString(queryString);
+            Assert.Contains($"owner_id={owner}", decoded);
+        }
+
+        [Fact]
+        public async Task QueryAsync_DateFilters_Emit_Rfc3339_Utc_Strings()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(OkJson(BuildPage(null, _ => { })));
+
+            var createdAfter  = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+            var createdBefore = new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero);
+            var updatedAfter  = new DateTimeOffset(2026, 3, 4, 5, 6, 7, TimeSpan.Zero);
+            var updatedBefore = new DateTimeOffset(2026, 4, 5, 6, 7, 8, TimeSpan.Zero);
+
+            await store.QueryAsync(new CharacterAssetQuery(
+                createdAfter: createdAfter,
+                createdBefore: createdBefore,
+                updatedAfter: updatedAfter,
+                updatedBefore: updatedBefore));
+
+            string url = handler.Requests[0].RequestUri!.ToString();
+            string decoded = Uri.UnescapeDataString(url);
+
+            // RFC3339 UTC with explicit "Z". We assert the date/time
+            // portion ("YYYY-MM-DDThh:mm:ss") rather than the full
+            // fractional-second tail so the test stays stable if
+            // FormatRfc3339Utc's precision setting is tightened later.
+            Assert.Contains("created_after=2026-01-02T03:04:05", decoded);
+            Assert.Contains("created_before=2026-02-03T04:05:06", decoded);
+            Assert.Contains("updated_after=2026-03-04T05:06:07", decoded);
+            Assert.Contains("updated_before=2026-04-05T06:07:08", decoded);
+            // Z suffix on every date filter — the wire contract is UTC.
+            Assert.Contains("Z&", decoded + "&");
+        }
+
+        /// <summary>
+        /// Defensive timestamp parse: query response items may carry
+        /// either <c>+00:00</c> or <c>Z</c> in the same response (the
+        /// spec mandates UTC but the on-wire suffix is server-defined).
+        /// Both forms MUST parse without error and round-trip to the
+        /// same UTC <see cref="DateTimeOffset"/>.
+        /// </summary>
+        [Fact]
+        public async Task QueryAsync_Item_Timestamps_With_Mixed_Z_And_PlusZeroOffset_Both_Parse()
+        {
+            var (store, handler) = Make();
+            byte[] body = BuildPage(null, w =>
+            {
+                WriteItem(w, AssetIdA,
+                    createdAt: "2026-01-02T03:04:05+00:00",
+                    updatedAt: "2026-01-02T03:04:06+00:00");
+                WriteItem(w, AssetIdB,
+                    createdAt: "2026-01-02T03:04:05Z",
+                    updatedAt: "2026-01-02T03:04:06Z");
+            });
+            handler.Enqueue(OkJson(body));
+
+            var page = await store.QueryAsync(new CharacterAssetQuery());
+
+            Assert.Equal(2, page.Items.Count);
+            var a = page.Items[0];
+            var b = page.Items[1];
+            Assert.Equal(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero), a.CreatedAt);
+            Assert.Equal(new DateTimeOffset(2026, 1, 2, 3, 4, 6, TimeSpan.Zero), a.UpdatedAt);
+            Assert.Equal(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero), b.CreatedAt);
+            Assert.Equal(new DateTimeOffset(2026, 1, 2, 3, 4, 6, TimeSpan.Zero), b.UpdatedAt);
+            // Both should land as TimeSpan.Zero (UTC) regardless of how
+            // the wire spelled them.
+            Assert.Equal(TimeSpan.Zero, a.CreatedAt.Offset);
+            Assert.Equal(TimeSpan.Zero, b.CreatedAt.Offset);
+        }
+
+        [Fact]
+        public async Task QueryAsync_MalformedCursor_Maps_422_Invalid_Cursor_To_Typed_Exception()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent("{\"error\":\"invalid_cursor\",\"detail\":\"cursor expired\"}"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetInvalidCursorException>(() =>
+                store.QueryAsync(new CharacterAssetQuery(cursor: "garbage")));
+            Assert.Equal(422, ex.StatusCode);
+            Assert.Contains("invalid_cursor", ex.ResponseBody);
+        }
+
+        /// <summary>
+        /// Regression test against #853's auth mapping when traffic
+        /// flows through the new query code path. 401 anywhere is
+        /// <see cref="RemoteAssetAuthException"/>.
+        /// </summary>
+        [Fact]
+        public async Task QueryAsync_401_Throws_RemoteAssetAuthException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"detail\":\"token expired\"}"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetAuthException>(() =>
+                store.QueryAsync(new CharacterAssetQuery()));
+            Assert.Equal(401, ex.StatusCode);
+            Assert.Contains("token expired", ex.ResponseBody);
+        }
+    }
+}

--- a/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreReadTests.cs
+++ b/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreReadTests.cs
@@ -454,12 +454,11 @@ namespace Pinder.RemoteAssets.Tests
             await Assert.ThrowsAsync<NotSupportedException>(() => store.ListIdsAsync());
         }
 
-        [Fact]
-        public async Task QueryAsync_Throws_NotSupported_In_853()
-        {
-            var (store, _) = Make();
-            await Assert.ThrowsAsync<NotSupportedException>(() => store.QueryAsync(new CharacterAssetQuery(limit: 10)));
-        }
+        // QueryAsync_Throws_NotSupported_In_853 was removed in #854 —
+        // the query path is now implemented (see
+        // EigencoreCharacterStoreQueryTests). The remaining write-path
+        // members (SaveAsync, PublishAsync, DeleteAsync) still throw and
+        // are pinned by the tests below until #855 lands.
 
         [Fact]
         public async Task SaveAsync_Throws_NotSupported_In_853()


### PR DESCRIPTION
Closes #854.

Sub-PR 2 of 3 from parent #819 (`Pinder.RemoteAssets` Eigencore wrapper). Extends #853's read path with the query / paging path of `IRemoteCharacterStore` against `GET /api/v1/assets`.

## What this PR adds

- `EigencoreCharacterStore.QueryAsync(CharacterAssetQuery, CancellationToken)` — full implementation.
- `Pinder.RemoteAssets.EigencoreCharacterStore.BuildQueryUri` / `FormatRfc3339Utc` / `ParseQueryResponse` / `ParseValidationBody` internals.
- `EigencoreCharacterStoreQueryTests` — 11 query-path tests pinning every bullet from the ticket's "Tests required" list.
- 422 `error=invalid_cursor` → `RemoteAssetInvalidCursorException` (the throw site the #853 stub was waiting for).

## Key wire invariants pinned by tests

- **`tag` is singular AND repeatable** (NOT `tags=`). FastAPI silently drops unknown query params, so the wrong spelling returns unfiltered results with no error signal. The `#1 regression test` (`QueryAsync_MultipleTags_Emits_Singular_Tag_Param_Never_Plural`) is written first and asserts the URL never contains `tags=` anywhere.
- `asset_kind=character/v1` URL-encodes the slash to `character%2Fv1`.
- Cursor is opaque pass-through; wrapper does NOT auto-paginate (multi-page test asserts two separate HTTP calls).
- Defensive timestamp parse: both `Z` and `+00:00` suffixes accepted on response items (via shared `CharacterAssetMetadataParser.ParseElement`).
- Date filters emit RFC3339 UTC with explicit `Z`.

## Minor `Pinder.Core` extension

`CharacterAssetQuery` gains optional `AssetKind`, `CreatedAfter`, `CreatedBefore`, `UpdatedAfter`, `UpdatedBefore` fields. The constructor extends additively (back-compat — existing call sites compile unchanged). This is the minimum surface change needed to honor the ticket's explicit URL-building tests (`asset_kind` encoding + date-filter formatting); the spec already calls these out as legal v1.x query growth (`docs/specs/character-asset-vocabulary.md` § Query semantics) and `CharacterAssetQuery` is intentionally a "strict subset" of the wire surface, growable on demand. Flagged here per the parent task's `## DO NOT` clause.

No other `Pinder.Core` or `Pinder.SessionSetup` changes; no write-path code (reserved for #855).

## Architectural audit (one-way Eigencore dependency)

```
$ grep -RIn 'using Eigencore' --include='*.cs' --exclude-dir=bin --exclude-dir=obj .
(no matches)

$ grep -RIn 'Pinder\.RemoteAssets' src/Pinder.Core/ src/Pinder.SessionSetup/
(no matches)
```

## DoD Evidence

**Build** (`dotnet build`, tail):
```
    153 Warning(s)
    0 Error(s)
Time Elapsed 00:00:20.68
```

**Test** (`dotnet test tests/Pinder.RemoteAssets.Tests/`, tail):
```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Passed!  - Failed:     0, Passed:    29, Skipped:     0, Total:    29, Duration: 106 ms - Pinder.RemoteAssets.Tests.dll (net8.0)
```

29 = 18 read-path tests from #853 (one `QueryAsync_Throws_NotSupported_In_853` removed — it's now implemented) + 11 new query-path tests.

**Architectural greps**:
- `grep -RIn 'using Eigencore' --include='*.cs' --exclude-dir=bin --exclude-dir=obj .` → 0 hits.
- `grep -RIn 'Pinder\.RemoteAssets' src/Pinder.Core/ src/Pinder.SessionSetup/` → 0 hits.

**Tags regression grep** (from ticket DoD):
- `grep -RIn '?tags=\|tags=a\|"tags"' src/Pinder.RemoteAssets/ tests/` → 5 hits, all legitimate:
  - 2 hits in `EigencoreCharacterStore.cs` comments explicitly naming the trap (anti-example: "Emitting `tags=a,b` ... is the canonical bug this PR pins against").
  - 1 hit in `CharacterAssetMetadataParser.cs` reading the JSON `"tags"` field — wire-correct plural for the metadata's tags **array** (separate concern from the URL `tag=` query param).
  - 2 hits in test JSON-building helpers writing `"tags"` array fields — same legitimate plural-array-in-JSON usage.
  - Zero hits in any URL-formation path.

**Pre-existing test failures unrelated to this PR**: `Pinder.Rules.Tests` (46 failures) and `Pinder.LlmAdapters.Tests` (63 failures) fail identically on `origin/main` (verified by stashing this PR's diff and re-running). Out of scope.

**Commit + push**:
```
$ git log -1 --oneline
401c15a feat(#854): Pinder.RemoteAssets query + paging path

$ git push -u origin fix/854-remoteassets-query-paging
* [new branch]      fix/854-remoteassets-query-paging -> fix/854-remoteassets-query-paging
```

## Deviations from contract

1. Minimal `CharacterAssetQuery` extension (5 optional fields) to honor URL-encoding + date-filter tests. Documented above; back-compat preserved.
2. Out of scope (deferred per ticket): publish/save/delete (#855), live staging tests, `IAsyncEnumerable` convenience iterator, query result caching.

## Research Log

| Topic | Source | Key finding |
|-------|--------|-------------|
| `Uri.EscapeDataString` behavior on `/` | Existing `CharacterAssetMetadataParser` + .NET docs | Encodes `/` to `%2F` per RFC 3986 unreserved-character rules. Matches the spec's required encoding for `asset_kind=character/v1`. |
| `DateTimeOffset` parsing with mixed `Z`/`+00:00` | .NET `DateTimeOffset.TryParse` docs | `DateTimeStyles.AssumeUniversal \| DateTimeStyles.AdjustToUniversal` already used in `CharacterAssetMetadataParser.ReadRequiredTimestamp`; both suffixes round-trip to `TimeSpan.Zero`. Reused the helper unchanged. |
| FastAPI query-param drop behavior | Wire spec § Query, line: "the reference backend silently drops unknown query parameters rather than returning 422" | Confirms why the `tags=` (plural) bug is a silent regression — no exception, no validation error, just unfiltered results. Drove the `#1 regression test`. |
| RFC3339 UTC format choice | Wire spec § Query semantics ("Range queries on `created_at` / `updated_at`") | Spec doesn't pin the exact emit string. Used `yyyy-MM-ddTHH:mm:ss.fffffffZ` (ticks-precision + explicit `Z`) which is RFC3339-compatible and what `DateTimeOffset.ToString("o").Replace("+00:00", "Z")` would have produced. Test asserts the date/time portion only, not the fractional tail, so the precision setting can be tightened later without test churn. |
| 422 body shape (FastAPI vs spec) | Wire spec ("422 with `error=invalid_cursor`") + Pydantic v2 known emits `{"detail": [...]}` | `ParseValidationBody` accepts both `error` and `code` discriminator keys. The cursor-test pins the `{"error": "invalid_cursor"}` form; a future server using `{"code": "invalid_cursor"}` works too. |
