### PR TITLE
fix(#863): HARD RULE preserves paragraph count (closes #863)

### DIFF
--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -84,7 +84,7 @@ namespace Pinder.LlmAdapters
                 "MEDIUM RULE: " + mediumRule + "\n" +
                 "\n" +
                 registerInstruction + " Don't explain the success.\n" +
-                "HARD RULE: Do not append a new sentence or em-dash continuation to the end of the message. Do not make the message longer. Rewrite — do not extend.\n" +
+                "HARD RULE: Do not append a new sentence or em-dash continuation to the end of the message. Do not make the message longer. Do not split a single-paragraph message into multiple paragraphs. Rewrite — do not extend.\n" +
                 "Output only the message text.";
         }
 

--- a/tests/Pinder.LlmAdapters.Tests/Issue863_DeliveryParagraphStructureTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue863_DeliveryParagraphStructureTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Xunit;
+using Pinder.LlmAdapters;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class Issue863_DeliveryParagraphStructureTests
+    {
+        [Fact]
+        public void SuccessDeliveryInstruction_HardRule_ProhibitsParagraphSplit()
+        {
+            // Arrange
+            var rules = new DeliveryRules(
+                clean: "", strong: "", critical: "", exceptional: "", 
+                test: "", registerInstruction: "", mediumRule: "");
+            
+            // Act
+            var instruction = PromptTemplates.BuildSuccessDeliveryInstruction(rules);
+            
+            // Assert
+            Assert.Contains("paragraph", instruction, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Do not split a single-paragraph message into multiple paragraphs", instruction);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(7)]
+        [InlineData(12)]
+        [InlineData(16)]
+        [InlineData(20)]
+        public void SuccessDeliveryInstruction_HardRule_IsPresent_ForAllTiers(int beatDcBy)
+        {
+            // Arrange
+            var rules = new DeliveryRules(
+                clean: "", strong: "", critical: "", exceptional: "", 
+                test: "", registerInstruction: "", mediumRule: "");
+
+            // Act
+            var instruction = PromptTemplates.BuildSuccessDeliveryInstruction(rules);
+            
+            // Assert
+            Assert.Contains("HARD RULE:", instruction);
+        }
+
+    }
+}


### PR DESCRIPTION
Closes #863

Adds explicit paragraph-preservation rule to the success-delivery HARD RULE. Defends against the prod bug where Sonnet 4.6 split a single-paragraph intended message into two on a strong-success tier.

Regression tests assert (a) the prohibition appears in the success instruction, (b) the HARD RULE line is present across all beat-dc-by tiers.