### PR TITLE
fix(#866): opponent response length cap (closes #866)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -396,3 +396,47 @@ discussion lives in the drain's `questions.md` (Q1) and in the
 intrinsically slow (p50 > 1ms after a real change), Step 2 ships
 then — but not speculatively against GC noise.
 
+
+### OPPONENT-LENGTH-RECIPROCITY
+
+**Symptom:** Opponent response length was governed entirely by the character's
+texting-style block, with no relative-length constraint. Observed in prod
+session `707fca72` turn 2: player sent 1054 chars (post-shadow-corruption),
+opponent replied with 957 chars — combined ~2000 chars in one turn, ~3 phone
+screens. A short player message ("k") could also trigger a full texting-style
+wall from a "long run-on" opponent.
+
+**Root cause:** The opponent-response prompt had a static length sentence
+("Length follows your character's texting style") with no reciprocal-length
+constraint tied to the player's message. This failed to model the implicit
+conversational norm of message-length convergence.
+
+**Fix (#866):** Replaced the static length sentence in
+`data/prompts/templates.yaml` → `opponent-response-instruction` with a
+`{length_hint}` placeholder. `SessionDocumentBuilder.BuildOpponentPrompt`
+computes `ceiling = min(600, max(playerLen × 2, 80))`, constructs a two-part
+hint ("Aim for roughly N characters... Do not exceed M characters..."), and
+injects it. Both `AnthropicLlmAdapter` and `OpenAiLlmAdapter` post-validate
+the LLM response length against `1.2 × ceiling` and log a `Console.Error`
+warning when exceeded (warn-only phase 1; no retry). The slop factor (20%)
+avoids noise from minor off-by-a-few-char cases. The 600-char absolute
+ceiling prevents essays regardless of player message length.
+
+**Rule:** Opponent response length must be reciprocally bounded to the
+player's message length with an absolute ceiling. The formula lives in
+`SessionDocumentBuilder.ComputeResponseCeiling` — any future tuning of the
+ceiling, floor, or multiplier should touch only that method. The
+`{length_hint}` placeholder in the prompt template is the inject point; the
+post-LLM warning is the observability hook.
+
+**Adjacent rule:** If the warn-only approach proves insufficient in
+production (frequent warnings), escalate to phase 2 (retry with
+length-clamped re-prompt) in a follow-up ticket. Do not silently add retry
+in a drive-by — it changes latency characteristics and should be tracked as
+a separate issue.
+
+**Discovered in:** #866 (2026-05-14). Full design discussion in the issue
+body; the chosen option (b) relative-window + 600-char-ceiling was resolved
+by the ticket-refiner agent. See also the 707fca72 session log that
+motivated the ticket.
+

--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -262,7 +262,8 @@ prompts:
       - React authentically to what was just said
       - If Interest dropped: show cooling without being melodramatic
       - If Interest rose: show warming without being gushing
-      - Match the register exactly as established in your system prompt above. Length follows your character's texting style — one word, one sentence, several short fragments, or one long run-on thought, whichever your texting-style block calls for.
+      - Match the register exactly as established in your system prompt above.
+      - {length_hint}
       
       Output format:
       Output your actual message text directly. Do not wrap it in quotes or [RESPONSE] tags.

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -219,6 +219,17 @@ namespace Pinder.LlmAdapters.Anthropic
                 assistantTextForHistory = responseText ?? string.Empty;
             }
 
+            // #866: post-LLM length validation (warn-only phase 1 — no retry)
+            int playerLen = context.PlayerDeliveredMessage.Length;
+            int ceiling = SessionDocumentBuilder.ComputeResponseCeiling(playerLen);
+            double slopCeiling = 1.2 * ceiling;
+            if (parsed.MessageText != null && parsed.MessageText.Length > slopCeiling)
+            {
+                Console.Error.WriteLine(
+                    $"[WARN] Opponent response over length ceiling (slop ceiling={slopCeiling:F0}): " +
+                    $"playerLen={playerLen} ceiling={ceiling} responseLen={parsed.MessageText.Length} character={context.OpponentName}");
+            }
+
             var newEntries = new ConversationMessage[]
             {
                 ConversationMessage.User(userContent),

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -138,6 +138,17 @@ namespace Pinder.LlmAdapters.OpenAi
             var responseText = await _client.SendChatCompletionAsync(requestJson, cancellationToken).ConfigureAwait(false);
             var parsed = ParseOpponentResponse(responseText);
 
+            // #866: post-LLM length validation (warn-only phase 1 — no retry)
+            int playerLen = context.PlayerDeliveredMessage.Length;
+            int ceiling = SessionDocumentBuilder.ComputeResponseCeiling(playerLen);
+            double slopCeiling = 1.2 * ceiling;
+            if (parsed.MessageText != null && parsed.MessageText.Length > slopCeiling)
+            {
+                Console.Error.WriteLine(
+                    $"[WARN] Opponent response over length ceiling (slop ceiling={slopCeiling:F0}): " +
+                    $"playerLen={playerLen} ceiling={ceiling} responseLen={parsed.MessageText.Length} character={context.OpponentName}");
+            }
+
             var newEntries = new ConversationMessage[]
             {
                 ConversationMessage.User(userContent),

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -385,10 +385,29 @@ namespace Pinder.LlmAdapters
             sb.AppendLine();
 
             string resistanceBlock = GetResistanceBlock(context.InterestAfter);
+
+            // #866: compute reciprocal length ceiling and inject length hint
+            int playerLen = context.PlayerDeliveredMessage.Length;
+            int ceiling = ComputeResponseCeiling(playerLen);
+            string lengthHint = $"Aim for roughly {playerLen} characters (matching the player's message length). " +
+                $"Do not exceed {ceiling} characters regardless of your texting style.";
+
             sb.Append(PromptTemplates.OpponentResponseInstruction
-                .Replace("{resistance_block}", resistanceBlock));
+                .Replace("{resistance_block}", resistanceBlock)
+                .Replace("{length_hint}", lengthHint));
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Computes the opponent response length ceiling from the player's message length.
+        /// Formula: ceiling = min(600, max(playerLen × 2, 80)).
+        /// #866: reciprocal length budget — opponent response shouldn't be wildly longer
+        /// than the player's message.
+        /// </summary>
+        public static int ComputeResponseCeiling(int playerMessageLength)
+        {
+            return Math.Min(600, Math.Max(playerMessageLength * 2, 80));
         }
 
         /// <summary>

--- a/tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Tests for Issue #866: opponent response length cap (relative window + 600-char ceiling).
+    /// Four prompt-injection tests verify the length hint is injected correctly across
+    /// the formula's boundary cases. One formula test verifies ComputeResponseCeiling at
+    /// the boundary values and the regression scenario from session 707fca72.
+    /// </summary>
+    public class Issue866_OpponentLengthCapTests
+    {
+        // ── Helpers ──
+
+        private static OpponentContext MakeOpponentContext(string playerDeliveredMessage)
+        {
+            return new OpponentContext(
+                playerPrompt: "player system prompt",
+                opponentPrompt: "opponent system prompt",
+                conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
+                opponentLastMessage: "hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 15,
+                playerDeliveredMessage: playerDeliveredMessage,
+                interestBefore: 14,
+                interestAfter: 15,
+                responseDelayMinutes: 2.0,
+                playerName: "Velvet",
+                opponentName: "Sable");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // AC1: playerLen=200 → ceiling = min(600, max(400, 80)) = 400
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OpponentPrompt_200CharPlayer_HasCeiling400()
+        {
+            var msg = new string('x', 200);
+            var ctx = MakeOpponentContext(msg);
+            var prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("400 characters", prompt);
+            Assert.Contains("200 characters", prompt);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // AC2: playerLen=1 → ceiling = min(600, max(2, 80)) = 80 (floor)
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OpponentPrompt_1CharPlayer_HasFloor80()
+        {
+            var msg = "x"; // 1 char
+            var ctx = MakeOpponentContext(msg);
+            var prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("80 characters", prompt);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // AC3: playerLen=500 → ceiling = min(600, max(1000, 80)) = 600 (cap)
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OpponentPrompt_500CharPlayer_HasCap600()
+        {
+            var msg = new string('y', 500);
+            var ctx = MakeOpponentContext(msg);
+            var prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("600 characters", prompt);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // AC4: Regression — 707fca72 scenario (1054-char player → cap 600)
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OpponentPrompt_RegressionScenario_1054CharPlayer_HasCap600()
+        {
+            var msg = new string('z', 1054);
+            var ctx = MakeOpponentContext(msg);
+            var prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
+
+            Assert.Contains("600 characters", prompt);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        // AC5: ComputeResponseCeiling — formula boundaries + regression
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void ComputeResponseCeiling_BoundaryValues()
+        {
+            // Floor: 1-char player → 80
+            Assert.Equal(80, SessionDocumentBuilder.ComputeResponseCeiling(1));
+            Assert.Equal(80, SessionDocumentBuilder.ComputeResponseCeiling(39)); // 39×2=78 < 80
+            Assert.Equal(80, SessionDocumentBuilder.ComputeResponseCeiling(40)); // 40×2=80 = floor
+
+            // Window: playerLen × 2
+            Assert.Equal(100, SessionDocumentBuilder.ComputeResponseCeiling(50));
+            Assert.Equal(200, SessionDocumentBuilder.ComputeResponseCeiling(100));
+            Assert.Equal(400, SessionDocumentBuilder.ComputeResponseCeiling(200));
+
+            // Cap: 600
+            Assert.Equal(600, SessionDocumentBuilder.ComputeResponseCeiling(300)); // 300×2=600
+            Assert.Equal(600, SessionDocumentBuilder.ComputeResponseCeiling(500)); // 500×2=1000 → capped
+            Assert.Equal(600, SessionDocumentBuilder.ComputeResponseCeiling(1054)); // 707fca72 scenario
+            Assert.Equal(600, SessionDocumentBuilder.ComputeResponseCeiling(5000)); // extreme
+        }
+    }
+}


### PR DESCRIPTION
Closes #866

Adds reciprocal length budget to opponent responses:
- `ceiling = min(600, max(playerLen × 2, 80))`
- Prompt injection via `{length_hint}` placeholder in `opponent-response-instruction`
- Warn-only post-LLM validation at 1.2× ceiling (no retry — phase 1)
- 5 unit tests pin the formula at floor / window / cap boundaries plus the 707fca72 regression scenario
- LESSONS_LEARNED gains an OPPONENT-LENGTH-RECIPROCITY entry

**Files changed:**
- `data/prompts/templates.yaml` — replaced static length sentence with `{length_hint}` placeholder
- `src/Pinder.LlmAdapters/SessionDocumentBuilder.cs` — computes ceiling + injects length hint + adds `ComputeResponseCeiling()`
- `src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs` — post-LLM length warning
- `src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs` — post-LLM length warning
- `tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs` — 5 unit tests
- `LESSONS_LEARNED.md` — OPPONENT-LENGTH-RECIPROCITY lesson