### PR TITLE
feat(i18n): add turn_result.nat20_explainer and nat1_explainer keys (pinder-web#595)

### DIFF
--- a/data/i18n/en/ui-turn-result.yaml
+++ b/data/i18n/en/ui-turn-result.yaml
@@ -51,3 +51,6 @@ strings:
   turn_result.trap_cleared_prefix: "🛡️ Trap cleared:"
   turn_result.trap_activated_legacy: "🪤 Trap activated: {name}"
   turn_result.active_trap_prefix: "🪤 Active trap:"
+
+  turn_result.nat20_explainer: "🎲 NAT 20 — automatic crit success. Grants advantage on the next roll."
+  turn_result.nat1_explainer: "🎲 NAT 1 — automatic miss (regardless of total)"


### PR DESCRIPTION
Companion to pinder-web#602 (closes pinder-web#595 — strip internal `#271` issue ref from player-visible NAT 20 explainer + move both nat strings to i18n).

This PR adds two new i18n keys to `data/i18n/en/ui-turn-result.yaml`:
- `turn_result.nat20_explainer` — clean copy, no issue ref
- `turn_result.nat1_explainer` — companion for symmetry

The pinder-web PR consumes these keys via `t()`.

## Merge order

1. Merge this PR first.
2. pinder-web#602 bumps the submodule pointer to this PR's merge commit and merges.

## DoD

- Keys exist in YAML source-of-truth.
- pinder-web build with this submodule pointer succeeds (verified in pinder-web#602 build evidence).

No code or test changes inside pinder-core — pure data addition.