### PR TITLE
fix(#884): serialize Issue527+Issue873 via xUnit [Collection]

### DIFF
--- a/tests/Pinder.Core.Tests/Issue527_SessionRunnerBioFormatTests.cs
+++ b/tests/Pinder.Core.Tests/Issue527_SessionRunnerBioFormatTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     [Trait("Category", "SessionRunner")]
+    [Collection("SessionRunnerReflection")]
     public sealed class Issue527_SessionRunnerBioFormatTests
     {
         [Fact]

--- a/tests/Pinder.Core.Tests/Issue873_ArchetypeCatalogPhase4Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue873_ArchetypeCatalogPhase4Tests.cs
@@ -21,7 +21,7 @@ namespace Pinder.Core.Tests
     ///   the resolver nor the in-memory dictionary can satisfy a lookup.
     /// </summary>
     [Trait("Category", "PromptCatalog")]
-    [Collection("BehaviorResolver")]
+    [Collection("SessionRunnerReflection")]
     public class Issue873_ArchetypeCatalogPhase4Tests
     {
         // ----- repo helpers ---------------------------------------------------


### PR DESCRIPTION
Closes #884

## Root cause

`Issue527_SessionRunnerBioFormatTests` reflects on `Pinder.SessionRunner.dll`; `Issue873_ArchetypeCatalogPhase4Tests` transitively loads YamlDotNet via `PromptCatalog.LoadFromDirectory`. xUnit's default parallelism let the two test classes run concurrently, and the AppDomain-level assembly-load interaction caused `BioFormattedAsBoldItalicParagraph_NotTableRow` to produce empty output ~2/3 of the time. Documented on the ticket; not a regression from #873.

## Fix

Put both classes in the same xUnit collection:

- \`Issue527_SessionRunnerBioFormatTests\`: add \`[Collection(\"SessionRunnerReflection\")]\`.
- \`Issue873_ArchetypeCatalogPhase4Tests\`: change \`[Collection(\"BehaviorResolver\")]\` → \`[Collection(\"SessionRunnerReflection\")]\`.

xUnit serializes test classes that share a collection name; no \`[CollectionDefinition]\` class is required for implicit collections. Issue873 was the sole member of \`BehaviorResolver\` (verified with \`grep -rn 'Collection(\"BehaviorResolver\")' tests/Pinder.Core.Tests/\`), so the rename costs nothing.

## DoD Evidence

Combined-filter 10/10 pass (Issue527 + Issue873):

\`\`\`
=== Run 1 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 2 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 3 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 4 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 5 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 6 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 7 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 8 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 9 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
=== Run 10 === Passed!  - Failed: 0, Passed: 3, Skipped: 1, Total: 4, Duration: 1 s
\`\`\`

(3 passes + 1 skip = Issue527.BioFormatted... pass, Issue527.EmptyBioHandledCorrectly pre-existing skip, Issue873 × 2 pass.)

Full \`Pinder.Core.Tests\` suite:

\`\`\`
Passed!  - Failed: 0, Passed: 2784, Skipped: 18, Total: 2802, Duration: 6 s
\`\`\`

Solution-wide Release build:

\`\`\`
191 Warning(s)
0 Error(s)
\`\`\`

(Pinder.GameApi.csproj does not exist in pinder-core; it lives in pinder-web. Built the Pinder.Core.sln in Release mode instead.)

## Research Log

**Read:** ticket #884 body + comments, `tests/Pinder.Core.Tests/Issue527_SessionRunnerBioFormatTests.cs`, `tests/Pinder.Core.Tests/Issue873_ArchetypeCatalogPhase4Tests.cs`, `grep -rn 'Collection(\"BehaviorResolver\")' tests/Pinder.Core.Tests/`.

**Baseline flake rate:** combined filter `Issue527|Issue873` ran 5× before fix attempts — flake did not reproduce on this main HEAD (660677e), possibly because Issue873 already had `[Collection(\"BehaviorResolver\")]` which gave it its own implicit serialization vs. other parallel test classes. The flake the ticket describes was on an older main; the right defensive fix is to make the isolation explicit by co-locating both reflection-heavy classes in one collection.

**Strategy chosen:** xUnit `[Collection]` rename (option 1 from the spawn task list). Smallest, most targeted change. Two-line diff.

**Alternatives rejected:**
- `[CollectionBehavior(DisableTestParallelization = true)]` at assembly level — would slow the whole 2800-test suite for the sake of two reflection-heavy classes. Rejected.
- Eager YamlDotNet load in a test fixture — guesses at the root cause; the [Collection] approach treats the symptom (parallelism) without needing to nail down which precise static initializer races.

**Mirror test updates:** none — this is a test-isolation change with no source edit to mirror.

**Cross-repo grep:** N/A — no symbols deleted.

## Filed follow-ups

None. The full-suite run did surface one unrelated flake during the implementer's earlier attempt — `Issue840_SingleLoaderPipelineTests.AssembleMicrobenchmark_P50_UnderOneMillisecond` failed with \`PromptBuilder.StructuralFragmentLookup is not wired\`, which is a different parallelism race against \`PromptWiring.Wire()\`. It did not reproduce on this PR's full-suite run. If it surfaces again, file a fresh ticket with the same template.