### PR TITLE
fix(#942): make StartTurnAsync transactional; add ResolveTurnAsync invariant guard

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -753,15 +753,21 @@ namespace Pinder.Core.Conversation
                 throw new GameEndedException(_outcome!.Value);
 
             // Check end conditions: interest at 0 or 25
+            //
+            // Issue #942: StartTurnAsync must be transactional — no observable state
+            // mutation (_ended, _outcome, shadow) when it throws GameEndedException.
+            // Callers (e.g. web prefetch/drain fallback) catch the exception and call
+            // session.MarkEnded(ex.Outcome) explicitly; they must not observe partial
+            // state from the failed call.
+            //
+            // Shadow growth events are still included in the exception for the SPA to
+            // display, but are NOT committed to _playerShadows before the throw.
             if (_interest.IsZero)
             {
-                _ended = true;
-                _outcome = GameOutcome.Unmatched;
-                // End-of-game Dread +1: conversation ended without date
+                // End-of-game Dread +1 event: compute description WITHOUT applying to tracker.
                 if (_playerShadows != null)
                 {
-                    _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
-                    var dreadEvents = _playerShadows.DrainGrowthEvents();
+                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
                     throw new GameEndedException(GameOutcome.Unmatched, dreadEvents);
                 }
                 throw new GameEndedException(GameOutcome.Unmatched);
@@ -769,8 +775,6 @@ namespace Pinder.Core.Conversation
 
             if (_interest.IsMaxed)
             {
-                _ended = true;
-                _outcome = GameOutcome.DateSecured;
                 throw new GameEndedException(GameOutcome.DateSecured);
             }
 
@@ -780,14 +784,12 @@ namespace Pinder.Core.Conversation
                 int ghostRoll = _dice.Roll(4);
                 if (ghostRoll == 1)
                 {
-                    _ended = true;
-                    _outcome = GameOutcome.Ghosted;
-
-                    // Shadow growth: Ghosted → +1 Dread (#44 trigger 8)
+                    // Shadow growth: Ghosted → +1 Dread (#44 trigger 8).
+                    // Event description is surfaced via the exception for SPA display;
+                    // tracker state is NOT mutated (transactional — #942).
                     if (_playerShadows != null)
                     {
-                        _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Ghosted");
-                        var events = _playerShadows.DrainGrowthEvents();
+                        var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
                         throw new GameEndedException(GameOutcome.Ghosted, events);
                     }
 
@@ -1871,6 +1873,19 @@ namespace Pinder.Core.Conversation
             _currentDicePools = null;
 
             // 15. Build result
+
+            // Issue #942 invariant guard: a successful roll MUST NOT produce a negative
+            // base interest delta. SuccessScale always returns ≥ 1 for success; a negative
+            // baseInterestDelta here means the session state was pre-corrupted (e.g. by a
+            // phantom turn from the prefetch/fallback bug). Fail loudly rather than persist
+            // an incoherent turn record.
+            if (rollResult.IsSuccess && baseInterestDelta < 0)
+                throw new InvariantViolationException(
+                    $"#942 invariant violated on turn {_turnNumber}: roll.IsSuccess=true " +
+                    $"but baseInterestDelta={baseInterestDelta} (expected ≥0). " +
+                    "SuccessScale cannot produce a negative delta for a success roll. " +
+                    "This indicates a phantom turn produced from a pre-corrupted session state.");
+
             var stateSnapshot = CreateSnapshot();
 
             return new TurnResult(

--- a/src/Pinder.Core/Conversation/InvariantViolationException.cs
+++ b/src/Pinder.Core/Conversation/InvariantViolationException.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Thrown when a per-turn game invariant is violated, indicating a data-corruption
+    /// or state-mutation bug (e.g. a successful roll with a negative base interest delta).
+    ///
+    /// Issue #942: added as a hard guard on the ResolveTurnAsync output path.
+    /// The invariant "roll.is_success == true ⇒ base_interest_delta ≥ 0" can never be
+    /// violated by correct gameplay logic (SuccessScale always returns ≥ 1 for success
+    /// rolls). A violation means a phantom turn was produced from a pre-corrupted session.
+    /// </summary>
+    public sealed class InvariantViolationException : InvalidOperationException
+    {
+        public InvariantViolationException(string message)
+            : base(message) { }
+
+        public InvariantViolationException(string message, Exception inner)
+            : base(message, inner) { }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Issue #942: GameSession.StartTurnAsync must be transactional —
+    /// if it throws GameEndedException, no observable state mutation
+    /// (interest, turnNumber, activeTraps, shadowState) should be visible.
+    ///
+    /// Regression-test per REGRESSION-TESTS-ON-BUGS (canonical lesson).
+    ///
+    /// AC1: StartTurnAsync_ThrowsGameEnded_LeavesSessionStateUnchanged
+    /// AC2: InvariantGuard_SuccessRollWithNegativeBaseInterestDelta_Throws
+    /// </summary>
+    [Collection("GameSession")]
+    [Trait("Category", "Core")]
+    public class Issue942_StartTurnTransactionalTests
+    {
+        // ── Snapshot helper ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Captures observable session state that StartTurnAsync must not mutate
+        /// when it throws GameEndedException: interest, turnNumber, activeTraps,
+        /// and shadow effective values for every ShadowStatType.
+        /// </summary>
+        private sealed record SessionSnapshot(
+            int Interest,
+            int TurnNumber,
+            IReadOnlyList<string> ActiveTrapNames,
+            IReadOnlyDictionary<ShadowStatType, int> ShadowEffectiveValues)
+        {
+            /// <summary>
+            /// Captures current observable state from a GameSession and its shadow tracker.
+            /// </summary>
+            public static SessionSnapshot Capture(
+                GameSession session,
+                SessionShadowTracker? shadows)
+            {
+                // activeTraps via snapshot
+                var snap = session.CreateSnapshot();
+
+                // shadow effective values — capture all six shadow stats
+                var shadowValues = new Dictionary<ShadowStatType, int>();
+                if (shadows != null)
+                {
+                    foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+                        shadowValues[s] = shadows.GetEffectiveShadow(s);
+                }
+                else
+                {
+                    foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+                        shadowValues[s] = 0;
+                }
+
+                return new SessionSnapshot(
+                    Interest: snap.Interest,
+                    TurnNumber: snap.TurnNumber,
+                    ActiveTrapNames: snap.ActiveTrapNames,
+                    ShadowEffectiveValues: shadowValues);
+            }
+        }
+
+        // ── Test helpers ──────────────────────────────────────────────────────
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        /// <summary>
+        /// Builds a session in Bored state (interest = 2, Bored range = 1–4).
+        /// The FixedDice is pre-loaded with:
+        ///   - d4 = 1 for the ghost trigger (25% chance fires deterministically)
+        /// </summary>
+        private static (GameSession Session, SessionShadowTracker Shadows) BuildBoredSessionWithShadow()
+        {
+            var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2, 0));
+
+            // QueueOrDefaultDice: first value=horniness d10, second=d4 ghost trigger (1=fires),
+            // falls back to 10 for any remaining rolls.
+            var dice = new QueueOrDefaultDice(10, /*horniness*/5, /*ghost d4*/1);
+
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                playerShadows: shadows,
+                startingInterest: 2); // Bored: 1–4
+
+            var session = new GameSession(
+                MakeProfile("player"),
+                MakeProfile("opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            return (session, shadows);
+        }
+
+        // ── AC1: transactional StartTurnAsync ─────────────────────────────────
+
+        /// <summary>
+        /// AC1 — reverse-verification test:
+        /// StartTurnAsync on a Bored session whose ghost trigger fires must throw
+        /// GameEndedException and leave interest, turnNumber, activeTraps, and
+        /// shadowState unchanged from before the call.
+        ///
+        /// MUST FAIL before the fix (proving the bug); MUST PASS after.
+        /// </summary>
+        [Fact]
+        public async Task StartTurnAsync_ThrowsGameEnded_LeavesSessionStateUnchanged()
+        {
+            var (session, shadows) = BuildBoredSessionWithShadow();
+
+            var snapshotBefore = SessionSnapshot.Capture(session, shadows);
+
+            // Ghost trigger fires deterministically (dice=1 on d4).
+            await Assert.ThrowsAsync<GameEndedException>(
+                () => session.StartTurnAsync());
+
+            var snapshotAfter = SessionSnapshot.Capture(session, shadows);
+
+            // All observable state must be unchanged.
+            Assert.Equal(snapshotBefore.Interest, snapshotAfter.Interest);
+            Assert.Equal(snapshotBefore.TurnNumber, snapshotAfter.TurnNumber);
+            Assert.Equal(snapshotBefore.ActiveTrapNames, snapshotAfter.ActiveTrapNames);
+
+            // Shadow state — every shadow stat effective value must be unchanged.
+            foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+            {
+                Assert.Equal(
+                    snapshotBefore.ShadowEffectiveValues[s],
+                    snapshotAfter.ShadowEffectiveValues[s]);
+            }
+        }
+
+        /// <summary>
+        /// Confirms the thrown exception carries the correct outcome (Ghosted)
+        /// and includes the Dread growth event — even though the tracker was
+        /// not mutated (transactional contract).
+        /// </summary>
+        [Fact]
+        public async Task StartTurnAsync_ThrowsGameEnded_ExceptionCarriesDreadGrowthEvent()
+        {
+            var (session, _) = BuildBoredSessionWithShadow();
+
+            var ex = await Assert.ThrowsAsync<GameEndedException>(
+                () => session.StartTurnAsync());
+
+            Assert.Equal(GameOutcome.Ghosted, ex.Outcome);
+            // The exception must still surface the shadow-growth event for the SPA.
+            Assert.Contains(ex.ShadowGrowthEvents,
+                e => e.Contains("Dread") && e.Contains("Ghosted"));
+        }
+
+        // ── AC2: per-turn invariant guard ─────────────────────────────────────
+
+        /// <summary>
+        /// AC2 — invariant guard:
+        /// ResolveTurnAsync must throw InvariantViolationException when
+        /// roll.IsSuccess == true AND baseInterestDelta &lt; 0.
+        /// This state cannot occur in legitimate gameplay (SuccessScale always
+        /// returns ≥ 0 for success) but CAN occur when a phantom turn is created
+        /// from a pre-corrupted session — exactly the #942 scenario.
+        ///
+        /// This test injects a custom IRuleResolver that deliberately returns -1
+        /// for a success delta, forcing the invariant check to fire.
+        /// </summary>
+        [Fact]
+        public async Task ResolveTurnAsync_SuccessRollWithNegativeBaseInterestDelta_ThrowsInvariantViolation()
+        {
+            // Use a rule resolver that returns -1 success delta (impossible in real rules).
+            var rules = new NegativeSuccessDeltaRuleResolver();
+
+            // Build a session with interest = 10 (Interested — ghost trigger never fires).
+            // Dice queue (in consumption order):
+            //   [0]=5  → constructor d10 horniness roll
+            //   [1]=20 → FillChosenDicePool d20 main roll (Nat-20 ensures is_success=true)
+            //   [2]=50 → FillChosenDicePool d100 timing variance
+            // Remaining values default to 10 via the FixedDice sentinel below.
+            // Shadow stat = 0 on all stats so no shadow check fires (no extra dice).
+            // QueueOrDefaultDice: first value=horniness d10 roll, second=main d20 roll
+            // (20 = Nat-20 ensures is_success=true regardless of DC),
+            // then falls back to 10 for any remaining rolls (timing d100, etc.).
+            var dice = new QueueOrDefaultDice(10, /*horniness*/5, /*main d20*/20);
+
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                rules: rules,
+                startingInterest: 10);
+
+            var session = new GameSession(
+                MakeProfile("player"),
+                MakeProfile("opponent"),
+                new NullLlmAdapter(),
+                dice,
+                new NullTrapRegistry(),
+                config);
+
+            await session.StartTurnAsync();
+
+            await Assert.ThrowsAsync<InvariantViolationException>(
+                () => session.ResolveTurnAsync(0));
+        }
+
+        // ── Fakes ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Rule resolver that returns -1 for every success interest delta,
+        /// simulating the impossible invariant-violation state.
+        /// All other lookups return null (fall through to defaults).
+        /// </summary>
+        /// <summary>
+        /// Like FixedDice but returns a fallback value (10) when the queue is exhausted.
+        /// Prevents "no more values" exceptions in tests that don't need to control
+        /// every dice roll in the pipeline.
+        /// </summary>
+        private sealed class QueueOrDefaultDice : IDiceRoller
+        {
+            private readonly Queue<int> _queue;
+            private readonly int _default;
+            public QueueOrDefaultDice(int @default, params int[] values)
+            {
+                _default = @default;
+                _queue = new Queue<int>(values);
+            }
+            public int Roll(int sides) => _queue.Count > 0 ? _queue.Dequeue() : _default;
+        }
+
+        private sealed class NegativeSuccessDeltaRuleResolver : IRuleResolver
+        {
+            public int? GetSuccessInterestDelta(int beatMargin, int naturalRoll) => -1;
+            public int? GetFailureInterestDelta(int missMargin, int naturalRoll) => null;
+            public int? GetMomentumBonus(int streak) => null;
+            public InterestState? GetInterestState(int interest) => null;
+            public int? GetShadowThresholdLevel(int shadowValue) => null;
+            public double? GetRiskTierXpMultiplier(Pinder.Core.Rolls.RiskTier riskTier) => null;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -579,9 +579,14 @@ namespace Pinder.Core.Tests.Integration
             var session = new GameSession(gerald, velvet, llm, dice, new NullTrapRegistry(), config);
 
             // First call triggers ghost
-            await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
+            var ghostEx = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
+            Assert.Equal(GameOutcome.Ghosted, ghostEx.Outcome);
 
-            // Mutation: Fails if ended game allows further actions
+            // #942 transactional contract: StartTurnAsync does NOT set _ended on throw.
+            // Caller must call MarkEnded after catching so the session is properly closed.
+            session.MarkEnded(ghostEx.Outcome);
+
+            // Subsequent call on a MarkEnded session throws immediately.
             await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
         }
 

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -263,6 +263,8 @@ namespace Pinder.Core.Tests
 
         // ======================== Trigger 8: Ghost → +1 Dread ========================
 
+        // #942 transactional fix: tracker is NOT mutated when StartTurnAsync throws.
+        // The exception carries the event description; tracker unchanged.
         [Fact]
         public async Task Ghost_GrowsDread()
         {
@@ -277,7 +279,8 @@ namespace Pinder.Core.Tests
             var ex = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
             Assert.Equal(GameOutcome.Ghosted, ex.Outcome);
             Assert.Contains(ex.ShadowGrowthEvents, e => e.Contains("Dread") && e.Contains("Ghosted"));
-            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Dread));
+            // Tracker unchanged (#942 transactional contract): caller uses MarkEnded after catch.
+            Assert.Equal(0, shadows.GetDelta(ShadowStatType.Dread));
         }
 
         // ======================== Trigger 9: SA used 3+ times → +1 Overthinking ========================

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -140,7 +140,8 @@ namespace Pinder.Core.Tests
             Assert.True(shadows.GetDelta(ShadowStatType.Dread) >= 2);
         }
 
-        // Mutation: would catch if ghost didn't apply Dread growth
+        // #942 transactional fix: shadow tracker must NOT be mutated when StartTurnAsync throws;
+        // Dread growth is surfaced via the exception's ShadowGrowthEvents instead.
         [Fact]
         public async Task AC1_Ghosted_GrowsDread1()
         {
@@ -150,7 +151,9 @@ namespace Pinder.Core.Tests
 
             var ex = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
             Assert.Equal(GameOutcome.Ghosted, ex.Outcome);
-            Assert.Equal(1, shadows.GetDelta(ShadowStatType.Dread));
+            // Tracker must be unchanged (#942): caller applies MarkEnded after catching.
+            Assert.Equal(0, shadows.GetDelta(ShadowStatType.Dread));
+            // Exception still carries the Dread growth event for the SPA to display.
             Assert.Contains(ex.ShadowGrowthEvents, e => e.Contains("Ghosted") && e.Contains("Dread"));
         }
 


### PR DESCRIPTION
## Summary

Fixes the core half of the P0 state-corruption bug (#942).

### Root cause

`StartTurnAsync` mutated `_ended`, `_outcome`, and `_playerShadows` (Dread +1) **before** throwing `GameEndedException` in the ghost-trigger, IsZero, and IsMaxed paths. These mutations persisted on the session object. The web-side speculative prefetch caught the exception but left the session in a half-mutated state; the synchronous fallback then re-entered the session and produced a phantom turn with `is_success=true` but `delta_from_roll=-3`.

### Fix

**Strategy B (reorder)** — throw before any state mutation:

- `StartTurnAsync` now throws `GameEndedException` without setting `_ended`, `_outcome`, or mutating `_playerShadows`. Shadow growth event descriptions are computed inline and carried in the exception (`ShadowGrowthEvents`) for the SPA to display, but the tracker is untouched.
- **Caller contract**: after catching `GameEndedException` from `StartTurnAsync`, callers must call `session.MarkEnded(ex.Outcome)`. The web PR will enforce this on the prefetch/drain-fallback path.
- Added `InvariantViolationException`: thrown by `ResolveTurnAsync` when `roll.IsSuccess == true` but `baseInterestDelta < 0` — a state that cannot occur in legitimate gameplay (SuccessScale returns ≥ 1 for success). This turns the phantom-turn scenario into a loud failure instead of silent data corruption.

### Tests

- `Issue942_StartTurnTransactionalTests.cs` — AC1 reverse-verification (ghost trigger leaves session state unchanged) + AC2 invariant guard.
- Updated `ShadowGrowthSpecTests.AC1_Ghosted_GrowsDread1`, `ShadowGrowthEventTests.Ghost_GrowsDread`, `FullConversationIntegrationTest.GameAlreadyEnded_SubsequentCallThrows` to match new transactional contract.
- Full suite: 2787 passed, 18 skipped, 0 failed.

## DoD Evidence

**Build**: `dotnet build -c Release` → 0 errors, 89 warnings (pre-existing)
**Tests targeted**: 180 passed, 1 skipped, 0 failed
**Tests full**: 2787 passed, 18 skipped, 0 failed

Partially addresses #942 (core engine side; web-side prefetch fix tracked separately and required before this issue closes).