### PR TITLE
feat(steering): expose AttackerGroup/DefenderGroup/DcBase on SteeringRollResult (#932)

### DIFF
--- a/src/Pinder.Core/Conversation/SteeringEngine.cs
+++ b/src/Pinder.Core/Conversation/SteeringEngine.cs
@@ -121,7 +121,10 @@ namespace Pinder.Core.Conversation
                 steeringMod: steeringMod,
                 steeringDC: steeringDC,
                 steeringQuestion: steeringQuestion,
-                check: check);
+                check: check,
+                attackerGroup: new[] { "Charm", "Wit", "SelfAwareness" },
+                defenderGroup: new[] { "SelfAwareness", "Rizz", "Honesty" },
+                dcBase: 16);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/SteeringRollResult.cs
+++ b/src/Pinder.Core/Conversation/SteeringRollResult.cs
@@ -1,6 +1,9 @@
 namespace Pinder.Core.Conversation
 {
+    using System.Collections.Generic;
+
     /// <summary>
+
     /// Result of the steering roll that determines whether the player character
     /// appends a date-steering question to their delivered message.
     /// </summary>
@@ -24,8 +27,18 @@ namespace Pinder.Core.Conversation
         /// <summary>The steering question text, or null if the roll failed.</summary>
         public string SteeringQuestion { get; }
 
+        /// <summary>Stat names contributing to the steering modifier.</summary>
+        public IReadOnlyList<string> AttackerGroup { get; }
+
+        /// <summary>Stat names contributing to the steering DC.</summary>
+        public IReadOnlyList<string> DefenderGroup { get; }
+
+        /// <summary>The base DC before the opponent's stat average is added.</summary>
+        public int DcBase { get; }
+
         /// <summary>
         /// Canonical check result from <see cref="RollEngine.ResolveCheck"/>.
+
         /// Captures the raw roll before LLM success/failure affects <see cref="SteeringSucceeded"/>.
         /// Phase 1 (additive): attached alongside existing bespoke fields.
         /// Null only for the <see cref="NotAttempted"/> sentinel.
@@ -39,7 +52,10 @@ namespace Pinder.Core.Conversation
             int steeringMod,
             int steeringDC,
             string steeringQuestion,
-            Pinder.Core.Rolls.RollCheckResult? check = null)
+            Pinder.Core.Rolls.RollCheckResult? check = null,
+            IReadOnlyList<string>? attackerGroup = null,
+            IReadOnlyList<string>? defenderGroup = null,
+            int dcBase = 0)
         {
             SteeringAttempted = steeringAttempted;
             SteeringSucceeded = steeringSucceeded;
@@ -48,9 +64,22 @@ namespace Pinder.Core.Conversation
             SteeringDC = steeringDC;
             SteeringQuestion = steeringQuestion;
             Check = check;
+            AttackerGroup = attackerGroup ?? new List<string>().AsReadOnly();
+            DefenderGroup = defenderGroup ?? new List<string>().AsReadOnly();
+            DcBase = dcBase;
         }
 
         /// <summary>A no-op result when steering was not attempted.</summary>
-        public static SteeringRollResult NotAttempted { get; } = new SteeringRollResult(false, false, 0, 0, 0, null);
+        public static SteeringRollResult NotAttempted { get; } = new SteeringRollResult(
+            steeringAttempted: false,
+            steeringSucceeded: false,
+            steeringRoll: 0,
+            steeringMod: 0,
+            steeringDC: 0,
+            steeringQuestion: null,
+            check: null,
+            attackerGroup: null,
+            defenderGroup: null,
+            dcBase: 0);
     }
 }

--- a/tests/Pinder.Core.Tests/SteeringRollTests.cs
+++ b/tests/Pinder.Core.Tests/SteeringRollTests.cs
@@ -166,5 +166,54 @@ namespace Pinder.Core.Tests
             Assert.Equal(19, result.Steering.SteeringDC);
             Assert.Null(result.Steering.SteeringQuestion);
         }
+
+        /// <summary>
+        /// #932 DI/wiring integration test: assert that AttackerGroup, DefenderGroup,
+        /// and DcBase are populated correctly by SteeringEngine when a roll is attempted.
+        /// Reverse-verify: stripping the populate-from-engine wiring must make this test fail.
+        /// </summary>
+        [Fact]
+        public async Task SteeringRoll_ExposesGroupAndBase()
+        {
+            // Player stats: Charm=5, Wit=5, SA=5 → steering mod = 5
+            var playerStats = MakeStatBlockWithValues(charm: 5, wit: 5, sa: 5);
+            // Opponent stats: SA=0, Rizz=0, Honesty=0 → steering DC = 16
+            var opponentStats = MakeStatBlockWithValues(sa: 0, rizz: 0, honesty: 0);
+
+            var player = new CharacterProfile(
+                playerStats, "You are Player.", "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+            var opponent = new CharacterProfile(
+                opponentStats, "You are Opponent.", "Opponent",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+
+            var dice = new FixedDice(1, 15, 50);
+            var steeringRng = new FixedRandom(20);
+
+            var llm = new NullLlmAdapter();
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), steeringRng: steeringRng);
+            var session = new GameSession(player, opponent, llm, dice, new NullTrapRegistry(), config);
+
+            var turnStart = await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // Assert new fields (TitleCase StatType.ToString())
+            Assert.Equal(new[] { "Charm", "Wit", "SelfAwareness" }, result.Steering.AttackerGroup);
+            Assert.Equal(new[] { "SelfAwareness", "Rizz", "Honesty" }, result.Steering.DefenderGroup);
+            Assert.Equal(16, result.Steering.DcBase);
+        }
+
+        /// <summary>
+        /// #932: the NotAttempted sentinel returns empty lists and DcBase=0.
+        /// </summary>
+        [Fact]
+        public void SteeringRoll_NotAttempted_ReturnsZeroedGroupsAndBase()
+        {
+            var result = SteeringRollResult.NotAttempted;
+
+            Assert.Empty(result.AttackerGroup);
+            Assert.Empty(result.DefenderGroup);
+            Assert.Equal(0, result.DcBase);
+        }
     }
 }


### PR DESCRIPTION
## What

Adds three additive properties to `SteeringRollResult` so the web wire DTO can carry the full steering check formula (per Daniel's Q1=E decision in sprint 2026-05-16-d1d40c). The aggregate `SteeringMod` (attacker average) and `SteeringDC` (= `DcBase + defender average`) remain unchanged.

- `AttackerGroup: IReadOnlyList<string>` = `['Charm', 'Wit', 'SelfAwareness']`
- `DefenderGroup: IReadOnlyList<string>` = `['SelfAwareness', 'Rizz', 'Honesty']`
- `DcBase: int` = `16`

**Naming convention**: TitleCase `StatType.ToString()` (matches existing `OpponentDefenseSnapshotDto`).

**NotAttempted sentinel** returns empty lists + `DcBase = 0` (consistent with the existing zero-out pattern).

**Constructor signature is additive** (new params default to sensible zero-values), so no existing callers need updating.

## Wiring + DI integration test

Per sprint L4, the ticket explicitly required a DI/wiring integration test that calls `AttemptSteeringRollAsync` against a realistic `CharacterProfile` pair and asserts the result has the expected fields. Added `SteeringRoll_ExposesGroupAndBase` to `SteeringRollTests` — it goes through `GameSession.ResolveTurnAsync` (the production entry-point), not a unit-level invocation. Reverse-verified: stripping the `attackerGroup:` / `defenderGroup:` / `dcBase:` populate-from-engine kwargs in `SteeringEngine.AttemptSteeringRollAsync` makes this test fail.

Also added `SteeringRoll_NotAttempted_ReturnsZeroedGroupsAndBase` for the sentinel.

The pre-existing `SteeringRoll_Failure_NoQuestionAppended` regression test is preserved unchanged.

## DoD evidence

**Build:**
```
    84 Warning(s)
    0 Error(s)
```
(84 warnings are pre-existing on main, none introduced.)

**Steering tests:**
```
Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17, Duration: 67 ms - Pinder.Core.Tests.dll
```

**Full Pinder.Core test suite:**
```
Passed!  - Failed:     0, Passed:  2784, Skipped:    18, Total:  2802, Duration: 10 s - Pinder.Core.Tests.dll
```

**Note on Pinder.Rules.Tests + Pinder.LlmAdapters.Tests failures:** these test projects fail on main today (verified independently — `GameDefinitionYamlTests` and related YAML-content tests fail before this change is applied). Out of scope for this ticket; pre-existing.

Sprint: 2026-05-16-d1d40c. Q1=E resolution path.

Closes #932