### PR TITLE
docs: sprint-end documentation pass for Pinder.RemoteAssets epic (#819)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -323,6 +323,29 @@ never drift behind the implementation.
 **Discovered in:** #836 (2026-05-10). Designed alongside the
 implementation, not after.
 
+### WIRE-CONTRACT-REGRESSION-TESTS
+
+**Pattern:** when a wire detail has a well-known implementer trap — one where the wrong implementation often works in the common case and silently succeeds — pin it with a regression test that uses inputs that would *pass* under the wrong implementation but *fail* correctly only under the right one.
+
+**Two canonical examples from #819 (`Pinder.RemoteAssets`):**
+
+**Base64 alphabet (`X-Asset-Metadata` header).**
+The spec requires RFC 4648 *standard padded* base64 (`Convert.FromBase64String`), not base64url (`WebEncoders.Base64UrlDecode`). The two alphabets differ only on two characters: `+`/`/` (standard) vs `-`/`_` (base64url). A developer reaching for the URL-safe variant is a natural mistake (the header travels in an HTTP response header, which feels "URL-adjacent"). Most test inputs happen to encode to only alphanumeric characters and never expose the difference.
+The regression test uses byte sequence `0xFB 0xFF 0xBF`, which encodes to `+/+/` in standard base64 and `-_-_` in base64url. The test:
+1. Asserts the standard base64 form (`+/+/=`) decodes without error.
+2. Asserts the base64url form (`-_-_`) throws `RemoteAssetMalformedMetadataException`.
+Any future refactor that swaps the decoder breaks the test immediately on a distinguishing input, not silently on production data.
+
+**Query parameter name (`tag` vs `tags`).**
+The eigencore asset-query endpoint uses the singular repeatable `tag=` parameter for multi-tag filtering. The plural `tags=` is not recognized; the backend silently drops unknown query parameters and returns unfiltered results with no error signal. This is exactly the class of bug that manual testing doesn't catch (results look correct for untagged or single-tag queries) and that only shows up in production as mysteriously unfiltered result sets.
+The regression test asserts `Assert.DoesNotContain("tags=", builtUrl)` on every code path in `BuildQueryUri`. The test is a canary: any future refactor that introduces a `tags=` emission fails immediately.
+
+**Rule:** when you implement against a wire contract and find yourself handling a detail that has a known "looks right but is wrong" alternative implementation, write the regression test first. The test documents the trap for the next developer and survives refactoring that the original author can no longer reason about.
+
+**Discovered in:** #819 sprint (sub-PRs #856/#857/#858, 2026-05-13). The base64url test and tags-regression test are in `Pinder.RemoteAssets.Tests`. See also pinder-core#851 — the May 2026 drift discovery that revealed both traps existed in the original Pinder-side implementation.
+
+---
+
 ### MEASURE-BEFORE-CACHING-AND-USE-P50-NOT-P99-WHEN-GC-DOMINATES-THE-TAIL
 
 **Symptom:** Issue #840 framed itself around "replace the dual loader

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,12 +11,14 @@ pinder-core/
 ├── src/
 │   ├── Pinder.Core/          # Domain model, game loop, interfaces (netstandard2.0)
 │   ├── Pinder.LlmAdapters/   # LLM provider integrations + prompt assembly (netstandard2.0)
+│   ├── Pinder.RemoteAssets/  # HTTP client for eigencore character-assets API (netstandard2.0)
 │   ├── Pinder.Rules/         # Data-driven rule resolution from YAML (netstandard2.0)
 │   └── Pinder.SessionSetup/  # Pre-session matchup + stake generation (netstandard2.0)
 ├── session-runner/            # CLI harness — runs a full game session (net8.0)
 ├── tests/
 │   ├── Pinder.Core.Tests/
 │   ├── Pinder.LlmAdapters.Tests/
+│   ├── Pinder.RemoteAssets.Tests/
 │   └── Pinder.Rules.Tests/
 ├── data/                      # YAML + JSON game data files
 ├── rules/tools/               # Python rules pipeline (YAML ↔ Markdown)
@@ -28,7 +30,9 @@ pinder-core/
 Consumers: the `session-runner` CLI harness uses Core + LlmAdapters + Rules.
 The web-tier `Pinder.GameApi` (separate repo `pinder-web`, mounts this repo as
 a git submodule) additionally uses `Pinder.SessionSetup` for matchup + stake
-generation outside the per-turn game loop.
+generation outside the per-turn game loop, and wires `Pinder.RemoteAssets` via
+DI as the `IRemoteCharacterStore` implementation for the eigencore character-assets
+API. `Pinder.RemoteAssets` is NOT used by the engine or the CLI harness directly.
 
 ## 2. Assembly Map
 
@@ -63,6 +67,21 @@ Prompt construction and LLM API integration. Depends on Pinder.Core and Pinder.R
 | | `RollContextBuilder.cs` — YAML-sourced roll flavor text |
 | | `Anthropic/AnthropicLlmAdapter.cs` — Claude adapter (implements IStatefulLlmAdapter) |
 | | `OpenAi/OpenAiLlmAdapter.cs` — OpenAI-compatible adapter (Groq, Together, OpenRouter, Ollama) |
+
+### Pinder.RemoteAssets
+
+Outbound HTTP client for the eigencore character-assets API. This is the **only** assembly in this repo that knows eigencore exists. `Pinder.Core` and all other assemblies have zero knowledge of eigencore; the dependency arrow is one-way. The module is consumed by `pinder-web`'s `Pinder.GameApi` via DI (injected as `IRemoteCharacterStore`); the engine itself does not reference it.
+
+| Depends on | Pinder.Core (for `IRemoteCharacterStore`, `CharacterAssetQuery`, `CharacterAssetPage`, `CharacterAssetMetadata`, `CharacterDefinition`) |
+|---|---|
+| **Purpose** | HTTP read/query/write against the eigencore character-assets API. Boundary-renames wire fields (`asset_id`) to Pinder POCO fields (`CharacterId`). Typed exception hierarchy for all HTTP error cases. |
+| **Key files** | `Configuration.cs` — DI configuration bag: BaseUrl, HttpMessageHandler, AuthTokenProvider, CharacterPayloadParser, size caps, DefaultRetryAfter |
+| | `EigencoreCharacterStore.cs` — `IRemoteCharacterStore` implementation. Read: `LoadAsync`/`GetMetadataAsync`/`ExistsAsync`. Query: `QueryAsync`. Write: `PublishAsync`/`SaveAsync`/`DeleteAsync`. `ListIdsAsync` throws `NotSupportedException` (no v1 list-all endpoint). |
+| | `CharacterAssetMetadataParser.cs` — wire→POCO, decodes RFC 4648 standard-padded base64 `X-Asset-Metadata` header, renames `asset_id`→`CharacterId` |
+| | `CharacterAssetMetadataSerializer.cs` — POCO→wire (write path), renames `CharacterId`→`asset_id`, never emits `character_id` |
+| | `Exceptions/*.cs` — typed exception hierarchy: `RemoteAssetException` (root) → Auth / Forbidden / Validation / InvalidCursor / TooLarge / MalformedMetadata / RateLimit / Server |
+
+See [`docs/modules/remote-assets.md`](modules/remote-assets.md) and [`docs/specs/character-asset-vocabulary.md`](specs/character-asset-vocabulary.md) for wire-contract details.
 
 ### Pinder.Rules
 

--- a/docs/modules/remote-assets.md
+++ b/docs/modules/remote-assets.md
@@ -1,0 +1,102 @@
+# Remote Assets
+
+## Overview
+
+`Pinder.RemoteAssets` is the HTTP client that talks to eigencore on Pinder's behalf. It is the **only** assembly in this repository that knows eigencore exists. The dependency arrow is strictly one-way: `Pinder.RemoteAssets → Pinder.Core`, never the reverse. `Pinder.Core`, the session runner, and every other assembly in this repo have zero knowledge of eigencore's types, endpoints, or schemas.
+
+The architectural rule is explicit: **eigencore is a third-party app from Pinder's perspective** — equivalent to Stripe or Auth0. Pinder calls a documented API surface and gets opaque results. The wire vocabulary is defined in [`docs/specs/character-asset-vocabulary.md`](../specs/character-asset-vocabulary.md); any delta between Pinder's understanding and eigencore's deployed interface is fixed on Pinder's side (in this module + the spec) unless another game built on eigencore would also benefit. Drift found in May 2026 (`character_id`/`?tags=`/silent-strip vs eigencore's `asset_id`/`?tag=`/403-reject) was all fixed here as pinder-core#851; use that as the precedent.
+
+## Key Components
+
+| File | Description |
+|------|-------------|
+| `src/Pinder.RemoteAssets/Configuration.cs` | DI-friendly configuration bag: `BaseUrl`, `HttpMessageHandler` (injection seam for tests), `AuthTokenProvider` (Func&lt;CT, Task&lt;string&gt;&gt;), `CharacterPayloadParser` (delegate that converts payload bytes → `CharacterDefinition`, keeping the assembly free of a `Pinder.SessionSetup` dep), `MetadataSizeCapBytes` (default 4 096), `PayloadSizeCapBytes` (default 262 144), `DefaultRetryAfter`. |
+| `src/Pinder.RemoteAssets/EigencoreCharacterStore.cs` | The `IRemoteCharacterStore` implementation. **Read path**: `LoadAsync`, `GetMetadataAsync`, `ExistsAsync` (all issue `GET /assets/{id}` and read the `X-Asset-Metadata` header). **Query path**: `QueryAsync` (issues `GET /assets?...`). **Write path**: `PublishAsync`, `SaveAsync` (thin delegate to `PublishAsync` with synthesised minimal metadata), `DeleteAsync`. `ListIdsAsync` deliberately throws `NotSupportedException` — the v1 wire has no list-all endpoint; discovery is via `QueryAsync`. One-retry budget on 429 for every operation. Network-level errors propagate as `HttpRequestException` (not wrapped). |
+| `src/Pinder.RemoteAssets/CharacterAssetMetadataParser.cs` | Wire→POCO. Reads JSON metadata bytes (from `X-Asset-Metadata` response header on read endpoints, or from query response items). Decodes the header using `Convert.FromBase64String` — **RFC 4648 standard padded base64, NOT base64url**. Boundary-renames `asset_id` → `CharacterId`. Tolerates unknown attributes (forward-compat). |
+| `src/Pinder.RemoteAssets/CharacterAssetMetadataSerializer.cs` | POCO→wire (outbound write path). Boundary-renames `CharacterId` → `asset_id`. Never emits `character_id`. Does not emit server-controlled fields (`owner_id`, `created_at`, `updated_at`, `payload_size`). Pinned by regression test. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetException.cs` | Abstract root of the typed exception hierarchy. Carries `StatusCode` (int, 0 when non-HTTP) and `ResponseBody` (verbatim body for triage). Network errors propagate as `HttpRequestException` and are NOT wrapped here. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetAuthException.cs` | 401 — invalid or expired credentials. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetForbiddenException.cs` | 403 — reserved-prefix tag violation (`auto-*` from any caller, `official-*` from a non-allowlisted caller) **or** not-owner on DELETE/overwrite. The wrapper does not enforce reserved-prefix rules itself; the server does. The wrapper surfaces the 403 cleanly and attempts best-effort extraction of the offending prefix from the response body. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetValidationException.cs` | 422 (generic) — malformed multipart or other validation failure. Carries an `Errors` string list parsed from the body. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetInvalidCursorException.cs` | 422 with `error=invalid_cursor` — the cursor passed to `QueryAsync` was malformed or expired. Distinct from generic validation so callers can restart pagination cleanly. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetTooLargeException.cs` | 422 with `code=metadata_too_large` or `code=payload_too_large`, **or** a pre-flight local check on `PublishAsync` before any HTTP call. Carries `Subject` (`"metadata"` or `"payload"`) and the cap that was exceeded. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetMalformedMetadataException.cs` | 200 with a missing or non-base64 `X-Asset-Metadata` header, or a valid header whose JSON is unparseable. Signals a server-side encoding bug, not a client mistake. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetRateLimitException.cs` | Second 429 (after one automatic retry with the server's `Retry-After` delay). Carries `RetryAfter`. |
+| `src/Pinder.RemoteAssets/Exceptions/RemoteAssetServerException.cs` | 5xx, or any unexpected status code not otherwise mapped. Carries `StatusCode`. |
+
+## Wire-Contract Summary
+
+The full contract is in [`docs/specs/character-asset-vocabulary.md`](../specs/character-asset-vocabulary.md). What follows is the orientation a developer needs to use or extend this module.
+
+**Endpoint set** (relative to `Configuration.BaseUrl`, which absorbs the `/api/v1` prefix):
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| Fetch character | `GET` | `/assets/{asset_id}` |
+| Query characters | `GET` | `/assets` |
+| Publish (upsert) | `POST` | `/assets` |
+| Delete | `DELETE` | `/assets/{asset_id}` |
+
+**Multipart shape on write (POST /assets):** exactly two parts. Part names are exact and case-sensitive:
+- `metadata` — `application/json`, the serialised `CharacterAssetMetadata` (client-controlled fields only; ≤ 4 KiB). Never includes `character_id`.
+- `payload` — `application/octet-stream`, the raw v1 `CharacterDefinition` JSON bytes (≤ 256 KiB by default). Both caps are pre-validated locally before the HTTP request is sent.
+
+**The two most-likely-to-break wire details (both pinned by regression tests):**
+
+1. **`X-Asset-Metadata` is RFC 4648 standard padded base64, NOT base64url.** Use `Convert.FromBase64String`, NOT `WebEncoders.Base64UrlDecode`. Standard base64 uses `+` and `/`; base64url uses `-` and `_`. An implementation using the wrong decoder will silently succeed on most payloads (characters that encode to only `A-Z`, `a-z`, `0-9`) and fail or corrupt on payloads that happen to produce `+` or `/` characters in the encoded form. The regression test uses byte sequence `0xFB 0xFF 0xBF` which encodes as `+/+/=` in standard base64 and `-_-_` in base64url, asserting that the `+/+/=` form round-trips cleanly and the `-_-_` form throws.
+
+2. **Query parameter is `tag` (singular, repeatable), NOT `tags`.** The reference backend silently drops unknown query parameters rather than returning 422, so `?tags=foo` returns unfiltered results with no error signal. Regression test asserts `Assert.DoesNotContain("tags=", url)` on every built query URI.
+
+**Boundary rename:** the wire uses `asset_id` everywhere; the POCO uses `CharacterId`. Direction matters:
+- **Read** (`CharacterAssetMetadataParser`): wire `asset_id` → POCO `CharacterId`
+- **Write** (`CharacterAssetMetadataSerializer`): POCO `CharacterId` → wire `asset_id`
+
+## Error Mapping
+
+| HTTP status + condition | Exception thrown |
+|-------------------------|-----------------|
+| `401` | `RemoteAssetAuthException` |
+| `403` (reserved tag prefix or not-owner) | `RemoteAssetForbiddenException` |
+| `422` — `error=invalid_cursor` on query | `RemoteAssetInvalidCursorException` |
+| `422` — `code=metadata_too_large` | `RemoteAssetTooLargeException(subject="metadata")` |
+| `422` — `code=payload_too_large` | `RemoteAssetTooLargeException(subject="payload")` |
+| `422` — other | `RemoteAssetValidationException` |
+| `429` — first occurrence | automatic retry after `Retry-After` (or `DefaultRetryAfter`) |
+| `429` — second occurrence | `RemoteAssetRateLimitException` |
+| `5xx` or unexpected | `RemoteAssetServerException` |
+| `200` — missing or malformed `X-Asset-Metadata` | `RemoteAssetMalformedMetadataException` |
+| Pre-flight cap exceeded (no HTTP call sent) | `RemoteAssetTooLargeException` |
+| Network error (DNS, timeout, connection reset) | `HttpRequestException` (NOT wrapped) |
+
+See [`docs/specs/character-asset-vocabulary.md`](../specs/character-asset-vocabulary.md) § Error handling for the server-side perspective.
+
+## Architectural Invariants (Enforced by Tests and On-Merge Greps)
+
+- **Zero `using Eigencore.*`** outside this assembly. A merge-time grep blocks any drift.
+- **One-way dependency arrow.** `Pinder.Core` and `Pinder.SessionSetup` do not reference `Pinder.RemoteAssets`. The interface the engine calls (`IRemoteCharacterStore`) lives in `Pinder.Core`; the HTTP implementation lives here.
+- **The wrapper does not enforce reserved-prefix rules.** It passes tags verbatim and surfaces 403 cleanly. The server is the authority.
+- **`CharacterAssetMetadataSerializer` never emits `character_id`.** Pinned by regression test in `EigencoreCharacterStoreWriteTests`.
+- **Query URI never contains `tags=`.** Pinned by regression test in `EigencoreCharacterStoreQueryTests`.
+
+## What Is NOT in This Module
+
+- **No caching layer.** Every call hits the wire; results are not stored locally.
+- **No auto-pagination.** `QueryAsync` returns one page. The caller drives the cursor loop.
+- **No live-staging integration tests.** Out of scope for #819; noted as a potential follow-up.
+- **No streaming response handling.** The current contract caps payloads at 256 KiB; full body reads are fine at that scale.
+- **No HEAD support.** `ExistsAsync` and `GetMetadataAsync` issue a full `GET` (v1 wire has no HEAD endpoint).
+
+## Follow-Up Tickets Opened During the Sprint
+
+- **#859 — HTTPS-scheme enforcement.** `Configuration` currently accepts any `Uri` for `BaseUrl`, including `http://`. Defence-in-depth: add a constructor guard that throws if the scheme is not `https` in non-test contexts, or at minimum emit a warning.
+- **#860 — Response-size cap.** The current read/query paths do an unbounded `ReadAsByteArrayAsync`. Defence-in-depth: cap the response body read at a configurable limit to prevent a misbehaving server from causing an OOM.
+
+## Source of Truth
+
+The binding contract is [`docs/specs/character-asset-vocabulary.md`](../specs/character-asset-vocabulary.md). This module doc is the orientation; the spec is the contract. When the two disagree, the spec wins and this doc should be corrected.
+
+## Change Log
+
+| Date | Issue | Summary |
+|------|-------|---------|
+| 2026-05-13 | #819 (#856, #857, #858) | Initial creation — read path, query path, write path. Full `IRemoteCharacterStore` implementation against the eigencore character-assets API. |


### PR DESCRIPTION
Sprint-end documentation pass for #819 epic (PRs #856, #857, #858).

This PR adds and updates documentation only. No `.cs` files were touched.

## Summary

Three docs changes covering the `Pinder.RemoteAssets` library that shipped with the #819 epic:

**`docs/modules/remote-assets.md`** — new module doc:
- Overview: what the module is, the one-way dep arrow, and the third-party-app boundary.
- Key Components table: file-by-file map of all public files including the full exception hierarchy.
- Wire-Contract Summary: endpoint set, multipart shape, the two regression-pinned wire traps (base64 alphabet and `tag` vs `tags`), and the boundary rename (`asset_id` ↔ `CharacterId`).
- Error Mapping table: HTTP status + condition → typed exception.
- Architectural Invariants enforced by tests and on-merge greps.
- What Is NOT in This Module (no caching, no auto-pagination, no streaming, no HEAD).
- Follow-up tickets #859 (https-scheme enforcement) and #860 (response-size cap).
- Pointer to `docs/specs/character-asset-vocabulary.md` as the binding source of truth.

**`docs/ARCHITECTURE.md`** — additive updates:
- Repo tree: `src/Pinder.RemoteAssets/` and `tests/Pinder.RemoteAssets.Tests/` added.
- Assembly Map: new `Pinder.RemoteAssets` section (deps, purpose, key files, links to module doc + spec).
- Consumer paragraph: updated to note `Pinder.GameApi` wires `Pinder.RemoteAssets` via DI; the engine does not.

**`LESSONS_LEARNED.md`** — one new lesson:
- `WIRE-CONTRACT-REGRESSION-TESTS`: when a wire detail has a known implementer trap, pin it with a regression test using inputs that distinguish the wrong implementation from the right one. Two canonical examples: the base64 alphabet test (`0xFB 0xFF 0xBF` → `+/+/` vs `-_-_`) and the `tags=` vs `tag=` regression.

## DoD Evidence

- `docs/modules/remote-assets.md` created, follows the style of `docs/modules/characters.md` and `docs/modules/llm-adapters.md` (Key Components table, Architecture Notes, Change Log sections, consistent table format and prose tone).
- `docs/ARCHITECTURE.md` Assembly Map includes `Pinder.RemoteAssets` row with dep table and key files.
- `docs/ARCHITECTURE.md` repo tree includes `src/Pinder.RemoteAssets/` and `tests/Pinder.RemoteAssets.Tests/`.
- `LESSONS_LEARNED.md` has exactly ONE new lesson entry (`WIRE-CONTRACT-REGRESSION-TESTS`).
- Cross-links: `ARCHITECTURE.md` links to `modules/remote-assets.md` and `specs/character-asset-vocabulary.md`; module doc links back to the spec.
- `dotnet build Pinder.Core.sln`: 0 errors, 182 warnings (all pre-existing). No `.cs` files modified.
- Commit: `bb5c44b docs: sprint-end documentation pass for Pinder.RemoteAssets epic (#819)`

```
git log -1 --oneline
bb5c44b docs: sprint-end documentation pass for Pinder.RemoteAssets epic (#819)

Files touched:
  modified:   LESSONS_LEARNED.md
  modified:   docs/ARCHITECTURE.md
  new file:   docs/modules/remote-assets.md
```

## Research Log

**Existing docs read to match style:**
- `docs/ARCHITECTURE.md` — read end-to-end for Assembly Map table format, dep-arrow prose, ASCII tree format, and repo consumer paragraph.
- `docs/modules/characters.md` — Key Components table format, Change Log section, prose tone.
- `docs/modules/llm-adapters.md` — longer Architecture Notes style, more detailed Key Components entries, how to handle sub-sections.
- `docs/specs/character-asset-vocabulary.md` — wire contract in full; cited from module doc but not duplicated.
- `LESSONS_LEARNED.md` — tone, lesson template (Symptom/Root cause/Rule/Discovered in), how existing lessons cite tickets.

**Facts verified against source code (not invented):**
- `Configuration.cs`: confirmed `MetadataSizeCapBytes` defaults to `4 * 1024` and `PayloadSizeCapBytes` to `256 * 1024`; `AuthTokenProvider` type is `Func<CancellationToken, Task<string>>`.
- `EigencoreCharacterStore.cs`: confirmed `ListIdsAsync` throws `NotSupportedException`; one-retry budget per operation; `SaveAsync` is a thin delegate to `PublishAsync`; network errors propagate as `HttpRequestException` (not wrapped).
- `CharacterAssetMetadataParser.cs`: confirmed `Convert.FromBase64String` (not `WebEncoders.Base64UrlDecode`); the inline comment explicitly calls out the trap and the regression test.
- `CharacterAssetMetadataSerializer.cs`: confirmed `asset_id` is emitted (never `character_id`); server-controlled fields (`owner_id`, `created_at`, `updated_at`, `payload_size`) are not emitted.
- Exception hierarchy: verified all 8 concrete exception types from directory listing and read of `RemoteAssetException.cs` (root) and `RemoteAssetTooLargeException.cs` (representative leaf).
- `IRemoteCharacterStore.cs`: confirmed interface adds `QueryAsync`, `GetMetadataAsync`, `PublishAsync` on top of `ICharacterStore`; no HTTP types in the interface.
- PR numbering for sub-PRs: verified as #856/857/858 from `EigencoreCharacterStore.cs` XML doc comment and the commit message on `a5b6296`.