### PR TITLE
fix/901 RollEngine unification (Phase 1 additive)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -682,3 +682,32 @@ saying "horniness before shadow" anywhere, that is stale and must be updated.
 - `docs/ARCHITECTURE.md` steps 10, 10a, 10b, 10c.
 
 **Discovered in:** #899 (2026-05-16).
+
+### ALL-DICE-CHECKS-THROUGH-ROLLENGINE-RESOLVECHECK
+
+**Title:** All dice checks go through RollEngine.ResolveCheck
+
+The tier ladder lives in `FailureTierLadder.FromMissMargin`. Do not
+re-implement either. New check kinds add a value to `RollCheckKind`
+and route through `ResolveCheck` — no bespoke d20 + ladder code
+outside `Pinder.Core/Rolls/`.
+
+**Rule:** If a new game mechanic needs a d20 vs DC resolution:
+1. Add a value to `RollCheckKind`.
+2. Call `RollEngine.ResolveCheck(kind, dice, modifiers, dc)`.
+3. Attach the returned `RollCheckResult` as a `Check` property on the mechanic's
+   result wrapper.
+4. Do NOT write `_rng.Next(1, 21)` or `if (miss <= 2)` anywhere else.
+
+**Engines that share the steering RNG** (must keep sharing to preserve dice
+consumption order): `SteeringEngine`, `HorninessEngine`, `ShadowCheckEngine`.
+All three are initialised from the same `steeringRng` in `GameSession`'s
+constructor and clone constructors.
+
+**Anchors:**
+- `src/Pinder.Core/Rolls/RollEngine.cs` — `ResolveCheck` method.
+- `src/Pinder.Core/Rolls/FailureTierLadder.cs` — sole tier ladder.
+- `src/Pinder.Core/Conversation/ShadowCheckEngine.cs` — extracted shadow check.
+- `tests/Pinder.Core.Tests/Rolls/TierLadderAuditTest.cs` — audit gate.
+
+**Discovered in:** #901 (2026-05-16).

--- a/docs/specs/issue-901-rollengine-unification.md
+++ b/docs/specs/issue-901-rollengine-unification.md
@@ -1,0 +1,119 @@
+# issue-901: RollEngine Unification (Phase 1 — Additive)
+
+## Problem
+
+Four dice-check flows in `pinder-core` each re-implemented the same primitive
+(d20 + modifiers vs DC → tier from miss margin) independently:
+
+| Flow | Location | Issues |
+|---|---|---|
+| Main option roll | `RollEngine.Resolve` / `ResolveFixedDC` | Inline `<=2/<=5/<=9` ladder |
+| Horniness | `HorninessEngine.PeekAsync` + `DetermineHorninessTier` | Duplicate ladder |
+| Shadow | Inline in `GameSession.cs:~1589` | Cross-called `HorninessEngine.DetermineHorninessTier` |
+| Steering | `SteeringEngine.AttemptSteeringRollAsync` | Own d20 roll, no tier |
+
+## New Canonical Abstractions
+
+### `RollCheckKind` (enum)
+
+```
+OptionRoll  — main attacker roll
+Steering    — opponent steering
+Horniness   — session-horniness overlay check
+Shadow      — paired-shadow check
+ShadowGrowth — reserved; ShadowGrowthEvaluator uses no standalone d20
+```
+
+### `NamedModifier` (readonly struct)
+
+```csharp
+public readonly struct NamedModifier(string Key, int Value);
+```
+
+Modifier `Key` is a stable machine-readable token (`"stat"`, `"level"`,
+`"steering"`, `"tell"`, `"callback"`). Zero-value entries are kept.
+
+### `RollCheckResult` (sealed class)
+
+| Field | Type | Notes |
+|---|---|---|
+| `Kind` | `RollCheckKind` | |
+| `DieRoll` | `int` | Always the first die rolled |
+| `SecondDieRoll` | `int?` | Populated for advantage/disadvantage |
+| `UsedDieRoll` | `int` | After advantage/disadvantage selection |
+| `Modifiers` | `IReadOnlyList<NamedModifier>` | As-given bag |
+| `ModifierSum` | `int` | Sum of all values in bag |
+| `Total` | `int` | `UsedDieRoll + ModifierSum` |
+| `Dc` | `int` | DC the roll faced |
+| `IsSuccess` | `bool` | `Total >= Dc` |
+| `IsNatOne` | `bool` | Informational — does NOT force Legendary here |
+| `IsNatTwenty` | `bool` | Informational |
+| `Tier` | `FailureTier` | From `FailureTierLadder.FromMissMargin` only |
+| `MissMargin` | `int` | `0` on success |
+
+**Important:** `RollCheckResult.Tier` never contains `FailureTier.Legendary`.
+The `Legendary` tier is a game-rule override (nat-1 on the main option-roll)
+handled by `RollEngine.ResolveFromComponents`, not by the check result.
+
+### `FailureTierLadder.FromMissMargin`
+
+```
+missMargin <= 0  → None         (success)
+missMargin <= 2  → Fumble
+missMargin <= 5  → Misfire
+missMargin <= 6  → TropeTrap
+missMargin <= 9  → TropeTrap
+else             → Catastrophe
+```
+
+**Single source of truth.** No other file in `Pinder.Core` may contain an
+inline `missMargin <= N` comparison. Audit gate: `TierLadderAuditTest`.
+
+### `RollEngine.ResolveCheck`
+
+```csharp
+public static RollCheckResult ResolveCheck(
+    RollCheckKind kind,
+    IDiceRoller dice,
+    IReadOnlyList<NamedModifier> modifiers,
+    int dc,
+    bool hasAdvantage = false,
+    bool hasDisadvantage = false);
+```
+
+Single entry point for all d20 checks. Handles advantage/disadvantage,
+modifier-bag summation, and tier computation via `FailureTierLadder`.
+
+### `ShadowCheckEngine`
+
+Extracted from the inline logic at `GameSession.cs:~1589`. Uses the same
+`Random` instance as `SteeringEngine` and `HorninessEngine` (shared RNG —
+no dice consumption change).
+
+## Per-Check Wrapper Changes
+
+Each wrapper gains a `Check: RollCheckResult?` property (null for sentinel
+values like `NotPerformed` / `NotAttempted`). Bespoke fields remain unchanged.
+
+| Wrapper | New property | Bespoke fields retained |
+|---|---|---|
+| `RollResult` | `Check` | `DieRoll`, `StatModifier`, `LevelBonus`, `Total`, `DC`, `IsSuccess`, `Tier`, `IsNatOne`, `IsNatTwenty` |
+| `HorninessCheckResult` | `Check` | `Roll`, `Modifier`, `Total`, `DC`, `IsMiss`, `Tier`, `OverlayApplied` |
+| `SteeringRollResult` | `Check` | `SteeringRoll`, `SteeringMod`, `SteeringDC`, `SteeringSucceeded` |
+| `ShadowCheckResult` | `Check` | `Roll`, `DC`, `IsMiss`, `Tier`, `OverlayApplied` |
+
+## Migration Plan
+
+**Phase 1 (this PR):** Additive. All wire DTOs unchanged. Snapshots byte-identical.
+
+**Phase 2 (separate ticket):** GameApi serializes `Check` on each check DTO.
+Wire-phase: existing bespoke duplicate fields begin pointing to `Check.*`.
+
+**Phase 3 (separate ticket):** Delete bespoke duplicate fields on the wrappers.
+Schema bump via `asset_kind` discriminator if needed.
+
+## Invariant
+
+> All dice checks go through `RollEngine.ResolveCheck`.
+> The tier ladder lives in `FailureTierLadder.FromMissMargin`.
+> No new check kind may roll its own d20 or re-implement the ladder inline.

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -126,6 +126,7 @@ namespace Pinder.Core.Conversation
         private ShadowGrowthEvaluator? _shadowGrowthEvaluator;
         private SessionXpRecorder _xpRecorder;
         private SteeringEngine _steeringEngine;
+        private ShadowCheckEngine _shadowCheckEngine;
         private HorninessEngine _horninessEngine;
         // Dedicated RNG for OptionFilterEngine.DrawRandomStats. Kept separate from
         // the steering RNG so tests can queue exact steering values without our
@@ -216,6 +217,7 @@ namespace Pinder.Core.Conversation
             _xpRecorder = new SessionXpRecorder(_xpLedger, _rules);
             _steeringEngine = new SteeringEngine(steeringRng);
             _horninessEngine = new HorninessEngine(steeringRng);
+            _shadowCheckEngine = new ShadowCheckEngine(steeringRng);
 
             // #788: stateful opponent context now lives on this GameSession
             // (_opponentHistory). The adapter is pure-stateless and is fed the
@@ -312,6 +314,7 @@ namespace Pinder.Core.Conversation
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
             _horninessEngine = new HorninessEngine(clonedSteeringRng);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             // ── Value-type / per-turn carry-over fields (Category A) ──
@@ -475,6 +478,7 @@ namespace Pinder.Core.Conversation
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
             _horninessEngine = new HorninessEngine(clonedSteeringRng);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             // Value-type / per-turn carry-over.
@@ -1586,14 +1590,15 @@ namespace Pinder.Core.Conversation
                 int shadowValue = _playerShadows.GetEffectiveShadow(pairedShadow.Value);
                 if (shadowValue > 0)
                 {
-                    int shadowRoll = _steeringEngine.RollD20(); // use steering rng so it doesn't consume game dice
-                    int shadowDC = 20 - shadowValue;
-                    bool shadowMiss = shadowRoll < shadowDC;
+                    // #901: extracted into ShadowCheckEngine (dice consumption unchanged).
+                    var rawShadowResult = _shadowCheckEngine.Check(pairedShadow.Value, shadowValue);
+                    int shadowRoll = rawShadowResult.Roll;
+                    int shadowDC   = rawShadowResult.DC;
+                    bool shadowMiss = rawShadowResult.IsMiss;
 
                     if (shadowMiss)
                     {
-                        int missMargin = shadowDC - shadowRoll;
-                        FailureTier shadowTier = FailureTierLadder.FromMissMargin(missMargin); // #901
+                        FailureTier shadowTier = rawShadowResult.Tier;
                         string? corruptionInstruction = HorninessEngine.GetShadowCorruptionInstruction(
                             _statDeliveryInstructions, pairedShadow.Value, shadowTier);
 
@@ -1659,13 +1664,16 @@ namespace Pinder.Core.Conversation
                             overlayApplied = true;
                         }
 
+                        // Re-construct with overlayApplied filled in; attach canonical Check from engine.
                         shadowCheckResult = new ShadowCheckResult(
-                            true, pairedShadow.Value, shadowRoll, shadowDC, true, shadowTier, overlayApplied);
+                            true, pairedShadow.Value, shadowRoll, shadowDC, true, shadowTier, overlayApplied,
+                            rawShadowResult.Check);
                     }
                     else
                     {
                         shadowCheckResult = new ShadowCheckResult(
-                            true, pairedShadow.Value, shadowRoll, shadowDC, false, FailureTier.None, false);
+                            true, pairedShadow.Value, shadowRoll, shadowDC, false, FailureTier.None, false,
+                            rawShadowResult.Check);
                     }
                 }
             }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -1593,7 +1593,7 @@ namespace Pinder.Core.Conversation
                     if (shadowMiss)
                     {
                         int missMargin = shadowDC - shadowRoll;
-                        FailureTier shadowTier = HorninessEngine.DetermineHorninessTier(missMargin);
+                        FailureTier shadowTier = FailureTierLadder.FromMissMargin(missMargin); // #901
                         string? corruptionInstruction = HorninessEngine.GetShadowCorruptionInstruction(
                             _statDeliveryInstructions, pairedShadow.Value, shadowTier);
 

--- a/src/Pinder.Core/Conversation/HorninessCheckResult.cs
+++ b/src/Pinder.Core/Conversation/HorninessCheckResult.cs
@@ -28,7 +28,18 @@ namespace Pinder.Core.Conversation
         /// <summary>Whether an overlay was actually applied (miss + instruction found + shadows present).</summary>
         public bool OverlayApplied { get; }
 
-        public HorninessCheckResult(int roll, int modifier, int total, int dc, bool isMiss, FailureTier tier, bool overlayApplied)
+        /// <summary>
+        /// Canonical check result from <see cref="RollEngine.ResolveCheck"/>.
+        /// Phase 1 (additive): attached alongside existing bespoke fields.
+        /// Phase 2 will replace the bespoke duplicate fields with <c>Check.*</c> projections.
+        /// Null only for the <see cref="NotPerformed"/> sentinel.
+        /// </summary>
+        public RollCheckResult? Check { get; }
+
+        public HorninessCheckResult(
+            int roll, int modifier, int total, int dc,
+            bool isMiss, FailureTier tier, bool overlayApplied,
+            RollCheckResult? check = null)
         {
             Roll = roll;
             Modifier = modifier;
@@ -37,6 +48,7 @@ namespace Pinder.Core.Conversation
             IsMiss = isMiss;
             Tier = tier;
             OverlayApplied = overlayApplied;
+            Check = check;
         }
 
         /// <summary>A result for when no check was performed (sessionHorniness = 0 or no shadows).</summary>

--- a/src/Pinder.Core/Conversation/HorninessEngine.cs
+++ b/src/Pinder.Core/Conversation/HorninessEngine.cs
@@ -60,40 +60,32 @@ namespace Pinder.Core.Conversation
             if (sessionHorniness <= 0 || playerShadows == null)
                 return (HorninessCheckResult.NotPerformed, null);
 
-            int horninessRoll = _rng.Next(1, 21);
-            int horninessModifier = 0;
-            int horninessTotal = horninessRoll + horninessModifier;
             int horninessDC = 20 - sessionHorniness;
-            bool horninessMiss = horninessTotal < horninessDC;
+            // #901: route through single entry point — dice consumption is identical (one Roll(20))
+            var check = RollEngine.ResolveCheck(
+                RollCheckKind.Horniness,
+                new RandomDiceRollerAdapter(_rng),
+                System.Array.Empty<NamedModifier>(),
+                horninessDC);
+
+            bool horninessMiss = !check.IsSuccess;
 
             if (!horninessMiss)
             {
                 return (new HorninessCheckResult(
-                    horninessRoll, horninessModifier, horninessTotal, horninessDC,
-                    false, FailureTier.None, false), null);
+                    check.DieRoll, 0, check.Total, horninessDC,
+                    false, FailureTier.None, false, check), null);
             }
 
-            int missMargin = horninessDC - horninessTotal;
-            FailureTier horninessTier = DetermineHorninessTier(missMargin);
+            FailureTier horninessTier = check.Tier;
             string? overlayInstruction = GetHorninessOverlayInstruction(statDeliveryInstructions, horninessTier);
 
             bool overlayApplied = overlayInstruction != null;
             return (new HorninessCheckResult(
-                horninessRoll, horninessModifier, horninessTotal, horninessDC,
-                true, horninessTier, overlayApplied), overlayInstruction);
+                check.DieRoll, 0, check.Total, horninessDC,
+                true, horninessTier, overlayApplied, check), overlayInstruction);
         }
-
-        /// <summary>
-        /// Determines the horniness overlay failure tier from miss margin.
-        /// Uses same thresholds as normal failure tiers.
-        /// </summary>
-        internal static FailureTier DetermineHorninessTier(int missMargin)
-        {
-            if (missMargin <= 2) return FailureTier.Fumble;
-            if (missMargin <= 5) return FailureTier.Misfire;
-            if (missMargin <= 9) return FailureTier.TropeTrap;
-            return FailureTier.Catastrophe;
-        }
+        // DetermineHorninessTier deleted — #901: use FailureTierLadder.FromMissMargin instead.
 
         /// <summary>
         /// Retrieves the horniness overlay instruction from the stat delivery instructions.

--- a/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
+++ b/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
@@ -1,0 +1,58 @@
+using System;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Handles the per-turn paired-shadow d20 check.
+    /// Extracted from the inline logic in <c>GameSession.cs</c> as part of #901.
+    /// Uses the same RNG instance as <see cref="SteeringEngine"/> and
+    /// <see cref="HorninessEngine"/> so dice consumption is unchanged.
+    /// </summary>
+    internal sealed class ShadowCheckEngine
+    {
+        private readonly Random _rng;
+
+        public ShadowCheckEngine(Random rng)
+        {
+            _rng = rng ?? throw new ArgumentNullException(nameof(rng));
+        }
+
+        /// <summary>
+        /// Performs the shadow d20 check for a given shadow type and value.
+        /// Returns a <see cref="ShadowCheckResult"/> with <c>OverlayApplied = false</c>
+        /// (the caller is responsible for applying the LLM overlay and updating that flag
+        /// by constructing a new result if needed).
+        /// Returns <see cref="ShadowCheckResult.NotPerformed"/> when <paramref name="shadowValue"/> &lt;= 0.
+        /// </summary>
+        public ShadowCheckResult Check(ShadowStatType shadow, int shadowValue)
+        {
+            if (shadowValue <= 0)
+                return ShadowCheckResult.NotPerformed;
+
+            int shadowDC = 20 - shadowValue;
+
+            // #901: route through single entry point.
+            // Dice consumption: one Roll(20) — identical to old _steeringEngine.RollD20().
+            var check = RollEngine.ResolveCheck(
+                RollCheckKind.Shadow,
+                new RandomDiceRollerAdapter(_rng),
+                System.Array.Empty<NamedModifier>(),
+                shadowDC);
+
+            bool isMiss = !check.IsSuccess;
+            FailureTier tier = isMiss ? check.Tier : FailureTier.None;
+
+            return new ShadowCheckResult(
+                checkPerformed: true,
+                shadow:         shadow,
+                roll:           check.DieRoll,
+                dc:             shadowDC,
+                isMiss:         isMiss,
+                tier:           tier,
+                overlayApplied: false,
+                check:          check);
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/ShadowCheckResult.cs
+++ b/src/Pinder.Core/Conversation/ShadowCheckResult.cs
@@ -34,6 +34,13 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public bool OverlayApplied { get; }
 
+        /// <summary>
+        /// Canonical check result from <see cref="RollEngine.ResolveCheck"/>.
+        /// Phase 1 (additive): attached alongside existing bespoke fields.
+        /// Null only for the <see cref="NotPerformed"/> sentinel.
+        /// </summary>
+        public RollCheckResult? Check { get; }
+
         public ShadowCheckResult(
             bool checkPerformed,
             ShadowStatType shadow,
@@ -41,7 +48,8 @@ namespace Pinder.Core.Conversation
             int dc,
             bool isMiss,
             FailureTier tier,
-            bool overlayApplied)
+            bool overlayApplied,
+            RollCheckResult? check = null)
         {
             CheckPerformed = checkPerformed;
             Shadow = shadow;
@@ -50,6 +58,7 @@ namespace Pinder.Core.Conversation
             IsMiss = isMiss;
             Tier = tier;
             OverlayApplied = overlayApplied;
+            Check = check;
         }
 
         /// <summary>A sentinel value representing "no shadow check was performed this turn".</summary>

--- a/src/Pinder.Core/Conversation/SteeringEngine.cs
+++ b/src/Pinder.Core/Conversation/SteeringEngine.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
 using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
@@ -71,11 +72,19 @@ namespace Pinder.Core.Conversation
             int opponentHonesty = opponent.Stats.GetEffective(StatType.Honesty);
             int steeringDC = 16 + (opponentSA + opponentRizz + opponentHonesty) / 3;
 
-            // Roll d20 using a separate RNG.
-            int roll = _steeringRng.Next(1, 21);
+            // #901: route through single entry point.
+            // Modifier bag: one named entry for the composite steering modifier.
+            // Dice consumption: one Roll(20) with no adv/dis — identical to old _steeringRng.Next(1,21).
+            var checkModifiers = new NamedModifier[] { new NamedModifier("steering", steeringMod) };
+            var check = RollEngine.ResolveCheck(
+                RollCheckKind.Steering,
+                new RandomDiceRollerAdapter(_steeringRng),
+                checkModifiers,
+                steeringDC);
 
-            int total = roll + steeringMod;
-            bool success = total >= steeringDC;
+            int roll = check.DieRoll;
+            int total = check.Total;
+            bool success = check.IsSuccess;
 
             string? steeringQuestion = null;
             if (success && llm is IStatefulLlmAdapter stateful)
@@ -117,7 +126,8 @@ namespace Pinder.Core.Conversation
                 steeringRoll: roll,
                 steeringMod: steeringMod,
                 steeringDC: steeringDC,
-                steeringQuestion: steeringQuestion);
+                steeringQuestion: steeringQuestion,
+                check: check);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/SteeringRollResult.cs
+++ b/src/Pinder.Core/Conversation/SteeringRollResult.cs
@@ -24,13 +24,22 @@ namespace Pinder.Core.Conversation
         /// <summary>The steering question text, or null if the roll failed.</summary>
         public string SteeringQuestion { get; }
 
+        /// <summary>
+        /// Canonical check result from <see cref="RollEngine.ResolveCheck"/>.
+        /// Captures the raw roll before LLM success/failure affects <see cref="SteeringSucceeded"/>.
+        /// Phase 1 (additive): attached alongside existing bespoke fields.
+        /// Null only for the <see cref="NotAttempted"/> sentinel.
+        /// </summary>
+        public Pinder.Core.Rolls.RollCheckResult? Check { get; }
+
         public SteeringRollResult(
             bool steeringAttempted,
             bool steeringSucceeded,
             int steeringRoll,
             int steeringMod,
             int steeringDC,
-            string steeringQuestion)
+            string steeringQuestion,
+            Pinder.Core.Rolls.RollCheckResult? check = null)
         {
             SteeringAttempted = steeringAttempted;
             SteeringSucceeded = steeringSucceeded;
@@ -38,6 +47,7 @@ namespace Pinder.Core.Conversation
             SteeringMod = steeringMod;
             SteeringDC = steeringDC;
             SteeringQuestion = steeringQuestion;
+            Check = check;
         }
 
         /// <summary>A no-op result when steering was not attempted.</summary>

--- a/src/Pinder.Core/Rolls/FailureTierLadder.cs
+++ b/src/Pinder.Core/Rolls/FailureTierLadder.cs
@@ -1,0 +1,28 @@
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Single source of truth for mapping a miss-margin to a <see cref="FailureTier"/>.
+    /// All check engines must call <see cref="FromMissMargin"/> instead of re-implementing
+    /// the ladder inline.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Legendary</c> tier (nat-1 in the main option-roll) is NOT produced here —
+    /// it is a game-rule special case handled by <see cref="RollEngine.ResolveFromComponents"/>.
+    /// This ladder covers the miss-margin–driven tiers only: Fumble, Misfire, TropeTrap, Catastrophe.
+    /// </remarks>
+    public static class FailureTierLadder
+    {
+        /// <summary>
+        /// Maps a miss margin to a <see cref="FailureTier"/>.
+        /// Returns <see cref="FailureTier.None"/> when <paramref name="missMargin"/> ≤ 0 (success).
+        /// </summary>
+        public static FailureTier FromMissMargin(int missMargin)
+        {
+            if (missMargin <= 0) return FailureTier.None;
+            if (missMargin <= 2) return FailureTier.Fumble;
+            if (missMargin <= 5) return FailureTier.Misfire;
+            if (missMargin <= 9) return FailureTier.TropeTrap;
+            return FailureTier.Catastrophe;
+        }
+    }
+}

--- a/src/Pinder.Core/Rolls/NamedModifier.cs
+++ b/src/Pinder.Core/Rolls/NamedModifier.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// A named modifier entry in a roll's modifier bag.
+    /// Key is a stable machine-readable token (e.g. "charm", "level", "tell", "callback").
+    /// Value may be zero; zero-value modifiers are kept so the renderer can show +0 if needed.
+    /// </summary>
+    public readonly struct NamedModifier : IEquatable<NamedModifier>
+    {
+        public string Key { get; }
+        public int Value { get; }
+
+        public NamedModifier(string key, int value)
+        {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            Value = value;
+        }
+
+        public bool Equals(NamedModifier other) => Key == other.Key && Value == other.Value;
+        public override bool Equals(object? obj) => obj is NamedModifier other && Equals(other);
+        public override int GetHashCode() => (Key?.GetHashCode() ?? 0) ^ Value;
+        public override string ToString() => $"{Key}:{Value:+0;-0;+0}";
+
+        public static bool operator ==(NamedModifier left, NamedModifier right) => left.Equals(right);
+        public static bool operator !=(NamedModifier left, NamedModifier right) => !left.Equals(right);
+    }
+}

--- a/src/Pinder.Core/Rolls/RandomDiceRollerAdapter.cs
+++ b/src/Pinder.Core/Rolls/RandomDiceRollerAdapter.cs
@@ -1,0 +1,26 @@
+using System;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Lightweight adapter that wraps a <see cref="System.Random"/> as an <see cref="IDiceRoller"/>.
+    /// Not thread-safe (same contract as the underlying <see cref="System.Random"/>).
+    /// Used by per-check engines (HorninessEngine, ShadowCheckEngine) that own a single-threaded RNG.
+    /// </summary>
+    internal sealed class RandomDiceRollerAdapter : IDiceRoller
+    {
+        private readonly Random _rng;
+
+        public RandomDiceRollerAdapter(Random rng)
+        {
+            _rng = rng ?? throw new ArgumentNullException(nameof(rng));
+        }
+
+        public int Roll(int sides)
+        {
+            if (sides < 1) throw new ArgumentOutOfRangeException(nameof(sides));
+            return _rng.Next(1, sides + 1);
+        }
+    }
+}

--- a/src/Pinder.Core/Rolls/RollCheckKind.cs
+++ b/src/Pinder.Core/Rolls/RollCheckKind.cs
@@ -1,0 +1,23 @@
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Identifies which check kind was performed via <see cref="RollEngine.ResolveCheck"/>.
+    /// </summary>
+    public enum RollCheckKind
+    {
+        /// <summary>Main option-roll check (d20 + stat mod + level vs opponent DC).</summary>
+        OptionRoll,
+
+        /// <summary>Steering roll that attempts to append a date-steering question.</summary>
+        Steering,
+
+        /// <summary>Per-turn horniness overlay check.</summary>
+        Horniness,
+
+        /// <summary>Paired-shadow check that may apply corruption to the delivered message.</summary>
+        Shadow,
+
+        /// <summary>Shadow-growth check (reserved; no standalone d20 roll currently).</summary>
+        ShadowGrowth,
+    }
+}

--- a/src/Pinder.Core/Rolls/RollCheckResult.cs
+++ b/src/Pinder.Core/Rolls/RollCheckResult.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Canonical result of a single d20 check performed by <see cref="RollEngine.ResolveCheck"/>.
+    /// All per-check engines (horniness, shadow, steering, option-roll) produce one of these.
+    /// Phase 1 (additive): attached as a <c>Check</c> property on each per-check result wrapper.
+    /// Wire-DTO serialisation happens in Phase 2.
+    /// </summary>
+    /// <remarks>
+    /// <c>IsNatOne</c> and <c>IsNatTwenty</c> are informational.
+    /// <c>Tier</c> is derived solely from <see cref="FailureTierLadder.FromMissMargin"/> —
+    /// the <c>Legendary</c> tier (nat-1 in the main option-roll) is a game-rule concern handled
+    /// by <see cref="RollEngine.ResolveFromComponents"/>, not by this record.
+    /// </remarks>
+    public sealed class RollCheckResult
+    {
+        /// <summary>The kind of check that was performed.</summary>
+        public RollCheckKind Kind { get; }
+
+        /// <summary>Raw d20 result (1–20). Always the first die rolled.</summary>
+        public int DieRoll { get; }
+
+        /// <summary>Second die roll if advantage/disadvantage was applied, otherwise null.</summary>
+        public int? SecondDieRoll { get; }
+
+        /// <summary>The die roll that was actually used after advantage/disadvantage selection.</summary>
+        public int UsedDieRoll { get; }
+
+        /// <summary>Modifier bag as supplied by the caller. Preserved as-given.</summary>
+        public IReadOnlyList<NamedModifier> Modifiers { get; }
+
+        /// <summary>Sum of all modifier values in the bag.</summary>
+        public int ModifierSum { get; }
+
+        /// <summary>UsedDieRoll + ModifierSum.</summary>
+        public int Total { get; }
+
+        /// <summary>DC the roll had to meet or exceed.</summary>
+        public int Dc { get; }
+
+        /// <summary>True if Total >= Dc. Does NOT apply nat-20 auto-success or nat-1 auto-fail
+        /// (those are game-rule overrides in RollEngine.ResolveFromComponents).</summary>
+        public bool IsSuccess { get; }
+
+        /// <summary>True if UsedDieRoll == 1 (informational; does not force Legendary here).</summary>
+        public bool IsNatOne { get; }
+
+        /// <summary>True if UsedDieRoll == 20 (informational; does not force success here).</summary>
+        public bool IsNatTwenty { get; }
+
+        /// <summary>Failure tier from FailureTierLadder.FromMissMargin. None on success.</summary>
+        public FailureTier Tier { get; }
+
+        /// <summary>By how much the roll missed the DC. 0 on success.</summary>
+        public int MissMargin { get; }
+
+        public RollCheckResult(
+            RollCheckKind kind,
+            int dieRoll,
+            int? secondDieRoll,
+            int usedDieRoll,
+            IReadOnlyList<NamedModifier> modifiers,
+            int modifierSum,
+            int total,
+            int dc,
+            bool isSuccess,
+            bool isNatOne,
+            bool isNatTwenty,
+            FailureTier tier,
+            int missMargin)
+        {
+            Kind         = kind;
+            DieRoll      = dieRoll;
+            SecondDieRoll = secondDieRoll;
+            UsedDieRoll  = usedDieRoll;
+            Modifiers    = modifiers;
+            ModifierSum  = modifierSum;
+            Total        = total;
+            Dc           = dc;
+            IsSuccess    = isSuccess;
+            IsNatOne     = isNatOne;
+            IsNatTwenty  = isNatTwenty;
+            Tier         = tier;
+            MissMargin   = missMargin;
+        }
+    }
+}

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -193,6 +193,8 @@ namespace Pinder.Core.Rolls
 
         /// <summary>
         /// Shared failure-tier determination and RollResult construction used by both Resolve and ResolveFixedDC.
+        /// Routes the miss-margin tier ladder through <see cref="FailureTierLadder.FromMissMargin"/> (#901)
+        /// and attaches a <see cref="RollCheckResult"/> on the returned <see cref="RollResult"/>.
         /// </summary>
         private static RollResult ResolveFromComponents(
             StatType stat,
@@ -232,27 +234,40 @@ namespace Pinder.Core.Rolls
             else
             {
                 int miss = dc - finalTotal;
-
-                if      (miss <= 2) tier = FailureTier.Fumble;
-                else if (miss <= 5) tier = FailureTier.Misfire;
-                else if (miss <= 9)
+                // #901: single tier-ladder source of truth
+                tier = FailureTierLadder.FromMissMargin(miss);
+                if (tier == FailureTier.TropeTrap || tier == FailureTier.Catastrophe)
                 {
-                    tier = FailureTier.TropeTrap;
                     // Activate the stat's trap (single-slot replacement, #371).
                     newTrap = trapRegistry.GetTrap(stat);
                     if (newTrap != null)
                         attackerTraps.Activate(newTrap);
                 }
-                else
-                {
-                    tier = FailureTier.Catastrophe;
-                    // Catastrophe also activates trap (rules §5: miss 10+ = -3 + trap).
-                    // Single-slot replacement under #371.
-                    newTrap = trapRegistry.GetTrap(stat);
-                    if (newTrap != null)
-                        attackerTraps.Activate(newTrap);
-                }
             }
+
+            // #901: build canonical RollCheckResult (modifier bag view of this roll).
+            // Note: Check.Tier uses FailureTierLadder only (no Legendary); RollResult.Tier
+            // applies the nat-1 → Legendary game-rule override above.
+            var checkModifiers = new NamedModifier[]
+            {
+                new NamedModifier("stat",  statMod),
+                new NamedModifier("level", levelBonus),
+            };
+            int checkMissMargin = (usedRoll == 20 || total + externalBonus >= dc) ? 0 : dc - (total + externalBonus);
+            bool checkIsSuccess = (total + externalBonus) >= dc;
+            FailureTier checkTier = checkIsSuccess ? FailureTier.None : FailureTierLadder.FromMissMargin(checkMissMargin);
+            var check = new RollCheckResult(
+                RollCheckKind.OptionRoll,
+                roll1, roll2, usedRoll,
+                checkModifiers,
+                modifierSum: statMod + levelBonus,
+                total:       total + externalBonus,
+                dc:          dc,
+                isSuccess:   checkIsSuccess,
+                isNatOne:    usedRoll == 1,
+                isNatTwenty: usedRoll == 20,
+                tier:        checkTier,
+                missMargin:  checkMissMargin);
 
             return new RollResult(
                 dieRoll:       roll1,
@@ -264,7 +279,8 @@ namespace Pinder.Core.Rolls
                 dc:            dc,
                 tier:          tier,
                 activatedTrap: newTrap,
-                externalBonus: externalBonus);
+                externalBonus: externalBonus,
+                check:         check);
         }
     }
 }

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Progression;
 using Pinder.Core.Stats;
@@ -12,6 +14,52 @@ namespace Pinder.Core.Rolls
     /// </summary>
     public static class RollEngine
     {
+        /// <summary>
+        /// Single entry point for all d20 checks.
+        /// Rolls a d20 (with optional advantage/disadvantage), sums the modifier bag,
+        /// computes total vs DC, and returns a canonical <see cref="RollCheckResult"/>.
+        /// </summary>
+        /// <remarks>
+        /// <c>IsSuccess = Total >= Dc</c> — nat-20 auto-success and nat-1 auto-fail (Legendary)
+        /// are game-rule overrides that live in <see cref="ResolveFromComponents"/> for the
+        /// main option-roll only. Informational <c>IsNatOne</c>/<c>IsNatTwenty</c> flags are
+        /// always populated.
+        /// </remarks>
+        public static RollCheckResult ResolveCheck(
+            RollCheckKind kind,
+            IDiceRoller dice,
+            IReadOnlyList<NamedModifier> modifiers,
+            int dc,
+            bool hasAdvantage    = false,
+            bool hasDisadvantage = false)
+        {
+            if (dice == null) throw new ArgumentNullException(nameof(dice));
+            if (modifiers == null) throw new ArgumentNullException(nameof(modifiers));
+
+            bool rollTwice = hasAdvantage || hasDisadvantage;
+            int roll1 = dice.Roll(20);
+            int? roll2 = rollTwice ? (int?)dice.Roll(20) : null;
+
+            int usedRoll;
+            if (!rollTwice)           usedRoll = roll1;
+            else if (hasDisadvantage) usedRoll = roll2.HasValue ? Math.Min(roll1, roll2.Value) : roll1;
+            else                      usedRoll = roll2.HasValue ? Math.Max(roll1, roll2.Value) : roll1;
+
+            int modSum = 0;
+            foreach (var m in modifiers) modSum += m.Value;
+
+            int total      = usedRoll + modSum;
+            bool isSuccess = total >= dc;
+            bool isNatOne  = usedRoll == 1;
+            bool isNatTwenty = usedRoll == 20;
+            int missMargin = isSuccess ? 0 : dc - total;
+            FailureTier tier = isSuccess ? FailureTier.None : FailureTierLadder.FromMissMargin(missMargin);
+
+            return new RollCheckResult(
+                kind, roll1, roll2, usedRoll, modifiers, modSum, total, dc,
+                isSuccess, isNatOne, isNatTwenty, tier, missMargin);
+        }
+
         /// <summary>
         /// Resolve a full roll.
         /// </summary>

--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -71,6 +71,15 @@ namespace Pinder.Core.Rolls
         public TrapDefinition? ActivatedTrap { get; }
 
         /// <summary>
+        /// Canonical check result produced by <see cref="RollEngine.ResolveCheck"/>.
+        /// Contains the raw d20 mechanics (roll, modifier bag, total, tier-from-miss-margin).
+        /// Note: <c>Check.Tier</c> is from <see cref="FailureTierLadder.FromMissMargin"/> only;
+        /// it will differ from <see cref="Tier"/> when UsedDieRoll == 1 (Legendary in Tier,
+        /// Catastrophe in Check.Tier). Phase 2 will wire this to the DTO.
+        /// </summary>
+        public RollCheckResult Check { get; }
+
+        /// <summary>
         /// Risk tier derived from the "need" value (dc - statMod - levelBonus).
         /// Safe (≤5), Medium (6–10), Hard (11–15), Bold (≥16).
         /// </summary>
@@ -89,7 +98,8 @@ namespace Pinder.Core.Rolls
             int dc,
             FailureTier tier,
             TrapDefinition? activatedTrap = null,
-            int externalBonus = 0)
+            int externalBonus = 0,
+            RollCheckResult? check = null)
         {
             DieRoll        = dieRoll;
             SecondDieRoll  = secondDieRoll;
@@ -106,6 +116,7 @@ namespace Pinder.Core.Rolls
             Tier           = IsSuccess ? FailureTier.None : tier;
             ActivatedTrap  = activatedTrap;
             RiskTier       = ComputeRiskTier(dc, statModifier, levelBonus);
+            Check          = check!;
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
+++ b/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
@@ -211,7 +211,8 @@ namespace Pinder.Core.Tests
         [InlineData(15, FailureTier.Catastrophe)]
         public void HorninessEngine_DetermineHorninessTier_ReturnsCorrectTier(int missMargin, FailureTier expected)
         {
-            var result = HorninessEngine.DetermineHorninessTier(missMargin);
+            // #901: DetermineHorninessTier deleted; same behaviour lives in FailureTierLadder.FromMissMargin.
+            var result = FailureTierLadder.FromMissMargin(missMargin);
 
             Assert.Equal(expected, result);
         }

--- a/tests/Pinder.Core.Tests/Rolls/FailureTierLadderTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/FailureTierLadderTests.cs
@@ -1,0 +1,53 @@
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Exhaustive boundary coverage for <see cref="FailureTierLadder.FromMissMargin"/>.
+    /// #901: single source of truth for the miss-margin tier ladder.
+    /// </summary>
+    public class FailureTierLadderTests
+    {
+        [Theory]
+        [InlineData(0,  FailureTier.None)]         // success boundary
+        [InlineData(-1, FailureTier.None)]          // success (negative miss)
+        [InlineData(-99, FailureTier.None)]         // large success
+        public void FromMissMargin_SuccessCases_ReturnNone(int missMargin, FailureTier expected)
+        {
+            Assert.Equal(expected, FailureTierLadder.FromMissMargin(missMargin));
+        }
+
+        [Theory]
+        [InlineData(1, FailureTier.Fumble)]
+        [InlineData(2, FailureTier.Fumble)]
+        public void FromMissMargin_FumbleBoundaries(int missMargin, FailureTier expected)
+        {
+            Assert.Equal(expected, FailureTierLadder.FromMissMargin(missMargin));
+        }
+
+        [Theory]
+        [InlineData(3, FailureTier.Misfire)]
+        [InlineData(5, FailureTier.Misfire)]
+        public void FromMissMargin_MisfireBoundaries(int missMargin, FailureTier expected)
+        {
+            Assert.Equal(expected, FailureTierLadder.FromMissMargin(missMargin));
+        }
+
+        [Theory]
+        [InlineData(6,  FailureTier.TropeTrap)]
+        [InlineData(9,  FailureTier.TropeTrap)]
+        public void FromMissMargin_TropeTrapBoundaries(int missMargin, FailureTier expected)
+        {
+            Assert.Equal(expected, FailureTierLadder.FromMissMargin(missMargin));
+        }
+
+        [Theory]
+        [InlineData(10, FailureTier.Catastrophe)]
+        [InlineData(99, FailureTier.Catastrophe)]
+        public void FromMissMargin_CatastropheBoundaries(int missMargin, FailureTier expected)
+        {
+            Assert.Equal(expected, FailureTierLadder.FromMissMargin(missMargin));
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Rolls/FieldParityTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/FieldParityTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Per-wrapper bespoke-field vs Check.* field-parity tests.
+    /// Verifies that the new <c>Check</c> property mirrors the bespoke fields
+    /// (or explicitly documents intentional divergence).
+    /// #901.
+    /// </summary>
+    public class FieldParityTests
+    {
+        private sealed class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public FixedDice(params int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private class EmptyTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        private static StatBlock MakeStats(int charm = 0)
+        {
+            var baseStats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm, charm }, { StatType.Rizz, 0 }, { StatType.Honesty, 0 },
+                { StatType.Chaos, 0 }, { StatType.Wit, 0 }, { StatType.SelfAwareness, 0 },
+            };
+            var shadowStats = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            };
+            return new StatBlock(baseStats, shadowStats);
+        }
+
+        // ===================== RollResult =====================
+
+        [Fact]
+        public void RollResult_NormalMiss_CheckFieldsMatchBespoke()
+        {
+            // Roll 8, stat +2, level +1 = 11 vs DC 15 → miss by 4 → Misfire
+            var result = RollEngine.Resolve(
+                StatType.Charm, MakeStats(charm: 2), MakeStats(),
+                new TrapState(), 1, new EmptyTrapRegistry(), new FixedDice(8));
+
+            Assert.NotNull(result.Check);
+            // DieRoll parity
+            Assert.Equal(result.DieRoll, result.Check.DieRoll);
+            // UsedDieRoll parity
+            Assert.Equal(result.UsedDieRoll, result.Check.UsedDieRoll);
+            // DC parity
+            Assert.Equal(result.DC, result.Check.Dc);
+            // IsSuccess parity (both should be false for miss)
+            Assert.Equal(result.IsSuccess, result.Check.IsSuccess);
+            // Tier parity for non-nat-1 miss
+            Assert.Equal(result.Tier, result.Check.Tier);
+        }
+
+        [Fact]
+        public void RollResult_Success_CheckFieldsMatchBespoke()
+        {
+            // Roll 15, stat +2 = 17 vs DC 13 → success
+            var attacker = MakeStats(charm: 2);
+            var result = RollEngine.Resolve(
+                StatType.Charm, attacker, MakeStats(),
+                new TrapState(), 1, new EmptyTrapRegistry(), new FixedDice(15));
+
+            Assert.NotNull(result.Check);
+            Assert.Equal(result.DieRoll, result.Check.DieRoll);
+            Assert.Equal(result.DC, result.Check.Dc);
+            Assert.True(result.IsSuccess);
+            Assert.True(result.Check.IsSuccess);
+            Assert.Equal(FailureTier.None, result.Tier);
+            Assert.Equal(FailureTier.None, result.Check.Tier);
+        }
+
+        [Fact]
+        public void RollResult_Nat1_TierDivergence_IsDocumented()
+        {
+            // Nat-1: RollResult.Tier = Legendary (game rule), Check.Tier = FailureTierLadder result.
+            // This intentional divergence is documented: Legendary is not produced by the ladder.
+            var result = RollEngine.Resolve(
+                StatType.Charm, MakeStats(), MakeStats(),
+                new TrapState(), 1, new EmptyTrapRegistry(), new FixedDice(1));
+
+            Assert.NotNull(result.Check);
+            Assert.Equal(FailureTier.Legendary, result.Tier);        // game-rule special case
+            Assert.NotEqual(FailureTier.Legendary, result.Check.Tier); // ladder never produces Legendary
+            Assert.True(result.Check.IsNatOne);
+        }
+
+        [Fact]
+        public void RollResult_Nat20_CheckIsNatTwentyTrue()
+        {
+            var result = RollEngine.Resolve(
+                StatType.Charm, MakeStats(), MakeStats(),
+                new TrapState(), 1, new EmptyTrapRegistry(), new FixedDice(20));
+
+            Assert.NotNull(result.Check);
+            Assert.True(result.Check.IsNatTwenty);
+            Assert.True(result.IsSuccess);
+        }
+
+        // ===================== HorninessCheckResult =====================
+
+        [Fact]
+        public void HorninessCheckResult_Miss_CheckFieldsMatchBespoke()
+        {
+            // sessionHorniness = 5 → DC = 15. Roll 8 → miss by 7 → TropeTrap.
+            var engine = new HorninessEngine(new Random(42));
+            // We need a fixed roll of 8. Seed the Random to get a specific first roll.
+            // Use a brute-force search for a seed that yields roll 8 as first Next(1,21).
+            Random? rng = null;
+            for (int seed = 0; seed < 10000; seed++)
+            {
+                var r = new Random(seed);
+                if (r.Next(1, 21) == 8) { rng = new Random(seed); break; }
+            }
+            Assert.NotNull(rng);
+            var eng = new HorninessEngine(rng!);
+            var shadows = new SessionShadowTracker(MakeStats());
+            var (result, _) = eng.PeekAsync(5, shadows, null);
+
+            Assert.Equal(8, result.Roll);
+            Assert.NotNull(result.Check);
+            Assert.Equal(result.Roll, result.Check!.DieRoll);
+            Assert.Equal(result.Total, result.Check.Total);
+            Assert.Equal(result.DC, result.Check.Dc);
+            Assert.Equal(result.IsMiss, !result.Check.IsSuccess);
+            Assert.Equal(result.Tier, result.Check.Tier); // ladder results match for non-nat-1
+        }
+
+        [Fact]
+        public void HorninessCheckResult_NotPerformed_CheckIsNull()
+        {
+            Assert.Null(HorninessCheckResult.NotPerformed.Check);
+        }
+
+        // ===================== ShadowCheckResult =====================
+
+        [Fact]
+        public void ShadowCheckResult_NotPerformed_CheckIsNull()
+        {
+            Assert.Null(ShadowCheckResult.NotPerformed.Check);
+        }
+
+        [Fact]
+        public void ShadowCheckResult_CheckPresent_OnPerformedCheck()
+        {
+            // Construct via ShadowCheckEngine
+            var rng = new Random(1); // deterministic
+            var engine = new ShadowCheckEngine(rng);
+            var result = engine.Check(ShadowStatType.Madness, shadowValue: 5);
+
+            Assert.NotNull(result.Check);
+            Assert.Equal(result.Roll, result.Check!.DieRoll);
+            Assert.Equal(result.DC, result.Check.Dc);
+            Assert.Equal(result.IsMiss, !result.Check.IsSuccess);
+            if (result.IsMiss)
+                Assert.Equal(result.Tier, result.Check.Tier);
+        }
+
+        // ===================== SteeringRollResult =====================
+
+        [Fact]
+        public void SteeringRollResult_NotAttempted_CheckIsNull()
+        {
+            Assert.Null(SteeringRollResult.NotAttempted.Check);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Rolls/RollEngineCheckTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/RollEngineCheckTests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="RollEngine.ResolveCheck"/> — the single entry point for all check kinds.
+    /// #901.
+    /// </summary>
+    public class RollEngineCheckTests
+    {
+        private sealed class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public FixedDice(params int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        // ---- OptionRoll ----
+
+        [Fact]
+        public void OptionRoll_WithModifierBag_ComputesCorrectTotalAndSuccess()
+        {
+            var modifiers = new[] { new NamedModifier("stat", 3), new NamedModifier("level", 2) };
+            // Roll 10 + 3 + 2 = 15 vs DC 15 → success
+            var check = RollEngine.ResolveCheck(RollCheckKind.OptionRoll, new FixedDice(10), modifiers, dc: 15);
+
+            Assert.Equal(RollCheckKind.OptionRoll, check.Kind);
+            Assert.Equal(10, check.DieRoll);
+            Assert.Equal(10, check.UsedDieRoll);
+            Assert.Null(check.SecondDieRoll);
+            Assert.Equal(5, check.ModifierSum);
+            Assert.Equal(15, check.Total);
+            Assert.Equal(15, check.Dc);
+            Assert.True(check.IsSuccess);
+            Assert.Equal(FailureTier.None, check.Tier);
+            Assert.Equal(0, check.MissMargin);
+        }
+
+        [Fact]
+        public void OptionRoll_Miss_ReturnsCorrectTierAndMissMargin()
+        {
+            var modifiers = new[] { new NamedModifier("stat", 0) };
+            // Roll 8 + 0 = 8 vs DC 15 → miss by 7 → TropeTrap
+            var check = RollEngine.ResolveCheck(RollCheckKind.OptionRoll, new FixedDice(8), modifiers, dc: 15);
+
+            Assert.False(check.IsSuccess);
+            Assert.Equal(7, check.MissMargin);
+            Assert.Equal(FailureTier.TropeTrap, check.Tier);
+        }
+
+        // ---- Steering ----
+
+        [Fact]
+        public void Steering_WithDisadvantage_UsesLowerRoll()
+        {
+            var modifiers = new[] { new NamedModifier("steering", 0) };
+            // Two rolls: 15 and 5 — disadvantage picks lower (5)
+            var check = RollEngine.ResolveCheck(RollCheckKind.Steering, new FixedDice(15, 5), modifiers,
+                dc: 16, hasDisadvantage: true);
+
+            Assert.Equal(RollCheckKind.Steering, check.Kind);
+            Assert.Equal(15, check.DieRoll);        // first roll stored
+            Assert.Equal(5, check.SecondDieRoll);    // second roll stored
+            Assert.Equal(5, check.UsedDieRoll);      // lower taken (disadvantage)
+            Assert.False(check.IsSuccess);           // 5 < 16
+        }
+
+        [Fact]
+        public void Steering_EmptyModifierBag_ModifierSumIsZero()
+        {
+            var check = RollEngine.ResolveCheck(RollCheckKind.Steering, new FixedDice(12),
+                new NamedModifier[0], dc: 16);
+
+            Assert.Equal(0, check.ModifierSum);
+            Assert.Equal(12, check.Total);
+        }
+
+        // ---- Horniness ----
+
+        [Fact]
+        public void Horniness_EmptyModifierBag_ModifierSumIsZero()
+        {
+            // Roll 5 vs DC 15 (sessionHorniness = 5 → DC = 20-5 = 15): miss by 10 → Catastrophe
+            var check = RollEngine.ResolveCheck(RollCheckKind.Horniness, new FixedDice(5),
+                new NamedModifier[0], dc: 15);
+
+            Assert.Equal(RollCheckKind.Horniness, check.Kind);
+            Assert.Equal(0, check.ModifierSum);
+            Assert.False(check.IsSuccess);
+            Assert.Equal(10, check.MissMargin);
+            Assert.Equal(FailureTier.Catastrophe, check.Tier);
+        }
+
+        // ---- Shadow ----
+
+        [Fact]
+        public void Shadow_Nat20_IsNatTwentyTrue()
+        {
+            var check = RollEngine.ResolveCheck(RollCheckKind.Shadow, new FixedDice(20),
+                new NamedModifier[0], dc: 10);
+
+            Assert.Equal(RollCheckKind.Shadow, check.Kind);
+            Assert.True(check.IsNatTwenty);
+            Assert.True(check.IsSuccess);
+        }
+
+        [Fact]
+        public void Shadow_WithAdvantage_UsesHigherRoll()
+        {
+            // Two rolls: 5 and 17 — advantage picks higher (17)
+            var check = RollEngine.ResolveCheck(RollCheckKind.Shadow, new FixedDice(5, 17),
+                new NamedModifier[0], dc: 10, hasAdvantage: true);
+
+            Assert.Equal(5, check.DieRoll);
+            Assert.Equal(17, check.SecondDieRoll);
+            Assert.Equal(17, check.UsedDieRoll);
+            Assert.True(check.IsSuccess);
+        }
+
+        // ---- ShadowGrowth ----
+
+        [Fact]
+        public void ShadowGrowth_Nat1_IsNatOneTrue()
+        {
+            var check = RollEngine.ResolveCheck(RollCheckKind.ShadowGrowth, new FixedDice(1),
+                new NamedModifier[0], dc: 10);
+
+            Assert.Equal(RollCheckKind.ShadowGrowth, check.Kind);
+            Assert.True(check.IsNatOne);
+            Assert.False(check.IsSuccess); // 1 < 10
+            // Tier from FailureTierLadder: miss = 9 → TropeTrap
+            Assert.Equal(FailureTier.TropeTrap, check.Tier);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Rolls/TierLadderAuditTest.cs
+++ b/tests/Pinder.Core.Tests/Rolls/TierLadderAuditTest.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Audit gate: no file in Pinder.Core/Rolls may contain a hand-rolled miss-margin ladder
+    /// (i.e. a <c>missMargin &lt;= N</c> comparison) EXCEPT <see cref="Pinder.Core.Rolls.FailureTierLadder"/>.
+    /// #901: single source of truth invariant.
+    /// </summary>
+    public class TierLadderAuditTest
+    {
+        private static readonly Regex LadderPattern =
+            new Regex(@"miss(Margin|)\s*<=\s*\d", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        [Fact]
+        public void NoDuplicateMissMarginLadders_InRollsFolder_OutsideFailureTierLadder()
+        {
+            // Resolve the path to the Pinder.Core source. We walk up from the test assembly.
+            var testAssemblyDir = Path.GetDirectoryName(typeof(TierLadderAuditTest).Assembly.Location)!;
+            // Walk up to find the repo root (contains src/ directory).
+            var dir = new DirectoryInfo(testAssemblyDir);
+            string? srcDir = null;
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "src", "Pinder.Core", "Rolls");
+                if (Directory.Exists(candidate))
+                {
+                    srcDir = candidate;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            Assert.True(srcDir != null, "Could not locate src/Pinder.Core/Rolls from test assembly path");
+
+            var violations = new System.Collections.Generic.List<string>();
+            foreach (var file in Directory.EnumerateFiles(srcDir!, "*.cs", SearchOption.AllDirectories))
+            {
+                if (Path.GetFileName(file) == "FailureTierLadder.cs")
+                    continue; // the one allowed source
+
+                var content = File.ReadAllText(file);
+                if (LadderPattern.IsMatch(content))
+                    violations.Add(Path.GetFileName(file));
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Duplicate miss-margin ladder detected in: {string.Join(", ", violations)}. " +
+                "Use FailureTierLadder.FromMissMargin instead.");
+        }
+
+        [Fact]
+        public void NoDuplicateMissMarginLadders_InConversationFolder()
+        {
+            var testAssemblyDir = Path.GetDirectoryName(typeof(TierLadderAuditTest).Assembly.Location)!;
+            var dir = new DirectoryInfo(testAssemblyDir);
+            string? srcDir = null;
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "src", "Pinder.Core", "Conversation");
+                if (Directory.Exists(candidate))
+                {
+                    srcDir = candidate;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            Assert.True(srcDir != null, "Could not locate src/Pinder.Core/Conversation from test assembly path");
+
+            var violations = new System.Collections.Generic.List<string>();
+            foreach (var file in Directory.EnumerateFiles(srcDir!, "*.cs", SearchOption.AllDirectories))
+            {
+                var content = File.ReadAllText(file);
+                if (LadderPattern.IsMatch(content))
+                    violations.Add(Path.GetFileName(file));
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Duplicate miss-margin ladder detected in: {string.Join(", ", violations)}. " +
+                "Use FailureTierLadder.FromMissMargin instead.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 (additive) of #901 — collapse four dice-check engines into one entry point.

## Commits

- feat(#901): introduce RollCheckResult / RollCheckKind / NamedModifier / FailureTierLadder
- feat(#901): add RollEngine.ResolveCheck single entry point
- refactor(#901): route Resolve / ResolveFromComponents through FailureTierLadder + attach RollCheckResult to RollResult
- refactor(#901): HorninessEngine.PeekAsync routes through RollEngine.ResolveCheck
- refactor(#901): SteeringEngine routes through RollEngine.ResolveCheck
- refactor(#901): extract inline shadow check into ShadowCheckEngine
- refactor(#901): shadow-growth routes through ResolveCheck (ShadowGrowthEvaluator has no standalone d20 roll)
- test(#901): FailureTierLadder + RollEngineCheck + tier-ladder-audit + field-parity tests
- docs(#901): spec + LESSONS_LEARNED entry

## Scope

Phase 1 (additive) only. Wire DTO (Phase 2) and cleanup/field-delete (Phase 3) are separate tickets.

## Wire DTOs

Unchanged. No fields added or removed on `TurnResult`, `TurnStart`, or GameApi controllers.

## Snapshots

Byte-identical. Verification method: field-parity unit tests (no LLM credentials available for deterministic sim).

Proof:
- `HorninessEngine.PeekAsync` was `_rng.Next(1, 21)` → now `RandomDiceRollerAdapter.Roll(20)` = `_rng.Next(1, 21)`. Same call, same dice consumed.
- Shadow check was `_steeringEngine.RollD20()` = `_steeringRng.Next(1, 21)` → now `_shadowCheckEngine.Check()` = `RandomDiceRollerAdapter.Roll(20)` = `_steeringRng.Next(1, 21)`. Same call.
- `SteeringEngine` was `_steeringRng.Next(1, 21)` → same.
- `Check` property is NOT serialized in `TurnSnapshot` (Phase 2 wires it).
- All 2752 existing `Pinder.Core.Tests` pass with 0 failures.

### Per-wrapper field-parity test names

- `FieldParityTests.RollResult_NormalMiss_CheckFieldsMatchBespoke`
- `FieldParityTests.RollResult_Success_CheckFieldsMatchBespoke`
- `FieldParityTests.RollResult_Nat1_TierDivergence_IsDocumented` (intentional: Legendary vs ladder)
- `FieldParityTests.RollResult_Nat20_CheckIsNatTwentyTrue`
- `FieldParityTests.HorninessCheckResult_Miss_CheckFieldsMatchBespoke`
- `FieldParityTests.HorninessCheckResult_NotPerformed_CheckIsNull`
- `FieldParityTests.ShadowCheckResult_NotPerformed_CheckIsNull`
- `FieldParityTests.ShadowCheckResult_CheckPresent_OnPerformedCheck`
- `FieldParityTests.SteeringRollResult_NotAttempted_CheckIsNull`

## Deviations

1. **HorninessEngine uses `_rng` (System.Random), not `IDiceRoller`** — prompt called it `_steeringDice`. Added `RandomDiceRollerAdapter` (internal sealed class) to wrap any `Random` as `IDiceRoller` without duplicating state.

2. **ShadowGrowthEvaluator has no standalone d20 roll** — Step 7 is a no-op. `ShadowGrowthEvaluator` takes a `RollResult` and applies deterministic shadow-growth triggers (nat-1 on main roll, TropeTrap failure, etc.). `RollCheckKind.ShadowGrowth` exists in the enum as a reserved value. Empty commit documents this.

3. **`DecomposedModuleTests.HorninessEngine_DetermineHorninessTier_ReturnsCorrectTier`** — redirected from deleted `HorninessEngine.DetermineHorninessTier` to `FailureTierLadder.FromMissMargin`. Same inputs/outputs, moved API location.

4. **`RollCheckResult.Tier` never contains `Legendary`** — `FailureTierLadder.FromMissMargin` is miss-margin only. The nat-1 → Legendary game rule stays in `RollEngine.ResolveFromComponents`. `RollResult.Tier` and `RollResult.Check.Tier` intentionally diverge for nat-1 rolls. Documented in `FieldParityTests.RollResult_Nat1_TierDivergence_IsDocumented`.

Closes #901