### PR TITLE
chore(#877): add xmldoc for Configuration.allowInsecureBaseUrl ctor param

### DIFF
--- a/src/Pinder.RemoteAssets/Configuration.cs
+++ b/src/Pinder.RemoteAssets/Configuration.cs
@@ -133,6 +133,12 @@ namespace Pinder.RemoteAssets
         /// </summary>
         public CharacterPayloadSerializer? PayloadSerializer { get; }
 
+        /// <param name="allowInsecureBaseUrl">
+        /// Defaults to <c>false</c>. When <c>true</c>, permits <c>http://</c>
+        /// URIs in <see cref="BaseUrl"/> instead of enforcing the HTTPS
+        /// scheme. Intended ONLY for tests against local fake servers; never
+        /// used in production code.
+        /// </param>
         public Configuration(
             Uri baseUrl,
             HttpMessageHandler httpMessageHandler,


### PR DESCRIPTION
Closes #877

Adds an `<param name="allowInsecureBaseUrl">` xmldoc to the
`Pinder.RemoteAssets.Configuration` constructor. Pure documentation
change — no signature, default, or validation logic touched.

Flagged Low by #876 (closes #859) code-review and security-review
pass-1: the new ctor parameter had no xmldoc even though the `BaseUrl`
property xmldoc already mentions the HTTPS-enforcement opt-out.

## DoD Evidence

### `dotnet build` (last 3 lines)
```
    191 Warning(s)
    0 Error(s)

Time Elapsed 00:00:21.31
```

### `dotnet test` summary (per-assembly, no regression vs main baseline)
```
Passed!  - Failed:     0, Passed:    54, Skipped:     0, Total:    54 - Pinder.RemoteAssets.Tests.dll
Failed!  - Failed:    46, Passed:   198, Skipped:     0, Total:   244 - Pinder.Rules.Tests.dll
Passed!  - Failed:     0, Passed:  2784, Skipped:    18, Total:  2802 - Pinder.Core.Tests.dll
Failed!  - Failed:    65, Passed:  1005, Skipped:     9, Total:  1079 - Pinder.LlmAdapters.Tests.dll
```
Baseline: Core 2784P/0F/18S; Rules 198P/46F; LlmAdapters 1005P/65F/9S;
RemoteAssets 54P/0F. Match exactly.

### `git diff origin/main --stat`
```
 src/Pinder.RemoteAssets/Configuration.cs | 6 ++++++
 1 file changed, 6 insertions(+)
```

## Research Log

- [x] AC bullet 1: `<param name="allowInsecureBaseUrl">` xmldoc present
  on the `Configuration` ctor.
- [x] AC bullet 2: doc text covers default-false, http opt-in, and the
  test-only intent.
- Mirrored tone from the `BaseUrl` property xmldoc which already
  references the opt-out ("MUST be absolute and use the HTTPS scheme").
- Used 4 short sentences in 1 `<param>` block; `<see cref="BaseUrl"/>`
  cross-link for navigability; `<c>http://</c>` / `<c>false</c>` /
  `<c>true</c>` match the surrounding xmldoc voice in this file.
- Verified pure-doc: `git diff origin/main` shows only added lines
  inside an xmldoc comment block above the ctor signature; no code
  lines moved.
