### PR TITLE
chore(#949): LlmStakeGenerator prompt -> bullet-list format

### DIFF
--- a/data/prompts/stake.yaml
+++ b/data/prompts/stake.yaml
@@ -20,7 +20,7 @@ prompts:
       You are a sentence-completion engine for a comedy hookup-app simulator where the protagonists are sentient penises.
       Read the character profile and produce exactly 15 lines — one for each numbered stem below — written in the character's first-person voice.
       Each line completes the stem with one specific, concrete, slightly absurd, embodied answer that the character believes completely and would never realise is funny.
-      Plain text only. One stem-completion per line. Include the stem prefix. ~10-15 words per line. No markdown, no dashes, no numbering, no headings.
+      Output a markdown bullet list. One bullet per stem-completion. Each line starts with `- ` (dash + space). Include the stem prefix in the bullet body. ~10-15 words per bullet. No nested bullets. No numbering. No headings.
       The character treats absurd things as completely real. Specific over generic. Embodied over emotional-meta. Undignified is a feature.
       BIOGRAPHICAL ANCHOR REQUIREMENT: every completed stem MUST contain at least one of the following —
       (a) a proper name (e.g. 'Margot', not 'an ex'),

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -25,13 +25,13 @@ namespace Pinder.SessionSetup
     /// turn relative to the legacy prompt.
     /// </para>
     /// <para>
-    /// Output contract (issue pinder-web #136): each yielded fragment is
-    /// plain text — no markdown headings, bold, italics, bullet or
-    /// numbered lists, blockquotes, or code fences. The transport sees
-    /// one fragment per line. Both the system and user prompts forbid
-    /// markdown explicitly. <c>Pinder.GameApi</c> runs a
-    /// <c>MarkdownSanitizer</c> as defence-in-depth before storing the
-    /// result.
+    /// Output contract (issue pinder-web #136, refined by #949): the
+    /// model emits a 15-item markdown bullet list — one <c>- </c>-
+    /// prefixed bullet per stem-completion. No headings, bold, italics,
+    /// nested bullets, numbered lists, blockquotes, or code fences.
+    /// <c>Pinder.GameApi</c> runs a <c>MarkdownSanitizer</c> as defence-
+    /// in-depth; per #949 that sanitizer preserves the <c>- </c> bullets
+    /// unchanged so the stake renders as a bullet list in the SPA.
     /// </para>
     /// <para>
     /// Streaming: when an <see cref="IStreamingLlmTransport"/> is supplied,
@@ -55,7 +55,7 @@ namespace Pinder.SessionSetup
             "You are a sentence-completion engine for a comedy hookup-app simulator where the protagonists are sentient penises. " +
             "Read the character profile and produce exactly 15 lines — one for each numbered stem below — written in the character's first-person voice. " +
             "Each line completes the stem with one specific, concrete, slightly absurd, embodied answer that the character believes completely and would never realise is funny. " +
-            "Plain text only. One stem-completion per line. Include the stem prefix. ~10-15 words per line. No markdown, no dashes, no numbering, no headings. " +
+            "Output a markdown bullet list. One bullet per stem-completion. Each line starts with `- ` (dash + space). Include the stem prefix in the bullet body. ~10-15 words per bullet. No nested bullets. No numbering. No headings. " +
             "The character treats absurd things as completely real. Specific over generic. Embodied over emotional-meta. Undignified is a feature. " +
             "BIOGRAPHICAL ANCHOR REQUIREMENT: every completed stem MUST contain at least one of the following — " +
             "(a) a proper name (e.g. 'Margot', not 'an ex'), " +

--- a/src/Pinder.SessionSetup/README.md
+++ b/src/Pinder.SessionSetup/README.md
@@ -24,10 +24,12 @@ All LLM I/O goes through `ILlmTransport` (provider-agnostic). The web tier
 (`Pinder.GameApi`) builds these helpers around a per-session transport and
 calls them from `ActiveSession.SetupAsync`.
 
-## Plain-Text Output Contract
+## Output Contracts
 
-**The per-character psychological stake and the outfit description MUST
-be emitted as plain prose. No markdown markers.**
+### Outfit description — plain prose
+
+**The outfit description MUST be emitted as plain prose. No markdown
+markers.**
 
 Forbidden:
 
@@ -37,6 +39,21 @@ Forbidden:
 - Numbered lists (`1. `, `2. ` …)
 - Fenced code (```` ``` ````) and inline code (backticks)
 - Blockquotes (`> `)
+
+### Psychological stake — markdown bullet list (#949)
+
+**The per-character psychological stake MUST be emitted as a 15-item
+markdown bullet list, one `- `-prefixed bullet per stem-completion.**
+From #949 onward, the SPA renders the stake as a bullet list and the
+`MarkdownSanitizer` preserves `- ` line prefixes unchanged.
+
+Still forbidden for the stake field:
+
+- Headings (`#`, `##`, `###`)
+- Bold / italic emphasis
+- Nested bullets
+- Numbered lists
+- Fenced code, inline code, blockquotes
 
 Paragraph breaks (blank lines between paragraphs) and inline punctuation are
 preserved.
@@ -51,13 +68,16 @@ context.
 
 ### Defense in depth
 
-1. **Prompt-level constraint.** The system + user prompts in
-   `LlmStakeGenerator` and `LlmOutfitDescriber` explicitly forbid markdown
-   formatting (issue
-   [pinder-web#136](https://github.com/decay256/pinder-web/issues/136)).
+1. **Prompt-level constraint.** The outfit prompt forbids all markdown
+   (issue
+   [pinder-web#136](https://github.com/decay256/pinder-web/issues/136));
+   the stake prompt requests a `- `-prefixed bullet list and forbids
+   every other marker (#949).
 2. **Backend sanitizer (web tier).** `Pinder.GameApi` runs the LLM output
-   through a `MarkdownSanitizer` before storing it on the session, catching
-   stray markers when the model ignores the prompt.
+   through a `MarkdownSanitizer` before storing it on the session. Per
+   #949 the sanitizer preserves `- ` line prefixes so the stake bullets
+   survive, while still stripping headings, emphasis, code fences, and
+   blockquotes.
 3. **This README.** A reminder for any future engine-side change to either
    helper.
 

--- a/tests/Pinder.Core.Tests/SessionSetup/LlmStakeGeneratorStreamTests.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/LlmStakeGeneratorStreamTests.cs
@@ -38,7 +38,7 @@ namespace Pinder.Core.Tests.SessionSetup
         }
 
         [Fact]
-        public async Task StreamStakeAsync_ForwardsPlainTextSystemPrompt()
+        public async Task StreamStakeAsync_ForwardsBulletListSystemPrompt()
         {
             var streaming = new FakeStreamingTransport(new[] { "ok" });
             var gen = new LlmStakeGenerator(new StubLlmTransport(), streaming);
@@ -46,12 +46,12 @@ namespace Pinder.Core.Tests.SessionSetup
             await foreach (var _ in gen.StreamStakeAsync("Alice", Prompt)) { }
 
             Assert.NotNull(streaming.LastSystemPrompt);
-            // Plain-text contract: the system prompt must explicitly forbid markdown.
-            // #826 reshaped the prompt from prose to a 5-7 single-line fragment list, but
-            // the no-markdown contract is unchanged — just expressed as "plain text" /
-            // "no markdown" rather than the legacy "plain prose" / "Do NOT use markdown".
-            Assert.Contains("Plain text", streaming.LastSystemPrompt!);
-            Assert.Contains("No markdown", streaming.LastSystemPrompt!);
+            // Bullet-list contract (#949): the system prompt must explicitly
+            // request a markdown bullet list, one `- `-prefixed bullet per
+            // stem-completion. This inverts the legacy "plain text / no markdown"
+            // contract enforced before #949.
+            Assert.Contains("markdown bullet list", streaming.LastSystemPrompt!);
+            Assert.Contains("- ", streaming.LastSystemPrompt!);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #949

## DoD Evidence
- [x] `DefaultSystemPrompt` updated to request a `- ` bullet list per stem
- [x] `data/prompts/stake.yaml` `stake` entry byte-identical to the new C# constant (after whitespace-normalisation, per the existing `Issue843_PromptCatalogPhase1Tests` invariant)
- [x] `Issue843_PromptCatalogPhase1Tests`: 10/10 pass
- [x] MarkdownSanitizer audit: **strip confirmed** \u2014 the sanitizer's `UnorderedListPrefix` regex removes line-start `- ` markers from stake output; a companion pinder-web PR will land to preserve them. Without that companion change the new bullets would never reach the SPA.
- [x] `dotnet build Pinder.Core.sln`: 0 errors, warnings only
- [x] `dotnet test Pinder.Core.Tests`: 2790/2790 pass (18 skipped, pre-existing)

## Research Log
The legacy stake system prompt explicitly forbade markdown (`Plain text only. One stem-completion per line. ... No markdown, no dashes, no numbering, no headings.`). #949 inverts that for the stake field only: the prompt now asks the model for a 15-item bullet list (one `- `-prefixed bullet per stem-completion, ~10-15 words per bullet, no nested bullets / numbering / headings). The byte-identical lockstep contract from #843 Phase 1 is preserved: `LlmStakeGenerator.DefaultSystemPrompt` and `data/prompts/stake.yaml`'s `prompts.stake.system_prompt` are updated together, and the `Issue843_PromptCatalogPhase1Tests` `StakeYaml_SystemPrompt_MatchesConstFallback_ByteForByte` test still passes after the change.

The pinder-web `MarkdownSanitizer` audit found a real strip: `UnorderedListPrefix = ^[ \t]*[-*+][ \t]+` removes line-start `- ` markers, and `ActiveSession.SetupAsync` routes every stake (streaming and non-streaming) through `MarkdownSanitizer.Strip` before storing it on the character. Without a companion pinder-web change the new bullets would be stripped server-side and never render. The companion PR will modify the sanitizer to preserve `- ` bullets for the stake field (the cleanest path \u2014 `- ` bullets are safe markdown and the SPA already renders them) and add a test pinning the new behaviour. Then it will bump the pinder-core submodule pointer to this PR's merge SHA.

Two stale callouts were also refreshed in lockstep: `LlmStakeGenerator`'s class-level doc-comment and `src/Pinder.SessionSetup/README.md`'s 'Plain-Text Output Contract' section. The README now has two sub-sections \u2014 outfit (still plain prose) and stake (markdown bullet list) \u2014 instead of one blanket plain-text contract. The `LlmStakeGeneratorStreamTests.StreamStakeAsync_ForwardsPlainTextSystemPrompt` test was renamed to `StreamStakeAsync_ForwardsBulletListSystemPrompt` and rewritten to assert `'markdown bullet list'` + `'- '` instead of the legacy `'Plain text'` + `'No markdown'` markers.