### PR TITLE
feat(i18n): drop turn_result.annotations_heading (#596)

### DIFF
--- a/data/i18n/en/ui-turn-result.yaml
+++ b/data/i18n/en/ui-turn-result.yaml
@@ -3,7 +3,10 @@
 schema_version: 1
 locale: en
 strings:
-  turn_result.annotations_heading: "Annotations"
+  # #596: turn_result.annotations_heading removed — the outer
+  # <TurnAnnotations> frame was dropped and the four annotation events
+  # (triple / combo / tell / callback) now render as sibling EventBox
+  # nodes without a section heading.
   turn_result.steering_heading: "🧭 Steering"
   turn_result.steering_explainer: "Steering: an extra roll that lets the player nudge the conversation by adding a follow-up question."
   turn_result.vs_dc: "vs DC"


### PR DESCRIPTION
Follow-up to decay256/pinder-web#633.

Frontend #596 dropped the outer `<TurnAnnotations>` frame and the "Annotations" section heading along with it. The four annotation events (triple / combo / tell / callback) now render as sibling EventBox nodes without a wrapping heading, so this i18n key has no remaining consumer in pinder-web.

Frontend stops referencing the key in pinder-web#633; this commit removes it from the upstream YAML so it doesn't sit orphaned. A comment in place of the removed line documents the migration for future spelunkers.

Refs decay256/pinder-web#596