### PR TITLE
fix/904 TropeTrap tier display label per check kind

### DIFF
--- a/docs/specs/issue-904-failure-tier-display.md
+++ b/docs/specs/issue-904-failure-tier-display.md
@@ -1,0 +1,77 @@
+# FailureTierDisplay: Per-Kind Player-Facing Label
+
+**Issue:** pinder-core #904  
+**Added in:** `Pinder.Core/Rolls/FailureTierDisplay.cs`  
+**Status:** Shipped
+
+## Summary
+
+`FailureTierDisplay.Label(FailureTier tier, RollCheckKind kind)` returns the
+player-facing string for a failure tier in the context of a specific check kind.
+
+## Why Enum and Wire Stay Unchanged
+
+`FailureTier.TropeTrap` is kept as-is (enum name, YAML key `trope_trap`, wire DTO
+field) because it is the correct mechanical identity — **a miss by 6–9 points**.
+The enum value, serialization key, and any persistence / network contract are all
+literal `TropeTrap` / `trope_trap` and must stay that way.
+
+Only the **player-facing display string** is kind-dependent.
+
+## Why the Display Diverges Per Kind
+
+On an **OptionRoll**, a `TropeTrap` result actually fires a stat-specific social
+trap (the trope mechanic). Showing "TropeTrap" to the player is accurate — it
+tells them the trap activated.
+
+On a **Horniness / Shadow / ShadowGrowth / Steering** check, no trap fires. The
+tier just means "miss margin 6–9, more damaging than Misfire but not catastrophic".
+Showing "TropeTrap" implies a trap fired when one did not; it is confusing and
+breaks narrative coherence. The chosen label **"Severe"** is:
+- Consistent with the rest of the tier scale (None / Fumble / Misfire / **Severe** / Catastrophe / Legendary).
+- Unambiguous: no trap connotation.
+- Crisp: one word, same visual weight as the other labels.
+
+## API Contract
+
+```csharp
+// src/Pinder.Core/Rolls/FailureTierDisplay.cs
+public static string Label(FailureTier tier, RollCheckKind kind);
+```
+
+| Inputs | Return value |
+|---|---|
+| `TropeTrap`, `OptionRoll` | `"TropeTrap"` |
+| `TropeTrap`, `Horniness` | `"Severe"` |
+| `TropeTrap`, `Shadow` | `"Severe"` |
+| `TropeTrap`, `ShadowGrowth` | `"Severe"` |
+| `TropeTrap`, `Steering` | `"Severe"` |
+| Any other tier, any kind | `tier.ToString()` |
+
+All tier values other than `TropeTrap` pass through `tier.ToString()` — they are
+unambiguous across all check kinds.
+
+## SessionDocumentBuilder — No Routing Required
+
+`SessionDocumentBuilder.GetFailureTierName()` (line 554) and `GetTierInstruction()`
+(line 567) return LLM-internal prompt codes (`"TROPE_TRAP"` with underscore, all-caps),
+not player-facing labels. These are exclusively called from `BuildDeliveryPrompt` and
+`BuildOpponentPrompt`, both of which are pure option-roll paths (`DeliveryContext`
+carries `ChosenOption`; `OpponentContext` carries `DeliveryTier` from a completed
+option roll). Routing these through `FailureTierDisplay.Label()` would change the
+LLM instruction format (from `"TROPE_TRAP"` to `"TropeTrap"` / `"Severe"`) and
+would be a behavior change for the option-roll prompt, not a display fix.
+Neither site needs modification.
+
+## Frontend Follow-Up
+
+pinder-web must mirror this helper when rendering failure-tier labels in the game UI
+(turn history, live result banners, etc.). Frontend ticket: see pinder-web#TBD.
+
+## Do Not
+
+- Do not rename `FailureTier.TropeTrap` enum value.
+- Do not change YAML keys (`trope_trap`).
+- Do not change wire DTO fields.
+- Do not change `GetFailureTierName()` in `SessionDocumentBuilder` — it returns
+  LLM prompt codes, not display labels, and must remain `"TROPE_TRAP"`.

--- a/src/Pinder.Core/Rolls/FailureTierDisplay.cs
+++ b/src/Pinder.Core/Rolls/FailureTierDisplay.cs
@@ -1,0 +1,28 @@
+namespace Pinder.Core.Rolls
+{
+    /// <summary>
+    /// Maps (FailureTier, RollCheckKind) → player-facing label.
+    /// Decouples display from enum identity: TropeTrap activates a trap ONLY on option rolls;
+    /// on other check kinds it's just "miss margin 6-9" and should not imply a trap fired.
+    /// Wire DTOs, YAML keys, and the FailureTier enum itself are unchanged — only the
+    /// human-readable string changes per kind.
+    /// </summary>
+    public static class FailureTierDisplay
+    {
+        /// <summary>
+        /// Returns the player-facing label for a <see cref="FailureTier"/> in the context of a
+        /// specific <see cref="RollCheckKind"/>.
+        /// <para>
+        /// <c>TropeTrap</c> is labelled <c>"TropeTrap"</c> on <c>OptionRoll</c> (the trap fires)
+        /// and <c>"Severe"</c> on all other check kinds (no trap; scale-consistent label only).
+        /// All other tiers pass through <c>tier.ToString()</c> regardless of kind.
+        /// </para>
+        /// </summary>
+        public static string Label(FailureTier tier, RollCheckKind kind)
+        {
+            if (tier == FailureTier.TropeTrap && kind != RollCheckKind.OptionRoll)
+                return "Severe";
+            return tier.ToString();
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Rolls/FailureTierDisplayTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/FailureTierDisplayTests.cs
@@ -1,0 +1,42 @@
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class FailureTierDisplayTests
+    {
+        [Fact]
+        public void TropeTrap_OnOptionRoll_LabelIsTropeTrap()
+            => Assert.Equal("TropeTrap", FailureTierDisplay.Label(FailureTier.TropeTrap, RollCheckKind.OptionRoll));
+
+        [Theory]
+        [InlineData(RollCheckKind.Horniness)]
+        [InlineData(RollCheckKind.Shadow)]
+        [InlineData(RollCheckKind.ShadowGrowth)]
+        [InlineData(RollCheckKind.Steering)]
+        public void TropeTrap_OnNonOptionKinds_LabelIsSevere(RollCheckKind kind)
+            => Assert.Equal("Severe", FailureTierDisplay.Label(FailureTier.TropeTrap, kind));
+
+        [Theory]
+        [InlineData(FailureTier.None)]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.Catastrophe)]
+        [InlineData(FailureTier.Legendary)]
+        public void NonTropeTrapTiers_LabelPassesThrough(FailureTier tier)
+        {
+            Assert.Equal(tier.ToString(), FailureTierDisplay.Label(tier, RollCheckKind.OptionRoll));
+            Assert.Equal(tier.ToString(), FailureTierDisplay.Label(tier, RollCheckKind.Horniness));
+            Assert.Equal(tier.ToString(), FailureTierDisplay.Label(tier, RollCheckKind.Shadow));
+        }
+
+        [Fact]
+        public void Enum_Identity_Unchanged()
+        {
+            // Guard against accidental enum mutation. Wire/YAML rely on these names.
+            Assert.Equal("TropeTrap", FailureTier.TropeTrap.ToString());
+            Assert.Equal("Fumble", FailureTier.Fumble.ToString());
+            Assert.Equal("Catastrophe", FailureTier.Catastrophe.ToString());
+        }
+    }
+}


### PR DESCRIPTION
- feat(#904): add FailureTierDisplay.Label per-kind helper
- test(#904): FailureTierDisplay per-kind label tests
- docs(#904): spec doc for FailureTierDisplay per-kind label

Player-facing label decoupled from FailureTier enum: 'TropeTrap' on option rolls (trap fires);
'Severe' on horniness/shadow/shadow-growth/steering (no trap). Enum, wire DTO, and YAML keys unchanged.
SessionDocumentBuilder not modified — its GetFailureTierName() returns LLM-internal codes ("TROPE_TRAP"),
not display labels, and is purely option-roll; see spec doc for full reasoning.
Frontend mirror is a separate pinder-web follow-up.

Closes #904