### PR TITLE
[security] Pinder.RemoteAssets: enforce https scheme on Configuration.BaseUrl

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -1105,3 +1105,4 @@
 {"ts":"2026-05-13T07:06:48Z","agent":"backend-engineer","issue":"#853","component":"Pinder.RemoteAssets","action":"started","detail":"Implementing #853 per branch fix/853-remoteassets-scaffold-readpath","commit":null}
 {"ts":"2026-05-13T07:18:32Z","agent":"backend-engineer","issue":"#853","component":"Pinder.RemoteAssets","action":"completed","detail":"PR #856 opened: https://github.com/decay256/pinder-core/pull/856","commit":"d09a276"}
 {"ts":"2026-05-13T08:30:37Z","agent":"orchestrator","issue":"#819","action":"docs-merged","detail":"PR #861 (sprint-end docs pass) squash-merged","pr":861,"commit":"d130f97"}
+{"ts":"2026-05-14T09:25:52Z","agent":"backend-engineer","action":"start","detail":"Implementing HTTPS enforcement in Pinder.RemoteAssets.Configuration (pinder-core#859)","issue":"GH-859"}

--- a/src/Pinder.RemoteAssets/Configuration.cs
+++ b/src/Pinder.RemoteAssets/Configuration.cs
@@ -51,7 +51,7 @@ namespace Pinder.RemoteAssets
         /// <c>/api/v1</c> (or future-rev) prefix here so the wire-level
         /// route code does NOT hard-code <c>/api/v1</c>. Example for the
         /// reference backend: <c>https://eigencore.example.com/api/v1</c>.
-        /// MUST be absolute. A trailing slash is tolerated either way.
+        /// MUST be absolute and use the HTTPS scheme.
         /// </summary>
         public Uri BaseUrl { get; }
 
@@ -142,11 +142,14 @@ namespace Pinder.RemoteAssets
             TimeSpan? defaultRetryAfter = null,
             int? metadataSizeCapBytes = null,
             int? payloadSizeCapBytes = null,
-            CharacterPayloadSerializer? payloadSerializer = null)
+            CharacterPayloadSerializer? payloadSerializer = null,
+            bool allowInsecureBaseUrl = false)
         {
             if (baseUrl == null) throw new ArgumentNullException(nameof(baseUrl));
             if (!baseUrl.IsAbsoluteUri)
                 throw new ArgumentException("BaseUrl must be absolute.", nameof(baseUrl));
+            if (!allowInsecureBaseUrl && baseUrl.Scheme != "https")
+                throw new ArgumentException($"BaseUrl must use the HTTPS scheme. Rejected scheme: {baseUrl.Scheme}.", nameof(baseUrl));
             BaseUrl = baseUrl;
             HttpMessageHandler = httpMessageHandler ?? throw new ArgumentNullException(nameof(httpMessageHandler));
             AuthTokenProvider = authTokenProvider ?? throw new ArgumentNullException(nameof(authTokenProvider));

--- a/tests/Pinder.RemoteAssets.Tests/ConfigurationTests.cs
+++ b/tests/Pinder.RemoteAssets.Tests/ConfigurationTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.RemoteAssets;
+
+namespace Pinder.RemoteAssets.Tests
+{
+    public class ConfigurationTests
+    {
+        private readonly HttpMessageHandler _handler = new FakeHttpMessageHandler();
+        private readonly Func<CancellationToken, Task<string>> _auth = _ => Task.FromResult("token");
+        private readonly CharacterPayloadParser _parser = _ => null;
+
+        [Fact]
+        public void Configuration_HttpsBaseUrl_Succeeds()
+        {
+            var uri = new Uri("https://example.com");
+            var config = new Configuration(uri, _handler, _auth, _parser);
+            Assert.Equal(uri, config.BaseUrl);
+        }
+
+        [Fact]
+        public void Configuration_HttpBaseUrl_ThrowsArgumentException()
+        {
+            var uri = new Uri("http://example.com");
+            var ex = Assert.Throws<ArgumentException>(() => new Configuration(uri, _handler, _auth, _parser));
+            Assert.Contains("HTTPS", ex.Message);
+            Assert.Contains("http", ex.Message);
+        }
+
+        [Fact]
+        public void Configuration_TestOptOut_AllowsHttpBaseUrl()
+        {
+            var uri = new Uri("http://example.com");
+            var config = new Configuration(uri, _handler, _auth, _parser, allowInsecureBaseUrl: true);
+            Assert.Equal(uri, config.BaseUrl);
+            Assert.Equal("http", config.BaseUrl.Scheme);
+        }
+    }
+}


### PR DESCRIPTION
Closes #859

Implemented HTTPS enforcement in Pinder.RemoteAssets.Configuration.

- Modified constructor to reject non-HTTPS BaseUrl by default.
- Added allowInsecureBaseUrl opt-out for tests.
- Updated BaseUrl xmldoc.
- Added regression tests:
    - Configuration_HttpBaseUrl_ThrowsArgumentException
    - Configuration_TestOptOut_AllowsHttpBaseUrl