### PR TITLE
fix(#883): restore ArchetypeYamlLoader.LoadFromYaml — pinder-web/Pinder.GameApi is a live caller (deploy hot-fix)

### DIFF
--- a/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
+++ b/src/Pinder.LlmAdapters/ArchetypeYamlLoader.cs
@@ -1,16 +1,34 @@
 using System;
+using System.Collections.Generic;
 using Pinder.Core.Characters;
+using YamlDotNet.RepresentationModel;
 
 namespace Pinder.LlmAdapters
 {
     /// <summary>
-    /// Wires <see cref="ArchetypeCatalog"/> so the LLM directive
-    /// ("ACTIVE ARCHETYPE: ...") is sourced from the canonical yaml
-    /// (<c>data/prompts/archetypes.yaml</c>) rather than from hand-copied
-    /// literals in <see cref="ArchetypeCatalog"/>'s static initialiser.
+    /// Loads archetype behavior text from yaml and registers it with
+    /// <see cref="ArchetypeCatalog"/> so the LLM directive
+    /// ("ACTIVE ARCHETYPE: ...") is sourced from the canonical yaml rather
+    /// than from hand-copied literals in <see cref="ArchetypeCatalog"/>'s
+    /// static initialiser.
     ///
     /// <para>
-    /// <see cref="LoadFromPromptCatalog"/> consumes a
+    /// Two loading paths are supported:
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Legacy (<see cref="LoadFromYaml"/>):</b> parses
+    /// <c>archetypes-enriched.yaml</c> — a flat list of section blocks where
+    /// each archetype is a block with <c>type: archetype_definition</c>,
+    /// a <c>title</c> field, and a <c>behavior</c> field. Still in active
+    /// use by <c>Pinder.GameApi/Program.cs</c> as defence-in-depth for the
+    /// Issue #372 hot-fix path; will be retired once that caller migrates
+    /// to <see cref="LoadFromPromptCatalog"/>-only wiring (tracked in the
+    /// #883 follow-up ticket).
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Current (<see cref="LoadFromPromptCatalog"/>):</b> consumes a
     /// <see cref="PromptCatalog"/> loaded from
     /// <c>data/prompts/archetypes.yaml</c> (Issue #873 Phase 4). Each prompt
     /// entry's key is the archetype name (e.g. <c>"The Hey Opener"</c>) and
@@ -29,6 +47,90 @@ namespace Pinder.LlmAdapters
     /// </summary>
     public static class ArchetypeYamlLoader
     {
+        /// <summary>
+        /// Result of a load operation. Useful for logging at startup.
+        /// </summary>
+        public sealed class LoadResult
+        {
+            /// <summary>Number of (title, behavior) pairs registered with the catalog.</summary>
+            public int Registered { get; }
+
+            /// <summary>Names of archetype blocks skipped because they had no <c>behavior</c> text.</summary>
+            public IReadOnlyList<string> SkippedMissingBehavior { get; }
+
+            /// <summary>Error message when the YAML failed to parse, or null on success.</summary>
+            public string? Error { get; }
+
+            public LoadResult(int registered, IReadOnlyList<string> skippedMissingBehavior, string? error)
+            {
+                Registered = registered;
+                SkippedMissingBehavior = skippedMissingBehavior ?? Array.Empty<string>();
+                Error = error;
+            }
+        }
+
+        /// <summary>
+        /// Parse the supplied YAML text and register every archetype's
+        /// behaviour with <see cref="ArchetypeCatalog.RegisterBehavior"/>.
+        /// On any parse failure returns a <see cref="LoadResult"/> with
+        /// <c>Error</c> populated and <c>Registered = 0</c>; the catalog is
+        /// not modified in that case (callers should log the error so the
+        /// degraded fallback is visible).
+        /// </summary>
+        /// <param name="yamlContent">Full text of <c>archetypes-enriched.yaml</c>.</param>
+        /// <returns>Load summary.</returns>
+        public static LoadResult LoadFromYaml(string yamlContent)
+        {
+            if (string.IsNullOrWhiteSpace(yamlContent))
+                return new LoadResult(0, Array.Empty<string>(), "yaml content was empty");
+
+            int registered = 0;
+            var skipped = new List<string>();
+
+            try
+            {
+                var stream = new YamlStream();
+                using (var reader = new System.IO.StringReader(yamlContent))
+                    stream.Load(reader);
+
+                if (stream.Documents.Count == 0)
+                    return new LoadResult(0, skipped, "yaml had no documents");
+
+                if (!(stream.Documents[0].RootNode is YamlSequenceNode root))
+                    return new LoadResult(0, skipped, "yaml root was not a sequence");
+
+                foreach (var node in root.Children)
+                {
+                    if (!(node is YamlMappingNode block)) continue;
+
+                    string? type = GetScalar(block, "type");
+                    if (!string.Equals(type, "archetype_definition", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string? title = GetScalar(block, "title");
+                    string? behavior = GetScalar(block, "behavior");
+
+                    if (string.IsNullOrWhiteSpace(title))
+                        continue;
+
+                    if (string.IsNullOrWhiteSpace(behavior))
+                    {
+                        skipped.Add(title!);
+                        continue;
+                    }
+
+                    ArchetypeCatalog.RegisterBehavior(title!, behavior!);
+                    registered++;
+                }
+
+                return new LoadResult(registered, skipped, null);
+            }
+            catch (Exception ex)
+            {
+                return new LoadResult(0, skipped, ex.Message);
+            }
+        }
+
         /// <summary>
         /// Wire <see cref="ArchetypeCatalog.BehaviorResolver"/> so
         /// <see cref="ArchetypeCatalog.GetBehavior"/> prefers the yaml
@@ -63,6 +165,13 @@ namespace Pinder.LlmAdapters
             // boundary between Pinder.Core and Pinder.LlmAdapters).
             ArchetypeCatalog.BehaviorResolver = name =>
                 catalog.TryGet(name)?.SystemPrompt;
+        }
+
+        private static string? GetScalar(YamlMappingNode mapping, string key)
+        {
+            if (mapping.Children.TryGetValue(new YamlScalarNode(key), out var v) && v is YamlScalarNode scalar)
+                return scalar.Value;
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary

Hot-fix: restore `ArchetypeYamlLoader.LoadFromYaml(string)` + the
`LoadResult` nested class + private `GetScalar` helper that #883
(PR #939, commit `bb0d01a`) deleted as "dead code".

The deletion is unblocking the pinder-web staging deploy — pinder-web
fails to build against the post-#883 pinder-core submodule pointer:

```
error CS0117: 'ArchetypeYamlLoader' does not contain a definition for 'LoadFromYaml'
[pinder-web/src/Pinder.GameApi/Pinder.GameApi.csproj]
```

## Why #883's analysis was incomplete

PR #939 declared `LoadFromYaml` dead based on a grep scoped to
**pinder-core only**, finding `Issue372_ArchetypeYamlLoaderTests` as
the sole caller. That conclusion was wrong: there is a live
production caller in the sister repository.

`pinder-web/src/Pinder.GameApi/Program.cs` lines ~421–449 (Issue #372
hot-fix path, retained as defence-in-depth for the
`archetypes-enriched.yaml` flat-list loader) invokes:

```csharp
var loadResult = Pinder.LlmAdapters.ArchetypeYamlLoader.LoadFromYaml(
    File.ReadAllText(archetypePath));
if (loadResult.Error != null) { … log Error … }
else { … log Registered + SkippedMissingBehavior … }
```

The caller uses all three fields of `LoadResult` (`Error`,
`Registered`, `SkippedMissingBehavior`). #883 removed the entire
class and the method, so any pinder-web build pinning a
pinder-core ≥ `bb0d01a` fails compilation.

## Scope of this revert

This PR is a **partial** revert of #883:

- **Restored**: the `LoadFromYaml(string)` static method, the
  `LoadResult` nested class, the private `GetScalar(YamlMappingNode, string)`
  helper, the supporting `using System.Collections.Generic;` and
  `using YamlDotNet.RepresentationModel;` imports, and the xmldoc
  paragraph describing the legacy loading path.
- **NOT restored**: `tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeYamlLoaderTests.cs`.
  That deletion was correct — the test was genuinely orphaned and
  was contributing to the noise floor, so leaving it deleted is fine.

The xmldoc now also explicitly states that `LoadFromYaml` is
retained for the `Pinder.GameApi/Program.cs` caller and will be
retired once that caller migrates to `LoadFromPromptCatalog`
(tracked as a #883 follow-up ticket, blocked on #871 Phase 5).

## Build evidence

| Command | Pointer | Result |
|---|---|---|
| `dotnet build src/Pinder.LlmAdapters` | this branch | clean (0 errors, 102 warnings — all pre-existing) |
| `dotnet test tests/Pinder.LlmAdapters.Tests` | this branch | **64 failed**, 1003 passed, 9 skipped (matches f57876 sprint scoreboard baseline of 64 — **0 new failures**) |
| `dotnet build pinder-web/src/Pinder.GameApi` | pinder-core `bb0d01a` (current main) | **FAIL** — `error CS0117 'ArchetypeYamlLoader' does not contain a definition for 'LoadFromYaml'` |
| `dotnet build pinder-web/src/Pinder.GameApi` | pinder-core this branch (HEAD `02dfd02`) | **clean (0 errors)** — deploy unblocked |

The pinder-web verification was performed locally by fetching this
branch into pinder-web's `pinder-core` submodule and rebuilding;
the submodule pointer in pinder-web's HEAD is unchanged on disk.
The actual submodule bump in pinder-web can ride the next deploy
cycle in a separate small PR.

## Follow-up

A follow-up ticket will be filed in pinder-core titled
`[chore][883 follow-up] Delete ArchetypeYamlLoader.LoadFromYaml
after migrating Pinder.GameApi/Program.cs to PromptCatalog-only
path`. Rationale: `LoadFromYaml` *is* a legitimate dead-code
candidate, but only **after** the `Pinder.GameApi` caller migrates
to a `PromptCatalog`-only wiring path, which depends on #871
Phase 5 landing in pinder-core.

## Lesson captured

This PR also seeded a lesson on top of `sprint-runs/2026-05-17-f57876/lessons.md`
(committed directly to main per project convention):
`EIGENTAKT-DEAD-CODE-NEEDS-CROSS-REPO-GREP` — implementer prompts
for dead-code deletions must require greps across **both**
`pinder-core` and `pinder-web/src/` (and any other downstream
consumer) before declaring a symbol unused. The grep #883 ran was
scoped to pinder-core only; the live caller in `Pinder.GameApi`
was invisible from inside the pinder-core worktree.

Closes the deploy-build regression introduced by #883.
Refs #883, #939, #372.
