### PR TITLE
chore(steering): delete dead SteeringEngine.RollD20 (#919)

### DIFF
--- a/src/Pinder.Core/Conversation/SteeringEngine.cs
+++ b/src/Pinder.Core/Conversation/SteeringEngine.cs
@@ -34,16 +34,10 @@ namespace Pinder.Core.Conversation
         /// <para>
         /// Internal accessor; not part of the public API contract. Do not
         /// use this in production game-logic code paths — use
-        /// <see cref="RollD20"/> / <see cref="AttemptSteeringRollAsync"/>.
+        /// <see cref="AttemptSteeringRollAsync"/>.
         /// </para>
         /// </summary>
         internal Random SteeringRngForCloneOnly => _steeringRng;
-
-        /// <summary>
-        /// Rolls a d20 using the steering RNG (separate from game dice).
-        /// Used by the shadow check mechanic to avoid consuming game dice values.
-        /// </summary>
-        public int RollD20() => _steeringRng.Next(1, 21);
 
         /// <summary>
         /// Attempts a steering roll after message delivery.


### PR DESCRIPTION
Closes #919

## Summary
Deletes `SteeringEngine.RollD20()` — dead since the #901 unification refactor moved shadow checks to `ShadowCheckEngine` → `RollEngine.ResolveCheck`. No in-tree callers verified by repo-wide grep.

Also drops the now-broken `<see cref="RollD20"/>` xref in the XML doc on `SteeringRngForCloneOnly` at line 37.

The historical comment at `ShadowCheckEngine.cs:37` mentioning the old method is kept as migration archaeology.

## DoD Evidence
**Caller scan**: src/Pinder.Core/Conversation/ShadowCheckEngine.cs:37 (historical comment only)
**Build**: 0 Error(s)
**Tests (Core)**: Passed: 2782, Failed: 0
**Commit**: 1ae5af7 chore(steering): delete dead SteeringEngine.RollD20 (#919)
**Push**: Successfully pushed to origin
**PR**: Created
**Files**: src/Pinder.Core/Conversation/SteeringEngine.cs
**git status -s before commit**: M src/Pinder.Core/Conversation/SteeringEngine.cs
**Deviations**: none