### PR TITLE
chore(#925): rename TurnSnapshot.DefendingRollStat -> DefendingStat

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -1779,7 +1779,7 @@ class Program
             ConversationHistory = convEntries,
             OpponentHistory = opponentHistoryEntries,
             Events = events,
-            DefendingRollStat = result.Roll.DefendingStat.ToString(),
+            DefendingStat = result.Roll.DefendingStat.ToString(),
             GhostProbabilityPerTurn = state.GhostProbabilityPerTurn,
             OpponentDefenseSnapshot = opponentDefenseSnapshot != null
                 ? opponentDefenseSnapshot.ByAttackerStat.ToDictionary(

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -94,9 +94,11 @@ namespace Pinder.SessionRunner.Snapshot
     ///     list when no opponent calls have resolved yet.
     ///   </description></item>
     ///   <item><description>
-    ///     <c>DefendingRollStat</c> (issue #906): the defending stat used in
+    ///     <c>DefendingStat</c> (issue #906): the defending stat used in
     ///     the option roll on this turn (<c>StatBlock.DefenceTable[Stat]</c>).
-    ///     Empty string on turns with no roll.
+    ///     Empty string on turns with no roll. (Renamed from
+    ///     <c>DefendingRollStat</c> in #925; no collision with
+    ///     <c>TurnDefenseEntry.DefendingStat</c> — different class.)
     ///   </description></item>
     ///   <item><description>
     ///     <c>GhostProbabilityPerTurn</c> (issue #905): probability (0.0..1.0)
@@ -151,8 +153,11 @@ namespace Pinder.SessionRunner.Snapshot
         /// Issue #906: defending stat used in the roll for this turn.
         /// Derived from <c>StatBlock.DefenceTable[Stat]</c>. Empty string on turns
         /// with no roll (ghosted / skipped). Populated in <c>BuildTurnSnapshot</c>.
+        /// Renamed from <c>DefendingRollStat</c> in #925 to match the wire field
+        /// name (<c>defending_stat</c>). Lives on a different class from
+        /// <c>TurnDefenseEntry.DefendingStat</c>, so there is no collision.
         /// </summary>
-        public string DefendingRollStat { get; set; } = string.Empty;
+        public string DefendingStat { get; set; } = string.Empty;
 
         /// <summary>
         /// Issue #905: probability (0.0..1.0) that the opponent will ghost on


### PR DESCRIPTION
Closes #925

## DoD Evidence
- [x] `TurnSnapshot.DefendingRollStat` renamed to `DefendingStat`
- [x] No collision with `TurnDefenseEntry.DefendingStat` (different class — `OpponentDefenseSnapshot` entry vs. top-level `TurnSnapshot` property)
- [x] All call sites updated (one: `session-runner/Program.cs` in `BuildTurnSnapshot`)
- [x] Wire JSON shape: `TurnSnapshot` uses default JSON naming (no `[JsonPropertyName]` on this property), so the snapshot file key moves from `"DefendingRollStat"` to `"DefendingStat"`. The conceptual wire link to `defending_stat` on `RollResult` / `OpponentDefenseSnapshot` is preserved (those attributes are unchanged). The ticket explicitly recommends this rename to match that wire name.
- [x] `dotnet build Pinder.Core.sln`: 0 errors, 222 warnings (pre-existing, unrelated).
- [x] `dotnet test tests/Pinder.Core.Tests`: **2790 passed, 0 failed, 18 skipped** (13s)

```
Passed!  - Failed:     0, Passed:  2790, Skipped:    18, Total:  2808, Duration: 13 s - Pinder.Core.Tests.dll (net8.0)
```

## Research Log

- **Rename target**: `session-runner/Snapshot/SessionSnapshot.cs` — the property lived inside the `TurnSnapshot` sealed class (line ~155 pre-rename), no `[JsonPropertyName]` attribute attached. The class doc comment (the bulleted `<list>`) was also updated to use the new name and to record the rename + non-collision note.
- **Call sites**: `grep -rn DefendingRollStat` returned exactly one assignment site outside the declaring class: `session-runner/Program.cs` in the object-initialiser inside `BuildTurnSnapshot` (`DefendingRollStat = result.Roll.DefendingStat.ToString()`). No tests, no fixtures, no JSON files referenced the old name.
- **Wire attribute**: there was no `[JsonPropertyName("defending_stat")]` on this property — it serialized as PascalCase `"DefendingRollStat"`. Other classes (`RollResult`, `OpponentDefenseSnapshot`) keep their existing `[JsonPropertyName("defending_stat")]` attributes untouched, which is what the ticket meant by "match the wire field name".
- **No collision**: verified `TurnDefenseEntry.DefendingStat` (in `OpponentDefenseSnapshot`) is a property of a different type used inside `OpponentDefenseSnapshot.ByAttackerStat`. `TurnSnapshot.DefendingStat` is a string on the top-level snapshot. Two namespaces, two classes, no name clash.

## Deviations from contract
none.