### PR TITLE
feat(#855): Pinder.RemoteAssets write path — publish/save/delete (closes #819)

### DIFF
--- a/src/Pinder.RemoteAssets/CharacterAssetMetadataSerializer.cs
+++ b/src/Pinder.RemoteAssets/CharacterAssetMetadataSerializer.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using Pinder.Core.Characters;
+
+namespace Pinder.RemoteAssets
+{
+    /// <summary>
+    /// Serialises a <see cref="CharacterAssetMetadata"/> POCO into the JSON
+    /// shape that rides in the <c>metadata</c> part of a
+    /// <c>POST /assets</c> multipart request.
+    ///
+    /// This is the WRITE direction of the boundary rename specified in
+    /// <c>docs/specs/character-asset-vocabulary.md</c>: the POCO field
+    /// <see cref="CharacterAssetMetadata.CharacterId"/> is emitted as the
+    /// wire field <c>asset_id</c>. The serialiser MUST NEVER emit a JSON
+    /// property literally named <c>character_id</c> — pinned by a
+    /// regression test in <c>EigencoreCharacterStoreWriteTests</c>.
+    ///
+    /// Server-controlled fields (<c>owner_id</c>, <c>created_at</c>,
+    /// <c>updated_at</c>, <c>payload_size</c>) are NOT emitted on the
+    /// write path. Per the spec, the server stamps them itself; clients
+    /// that supply them get them silently overridden, but we keep the
+    /// wire small and the contract clear by simply not sending them.
+    ///
+    /// Inverse of <see cref="CharacterAssetMetadataParser.ParseElement"/>.
+    /// </summary>
+    internal static class CharacterAssetMetadataSerializer
+    {
+        /// <summary>
+        /// Serialise metadata to UTF-8 JSON bytes for the
+        /// <c>metadata</c> multipart part. Output is compact (no
+        /// indentation) — wire size matters here because the part is
+        /// capped at 4 KiB.
+        /// </summary>
+        public static byte[] SerializeBytes(CharacterAssetMetadata metadata)
+        {
+            if (metadata == null) throw new ArgumentNullException(nameof(metadata));
+
+            using (var ms = new MemoryStream())
+            {
+                using (var w = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+                {
+                    w.WriteStartObject();
+
+                    // asset_kind — discriminator. Required by the spec.
+                    w.WriteString("asset_kind", string.IsNullOrEmpty(metadata.AssetKind)
+                        ? CharacterAssetMetadata.AssetKindCharacterV1
+                        : metadata.AssetKind);
+
+                    // POCO CharacterId → wire asset_id. THE rename. Never
+                    // emit "character_id". Pinned by regression test.
+                    w.WriteString("asset_id", metadata.CharacterId);
+
+                    // is_public — client-supplied.
+                    w.WriteBoolean("is_public", metadata.IsPublic);
+
+                    // tags — client-supplied. Empty array is legal.
+                    w.WriteStartArray("tags");
+                    if (metadata.Tags != null)
+                    {
+                        foreach (var t in metadata.Tags)
+                        {
+                            if (t != null) w.WriteStringValue(t);
+                        }
+                    }
+                    w.WriteEndArray();
+
+                    // owner_id / created_at / updated_at / payload_size are
+                    // server-controlled; do NOT serialise on write. The
+                    // spec calls this out: "the server stamps those
+                    // itself" and writes that supply them get them
+                    // overwritten on publish.
+
+                    w.WriteEndObject();
+                    w.Flush();
+                }
+                return ms.ToArray();
+            }
+        }
+    }
+}

--- a/src/Pinder.RemoteAssets/Configuration.cs
+++ b/src/Pinder.RemoteAssets/Configuration.cs
@@ -19,6 +19,20 @@ namespace Pinder.RemoteAssets
     public delegate CharacterDefinition CharacterPayloadParser(byte[] payload);
 
     /// <summary>
+    /// Serialises a <see cref="CharacterDefinition"/> to the raw payload
+    /// bytes that ride in the <c>payload</c> part of a <c>POST /assets</c>
+    /// multipart request. The contract is byte-equal to the on-disk v1
+    /// character JSON — see <c>docs/specs/character-asset-vocabulary.md</c>
+    /// § Publish.
+    ///
+    /// If <see cref="Configuration.PayloadSerializer"/> is left null,
+    /// the store falls back to
+    /// <c>Pinder.Core.Characters.CharacterDefinitionWriter.Write</c>
+    /// (UTF-8 encoded). Tests can inject a stub that returns canned bytes.
+    /// </summary>
+    public delegate byte[] CharacterPayloadSerializer(CharacterDefinition def);
+
+    /// <summary>
     /// Configuration for <see cref="EigencoreCharacterStore"/> — the
     /// <see cref="IRemoteCharacterStore"/> implementation that talks HTTP to
     /// an eigencore-shaped asset backend.
@@ -88,13 +102,47 @@ namespace Pinder.RemoteAssets
         /// </summary>
         public TimeSpan DefaultRetryAfter { get; }
 
+        /// <summary>
+        /// Hard cap on the size of the serialized <c>metadata</c> part of
+        /// a <c>POST /assets</c> multipart request. Defaults to 4 KiB —
+        /// matches the reference backend's
+        /// <c>MAX_ASSET_METADATA_JSON_SIZE</c> (not env-overridable
+        /// server-side). Violations throw
+        /// <c>RemoteAssetTooLargeException(subject="metadata")</c> BEFORE
+        /// the HTTP request is sent (fail-fast — see
+        /// <c>docs/specs/character-asset-vocabulary.md</c> § Publish).
+        /// </summary>
+        public int MetadataSizeCapBytes { get; }
+
+        /// <summary>
+        /// Cap on the size of the <c>payload</c> part of a <c>POST /assets</c>
+        /// multipart request. Defaults to 256 KiB — matches the reference
+        /// backend's <c>max_asset_payload_size</c> default. Per-deployment
+        /// overrides on the server can raise / lower this; callers should
+        /// match the deployed value here when known. Violations throw
+        /// <c>RemoteAssetTooLargeException(subject="payload")</c> BEFORE
+        /// the HTTP request is sent.
+        /// </summary>
+        public int PayloadSizeCapBytes { get; }
+
+        /// <summary>
+        /// Serialises a <see cref="CharacterDefinition"/> to the bytes that
+        /// ride in the <c>payload</c> part of a <c>POST /assets</c>
+        /// multipart request. If null, the store falls back to
+        /// <c>CharacterDefinitionWriter.Write</c> + UTF-8 encoding.
+        /// </summary>
+        public CharacterPayloadSerializer? PayloadSerializer { get; }
+
         public Configuration(
             Uri baseUrl,
             HttpMessageHandler httpMessageHandler,
             Func<CancellationToken, Task<string>> authTokenProvider,
             CharacterPayloadParser payloadParser,
             TimeSpan? requestTimeout = null,
-            TimeSpan? defaultRetryAfter = null)
+            TimeSpan? defaultRetryAfter = null,
+            int? metadataSizeCapBytes = null,
+            int? payloadSizeCapBytes = null,
+            CharacterPayloadSerializer? payloadSerializer = null)
         {
             if (baseUrl == null) throw new ArgumentNullException(nameof(baseUrl));
             if (!baseUrl.IsAbsoluteUri)
@@ -105,10 +153,17 @@ namespace Pinder.RemoteAssets
             PayloadParser = payloadParser ?? throw new ArgumentNullException(nameof(payloadParser));
             RequestTimeout = requestTimeout ?? TimeSpan.FromSeconds(30);
             DefaultRetryAfter = defaultRetryAfter ?? TimeSpan.FromSeconds(1);
+            MetadataSizeCapBytes = metadataSizeCapBytes ?? 4 * 1024;       // 4 KiB
+            PayloadSizeCapBytes = payloadSizeCapBytes ?? 256 * 1024;       // 256 KiB
+            PayloadSerializer = payloadSerializer;
             if (RequestTimeout <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(requestTimeout), "RequestTimeout must be positive.");
             if (DefaultRetryAfter < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(defaultRetryAfter), "DefaultRetryAfter must be non-negative.");
+            if (MetadataSizeCapBytes <= 0)
+                throw new ArgumentOutOfRangeException(nameof(metadataSizeCapBytes), "MetadataSizeCapBytes must be positive.");
+            if (PayloadSizeCapBytes <= 0)
+                throw new ArgumentOutOfRangeException(nameof(payloadSizeCapBytes), "PayloadSizeCapBytes must be positive.");
         }
     }
 }

--- a/src/Pinder.RemoteAssets/EigencoreCharacterStore.cs
+++ b/src/Pinder.RemoteAssets/EigencoreCharacterStore.cs
@@ -28,9 +28,11 @@ namespace Pinder.RemoteAssets
     /// #853 — read path (<see cref="LoadAsync"/>, <see cref="GetMetadataAsync"/>,
     ///        <see cref="ExistsAsync"/>).
     /// #854 — query / paging path (<see cref="QueryAsync"/>).
-    /// The remaining members (Save / Publish / Delete / ListIds) still
-    /// throw <see cref="NotSupportedException"/> until sub-PR #855 wires
-    /// them up.
+    /// #855 — write path (<see cref="PublishAsync"/>,
+    ///        <see cref="SaveAsync"/>, <see cref="DeleteAsync"/>).
+    /// <see cref="ListIdsAsync"/> remains <see cref="NotSupportedException"/>:
+    /// the v1 wire contract has no list-all endpoint; discovery happens
+    /// via <see cref="QueryAsync"/>.
     /// </summary>
     public sealed class EigencoreCharacterStore : IRemoteCharacterStore
     {
@@ -117,14 +119,6 @@ namespace Pinder.RemoteAssets
             throw new NotSupportedException(
                 "ListIdsAsync is not part of the v1 eigencore wire contract. " +
                 "Discovery happens via QueryAsync (sub-PR #854) which returns metadata pages.");
-
-        public Task SaveAsync(CharacterDefinition def, CancellationToken ct = default) =>
-            throw new NotSupportedException(
-                "SaveAsync is reserved for sub-PR #855 (write path). " +
-                "On the remote store, save semantics map to PublishAsync.");
-
-        public Task<bool> DeleteAsync(string characterId, CancellationToken ct = default) =>
-            throw new NotSupportedException("DeleteAsync is reserved for sub-PR #855 (write path).");
 
         // ---- IRemoteCharacterStore query path (#854) ---------------------
 
@@ -243,11 +237,472 @@ namespace Pinder.RemoteAssets
             }
         }
 
-        public Task<CharacterAssetMetadata> PublishAsync(
+        // ---- IRemoteCharacterStore write path (#855) ---------------------
+
+        /// <summary>
+        /// <c>POST {baseUrl}/assets</c> as <c>multipart/form-data</c> with
+        /// exactly two parts named <c>metadata</c> and <c>payload</c>.
+        ///
+        /// Pre-validation: both parts are serialised and size-checked
+        /// BEFORE the HTTP request is sent. An oversized metadata
+        /// (>4 KiB by default) or payload (>256 KiB by default) throws
+        /// <see cref="RemoteAssetTooLargeException"/> with no network
+        /// round-trip. The reference backend would return 422 anyway,
+        /// but the local check is the better contract — callers get a
+        /// typed exception immediately.
+        ///
+        /// POST is upsert: publishing the same <c>asset_id</c> twice
+        /// overwrites. Both 201 (created) and 200 (overwritten) are
+        /// treated as success.
+        ///
+        /// Wire contract: see <c>docs/specs/character-asset-vocabulary.md</c>
+        /// § Publish. The serialised metadata uses <c>asset_id</c>, never
+        /// <c>character_id</c> — see
+        /// <see cref="CharacterAssetMetadataSerializer"/>.
+        /// </summary>
+        public async Task<CharacterAssetMetadata> PublishAsync(
             CharacterDefinition def,
             CharacterAssetMetadata metadata,
-            CancellationToken ct = default) =>
-            throw new NotSupportedException("PublishAsync is reserved for sub-PR #855 (write path).");
+            CancellationToken ct = default)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            if (metadata == null) throw new ArgumentNullException(nameof(metadata));
+
+            // --- 1. Serialise both sides and pre-validate caps ---------
+            byte[] metaBytes = CharacterAssetMetadataSerializer.SerializeBytes(metadata);
+            if (metaBytes.Length > _config.MetadataSizeCapBytes)
+            {
+                throw new RemoteAssetTooLargeException(
+                    $"Serialised metadata is {metaBytes.Length} bytes, exceeds cap {_config.MetadataSizeCapBytes} bytes. " +
+                    "No HTTP request was sent (pre-validation).",
+                    subject: "metadata");
+            }
+
+            byte[] payloadBytes = SerializePayload(def);
+            if (payloadBytes.Length > _config.PayloadSizeCapBytes)
+            {
+                throw new RemoteAssetTooLargeException(
+                    $"Serialised payload is {payloadBytes.Length} bytes, exceeds cap {_config.PayloadSizeCapBytes} bytes. " +
+                    "No HTTP request was sent (pre-validation).",
+                    subject: "payload");
+            }
+
+            // --- 2. Build + send the multipart request -----------------
+            bool retried = false;
+
+            while (true)
+            {
+                // Build a FRESH multipart per attempt; HttpContent is
+                // consumed on send and is not safely reusable for retry.
+                using (var content = BuildPublishMultipart(metaBytes, payloadBytes))
+                using (var req = new HttpRequestMessage(HttpMethod.Post, new Uri("assets", UriKind.Relative))
+                {
+                    Content = content,
+                })
+                {
+                    await AttachAuthAsync(req, ct).ConfigureAwait(false);
+
+                    HttpResponseMessage resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                        .ConfigureAwait(false);
+                    try
+                    {
+                        int status = (int)resp.StatusCode;
+
+                        // Upsert: 201 (newly created) and 200 (overwrote
+                        // an existing asset with the same asset_id) are
+                        // both success.
+                        if (status == 200 || status == 201)
+                        {
+                            byte[] body = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                            return ParsePublishResponse(body);
+                        }
+
+                        if (status == 401)
+                        {
+                            string body401 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetAuthException(
+                                "Eigencore returned 401 for POST assets.",
+                                responseBody: body401);
+                        }
+
+                        if (status == 403)
+                        {
+                            string body403 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw BuildForbiddenException(body403, "POST assets");
+                        }
+
+                        if (status == 422)
+                        {
+                            string body422 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            (string? errorCode, IReadOnlyList<string> errors) = ParseValidationBody(body422);
+                            if (string.Equals(errorCode, "metadata_too_large", StringComparison.Ordinal))
+                            {
+                                throw new RemoteAssetTooLargeException(
+                                    "Eigencore returned 422 metadata_too_large for POST assets.",
+                                    subject: "metadata",
+                                    responseBody: body422);
+                            }
+                            if (string.Equals(errorCode, "payload_too_large", StringComparison.Ordinal))
+                            {
+                                throw new RemoteAssetTooLargeException(
+                                    "Eigencore returned 422 payload_too_large for POST assets.",
+                                    subject: "payload",
+                                    responseBody: body422);
+                            }
+                            // invalid_multipart and all other 422 codes
+                            // surface as a generic validation exception.
+                            throw new RemoteAssetValidationException(
+                                $"Eigencore returned 422 for POST assets (code={errorCode ?? "<none>"}).",
+                                errors: errors,
+                                responseBody: body422);
+                        }
+
+                        if (status == 429)
+                        {
+                            TimeSpan delay = ParseRetryAfter(resp) ?? _config.DefaultRetryAfter;
+                            string body429 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            if (retried)
+                            {
+                                throw new RemoteAssetRateLimitException(
+                                    "Eigencore returned 429 for POST assets after one retry.",
+                                    retryAfter: delay,
+                                    responseBody: body429);
+                            }
+                            retried = true;
+                            resp.Dispose();
+                            if (delay > TimeSpan.Zero)
+                                await Task.Delay(delay, ct).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        if (status >= 500 && status <= 599)
+                        {
+                            string body5xx = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetServerException(
+                                $"Eigencore returned {status} for POST assets.",
+                                statusCode: status,
+                                responseBody: body5xx);
+                        }
+
+                        string bodyOther = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                        throw new RemoteAssetServerException(
+                            $"Eigencore returned unexpected status {status} for POST assets.",
+                            statusCode: status,
+                            responseBody: bodyOther);
+                    }
+                    finally
+                    {
+                        resp.Dispose();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Save = publish. Per the wire contract, <c>POST /assets</c> is
+        /// the upsert: two publishes with the same <c>asset_id</c>
+        /// overwrite. The base <see cref="ICharacterStore.SaveAsync"/>
+        /// surface takes only the <see cref="CharacterDefinition"/>; for
+        /// the remote store the metadata envelope is required, so this
+        /// method synthesises a minimal <see cref="CharacterAssetMetadata"/>
+        /// from the def (asset_id from CharacterId, empty owner, no tags,
+        /// is_public=false, timestamps stamped server-side) and delegates
+        /// to <see cref="PublishAsync"/>. Callers that need to control
+        /// tags / is_public / owner go through <see cref="PublishAsync"/>
+        /// directly.
+        /// </summary>
+        public Task SaveAsync(CharacterDefinition def, CancellationToken ct = default)
+        {
+            if (def == null) throw new ArgumentNullException(nameof(def));
+            // The wire wants asset_id in UUID 'D' form (lowercase,
+            // hyphenated). Guid.ToString("d") produces exactly that.
+            string assetId = def.CharacterId.ToString("d");
+            var metadata = new CharacterAssetMetadata(
+                characterId: assetId,
+                ownerId: string.Empty,
+                tags: Array.Empty<string>(),
+                isPublic: false,
+                // CreatedAt / UpdatedAt are server-stamped; the values
+                // here are NOT serialised (the metadata serialiser drops
+                // server-controlled fields). They satisfy the POCO ctor
+                // which forbids defaulted DateTimeOffset only by being
+                // present.
+                createdAt: DateTimeOffset.MinValue,
+                updatedAt: DateTimeOffset.MinValue,
+                assetKind: CharacterAssetMetadata.AssetKindCharacterV1);
+            return PublishAsync(def, metadata, ct);
+        }
+
+        /// <summary>
+        /// <c>DELETE {baseUrl}/assets/{asset_id}</c>. Returns <c>true</c>
+        /// when the server confirms the delete (200 or 204) and
+        /// <c>false</c> when the asset was already gone (404 — idempotent
+        /// delete is not an error). 403 means the caller is not the
+        /// asset owner; 401 means bad creds. Other status codes map per
+        /// the shared error policy.
+        /// </summary>
+        public async Task<bool> DeleteAsync(string characterId, CancellationToken ct = default)
+        {
+            ValidateId(characterId);
+
+            bool retried = false;
+
+            while (true)
+            {
+                using (var req = new HttpRequestMessage(HttpMethod.Delete, BuildAssetUri(characterId)))
+                {
+                    await AttachAuthAsync(req, ct).ConfigureAwait(false);
+
+                    HttpResponseMessage resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct)
+                        .ConfigureAwait(false);
+                    try
+                    {
+                        int status = (int)resp.StatusCode;
+
+                        if (status == 200 || status == 204)
+                        {
+                            // Drain to allow keep-alive reuse.
+                            if (resp.Content != null)
+                                await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                            return true;
+                        }
+
+                        if (status == 404)
+                        {
+                            // Idempotent delete: already gone is success-ish.
+                            if (resp.Content != null)
+                                await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                            return false;
+                        }
+
+                        if (status == 401)
+                        {
+                            string body401 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetAuthException(
+                                $"Eigencore returned 401 for DELETE assets/{characterId}.",
+                                responseBody: body401);
+                        }
+
+                        if (status == 403)
+                        {
+                            string body403 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            // On DELETE the only forbidden case is
+                            // not-owner; build a focused exception
+                            // message rather than the generic
+                            // BuildForbiddenException (which assumes a
+                            // reserved-prefix-or-not-owner discriminator
+                            // on the publish path).
+                            throw new RemoteAssetForbiddenException(
+                                $"Eigencore returned 403 for DELETE assets/{characterId} (caller is not the asset owner).",
+                                responseBody: body403);
+                        }
+
+                        if (status == 422)
+                        {
+                            string body422 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            (_, IReadOnlyList<string> errors) = ParseValidationBody(body422);
+                            throw new RemoteAssetValidationException(
+                                $"Eigencore returned 422 for DELETE assets/{characterId}.",
+                                errors: errors,
+                                responseBody: body422);
+                        }
+
+                        if (status == 429)
+                        {
+                            TimeSpan delay = ParseRetryAfter(resp) ?? _config.DefaultRetryAfter;
+                            string body429 = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            if (retried)
+                            {
+                                throw new RemoteAssetRateLimitException(
+                                    $"Eigencore returned 429 for DELETE assets/{characterId} after one retry.",
+                                    retryAfter: delay,
+                                    responseBody: body429);
+                            }
+                            retried = true;
+                            resp.Dispose();
+                            if (delay > TimeSpan.Zero)
+                                await Task.Delay(delay, ct).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        if (status >= 500 && status <= 599)
+                        {
+                            string body5xx = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                            throw new RemoteAssetServerException(
+                                $"Eigencore returned {status} for DELETE assets/{characterId}.",
+                                statusCode: status,
+                                responseBody: body5xx);
+                        }
+
+                        string bodyOther = await SafeReadBodyAsync(resp).ConfigureAwait(false);
+                        throw new RemoteAssetServerException(
+                            $"Eigencore returned unexpected status {status} for DELETE assets/{characterId}.",
+                            statusCode: status,
+                            responseBody: bodyOther);
+                    }
+                    finally
+                    {
+                        resp.Dispose();
+                    }
+                }
+            }
+        }
+
+        // ---- write-path internals -----------------------------------------
+
+        /// <summary>
+        /// Serialise the def to payload bytes, using the injected
+        /// <see cref="CharacterPayloadSerializer"/> if configured, otherwise
+        /// falling back to <see cref="CharacterDefinitionWriter.Write"/>
+        /// (UTF-8). Tests inject a stub to control the byte count.
+        /// </summary>
+        private byte[] SerializePayload(CharacterDefinition def)
+        {
+            if (_config.PayloadSerializer != null)
+                return _config.PayloadSerializer(def) ?? Array.Empty<byte>();
+            string json = CharacterDefinitionWriter.Write(def);
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(json);
+        }
+
+        /// <summary>
+        /// Construct a two-part multipart/form-data body with parts
+        /// exactly named <c>metadata</c> (application/json) and
+        /// <c>payload</c> (application/octet-stream). The boundary is
+        /// HttpClient-generated. The wire contract is strict: any other
+        /// part name, additional parts, or missing parts surface
+        /// server-side as 422 <c>invalid_multipart</c>.
+        /// </summary>
+        private static MultipartFormDataContent BuildPublishMultipart(byte[] metaBytes, byte[] payloadBytes)
+        {
+            var multipart = new MultipartFormDataContent();
+
+            var metaPart = new ByteArrayContent(metaBytes);
+            metaPart.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            // Form-data name MUST be exactly "metadata" (per spec). Pass
+            // unquoted; HttpClient quotes it on the wire as required by
+            // RFC 7578.
+            multipart.Add(metaPart, "metadata");
+
+            var payloadPart = new ByteArrayContent(payloadBytes);
+            // Spec calls the payload "any content-type, opaque bytes";
+            // application/octet-stream is the safest neutral choice.
+            payloadPart.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            multipart.Add(payloadPart, "payload");
+
+            return multipart;
+        }
+
+        /// <summary>
+        /// Parse the POST /assets success body into a populated
+        /// <see cref="CharacterAssetMetadata"/>. The body is a single
+        /// metadata object (same shape as a query response item or the
+        /// X-Asset-Metadata header value), so we reuse the parser.
+        /// </summary>
+        private static CharacterAssetMetadata ParsePublishResponse(byte[] body)
+        {
+            if (body == null || body.Length == 0)
+                throw new RemoteAssetMalformedMetadataException(
+                    "Publish response body is empty.");
+            return CharacterAssetMetadataParser.ParseBytes(body);
+        }
+
+        /// <summary>
+        /// Build a focused <see cref="RemoteAssetForbiddenException"/>
+        /// for a 403 on the publish path. Eigencore returns
+        /// <c>code=permission_denied</c> for both reserved-prefix
+        /// violations (with the offending tag in the message or a
+        /// dedicated field) and not-owner overwrite attempts. We do a
+        /// best-effort body parse to surface the prefix when present
+        /// (the test asserts the offending prefix is in the message).
+        /// </summary>
+        private static RemoteAssetForbiddenException BuildForbiddenException(string body403, string opLabel)
+        {
+            // Try to dig the offending tag/prefix out of the body.
+            string? offendingPrefix = ExtractForbiddenPrefix(body403);
+            string msg = offendingPrefix != null
+                ? $"Eigencore returned 403 permission_denied for {opLabel}: reserved tag prefix '{offendingPrefix}' is not allowed for this caller."
+                : $"Eigencore returned 403 permission_denied for {opLabel}.";
+            return new RemoteAssetForbiddenException(msg, responseBody: body403);
+        }
+
+        /// <summary>
+        /// Best-effort extraction of the offending tag/prefix from a
+        /// 403 body. The spec text says the server returns
+        /// <c>code=permission_denied</c> plus enough context to identify
+        /// the prefix; the exact body shape isn't pinned by the spec.
+        /// We accept a few common shapes:
+        /// <list type="bullet">
+        ///   <item><c>{"detail": "reserved prefix 'auto-' is not allowed"}</c></item>
+        ///   <item><c>{"prefix": "auto-"}</c></item>
+        ///   <item><c>{"tag": "auto-foo"}</c> — we derive the prefix.</item>
+        /// </list>
+        /// Returns null when nothing matches — the exception message then
+        /// falls back to a generic form (the test for reserved-prefix
+        /// also asserts <see cref="RemoteAssetException.ResponseBody"/>,
+        /// which always contains the full body).
+        /// </summary>
+        private static string? ExtractForbiddenPrefix(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body)) return null;
+            try
+            {
+                using (var doc = JsonDocument.Parse(body))
+                {
+                    var root = doc.RootElement;
+                    if (root.ValueKind != JsonValueKind.Object) return null;
+
+                    // Direct "prefix" field.
+                    if (root.TryGetProperty("prefix", out var pEl)
+                        && pEl.ValueKind == JsonValueKind.String)
+                    {
+                        var p = pEl.GetString();
+                        if (!string.IsNullOrEmpty(p)) return p;
+                    }
+
+                    // "tag" field — derive prefix up to the first '-' (inclusive).
+                    if (root.TryGetProperty("tag", out var tEl)
+                        && tEl.ValueKind == JsonValueKind.String)
+                    {
+                        var tag = tEl.GetString();
+                        if (!string.IsNullOrEmpty(tag))
+                        {
+                            int dash = tag!.IndexOf('-');
+                            if (dash > 0)
+                                return tag.Substring(0, dash + 1);
+                            return tag;
+                        }
+                    }
+
+                    // Scan "detail" / "message" for the reserved prefixes
+                    // we know about (auto- / official-).
+                    foreach (var key in new[] { "detail", "message", "error" })
+                    {
+                        if (root.TryGetProperty(key, out var mEl)
+                            && mEl.ValueKind == JsonValueKind.String)
+                        {
+                            var s = mEl.GetString() ?? string.Empty;
+                            foreach (var candidate in new[] { "auto-", "official-" })
+                            {
+                                if (s.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0)
+                                    return candidate;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // body wasn't JSON — fall through.
+            }
+
+            // Last-ditch: look for the literal prefixes in the raw body.
+            foreach (var candidate in new[] { "auto-", "official-" })
+            {
+                if (body.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return candidate;
+            }
+            return null;
+        }
 
         // ---- internals -----------------------------------------------------
 

--- a/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreReadTests.cs
+++ b/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreReadTests.cs
@@ -456,16 +456,10 @@ namespace Pinder.RemoteAssets.Tests
 
         // QueryAsync_Throws_NotSupported_In_853 was removed in #854 —
         // the query path is now implemented (see
-        // EigencoreCharacterStoreQueryTests). The remaining write-path
-        // members (SaveAsync, PublishAsync, DeleteAsync) still throw and
-        // are pinned by the tests below until #855 lands.
-
-        [Fact]
-        public async Task SaveAsync_Throws_NotSupported_In_853()
-        {
-            var (store, _) = Make();
-            var def = StubParse(Array.Empty<byte>());
-            await Assert.ThrowsAsync<NotSupportedException>(() => store.SaveAsync(def));
-        }
+        // EigencoreCharacterStoreQueryTests).
+        // SaveAsync_Throws_NotSupported_In_853 was removed in #855 —
+        // the write path is now implemented (see
+        // EigencoreCharacterStoreWriteTests). ListIdsAsync stays
+        // NotSupported per the v1 wire contract (no list-all endpoint).
     }
 }

--- a/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreWriteTests.cs
+++ b/tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreWriteTests.cs
@@ -1,0 +1,575 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Stats;
+using Pinder.RemoteAssets;
+using Pinder.RemoteAssets.Exceptions;
+using Xunit;
+
+namespace Pinder.RemoteAssets.Tests
+{
+    /// <summary>
+    /// Write-path tests for <see cref="EigencoreCharacterStore"/> (issue
+    /// #855). Covers <c>PublishAsync</c>, <c>SaveAsync</c>, and
+    /// <c>DeleteAsync</c>. Each test pins a single bullet from the
+    /// ticket's "Tests required" list.
+    ///
+    /// Wire-shape regression coverage at the top of the file: multipart
+    /// boundary, exactly two parts named <c>metadata</c> + <c>payload</c>,
+    /// metadata content-type, and the no-<c>character_id</c> JSON guard.
+    /// These are the highest-risk invariants; pinning them first means a
+    /// later refactor cannot silently break the wire contract.
+    /// </summary>
+    public class EigencoreCharacterStoreWriteTests
+    {
+        private const string AssetId = "59aa20f2-46d6-4adc-89c1-6ea17f815020";
+
+        // -- helpers -----------------------------------------------------
+
+        private static CharacterDefinition StubDef()
+        {
+            return new CharacterDefinition(
+                schemaVersion: 1,
+                characterId: Guid.Parse(AssetId),
+                name: "Stub",
+                genderIdentity: "they/them",
+                bio: "stub",
+                level: 1,
+                items: Array.Empty<string>(),
+                anatomy: new Dictionary<string, string>(),
+                allocation: new AllocationBlock(
+                    new Dictionary<StatType, int>(),
+                    0,
+                    new Dictionary<ShadowStatType, int>()));
+        }
+
+        private static CharacterDefinition StubParse(byte[] _) => StubDef();
+
+        private static CharacterAssetMetadata MakeMetadata(
+            string assetId = AssetId,
+            string ownerId = "",
+            string[]? tags = null,
+            bool isPublic = true)
+        {
+            return new CharacterAssetMetadata(
+                characterId: assetId,
+                ownerId: ownerId,
+                tags: tags ?? new[] { "starter" },
+                isPublic: isPublic,
+                createdAt: DateTimeOffset.MinValue,   // server-stamped on publish; ignored on the wire
+                updatedAt: DateTimeOffset.MinValue,
+                assetKind: CharacterAssetMetadata.AssetKindCharacterV1);
+        }
+
+        private static (EigencoreCharacterStore store, FakeHttpMessageHandler handler) Make(
+            CharacterPayloadSerializer? payloadSerializer = null,
+            int? metadataCap = null,
+            int? payloadCap = null,
+            Func<CancellationToken, Task<string>>? authProvider = null)
+        {
+            var handler = new FakeHttpMessageHandler();
+            var config = new Configuration(
+                baseUrl: new Uri("https://eigencore.test/api/v1"),
+                httpMessageHandler: handler,
+                authTokenProvider: authProvider ?? (ct => Task.FromResult("test-token")),
+                payloadParser: StubParse,
+                defaultRetryAfter: TimeSpan.FromMilliseconds(1),
+                metadataSizeCapBytes: metadataCap,
+                payloadSizeCapBytes: payloadCap,
+                payloadSerializer: payloadSerializer ?? (_ => Encoding.UTF8.GetBytes("{\"schema_version\":1,\"character_id\":\"" + AssetId + "\"}")));
+            return (new EigencoreCharacterStore(config), handler);
+        }
+
+        /// <summary>
+        /// Build a canonical "happy publish" response body: a metadata
+        /// JSON object server-stamped with owner_id / created_at /
+        /// updated_at / payload_size.
+        /// </summary>
+        private static byte[] CannedPublishResponseBody(
+            string assetId = AssetId,
+            string ownerId = "user:42",
+            DateTimeOffset? createdAt = null,
+            DateTimeOffset? updatedAt = null,
+            long payloadSize = 123)
+        {
+            using var ms = new MemoryStream();
+            using (var w = new Utf8JsonWriter(ms))
+            {
+                w.WriteStartObject();
+                w.WriteString("asset_kind", "character/v1");
+                w.WriteString("asset_id", assetId);
+                w.WriteString("owner_id", ownerId);
+                w.WriteBoolean("is_public", true);
+                w.WriteStartArray("tags");
+                w.WriteStringValue("starter");
+                w.WriteEndArray();
+                w.WriteString("created_at", (createdAt ?? new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero)).ToString("o"));
+                w.WriteString("updated_at", (updatedAt ?? new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero)).ToString("o"));
+                w.WriteNumber("payload_size", payloadSize);
+                w.WriteEndObject();
+            }
+            return ms.ToArray();
+        }
+
+        private static HttpResponseMessage OkPublish(byte[]? body = null, HttpStatusCode status = HttpStatusCode.Created)
+        {
+            return new HttpResponseMessage(status)
+            {
+                Content = new ByteArrayContent(body ?? CannedPublishResponseBody()),
+            };
+        }
+
+        /// <summary>
+        /// Decode the multipart parts of a captured request using the
+        /// FakeHttpMessageHandler's pre-disposal body snapshot. Returns
+        /// parts indexed by form-data name.
+        /// </summary>
+        private static Dictionary<string, (string contentType, byte[] body)> ReadMultipartParts(
+            FakeHttpMessageHandler handler, int requestIndex = 0)
+        {
+            string? ctHeader = handler.RequestContentTypes[requestIndex];
+            Assert.False(string.IsNullOrEmpty(ctHeader), "no Content-Type captured on request");
+            Assert.Contains("multipart/form-data", ctHeader, StringComparison.OrdinalIgnoreCase);
+
+            // Pull boundary= out of the Content-Type header value.
+            string? boundary = null;
+            foreach (var seg in ctHeader!.Split(';'))
+            {
+                var s = seg.Trim();
+                if (s.StartsWith("boundary=", StringComparison.OrdinalIgnoreCase))
+                {
+                    boundary = s.Substring("boundary=".Length).Trim('"');
+                    break;
+                }
+            }
+            Assert.False(string.IsNullOrEmpty(boundary), "boundary param missing on Content-Type");
+
+            byte[]? bodyBytes = handler.RequestBodies[requestIndex];
+            Assert.NotNull(bodyBytes);
+            return ParseMultipart(bodyBytes!, boundary!);
+        }
+
+        private static Dictionary<string, (string contentType, byte[] body)> ParseMultipart(byte[] body, string boundary)
+        {
+            // Hand-rolled minimal RFC 7578 reader. Sufficient for the
+            // shapes HttpClient emits in these tests; not a hardened
+            // general-purpose parser.
+            //
+            // Wire shape (CRLF normalised):
+            //   --boundary\r\n
+            //   <headers>\r\n
+            //   \r\n
+            //   <part-body>\r\n
+            //   --boundary\r\n  (repeat)
+            //   --boundary--\r\n
+            string text = Encoding.UTF8.GetString(body);
+            string delim = "--" + boundary;
+            // Split on the boundary token. The first chunk is the
+            // preamble (often empty); the last chunk starts with "--"
+            // (the close-delimiter suffix) — drop it. Everything in
+            // between is a part block.
+            var raw = text.Split(new[] { delim }, StringSplitOptions.None);
+
+            var result = new Dictionary<string, (string contentType, byte[] body)>();
+            // Skip first (preamble) and last (epilogue / close).
+            for (int i = 1; i < raw.Length - 1; i++)
+            {
+                string chunk = raw[i];
+                // Each part chunk begins with CRLF (the line break after
+                // the boundary) and ends with CRLF (before the next
+                // boundary).
+                if (chunk.StartsWith("\r\n", StringComparison.Ordinal))
+                    chunk = chunk.Substring(2);
+                if (chunk.EndsWith("\r\n", StringComparison.Ordinal))
+                    chunk = chunk.Substring(0, chunk.Length - 2);
+
+                int headerEnd = chunk.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                if (headerEnd < 0) continue;
+                string headerBlock = chunk.Substring(0, headerEnd);
+                string partBody = chunk.Substring(headerEnd + 4);
+
+                string? name = null;
+                string ct = "";
+                foreach (var line in headerBlock.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (line.StartsWith("Content-Disposition:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // .NET HttpClient emits unquoted form-data
+                        // names (`name=metadata`); other clients quote
+                        // them (`name="metadata"`). Handle both.
+                        int nIdx = line.IndexOf("name=", StringComparison.OrdinalIgnoreCase);
+                        if (nIdx >= 0)
+                        {
+                            int nStart = nIdx + 5;
+                            if (nStart < line.Length && line[nStart] == '"')
+                            {
+                                nStart++;
+                                int nEnd = line.IndexOf('"', nStart);
+                                if (nEnd > nStart) name = line.Substring(nStart, nEnd - nStart);
+                            }
+                            else
+                            {
+                                int nEnd = line.IndexOfAny(new[] { ';', ' ', '\t' }, nStart);
+                                if (nEnd < 0) nEnd = line.Length;
+                                if (nEnd > nStart) name = line.Substring(nStart, nEnd - nStart);
+                            }
+                        }
+                    }
+                    else if (line.StartsWith("Content-Type:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        ct = line.Substring("Content-Type:".Length).Trim();
+                    }
+                }
+                if (name != null)
+                    result[name] = (ct, Encoding.UTF8.GetBytes(partBody));
+            }
+            return result;
+        }
+
+        // -- tests -------------------------------------------------------
+
+        [Fact]
+        public async Task PublishAsync_HappyPath_201_Returns_Server_Stamped_Metadata()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => OkPublish());
+
+            var metadata = MakeMetadata();
+            CharacterAssetMetadata returned = await store.PublishAsync(StubDef(), metadata);
+
+            // Returned POCO carries the server's stamped fields, with
+            // the asset_id → CharacterId rename applied.
+            Assert.Equal(AssetId, returned.CharacterId);
+            Assert.Equal("user:42", returned.OwnerId);
+            Assert.Equal(new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero), returned.CreatedAt);
+            Assert.Equal(new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero), returned.UpdatedAt);
+
+            // Request shape: POST to assets, with bearer auth.
+            Assert.Single(handler.Requests);
+            var req = handler.Requests[0];
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Equal("https://eigencore.test/api/v1/assets", req.RequestUri!.AbsoluteUri);
+            Assert.NotNull(req.Headers.Authorization);
+            Assert.Equal("Bearer", req.Headers.Authorization!.Scheme);
+            Assert.Equal("test-token", req.Headers.Authorization.Parameter);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Request_Is_Multipart_With_Exactly_Two_Parts_Named_metadata_And_payload()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => OkPublish());
+
+            await store.PublishAsync(StubDef(), MakeMetadata());
+
+            var parts = ReadMultipartParts(handler);
+
+            // Exactly two parts, exact names.
+            Assert.Equal(2, parts.Count);
+            Assert.True(parts.ContainsKey("metadata"), "missing 'metadata' part");
+            Assert.True(parts.ContainsKey("payload"), "missing 'payload' part");
+
+            // metadata Content-Type = application/json.
+            Assert.StartsWith("application/json", parts["metadata"].contentType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Metadata_Json_Uses_asset_id_Never_character_id()
+        {
+            // The single highest-risk regression: the wire wants
+            // "asset_id"; the POCO calls the field CharacterId. The
+            // boundary rename MUST happen exactly once, here, in the
+            // outbound serializer. If anyone ever lets a literal
+            // "character_id" through the wire, the eigencore backend
+            // accepts the upload but indexes the WRONG key — silent
+            // corruption.
+            var (store, handler) = Make();
+            handler.Enqueue(_ => OkPublish());
+
+            await store.PublishAsync(StubDef(), MakeMetadata());
+
+            var parts = ReadMultipartParts(handler);
+            string metaJson = Encoding.UTF8.GetString(parts["metadata"].body);
+
+            Assert.Contains("\"asset_id\"", metaJson);
+            Assert.DoesNotContain("\"character_id\"", metaJson);
+
+            // Sanity: the asset_id value is the one we passed in.
+            Assert.Contains(AssetId, metaJson);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Oversize_Metadata_Throws_Before_Any_Http_Call()
+        {
+            var (store, handler) = Make(metadataCap: 4 * 1024);
+
+            // Build a tags array fat enough to blow the 4 KiB cap. Each
+            // tag is ~64 chars; 80 tags ≈ 5 KiB of JSON.
+            string[] hugeTags = Enumerable.Range(0, 80)
+                .Select(i => "filler-tag-" + new string('x', 60) + "-" + i)
+                .ToArray();
+            var metadata = MakeMetadata(tags: hugeTags);
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetTooLargeException>(() =>
+                store.PublishAsync(StubDef(), metadata));
+            Assert.Equal("metadata", ex.Subject);
+
+            // The wire was never touched.
+            Assert.Empty(handler.Requests);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Oversize_Payload_Throws_Before_Any_Http_Call()
+        {
+            // 300 KiB payload, default 256 KiB cap.
+            byte[] huge = new byte[300 * 1024];
+            var (store, handler) = Make(payloadSerializer: _ => huge);
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetTooLargeException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata()));
+            Assert.Equal("payload", ex.Subject);
+            Assert.Empty(handler.Requests);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Overwrite_Returns_200_Is_Success()
+        {
+            // Second publish of same asset_id: eigencore returns 200
+            // (overwrote) instead of 201 (created). The wrapper must
+            // treat both as success.
+            var (store, handler) = Make();
+            handler.Enqueue(_ => OkPublish(
+                CannedPublishResponseBody(updatedAt: new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero)),
+                HttpStatusCode.OK));
+
+            CharacterAssetMetadata returned = await store.PublishAsync(StubDef(), MakeMetadata());
+            Assert.Equal(AssetId, returned.CharacterId);
+            Assert.Equal(new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero), returned.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Reserved_Prefix_auto_Returns_403_Throws_Forbidden_With_Prefix()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"code\":\"permission_denied\",\"detail\":\"reserved tag prefix 'auto-' is not allowed\",\"tag\":\"auto-foo\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetForbiddenException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata(tags: new[] { "auto-foo" })));
+            Assert.Equal(403, ex.StatusCode);
+            Assert.Contains("auto-", ex.Message);
+        }
+
+        [Fact]
+        public async Task PublishAsync_Reserved_Prefix_official_From_NonAllowListed_Returns_403_Throws_Forbidden()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"code\":\"permission_denied\",\"detail\":\"tag prefix 'official-' is not allowed for this client\",\"prefix\":\"official-\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetForbiddenException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata(tags: new[] { "official-foo" })));
+            Assert.Equal(403, ex.StatusCode);
+            Assert.Contains("official-", ex.Message);
+        }
+
+        [Fact]
+        public async Task PublishAsync_401_Throws_RemoteAssetAuthException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"detail\":\"bad token\"}"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetAuthException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata()));
+            Assert.Equal(401, ex.StatusCode);
+            Assert.Contains("bad token", ex.ResponseBody);
+        }
+
+        [Fact]
+        public async Task PublishAsync_500_Throws_RemoteAssetServerException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("kaboom"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetServerException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata()));
+            Assert.Equal(500, ex.StatusCode);
+            Assert.Equal("kaboom", ex.ResponseBody);
+        }
+
+        [Fact]
+        public async Task PublishAsync_422_invalid_multipart_Throws_RemoteAssetValidationException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent(
+                    "{\"code\":\"invalid_multipart\",\"errors\":[\"unknown form field 'extra'\"]}",
+                    Encoding.UTF8, "application/json"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetValidationException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata()));
+            Assert.Equal(422, ex.StatusCode);
+            Assert.Contains("unknown form field 'extra'", ex.Errors);
+        }
+
+        [Fact]
+        public async Task PublishAsync_422_metadata_too_large_From_Server_Throws_TooLarge_Metadata()
+        {
+            // Pre-validation should normally catch this; this test
+            // covers the rare case of a server with a tighter cap than
+            // the client's MetadataSizeCapBytes (env override).
+            var (store, handler) = Make(metadataCap: 1024 * 1024);  // 1 MiB locally so we don't pre-trip
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.UnprocessableEntity)
+            {
+                Content = new StringContent(
+                    "{\"code\":\"metadata_too_large\",\"detail\":\"metadata exceeds 4096 bytes\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetTooLargeException>(() =>
+                store.PublishAsync(StubDef(), MakeMetadata()));
+            Assert.Equal("metadata", ex.Subject);
+            Assert.Equal(422, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_204_Returns_True()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+
+            bool deleted = await store.DeleteAsync(AssetId);
+            Assert.True(deleted);
+
+            Assert.Single(handler.Requests);
+            var req = handler.Requests[0];
+            Assert.Equal(HttpMethod.Delete, req.Method);
+            Assert.Equal($"https://eigencore.test/api/v1/assets/{AssetId}", req.RequestUri!.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_200_Returns_True()
+        {
+            // Some backends respond 200 with an empty body instead of 204.
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(""),
+            });
+
+            bool deleted = await store.DeleteAsync(AssetId);
+            Assert.True(deleted);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_404_Returns_False_No_Throw()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{\"detail\":\"not_found\"}"),
+            });
+
+            bool deleted = await store.DeleteAsync(AssetId);
+            Assert.False(deleted);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_403_NotOwner_Throws_RemoteAssetForbiddenException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"code\":\"permission_denied\",\"detail\":\"caller is not the asset owner\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetForbiddenException>(() => store.DeleteAsync(AssetId));
+            Assert.Equal(403, ex.StatusCode);
+            Assert.Contains("not the asset owner", ex.Message);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_401_Throws_RemoteAssetAuthException()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"detail\":\"bad token\"}"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetAuthException>(() => store.DeleteAsync(AssetId));
+            Assert.Equal(401, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task SaveAsync_HappyPath_Delegates_To_Publish_201()
+        {
+            // SaveAsync is a thin delegate to PublishAsync with a
+            // synthesised minimal metadata envelope. The wire shape is
+            // identical to PublishAsync: POST /assets multipart with
+            // metadata + payload parts.
+            var (store, handler) = Make();
+            handler.Enqueue(_ => OkPublish());
+
+            await store.SaveAsync(StubDef());
+
+            Assert.Single(handler.Requests);
+            var req = handler.Requests[0];
+            Assert.Equal(HttpMethod.Post, req.Method);
+
+            var parts = ReadMultipartParts(handler);
+            Assert.Equal(2, parts.Count);
+            Assert.True(parts.ContainsKey("metadata"));
+            Assert.True(parts.ContainsKey("payload"));
+
+            string metaJson = Encoding.UTF8.GetString(parts["metadata"].body);
+            // Boundary rename still applies on the synthesised metadata.
+            Assert.Contains("\"asset_id\"", metaJson);
+            Assert.DoesNotContain("\"character_id\"", metaJson);
+            // The synthesised asset_id is the def's CharacterId in
+            // lowercase 'D' format (UUID).
+            Assert.Contains(AssetId, metaJson);
+        }
+
+        [Fact]
+        public async Task SaveAsync_500_Surfaces_Server_Exception()
+        {
+            var (store, handler) = Make();
+            handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("upstream-fault"),
+            });
+
+            var ex = await Assert.ThrowsAsync<RemoteAssetServerException>(() => store.SaveAsync(StubDef()));
+            Assert.Equal(500, ex.StatusCode);
+            Assert.Equal("upstream-fault", ex.ResponseBody);
+        }
+    }
+}

--- a/tests/Pinder.RemoteAssets.Tests/FakeHttpMessageHandler.cs
+++ b/tests/Pinder.RemoteAssets.Tests/FakeHttpMessageHandler.cs
@@ -19,6 +19,23 @@ namespace Pinder.RemoteAssets.Tests
 
         public List<HttpRequestMessage> Requests { get; } = new List<HttpRequestMessage>();
 
+        /// <summary>
+        /// Snapshots of each request's body bytes, captured BEFORE the
+        /// production code disposes the <see cref="HttpRequestMessage"/>
+        /// (which disposes the underlying <see cref="HttpContent"/>).
+        /// Index-parallel to <see cref="Requests"/>. Entries for requests
+        /// with no body are <c>null</c>.
+        /// </summary>
+        public List<byte[]?> RequestBodies { get; } = new List<byte[]?>();
+
+        /// <summary>
+        /// Snapshots of each request's Content-Type header (value
+        /// including parameters like multipart boundary), captured BEFORE
+        /// disposal. Index-parallel to <see cref="Requests"/>. Null for
+        /// requests with no content.
+        /// </summary>
+        public List<string?> RequestContentTypes { get; } = new List<string?>();
+
         public void Enqueue(Func<HttpRequestMessage, HttpResponseMessage> responder)
         {
             _responders.Enqueue(responder);
@@ -29,16 +46,33 @@ namespace Pinder.RemoteAssets.Tests
             _responders.Enqueue(_ => response);
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Requests.Add(request);
+
+            // Capture body bytes + content-type NOW, before the
+            // production code's `using` block disposes the
+            // HttpRequestMessage. Required for multipart-write tests in
+            // #855 that need to assert on the on-wire body.
+            if (request.Content != null)
+            {
+                byte[] bodyBytes = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                RequestBodies.Add(bodyBytes);
+                RequestContentTypes.Add(request.Content.Headers.ContentType?.ToString());
+            }
+            else
+            {
+                RequestBodies.Add(null);
+                RequestContentTypes.Add(null);
+            }
+
             if (_responders.Count == 0)
                 throw new InvalidOperationException(
                     $"FakeHttpMessageHandler received an unexpected request: {request.Method} {request.RequestUri}");
             var responder = _responders.Dequeue();
             var resp = responder(request);
             resp.RequestMessage = request;
-            return Task.FromResult(resp);
+            return resp;
         }
     }
 }


### PR DESCRIPTION
Implements the three remaining `IRemoteCharacterStore` methods against the eigencore wire (`POST /assets` multipart + `DELETE /assets/{asset_id}`), completing sub-PR 3 of 3 from parent #819.

This is the last sub-PR of #819; merging it closes both #855 and #819.

## What's in this PR

**Public surface (in `src/Pinder.RemoteAssets/EigencoreCharacterStore.cs`):**

- `PublishAsync(def, metadata, ct)` — POSTs `multipart/form-data` with exactly two parts named `metadata` (`application/json`) and `payload` (`application/octet-stream`). Returns the server-stamped metadata. Treats both **201** (newly created) and **200** (overwrote existing asset) as success per the spec's upsert contract.
- `SaveAsync(def, ct)` — thin delegate to `PublishAsync`. Synthesises a minimal `CharacterAssetMetadata` envelope from the def's `CharacterId` (no tags, empty owner, `is_public=false`). Callers that need to control tags / visibility / owner call `PublishAsync` directly. **Decision documented in the method's xmldoc and called out in the spec section below.**
- `DeleteAsync(characterId, ct)` — `DELETE /assets/{asset_id}`. **200/204 → true**, **404 → false** (idempotent), **403 → `RemoteAssetForbiddenException`** (not-owner).

**Wire-shape regression coverage (new `CharacterAssetMetadataSerializer.cs`):**

The serializer is the WRITE-direction boundary rename: POCO `CharacterId` → wire `asset_id`. It never emits `character_id`. Pinned by `PublishAsync_Metadata_Json_Uses_asset_id_Never_character_id`.

**Pre-validation:** serialised metadata + payload are size-checked **before** any HTTP request. Oversized metadata (>4 KiB default) or payload (>256 KiB default) throws `RemoteAssetTooLargeException(subject="metadata"|"payload")`, asserted by the tests to fire with zero network calls.

**New error mappings on the write path:**

- 403 `permission_denied` (reserved-prefix violation OR not-owner) → `RemoteAssetForbiddenException`. Best-effort prefix extraction from the body so the message identifies the offending `auto-`/`official-` prefix (the test asserts the prefix is in the message).
- 422 `metadata_too_large` / `payload_too_large` → `RemoteAssetTooLargeException` with the correct `Subject` (server-side fallback for the rare case where the local cap is looser than the deployed server's).
- 422 `invalid_multipart` (or other 422 code) → `RemoteAssetValidationException`.
- 401, 429 (one retry then `RemoteAssetRateLimitException`), 5xx, network — reuse the shared mapping from #853/#854.

**Configuration additions (additive, with defaults — no breaking change to existing callers):**

- `MetadataSizeCapBytes` (default 4 KiB).
- `PayloadSizeCapBytes` (default 256 KiB).
- `PayloadSerializer` (optional; falls back to `CharacterDefinitionWriter.Write` + UTF-8 when null).

**Interface decision — `SaveAsync` vs `PublishAsync`:**

`IRemoteCharacterStore : ICharacterStore` ends up with both `SaveAsync(def)` (from the base) and `PublishAsync(def, metadata)` (the remote-specific surface). The spec says "POST is the upsert; two publishes with the same `asset_id` overwrite." That means `Save` is functionally `Publish` minus the explicit metadata input.

Decision: **`SaveAsync` synthesises a minimal metadata envelope and delegates to `PublishAsync`.** This keeps the base `ICharacterStore` contract honest (callers that take an `ICharacterStore` and call `SaveAsync` work transparently against the remote store), while preserving `PublishAsync` as the rich-metadata write API. Rejected alternatives:

- Making `SaveAsync` throw `NotSupportedException` — breaks LSP and the interface promise.
- Inventing a new public method — explicitly forbidden by the ticket ("do NOT invent a new public method").

## Tests

47 tests in `Pinder.RemoteAssets.Tests`, all green. Every bullet from the ticket's "Tests required" list is covered:

- Publish happy path (201 + server-stamped fields).
- Publish multipart shape: exactly two parts named `metadata` + `payload`, metadata Content-Type `application/json`.
- Publish JSON `asset_id` regression: `"asset_id"` present, `"character_id"` absent.
- Publish oversize metadata → `RemoteAssetTooLargeException(subject="metadata")` BEFORE any HTTP call (`handler.Requests` is empty).
- Publish oversize payload → same, `subject="payload"`.
- Publish overwrite: 200 (not 201) is treated as success.
- Publish reserved-prefix `auto-foo` → 403 → `RemoteAssetForbiddenException` with `auto-` in the message.
- Publish reserved-prefix `official-foo` from non-allow-listed client → same.
- Publish 401 → `RemoteAssetAuthException`.
- Publish 5xx → `RemoteAssetServerException`.
- Publish 422 `invalid_multipart` → `RemoteAssetValidationException`.
- Publish 422 server-side `metadata_too_large` → `RemoteAssetTooLargeException` (regression coverage for tighter server-side caps than the client's).
- Delete 200 + 204 → true.
- Delete 404 → false (no throw).
- Delete 403 → `RemoteAssetForbiddenException`.
- Delete 401 → `RemoteAssetAuthException`.
- Save happy path: delegates to Publish (asserts multipart shape + asset_id rename).
- Save 5xx: surfaces `RemoteAssetServerException`.

The read-path test pinning `SaveAsync_Throws_NotSupported_In_853` was removed (Save is now implemented). `ListIdsAsync` stays `NotSupported` (no list-all endpoint in v1).

## DoD Evidence

**Architectural greps (all clean):**

```
$ grep -RIn 'using Eigencore' --include='*.cs' --exclude-dir=bin --exclude-dir=obj .
(no hits)

$ grep -RIn 'Pinder\.RemoteAssets' src/Pinder.Core/ src/Pinder.SessionSetup/
(no hits)

$ grep -RIn '"character_id"' src/Pinder.RemoteAssets/ tests/
src/Pinder.RemoteAssets/CharacterAssetMetadataSerializer.cs:53:  // emit "character_id". Pinned by regression test.   ← anti-example comment
tests/Pinder.RemoteAssets.Tests/EigencoreCharacterStoreWriteTests.cs:292:  // "character_id" through the wire …      ← test comment
tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs: …                                            ← on-disk payload JSON (legit)
tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs: …                                                          ← on-disk payload JSON (legit)
```

None of the hits are in a wire-write path. The serializer code never emits `"character_id"`; only its anti-example comment mentions the string.

**`dotnet build` tail:**

```
    153 Warning(s)
    0 Error(s)

Time Elapsed 00:00:37.71
```

(Warnings are pre-existing nullable / async hygiene in `Pinder.Core` test projects, unchanged by this PR.)

**`dotnet test tests/Pinder.RemoteAssets.Tests/` tail:**

```
Passed!  - Failed:     0, Passed:    47, Skipped:     0, Total:    47, Duration: 213 ms - Pinder.RemoteAssets.Tests.dll (net8.0)
```

**Full-solution `dotnet test` summary:**

```
Pinder.RemoteAssets.Tests:   Passed!  Failed: 0,  Passed: 47,  Skipped: 0,   Total: 47
Pinder.Core.Tests:           Passed!  Failed: 0,  Passed: 2650, Skipped: 18, Total: 2668
Pinder.Rules.Tests:          Failed!  Failed: 46, Passed: 198,  Skipped: 0,  Total: 244    ← pre-existing, matches #855 ticket
Pinder.LlmAdapters.Tests:    Failed!  Failed: 63, Passed: 959,  Skipped: 9,  Total: 1031   ← pre-existing, matches #855 ticket
```

Pre-existing failure counts in `Pinder.Rules.Tests` (46) and `Pinder.LlmAdapters.Tests` (63) match the ticket's expectation exactly. No new failures introduced anywhere.

**Commit:**

```
db3c9d5 feat(#855): Pinder.RemoteAssets write path — publish/save/delete
```

**Branch push:** `fix/855-remoteassets-write-path` pushed to `origin`.

**Members implemented in this PR:**

- `PublishAsync` — full implementation.
- `SaveAsync` — thin delegate to `PublishAsync` (synthesises a minimal metadata envelope; documented in xmldoc).
- `DeleteAsync` — full implementation.

`ListIdsAsync` remains `NotSupported` per the v1 wire contract.

## Research Log

| Topic | Source | Key finding |
|-------|--------|-------------|
| Multipart wire shape | `docs/specs/character-asset-vocabulary.md` § Publish | Two parts named exactly `metadata` (application/json) + `payload` (any content-type). Boundary rename `CharacterId` → `asset_id` ONLY on the metadata part. |
| Size caps | spec § Publish | 4 KiB metadata, 256 KiB payload (env-overridable on server). Pre-validation is the better contract: fail fast, no network round-trip. |
| Reserved-prefix rejection | spec § `tags` attribute | `auto-*` server-only (all clients rejected); `official-*` per-OAuth2-client allow-list. Both surface as 403 `permission_denied`. No silent strip. |
| POST upsert semantics | spec § `asset_id` + § Publish | Two POSTs with the same `asset_id` overwrite. Server returns 201 on first, 200 on overwrite. Both are success. |
| `.NET HttpClient` multipart format | `System.Net.Http.MultipartFormDataContent` (probe + ASP.NET source) | Emits unquoted `name=foo` in Content-Disposition (not `name="foo"`). Multipart parser in `EigencoreCharacterStoreWriteTests` handles both. |
| `HttpClient.SendAsync` content disposal | empirical | `HttpRequestMessage` disposal disposes the underlying `HttpContent`, including its body stream. `FakeHttpMessageHandler` had to snapshot body bytes synchronously inside `SendAsync` before the production code's `using` block disposed the request. This new behaviour is the only diff to the shared fake handler; read-path tests are unaffected because they don't inspect request bodies. |
| `IRemoteCharacterStore` surface | `src/Pinder.Core/Characters/IRemoteCharacterStore.cs` + `ICharacterStore.cs` | `SaveAsync(def)` lives on the base; `PublishAsync(def, metadata)` is remote-specific. Per the ticket's instruction not to invent new methods, `SaveAsync` delegates to `PublishAsync` with a synthesised minimal metadata. |

Closes #855
Closes #819
