### PR TITLE
fix/906 expose roll.defending_stat on option rolls

### DIFF
--- a/docs/specs/issue-906-defending-stat.md
+++ b/docs/specs/issue-906-defending-stat.md
@@ -1,0 +1,102 @@
+# Wire Field: `defending_stat`
+
+**Issue:** pinder-core #906  
+**Added in:** `RollResult` (C# property) + `TurnSnapshot.DefendingRollStat` (session-runner)  
+**Frontend consumer:** pinder-web #601  
+**Status:** Shipped
+
+## Field Definition
+
+| Property | Value |
+|---|---|
+| JSON key | `defending_stat` |
+| C# property | `RollResult.DefendingStat` |
+| Type | `StatType` (serialized as enum name string) |
+| Placement | `RollResult` only — **NOT on `RollCheckResult`** |
+
+## Placement Rule
+
+`DefendingStat` is an **option-roll-specific** extra. It lives on `RollResult`, not on `RollCheckResult`. Per the #901 spec, `RollCheckResult` is the kind-agnostic check shape; option-roll-specific extras (`Stat`, `RiskTier`, `ActivatedTrap`, `DefendingStat`) stay on `RollResult`.
+
+## Derivation Formula
+
+```csharp
+DefendingStat = StatBlock.DefenceTable[stat];
+```
+
+Computed in `RollEngine.ResolveFromComponents` (shared by `Resolve` and `ResolveFixedDC`) and in `GameSession.CreateForcedFailResult`. Single source of truth: `StatBlock.DefenceTable`.
+
+## DefenceTable Mapping
+
+| Attacker Stat | Defending Stat |
+|---|---|
+| Charm | SelfAwareness |
+| Rizz | Wit |
+| Honesty | Chaos |
+| Chaos | Charm |
+| Wit | Rizz |
+| SelfAwareness | Honesty |
+
+Source: `StatBlock.DefenceTable` (static, authoritative).
+
+## Serialization
+
+`RollResult.DefendingStat` carries two attributes:
+
+```csharp
+[JsonPropertyName("defending_stat")]
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public StatType DefendingStat { get; }
+```
+
+- `[JsonPropertyName]` maps the C# `PascalCase` name to `snake_case` on the wire.
+- `[JsonConverter(typeof(JsonStringEnumConverter))]` ensures the value is the enum member name (e.g. `"Wit"`), not an integer.
+
+### Example JSON (option roll, attacker used Rizz)
+
+```json
+{
+  "stat": "Rizz",
+  "defending_stat": "Wit",
+  "die_roll": 14,
+  ...
+}
+```
+
+## Wire DTO
+
+`RollResultDto` in `pinder-web` (issue pinder-web#601) is the companion change that exposes `defending_stat` on the HTTP/SSE surface. The `[JsonPropertyName]` and `[JsonConverter]` on `RollResult` ensure that if `RollResult` is ever serialized directly, the field also appears correctly.
+
+## TurnSnapshot Mirror
+
+`TurnSnapshot` (in `session-runner/Snapshot/SessionSnapshot.cs`) exposes the defending stat from the actual roll via:
+
+```csharp
+public string DefendingRollStat { get; set; } = string.Empty;
+```
+
+Populated in `BuildTurnSnapshot`:
+
+```csharp
+DefendingRollStat = result.Roll.DefendingStat.ToString(),
+```
+
+Empty string is the default (forward-compatible on legacy snapshots that pre-date #906).
+
+## Invariant
+
+`DefendingStat` MUST always equal `StatBlock.DefenceTable[Stat]`. It is **not independently settable** — it is always derived at `RollResult` construction time. Audit test: `Issue906_DefendingStatTests.DefendingStat_AlwaysEqualsDefenceTableLookup_OnResolve`.
+
+## Synthetic / Forced-Fail Results
+
+`GameSession.CreateForcedFailResult` constructs a `RollResult` without access to a live `defender`. It derives `DefendingStat` from `original.Stat`:
+
+```csharp
+defendingStat: StatBlock.DefenceTable[original.Stat]
+```
+
+This preserves the invariant even on shadow-override failures.
+
+## Frontend Consumer Reference
+
+pinder-web #601 adds `defending_stat` to `RollResultDto.From()` so the SSE `roll_result` event carries the field to the React SPA. The frontend uses it to display which defending stat was in play for the roll.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1777,6 +1777,7 @@ class Program
             ConversationHistory = convEntries,
             OpponentHistory = opponentHistoryEntries,
             Events = events,
+            DefendingRollStat = result.Roll.DefendingStat.ToString(),
             GhostProbabilityPerTurn = state.GhostProbabilityPerTurn,
             OpponentDefenseSnapshot = opponentDefenseSnapshot != null
                 ? opponentDefenseSnapshot.ByAttackerStat.ToDictionary(

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -94,6 +94,11 @@ namespace Pinder.SessionRunner.Snapshot
     ///     list when no opponent calls have resolved yet.
     ///   </description></item>
     ///   <item><description>
+    ///     <c>DefendingRollStat</c> (issue #906): the defending stat used in
+    ///     the option roll on this turn (<c>StatBlock.DefenceTable[Stat]</c>).
+    ///     Empty string on turns with no roll.
+    ///   </description></item>
+    ///   <item><description>
     ///     <c>GhostProbabilityPerTurn</c> (issue #905): probability (0.0..1.0)
     ///     that the opponent ghosts on this turn. Derived from
     ///     <c>GameStateSnapshot.GhostProbabilityPerTurn</c> (0.25 when Bored,
@@ -137,6 +142,13 @@ namespace Pinder.SessionRunner.Snapshot
         public int SaUsageCount { get; set; }
         public bool SaOverthinkingTriggered { get; set; }
         public int RizzCumulativeFailureCount { get; set; }
+
+        /// <summary>
+        /// Issue #906: defending stat used in the roll for this turn.
+        /// Derived from <c>StatBlock.DefenceTable[Stat]</c>. Empty string on turns
+        /// with no roll (ghosted / skipped). Populated in <c>BuildTurnSnapshot</c>.
+        /// </summary>
+        public string DefendingRollStat { get; set; } = string.Empty;
 
         /// <summary>
         /// Issue #905: probability (0.0..1.0) that the opponent will ghost on

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -2124,7 +2124,8 @@ namespace Pinder.Core.Conversation
                 dc: original.DC,
                 tier: shadowTier,
                 activatedTrap: null,
-                externalBonus: 0);
+                externalBonus: 0,
+                defendingStat: Pinder.Core.Stats.StatBlock.DefenceTable[original.Stat]);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -270,17 +270,18 @@ namespace Pinder.Core.Rolls
                 missMargin:  checkMissMargin);
 
             return new RollResult(
-                dieRoll:       roll1,
-                secondDieRoll: roll2,
-                usedDieRoll:   usedRoll,
-                stat:          stat,
-                statModifier:  statMod,
-                levelBonus:    levelBonus,
-                dc:            dc,
-                tier:          tier,
-                activatedTrap: newTrap,
-                externalBonus: externalBonus,
-                check:         check);
+                dieRoll:        roll1,
+                secondDieRoll:  roll2,
+                usedDieRoll:    usedRoll,
+                stat:           stat,
+                statModifier:   statMod,
+                levelBonus:     levelBonus,
+                dc:             dc,
+                tier:           tier,
+                activatedTrap:  newTrap,
+                externalBonus:  externalBonus,
+                check:          check,
+                defendingStat:  StatBlock.DefenceTable[stat]);
         }
     }
 }

--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -26,6 +26,7 @@ namespace Pinder.Core.Rolls
         /// Always populated for option-roll results; use StatBlock.DefenceTable[Stat] as the canonical source.
         /// </summary>
         [JsonPropertyName("defending_stat")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public StatType DefendingStat { get; }
 
         /// <summary>Effective stat modifier at time of roll (after shadow penalty + traps).</summary>

--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Pinder.Core.Stats;
 using Pinder.Core.Traps;
 
@@ -19,6 +20,13 @@ namespace Pinder.Core.Rolls
 
         /// <summary>The stat used for the roll.</summary>
         public StatType Stat { get; }
+
+        /// <summary>
+        /// The defending stat (opponent's stat used to compute the DC via StatBlock.DefenceTable[Stat]).
+        /// Always populated for option-roll results; use StatBlock.DefenceTable[Stat] as the canonical source.
+        /// </summary>
+        [JsonPropertyName("defending_stat")]
+        public StatType DefendingStat { get; }
 
         /// <summary>Effective stat modifier at time of roll (after shadow penalty + traps).</summary>
         public int StatModifier { get; }
@@ -99,12 +107,14 @@ namespace Pinder.Core.Rolls
             FailureTier tier,
             TrapDefinition? activatedTrap = null,
             int externalBonus = 0,
-            RollCheckResult? check = null)
+            RollCheckResult? check = null,
+            StatType defendingStat = default)
         {
             DieRoll        = dieRoll;
             SecondDieRoll  = secondDieRoll;
             UsedDieRoll    = usedDieRoll;
             Stat           = stat;
+            DefendingStat  = defendingStat;
             StatModifier   = statModifier;
             LevelBonus     = levelBonus;
             Total          = usedDieRoll + statModifier + levelBonus;

--- a/tests/Pinder.Core.Tests/Rolls/Issue906_DefendingStatTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue906_DefendingStatTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests.Issue906
+{
+    /// <summary>
+    /// Issue #906: <see cref="RollResult.DefendingStat"/> —
+    /// must equal <c>StatBlock.DefenceTable[Stat]</c>; serializes as
+    /// <c>defending_stat</c>.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue906_DefendingStatTests
+    {
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private sealed class FixedDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public FixedDice(params int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private sealed class EmptyTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        private static StatBlock MakeStatBlock(int val = 2)
+        {
+            var stats = new System.Collections.Generic.Dictionary<StatType, int>
+            {
+                { StatType.Charm, val }, { StatType.Rizz, val }, { StatType.Honesty, val },
+                { StatType.Chaos, val }, { StatType.Wit, val }, { StatType.SelfAwareness, val }
+            };
+            var shadow = new System.Collections.Generic.Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 }, { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Fixation, 0 }, { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+            };
+            return new StatBlock(stats, shadow);
+        }
+
+        private static RollResult DoResolve(StatType attackStat, int dieRoll = 15)
+        {
+            var attacker = MakeStatBlock(3);
+            var defender = MakeStatBlock(2);
+            var traps = new TrapState();
+            return RollEngine.Resolve(
+                stat:            attackStat,
+                attacker:        attacker,
+                defender:        defender,
+                attackerTraps:   traps,
+                level:           1,
+                trapRegistry:    new EmptyTrapRegistry(),
+                dice:            new FixedDice(dieRoll));
+        }
+
+        // ── Per-stat mapping (6 stats) ────────────────────────────────────────
+
+        [Theory]
+        [InlineData(StatType.Charm,         StatType.SelfAwareness)]
+        [InlineData(StatType.Rizz,          StatType.Wit)]
+        [InlineData(StatType.Honesty,       StatType.Chaos)]
+        [InlineData(StatType.Chaos,         StatType.Charm)]
+        [InlineData(StatType.Wit,           StatType.Rizz)]
+        [InlineData(StatType.SelfAwareness, StatType.Honesty)]
+        public void DefendingStat_MatchesDefenceTable(StatType attackStat, StatType expectedDefending)
+        {
+            var result = DoResolve(attackStat);
+            Assert.Equal(expectedDefending, result.DefendingStat);
+        }
+
+        // ── Invariant: DefendingStat always equals DefenceTable[Stat] ─────────
+
+        [Fact]
+        public void DefendingStat_AlwaysEqualsDefenceTableLookup_OnResolve()
+        {
+            foreach (StatType stat in System.Enum.GetValues(typeof(StatType)))
+            {
+                var result = DoResolve(stat);
+                Assert.Equal(StatBlock.DefenceTable[result.Stat], result.DefendingStat);
+            }
+        }
+
+        // ── Serialization: [JsonPropertyName("defending_stat")] ──────────────
+
+        [Theory]
+        [InlineData(StatType.Charm,         "SelfAwareness")]
+        [InlineData(StatType.Rizz,          "Wit")]
+        [InlineData(StatType.Honesty,       "Chaos")]
+        [InlineData(StatType.Chaos,         "Charm")]
+        [InlineData(StatType.Wit,           "Rizz")]
+        [InlineData(StatType.SelfAwareness, "Honesty")]
+        public void Serialization_ContainsDefendingStatKey(StatType attackStat, string expectedValue)
+        {
+            var result = DoResolve(attackStat);
+            string json = JsonSerializer.Serialize(result);
+            Assert.Contains($"\"defending_stat\":\"{expectedValue}\"", json);
+        }
+
+        // ── ResolveFixedDC also populates DefendingStat ────────────────────────
+
+        [Fact]
+        public void ResolveFixedDC_PopulatesDefendingStat()
+        {
+            var attacker = MakeStatBlock(3);
+            var traps = new TrapState();
+            var result = RollEngine.ResolveFixedDC(
+                stat:          StatType.Rizz,
+                attacker:      attacker,
+                fixedDc:       14,
+                attackerTraps: traps,
+                level:         1,
+                trapRegistry:  new EmptyTrapRegistry(),
+                dice:          new FixedDice(12));
+
+            Assert.Equal(StatType.Wit, result.DefendingStat);  // DefenceTable[Rizz] = Wit
+        }
+    }
+}


### PR DESCRIPTION
- feat(#906): add DefendingStat to RollResult and populate at all construction sites
- test(#906): Issue906_DefendingStatTests
- feat(#906): TurnSnapshot mirrors DefendingRollStat
- docs(#906): spec doc for defending_stat

Additive field. Companion to pinder-web#601. Maps via StatBlock.DefenceTable[Stat] — single source of truth.

**Changes:**
- `RollResult.DefendingStat: StatType` — new property with `[JsonPropertyName("defending_stat")]` + `[JsonConverter(typeof(JsonStringEnumConverter))]`
- Populated in `RollEngine.ResolveFromComponents` (covers both `Resolve` and `ResolveFixedDC`) via `StatBlock.DefenceTable[stat]`
- Populated in `GameSession.CreateForcedFailResult` using `StatBlock.DefenceTable[original.Stat]`
- `TurnSnapshot.DefendingRollStat: string` added to session-runner snapshot shape; populated in `BuildTurnSnapshot`
- 14 new tests: per-stat mapping (6), serialization (6), invariant, ResolveFixedDC
- Spec doc: `docs/specs/issue-906-defending-stat.md`

**Placement:** `RollResult` only — `RollCheckResult` is NOT touched (kind-agnostic shape; option-roll extras live on `RollResult` per #901 spec).

Closes #906