### PR TITLE
fix(#935): retire orphan i18n key turn_result.active_trap_prefix

### DIFF
--- a/data/i18n/en/ui-turn-result.yaml
+++ b/data/i18n/en/ui-turn-result.yaml
@@ -53,7 +53,6 @@ strings:
   turn_result.shadow_growth_heading: "⚫ Shadow Growth"
   turn_result.trap_cleared_prefix: "🛡️ Trap cleared:"
   turn_result.trap_activated_legacy: "🪤 Trap activated: {name}"
-  turn_result.active_trap_prefix: "🪤 Active trap:"
 
   turn_result.nat20_explainer: "🎲 NAT 20 — automatic crit success. Grants advantage on the next roll."
   turn_result.nat1_explainer: "🎲 NAT 1 — automatic miss (regardless of total)"


### PR DESCRIPTION
Closes #935

After pinder-web#599 (#635) landed, the frontend no longer references
`turn_result.active_trap_prefix` — `TurnResultDisplay` now renders an
`<ActiveTrapBadge>` per the #371 (W2a) single-source-of-truth design.

The orphan key still lived in `data/i18n/en/ui-turn-result.yaml` (and
got mirrored into the downstream generated `en.ts`). Pure dead weight;
this PR retires it.

No in-repo i18n rebuild step exists in pinder-core; the consumer
(pinder-web) does its own build via `build-i18n.mjs`, mirroring how
PR #934 (`a43b7bd`, drop `turn_result.annotations_heading`) handled
the same kind of yaml-only deletion.

## DoD Evidence

**dotnet build (last 3 lines):**
```
    191 Warning(s)
    0 Error(s)

Time Elapsed 00:00:52.63
```

**dotnet test (per-assembly summary — flake counts unchanged vs. pre-existing baseline; the one-line yaml deletion has no path to affect C# test behavior):**
```
Passed!  - Failed:     0, Passed:    54, Skipped:     0, Total:    54, Duration: 344 ms - Pinder.RemoteAssets.Tests.dll (net8.0)
Failed!  - Failed:    46, Passed:   198, Skipped:     0, Total:   244, Duration: 11 s - Pinder.Rules.Tests.dll (net8.0)
Passed!  - Failed:     0, Passed:  2784, Skipped:    18, Total:  2802, Duration:  9 s - Pinder.Core.Tests.dll (net8.0)
Failed!  - Failed:    65, Passed:  1005, Skipped:     9, Total:  1079, Duration: 23 s - Pinder.LlmAdapters.Tests.dll (net8.0)
```

**Cross-repo grep — `grep -rn "active_trap_prefix" /root/projects/pinder-web/frontend/src/`:**
```
/root/projects/pinder-web/frontend/src/i18n/generated/en.ts:340:  "turn_result.active_trap_prefix": "🪤 Active trap:",
/root/projects/pinder-web/frontend/src/components/TurnResultDisplay.tsx:410:  // countdown and used the retired t('turn_result.active_trap_prefix') key.
/root/projects/pinder-web/frontend/src/components/TurnResultDisplay.activeTrapBadge.test.tsx:9: *   - The legacy `t('turn_result.active_trap_prefix')` rendering against
/root/projects/pinder-web/frontend/src/components/TurnResultDisplay.activeTrapBadge.test.tsx:158:  it('does NOT render the retired t("turn_result.active_trap_prefix") copy', () => {
```

Classification — **none are live callers**:
- `generated/en.ts` — derived bundle; regenerates when pinder-web reruns its i18n build against this PR's yaml.
- `TurnResultDisplay.tsx:410` — comment documenting the retirement (explicitly says "the retired ... key").
- `TurnResultDisplay.activeTrapBadge.test.tsx` — header comment + test name (`does NOT render`) asserting the key's *absence*.

**In-repo grep — `git grep -n active_trap_prefix` (from `/tmp/work-935`, after deletion):**
```
docs/sprint-runs/2026-05-17-f57876/kickoff.md:39:5. **core#935** — Retire orphan i18n key `turn_result.active_trap_prefix`.
docs/sprint-runs/2026-05-17-f57876/kickoff.md:41:   `grep -r active_trap_prefix` returns nothing under `frontend/`. ≤20min.
```

Both remaining hits are in this sprint's own kickoff doc describing *this very ticket* — expected and self-referential, not a live caller.

## Research Log

- Confirmed pre-existing line 56 in `data/i18n/en/ui-turn-result.yaml` matched the ticket exactly: `turn_result.active_trap_prefix: "🪤 Active trap:"`.
- Searched for an in-repo i18n rebuild step (`scripts/`, root `Makefile`, `*.sh` containing `i18n`) — none exists. The only producer is the downstream `build-i18n.mjs` in pinder-web; PR #934 (`a43b7bd`, by the same sprint pattern) confirms yaml-only deletions are the canonical pinder-core change shape.
- Cross-repo grep into `pinder-web/frontend/src/` returned 4 hits; inspected each and confirmed all three non-generated hits are *retirement-documenting* (comments + an absence-asserting test), not live `t(...)` calls.
- `dotnet build` + `dotnet test` post-deletion — build clean, test totals match the kickoff's known flake baseline (Rules / LlmAdapters carry pre-existing failures unrelated to i18n yaml content).
- `git diff origin/main --stat` confirms scope is exactly one file, one deletion — no drive-bys.
