### PR TITLE
chore(turnstart): add [JsonPropertyName] to OpponentDefenseSnapshot (#916)

### DIFF
--- a/docs/specs/issue-903-opponent-defense-snapshot.md
+++ b/docs/specs/issue-903-opponent-defense-snapshot.md
@@ -100,6 +100,12 @@ attributes for all snake_case keys. The outer key `by_attacker_stat` maps to a
 dictionary; each nested entry has `defending_stat`, `effective_modifier`, and
 `base_modifier`.
 
+Note: `TurnStart` is rebuilt by `SessionsController.BuildTurnState` before serialization
+to the SPA; the wire key is set explicitly in the controller mapping. The
+`[JsonPropertyName("opponent_defense_snapshot")]` attribute on `TurnStart.OpponentDefenseSnapshot`
+is added for consistency with the rest of the class's wire-attribute discipline,
+rather than as a primary wire-shape fix.
+
 `StatType` enum keys in the dictionary serialize using their default enum serializer
 (integer-keyed). Callers that need string keys should serialize via a custom
 converter or use `ByAttackerStat.ToDictionary(kvp => kvp.Key.ToString(), ...)`.

--- a/src/Pinder.Core/Conversation/TurnStart.cs
+++ b/src/Pinder.Core/Conversation/TurnStart.cs
@@ -24,6 +24,7 @@ namespace Pinder.Core.Conversation
         /// mapping each possible attacking stat to the defending stat and effective
         /// modifier the opponent will use when resisting that attack.
         /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("opponent_defense_snapshot")]
         public OpponentDefenseSnapshot OpponentDefenseSnapshot { get; }
 
         /// <summary>


### PR DESCRIPTION
Closes #916

## Summary
Adds `[JsonPropertyName("opponent_defense_snapshot")]` to `TurnStart.OpponentDefenseSnapshot` for consistency with the rest of TurnStart's wire-attribute discipline.

## Why it's not a wire-shape fix
TurnStart is rebuilt by `SessionsController.BuildTurnState` before going to the SPA; the wire key is set explicitly there. This change brings the class itself in line with the convention used for other properties (e.g. `WeaknessDcReduction`).

## Spec doc
Added a clarifying note to `docs/specs/issue-903-opponent-defense-snapshot.md` documenting the indirection.

## DoD evidence
**Build**: 0 Error(s)
**Tests (Core)**: Passed: 2782, Failed: 0
**Commit**: 05be5d9
**Push**: Success
**PR**: Pending