### PR TITLE
chore(web#651): add sessions_page.replay_pending i18n key

### DIFF
--- a/data/i18n/en/ui.yaml
+++ b/data/i18n/en/ui.yaml
@@ -58,6 +58,7 @@ strings:
   sessions_page.empty: "No sessions yet."
   sessions_page.start_new_game: "Start a new game"
   sessions_page.replay_button: "▶ Replay"
+  sessions_page.replay_pending: "Replay generation pending"
 
   # ── SessionLogPage (#45, migrated #440 Phase 5) ──────────────────
   session_log.loading: "Loading session log…"


### PR DESCRIPTION
Companion to pinder-web PR #664. Adds the missing i18n key referenced by SessionsPage.tsx for the 'Replay generation pending' state.

Single-line YAML addition. No code, no tests. Trivial.