### PR TITLE
feat/593 expose weakness_dc_reduction on TurnStart

### DIFF
--- a/docs/specs/issue-593-weakness-dc-reduction.md
+++ b/docs/specs/issue-593-weakness-dc-reduction.md
@@ -1,0 +1,68 @@
+# Spec: `weakness_dc_reduction` on `TurnStart` (pinder-core side of #593)
+
+**Issue:** pinder-web#593 (FoldableHintBanner for Tell + Weakness Window)  
+**Companion:** pinder-web PR implementing the UI component  
+**Date:** 2026-05-16
+
+---
+
+## Problem
+
+The frontend needed to display the DC-reduction magnitude (e.g. "DC -3") inside
+a `FoldableHintBanner` without re-implementing the active-window state that the
+engine already tracks as `_activeWeakness.DcReduction`.
+
+Previously the frontend only knew *whether* a weakness window was open on a given
+option (`has_weakness_window: bool`), but not *by how much* it reduced the DC.
+
+---
+
+## Solution
+
+Add `int? WeaknessDcReduction` to `TurnStart`:
+
+- **Non-null** when `_activeWeakness != null` at the moment `StartTurnAsync` builds
+  the `TurnStart`; the value is `_activeWeakness.DcReduction`.
+- **Null** when no window is open.
+
+The field is a pre-resolution hint — it reflects the active window's magnitude
+before any player pick or resolve occurs.
+
+### Wire key
+
+`weakness_dc_reduction` (snake_case, via `[JsonPropertyName]`).
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/Pinder.Core/Conversation/TurnStart.cs` | Added `int? WeaknessDcReduction` property + optional constructor param |
+| `src/Pinder.Core/Conversation/GameSession.cs` | Compute `weaknessDcReduction = _activeWeakness?.DcReduction` and pass to `TurnStart` ctor |
+| `session-runner/Snapshot/SessionSnapshot.cs` | Added `int? WeaknessDcReduction` to `TurnSnapshot`; updated `// Fields covered:` comment |
+| `session-runner/Program.cs` | `BuildTurnSnapshot` accepts and populates `weaknessDcReduction`; call site passes `turnStart.WeaknessDcReduction` |
+| `tests/.../Issue593_WeaknessDcReductionOnTurnStartTests.cs` | Unit + serialization tests |
+
+---
+
+## Constraints
+
+- The `_activeWeakness` field is read-only at `StartTurnAsync` time and is
+  cleared at the start of `ResolveTurnAsync`. `WeaknessDcReduction` is therefore
+  always consistent with what the engine will apply if the player picks the window
+  option this turn.
+- **No breaking change** — `weaknessDcReduction` is a trailing optional parameter;
+  all existing callers continue to compile unchanged.
+
+---
+
+## Testing
+
+See `tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs`:
+
+- AC1: `WeaknessDcReduction` is null when no window is open.
+- AC2: `WeaknessDcReduction` equals `_activeWeakness.DcReduction` when a window is active.
+- AC3: After a window is consumed by resolve, the next turn's start has null.
+- AC4a: JSON contains `"weakness_dc_reduction":3` when active.
+- AC4b: JSON contains `"weakness_dc_reduction":null` when not active.

--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1373,7 +1373,8 @@ class Program
                     session.OpponentHistory,
                     playerSender: player1,
                     i18nCatalog: snapshotI18nCatalog,
-                    opponentDefenseSnapshot: turnStart.OpponentDefenseSnapshot);
+                    opponentDefenseSnapshot: turnStart.OpponentDefenseSnapshot,
+                    weaknessDcReduction: turnStart.WeaknessDcReduction);
 
                 string turnSnapPath = Path.Combine(playtestDir, $"{sessionSlug}.turn-{turn:D2}.snap.json");
                 File.WriteAllText(turnSnapPath, JsonSerializer.Serialize(turnSnap, new JsonSerializerOptions { WriteIndented = true }));
@@ -1676,7 +1677,8 @@ class Program
         IReadOnlyList<Pinder.Core.Conversation.ConversationMessage>? opponentHistory = null,
         string? playerSender = null,
         Pinder.LlmAdapters.I18nCatalog? i18nCatalog = null,
-        Pinder.Core.Conversation.OpponentDefenseSnapshot? opponentDefenseSnapshot = null)
+        Pinder.Core.Conversation.OpponentDefenseSnapshot? opponentDefenseSnapshot = null,
+        int? weaknessDcReduction = null)
     {
         var state = result.StateAfter;
 
@@ -1789,6 +1791,7 @@ class Program
                         BaseModifier      = kvp.Value.BaseModifier,
                     })
                 : null,
+            WeaknessDcReduction = weaknessDcReduction,
         };
     }
 

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -112,6 +112,10 @@ namespace Pinder.SessionRunner.Snapshot
     ///     <c>EffectiveModifier</c>, and <c>BaseModifier</c>. Null when not
     ///     available (legacy snapshots before #903).
     ///   </description></item>
+    ///   <item><description>
+    ///     <c>WeaknessDcReduction</c> (issue #593): the active weakness window's
+    ///     DC reduction at the start of this turn. Null when no window was open.
+    ///   </description></item>
     /// </list>
     /// </summary>
     public sealed class TurnSnapshot
@@ -165,6 +169,12 @@ namespace Pinder.SessionRunner.Snapshot
         /// Null on legacy snapshots taken before #903.
         /// </summary>
         public Dictionary<string, TurnDefenseEntry>? OpponentDefenseSnapshot { get; set; }
+
+        /// <summary>
+        /// Issue #593: DC reduction from the active weakness window at the start
+        /// of this turn. Null when no window was active.
+        /// </summary>
+        public int? WeaknessDcReduction { get; set; }
 
         /// <summary>
         /// Full conversation history up to and including this turn.

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -937,7 +937,11 @@ namespace Pinder.Core.Conversation
             var defenseSnapshot = new OpponentDefenseSnapshot(
                 new System.Collections.ObjectModel.ReadOnlyDictionary<Pinder.Core.Stats.StatType, OpponentDefenseEntry>(defenseEntries));
 
-            return new TurnStart(options, snapshot, _currentDicePools, defenseSnapshot);
+            // #593: expose the active weakness window's DC reduction so the frontend
+            // can render the magnitude on its FoldableHintBanner.
+            int? weaknessDcReduction = _activeWeakness?.DcReduction;
+
+            return new TurnStart(options, snapshot, _currentDicePools, defenseSnapshot, weaknessDcReduction);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/TurnStart.cs
+++ b/src/Pinder.Core/Conversation/TurnStart.cs
@@ -4,7 +4,7 @@ using Pinder.Core.Rolls;
 namespace Pinder.Core.Conversation
 {
     // Fields covered by TurnSnapshot (session-runner/Snapshot/SessionSnapshot.cs):
-    //   Options, State, DicePools, OpponentDefenseSnapshot (#903)
+    //   Options, State, DicePools, OpponentDefenseSnapshot (#903), WeaknessDcReduction (#593)
     //
     /// <summary>
     /// Result of starting a turn: the dialogue options, current game state, and
@@ -27,6 +27,15 @@ namespace Pinder.Core.Conversation
         public OpponentDefenseSnapshot OpponentDefenseSnapshot { get; }
 
         /// <summary>
+        /// #593: The active weakness window's DC reduction at the start of this turn,
+        /// or <c>null</c> when no window is open. Emitted to the frontend so the
+        /// <c>FoldableHintBanner</c> can display the magnitude (e.g. "DC -3") without
+        /// the SPA re-implementing active-window state.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("weakness_dc_reduction")]
+        public int? WeaknessDcReduction { get; }
+
+        /// <summary>
         /// Pre-rolled dice pools, one per option index. Issue #789, Phase 2 (D1).
         ///
         /// <para>
@@ -47,12 +56,14 @@ namespace Pinder.Core.Conversation
         public PerOptionDicePool[] DicePools { get; }
 
         public TurnStart(DialogueOption[] options, GameStateSnapshot state, PerOptionDicePool[] dicePools,
-            OpponentDefenseSnapshot opponentDefenseSnapshot = null)
+            OpponentDefenseSnapshot opponentDefenseSnapshot = null,
+            int? weaknessDcReduction = null)
         {
             Options = options ?? throw new ArgumentNullException(nameof(options));
             State = state ?? throw new ArgumentNullException(nameof(state));
             DicePools = dicePools ?? throw new ArgumentNullException(nameof(dicePools));
             OpponentDefenseSnapshot = opponentDefenseSnapshot;
+            WeaknessDcReduction = weaknessDcReduction;
 
             if (dicePools.Length != options.Length)
                 throw new ArgumentException(

--- a/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Issue #593: <see cref="TurnStart.WeaknessDcReduction"/> exposes the active
+    /// weakness window's DC reduction so the frontend can render the magnitude on
+    /// the FoldableHintBanner without re-implementing active-window state.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue593_WeaknessDcReductionOnTurnStartTests
+    {
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private static CharacterProfile MakeProfile(string name, StatBlock? stats = null)
+        {
+            stats ??= TestHelpers.MakeStatBlock(2);
+            return new CharacterProfile(
+                stats: stats,
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private static GameSession MakeSession(ILlmAdapter? llm = null)
+        {
+            return new GameSession(
+                MakeProfile("Player"),
+                MakeProfile("Opponent"),
+                llm ?? new NullLlmAdapter(),
+                new FixedDice593(5, 5),
+                new NullTrapRegistry593(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 10));
+        }
+
+        // ── AC1: No active window → WeaknessDcReduction is null ──────────────
+
+        [Fact]
+        public async Task StartTurnAsync_NoActiveWeakness_WeaknessDcReductionIsNull()
+        {
+            var session = MakeSession();
+            var turnStart = await session.StartTurnAsync();
+
+            Assert.Null(turnStart.WeaknessDcReduction);
+        }
+
+        // ── AC2: Active window → WeaknessDcReduction equals window's DcReduction ─
+
+        [Fact]
+        public async Task StartTurnAsync_ActiveWeakness_WeaknessDcReductionMatchesWindow()
+        {
+            // Inject a weakness window via a custom LLM adapter that returns one.
+            const int expectedDcReduction = 3;
+            var window = new WeaknessWindow(StatType.SelfAwareness, expectedDcReduction);
+            var llm = new WindowInjectingLlmAdapter593(window);
+            var session = MakeSession(llm);
+
+            // Turn 1: LLM returns a weakness window in the opponent response.
+            // The window becomes active for the NEXT turn's StartTurnAsync.
+            // We must call ResolveTurnAsync (turn 1) then StartTurnAsync again (turn 2).
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2: window injected by the LLM on turn 1 is now _activeWeakness.
+            var turn2Start = await session.StartTurnAsync();
+
+            Assert.NotNull(turn2Start.WeaknessDcReduction);
+            Assert.Equal(expectedDcReduction, turn2Start.WeaknessDcReduction!.Value);
+        }
+
+        // ── AC3: Window consumed after resolve → next turn has null ──────────
+
+        [Fact]
+        public async Task AfterWindowConsumed_NextTurnWeaknessDcReductionIsNull()
+        {
+            const int dcReduction = 2;
+            var window = new WeaknessWindow(StatType.Charm, dcReduction);
+            var llm = new WindowInjectingLlmAdapter593(window);
+            var session = MakeSession(llm);
+
+            // Turn 1 ends, window set as active.
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2 start: window is active.
+            var turn2Start = await session.StartTurnAsync();
+            Assert.Equal(dcReduction, turn2Start.WeaknessDcReduction);
+
+            // Turn 2 resolve: window is consumed (cleared by ResolveTurnAsync regardless of match).
+            await session.ResolveTurnAsync(0);
+
+            // Turn 3 start: no new window from LLM → null.
+            var turn3Start = await session.StartTurnAsync();
+            Assert.Null(turn3Start.WeaknessDcReduction);
+        }
+
+        // ── AC4: Wire serialization — JSON key is "weakness_dc_reduction" ─────
+
+        [Fact]
+        public async Task TurnStart_SerializesWeaknessDcReductionWithCorrectKey_WhenActive()
+        {
+            const int dcReduction = 3;
+            var window = new WeaknessWindow(StatType.SelfAwareness, dcReduction);
+            var llm = new WindowInjectingLlmAdapter593(window);
+            var session = MakeSession(llm);
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+            var turn2Start = await session.StartTurnAsync();
+
+            string json = JsonSerializer.Serialize(turn2Start);
+
+            Assert.Contains("\"weakness_dc_reduction\"", json);
+            Assert.Contains($":{dcReduction}", json);
+        }
+
+        [Fact]
+        public async Task TurnStart_SerializesWeaknessDcReductionAsNull_WhenNoWindow()
+        {
+            var session = MakeSession();
+            var turnStart = await session.StartTurnAsync();
+
+            string json = JsonSerializer.Serialize(turnStart);
+
+            // Field must be present and null in the wire format.
+            Assert.Contains("\"weakness_dc_reduction\":null", json);
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────────
+
+        private sealed class FixedDice593 : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public FixedDice593(params int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides)
+            {
+                if (_values.Count == 0) return sides / 2 + 1;
+                return _values.Dequeue();
+            }
+        }
+
+        private sealed class NullTrapRegistry593 : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        /// <summary>
+        /// LLM adapter that injects a WeaknessWindow on the first opponent response,
+        /// then returns no window on subsequent calls.
+        /// </summary>
+        private sealed class WindowInjectingLlmAdapter593 : ILlmAdapter
+        {
+            private readonly WeaknessWindow _window;
+            private int _opponentCallCount;
+
+            public WindowInjectingLlmAdapter593(WeaknessWindow window) => _window = window;
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                var options = new[]
+                {
+                    new DialogueOption(StatType.Charm,   "Hey, you come here often?"),
+                    new DialogueOption(StatType.Honesty, "I have to be real with you..."),
+                    new DialogueOption(StatType.Wit,     "Did you know that penguins propose with pebbles?"),
+                    new DialogueOption(StatType.Chaos,   "I once ate a whole pizza in a bouncy castle."),
+                };
+                return Task.FromResult(options);
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(context.ChosenOption.IntendedText);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                var weakness = _opponentCallCount == 0 ? _window : null;
+                _opponentCallCount++;
+                return Task.FromResult(new OpponentResponse("Test response", weaknessWindow: weakness));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult<string?>(null);
+            }
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Companion to pinder-web#593 (FoldableHintBanner for Tell + Weakness Window).

## What

Adds `int? WeaknessDcReduction` to `TurnStart` so the frontend can render the DC-reduction magnitude on its `FoldableHintBanner` without re-implementing active-window state.

- **`TurnStart.WeaknessDcReduction`**: non-null when `_activeWeakness` is set at `StartTurnAsync` time; equals `_activeWeakness.DcReduction`. Null when no window is open.
- **Wire key**: `weakness_dc_reduction` (snake_case via `[JsonPropertyName]`).
- **`TurnSnapshot`** updated to mirror the field (Snapshot Schema Discipline).
- **5 new tests** covering null/non-null, window-consumed path, and JSON serialization.

## No breaking change

`weaknessDcReduction` is a trailing optional parameter — all existing callers compile unchanged.