### PR TITLE
fix(#951): opening message uses opponent name, not literal 'scene'

### DIFF
--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -439,10 +439,17 @@ namespace Pinder.LlmAdapters
             if (conversationHistory != null && conversationHistory.Count > 0)
             {
                 sb.AppendLine("RECENT CONVERSATION (for context — reference specific details in your response):");
-                int start = Math.Max(0, conversationHistory.Count - 6);
-                for (int i = start; i < conversationHistory.Count; i++)
+                // #951: skip scene entries (sender == "[scene]") before computing
+                // the last-6 window so turn-0 bios and outfit descriptions never
+                // appear as [OPPONENT] lines that confuse the LLM about the
+                // opponent's character name.
+                var filtered = new System.Collections.Generic.List<(string Sender, string Text)>(conversationHistory.Count);
+                foreach (var e in conversationHistory)
+                    if (!Senders.IsScene(e.Sender)) filtered.Add(e);
+                int start = Math.Max(0, filtered.Count - 6);
+                for (int i = start; i < filtered.Count; i++)
                 {
-                    var entry = conversationHistory[i];
+                    var entry = filtered[i];
                     string role = (!string.IsNullOrEmpty(playerName) && entry.Sender == playerName) ? "PLAYER" : "OPPONENT";
                     sb.AppendLine($"[{role}] \"{entry.Text}\"");
                 }
@@ -469,12 +476,21 @@ namespace Pinder.LlmAdapters
         {
             sb.AppendLine("[CONVERSATION_START]");
 
+            // #951: turn index must count only real conversational entries.
+            // Scene entries (sender == "[scene]") must never appear in the
+            // LLM context — GameSession.BuildHistoryForLlmContext() normally
+            // filters them, but a defense-in-depth guard here prevents any
+            // caller from accidentally passing an unfiltered list and having
+            // the LLM confuse "[scene]" for the opponent's character name.
+            int filteredIndex = 0;
             for (int i = 0; i < history.Count; i++)
             {
-                int turn = (i / 2) + 1;
                 var entry = history[i];
+                if (Senders.IsScene(entry.Sender)) continue;
+                int turn = (filteredIndex / 2) + 1;
                 string role = entry.Sender == playerName ? "PLAYER" : "OPPONENT";
                 sb.AppendLine($"[T{turn}|{role}|{entry.Sender}] \"{entry.Text}\"");
+                filteredIndex++;
             }
 
             sb.AppendLine("[CURRENT_TURN]");

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -584,5 +584,66 @@ namespace Pinder.LlmAdapters.Tests
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
             Assert.Contains("Turn 4", result);
         }
+
+        // ── Issue #951 regression: scene entries must never leak as the opponent name ──
+
+        [Fact]
+        public void BuildOpponentPrompt_SceneEntriesInHistory_AreFiltered()
+        {
+            // Arrange: history contains turn-0 scene entries followed by real conversation.
+            // Scene entries must not appear in the built prompt, and the opponent character
+            // name ("SABLE_XO") must be present instead of the literal word "scene".
+            var historyWithScenes = new List<(string, string)>
+            {
+                (Senders.Scene, "Player bio text."),
+                (Senders.Scene, "Opponent bio text."),
+                (Senders.Scene, "Both wear something quietly out of fashion."),
+                ("GERALD_42", "Hey there, I noticed your bio."),
+            };
+
+            var result = SessionDocumentBuilder.BuildOpponentPrompt(
+                MakeOpponentContext(
+                    conversationHistory: historyWithScenes,
+                    playerDeliveredMessage: "Hey there, I noticed your bio.",
+                    playerName: "GERALD_42",
+                    opponentName: "SABLE_XO"));
+
+            // Scene entries must not appear as [OPPONENT|[scene]] labels.
+            Assert.DoesNotContain("[scene]", result);
+            // The opponent’s real name must be present (substituted into engine block).
+            Assert.Contains("SABLE_XO", result);
+            // Standalone word “scene” must not appear as a whole word where it could
+            // be mistaken for a character name. (Use whole-word check to avoid false
+            // positives on words like "obscene".)
+            Assert.DoesNotMatch(@"(?i)\bscene\b", result);
+        }
+
+        [Fact]
+        public void BuildInterestChangeBeatPrompt_SceneEntriesInHistory_AreFiltered()
+        {
+            // Arrange: history with turn-0 scene entries.
+            var historyWithScenes = new List<(string, string)>
+            {
+                (Senders.Scene, "Player bio text."),
+                (Senders.Scene, "Opponent bio text."),
+                (Senders.Scene, "Both wear something out of fashion."),
+                ("GERALD_42", "Hey there!"),
+                ("SABLE_XO",  "Hi!"),
+            };
+
+            var result = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
+                opponentName: "SABLE_XO",
+                interestBefore: 5,
+                interestAfter: 10,
+                newState: InterestState.Interested,
+                conversationHistory: historyWithScenes,
+                playerName: "GERALD_42");
+
+            // Scene entries must not appear in the RECENT CONVERSATION block.
+            Assert.DoesNotContain("[scene]", result);
+            Assert.DoesNotMatch(@"(?i)\bscene\b", result);
+            // Opponent name must be substituted correctly.
+            Assert.Contains("SABLE_XO", result);
+        }
     }
 }


### PR DESCRIPTION
Closes #951.

## Root cause
`SessionDocumentBuilder.AppendConversationHistory` and `BuildInterestChangeBeatPrompt` did not filter turn-0 `[scene]` entries (sender == `Senders.Scene = "[scene]"`). When a caller passed an unfiltered conversation history, scene entries appeared as `[OPPONENT|[scene]]` (in the engine block) or `[OPPONENT]` (in the beat block), giving the LLM the impression the opponent's name is scene and causing it to use that word in the opening message.

## Fix
- `AppendConversationHistory`: skip any entry where `Senders.IsScene(entry.Sender)` is true; use a separate `filteredIndex` so turn numbers remain correct for real conversational entries.
- `BuildInterestChangeBeatPrompt`: pre-filter scene entries from the conversation list before taking the last-6 window.

## Tests
- `BuildOpponentPrompt_SceneEntriesInHistory_AreFiltered` — history with scene entries → prompt contains opponent name, not `[scene]` or standalone `scene`.
- `BuildInterestChangeBeatPrompt_SceneEntriesInHistory_AreFiltered` — same guard for the beat prompt.

## DoD
- Build: clean (0 errors, 186 pre-existing warnings)
- Tests: 1069/1069 pass