### PR TITLE
fix(#869): opponent texting-style parity (closes #869)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -487,3 +487,46 @@ remove it from the method whose role doesn't match.
 **Discovered in:** #867 (2026-05-14). Token audit of session `707fca72`
 cosmetic phase prompted by the refiner agent.
 
+
+## PROMPT-ENFORCEMENT-PARITY
+
+When a discipline rule lands on one LLM surface, apply it
+symmetrically to every other surface in the same conversational
+direction.
+
+**Symptom:** `DialogueOptionsInstruction` (player options surface)
+included a `WORD & PATTERN REPETITION` block + a self-check
+verify-then-rewrite step. `OpponentResponseInstruction` had neither.
+Production opponent messages drifted into repeating fillers
+("honestly", "literally", "okay but", "interesting that"), emoji,
+and structural patterns across multi-turn sessions because the
+freshness discipline was player-only.
+
+**Rule:** A prompt-discipline rule that ships for one role's LLM
+call must be ported to the equivalent surface for the other role
+(or any other surface that produces text in the same conversational
+direction). The two main pairs in Pinder:
+
+- Player options ↔ opponent response: both produce conversational
+  turns in the same direction (player→opponent for the player's
+  intended text, opponent→player for the response). Repetition,
+  voice, and register rules apply to both symmetrically.
+- Player delivery rewrite ↔ shadow corruption ↔ horniness overlay:
+  all three transform a player message in-place. Length, structural
+  fidelity, and word-soup-prevention rules apply to all three.
+
+**Detection rule:** when a new prompt-discipline rule is added,
+review every other prompt that produces text in the same direction.
+File a parity ticket if any surface is missing the rule. The opposite
+direction (e.g. opponent → player) is a separate audit — voice bleed
+and resistance rules are direction-specific.
+
+**Fix (#869):** Ported `WORD & PATTERN REPETITION` + self-check
+verify-then-rewrite from `dialogue-options-instruction` to
+`opponent-response-instruction` in `data/prompts/templates.yaml`,
+adapted to "your own previous 2 messages" framing.
+
+**Discovered in:** #869 (2026-05-14). Originally identified in the
+2026-05-09 prompt-engineering audit (pinder · planning thread) but
+not filed as a ticket until session `707fca72` showed repeat fillers
+in prod.

--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -257,6 +257,8 @@ prompts:
       - Below Interest 25: you may express interest, warmth, or curiosity, but NEVER commit to a specific time, place, or logistics. "We should get coffee sometime" is fine. "Coffee shop on Fifth at 6pm Tuesday" is NOT.
       - At Interest 25: the date is now real. You may suggest a specific venue or time that fits your character.
       
+      WORD & PATTERN REPETITION — check your own previous messages in the conversation above before writing this one. Do not repeat: (a) the same filler words or phrases you used in your previous 2 messages ('honestly', 'literally', 'actually', 'okay but', 'interesting that', 'slay', 'omg', etc.), (b) the same emoji you used in your previous message, (c) the same structural pattern (e.g. 'wait...???', 'omg...😭', 'I literally just realized...', 'interesting that you mention...') used in your last 2 messages. Each message should feel like a fresh move, not a variation on the last one.
+      
       Generate your next message.
       - Match your personality exactly as established in the system prompt
       - React authentically to what was just said
@@ -264,6 +266,8 @@ prompts:
       - If Interest rose: show warming without being gushing
       - Match the register exactly as established in your system prompt above.
       - {length_hint}
+      
+      Before sending: verify your message sounds exactly like the texting style established in your system prompt above. Verify you haven't reused fillers, emoji, or structural patterns from your last 2 messages. If either check fails, rewrite.
       
       Output format:
       Output your actual message text directly. Do not wrap it in quotes or [RESPONSE] tags.

--- a/tests/Pinder.LlmAdapters.Tests/Issue869_OpponentRepetitionGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue869_OpponentRepetitionGuardTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Pinder.LlmAdapters;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #869: porting the WORD & PATTERN REPETITION block + self-check
+    /// from <c>dialogue-options-instruction</c> to
+    /// <c>opponent-response-instruction</c>. These tests pin the prompt
+    /// contract so future yaml edits can't silently regress the parity.
+    /// </summary>
+    public class Issue869_OpponentRepetitionGuardTests
+    {
+        // Walks up from the test binary's BaseDirectory looking for
+        // data/prompts so the catalog can be loaded in test runs.
+        private static string FindPromptsRoot()
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null)
+            {
+                string candidate = Path.Combine(dir, "data", "prompts");
+                if (Directory.Exists(candidate)) return Path.GetFullPath(candidate);
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            throw new DirectoryNotFoundException(
+                "Could not locate data/prompts in any ancestor of the test binary.");
+        }
+
+        private static string LoadOpponentResponsePrompt()
+        {
+            var catalog = PromptCatalog.LoadFromDirectory(FindPromptsRoot());
+            var entry = catalog.Get("opponent-response-instruction");
+            return entry.SystemPrompt ?? string.Empty;
+        }
+
+        [Fact]
+        public void OpponentResponseInstruction_ContainsRepetitionGuard()
+        {
+            var prompt = LoadOpponentResponsePrompt();
+
+            Assert.Contains("WORD & PATTERN REPETITION", prompt);
+            Assert.Contains("fresh move", prompt);
+            // The opponent path checks the opponent's OWN previous messages,
+            // not the full conversation above (which is the player-side framing).
+            Assert.Contains("your own previous messages", prompt);
+        }
+
+        [Fact]
+        public void OpponentResponseInstruction_ContainsSelfCheck()
+        {
+            var prompt = LoadOpponentResponsePrompt();
+
+            Assert.Contains("Before sending: verify", prompt);
+            Assert.Contains("rewrite", prompt);
+        }
+
+        [Fact]
+        public void OpponentResponseInstruction_RepetitionGuard_ListsCommonFillers()
+        {
+            // Pin the specific fillers called out in the refined ticket
+            // so reviewers can confirm the wording survives future edits.
+            var prompt = LoadOpponentResponsePrompt();
+
+            Assert.Contains("honestly", prompt);
+            Assert.Contains("literally", prompt);
+            Assert.Contains("okay but", prompt);
+            Assert.Contains("interesting that", prompt);
+        }
+    }
+}


### PR DESCRIPTION
Closes #869

Ports WORD & PATTERN REPETITION block + self-check verify-then-rewrite step from `dialogue-options-instruction` to `opponent-response-instruction` in `data/prompts/templates.yaml`. Closes the player↔opponent prompt-discipline asymmetry identified in the 2026-05-09 audit.

LESSONS_LEARNED gains PROMPT-ENFORCEMENT-PARITY rule.

3 regression tests pin the new clauses.