### PR TITLE
chore(#920): synthesise RollCheckResult in CreateForcedFailResult; tighten RollResult.Check to non-null

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -2128,23 +2128,37 @@ namespace Pinder.Core.Conversation
         /// Creates a synthetic RollResult that represents a forced failure at the given tier.
         /// Used by the shadow check to compute the failure interest delta when overriding a success.
         /// </summary>
+        /// <remarks>
+        /// #920: explicitly synthesises a <see cref="Pinder.Core.Rolls.RollCheckResult"/> via
+        /// <see cref="Pinder.Core.Rolls.RollCheckResult.Synthesise"/> so the returned
+        /// <see cref="Pinder.Core.Rolls.RollResult.Check"/> is never null — prerequisite for the
+        /// Phase 2 wire-DTO serializer which will read <c>Check.*</c>.
+        /// </remarks>
         private static RollResult CreateForcedFailResult(RollResult original, FailureTier shadowTier)
         {
             // Build a result that looks like a miss at the given tier.
             // We derive a miss margin that maps to the tier, then compute a die roll that misses DC.
             int fakeDie = original.DC > 1 ? original.DC - 1 : 1; // just below DC
-            return new RollResult(
-                dieRoll: fakeDie,
+            var check = Pinder.Core.Rolls.RollCheckResult.Synthesise(
+                dieRoll:       fakeDie,
                 secondDieRoll: null,
-                usedDieRoll: fakeDie,
-                stat: original.Stat,
-                statModifier: 0,
-                levelBonus: 0,
-                dc: original.DC,
-                tier: shadowTier,
-                activatedTrap: null,
-                externalBonus: 0,
-                defendingStat: Pinder.Core.Stats.StatBlock.DefenceTable[original.Stat]);
+                usedDieRoll:   fakeDie,
+                statModifier:  0,
+                levelBonus:    0,
+                dc:            original.DC);
+            return new RollResult(
+                dieRoll:        fakeDie,
+                secondDieRoll:  null,
+                usedDieRoll:    fakeDie,
+                stat:           original.Stat,
+                statModifier:   0,
+                levelBonus:     0,
+                dc:             original.DC,
+                tier:           shadowTier,
+                activatedTrap:  null,
+                externalBonus:  0,
+                check:          check,
+                defendingStat:  Pinder.Core.Stats.StatBlock.DefenceTable[original.Stat]);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Rolls/RollCheckResult.cs
+++ b/src/Pinder.Core/Rolls/RollCheckResult.cs
@@ -85,5 +85,61 @@ namespace Pinder.Core.Rolls
             Tier         = tier;
             MissMargin   = missMargin;
         }
+
+        /// <summary>
+        /// Synthesise a <see cref="RollCheckResult"/> from the bespoke fields a
+        /// <see cref="RollResult"/> already carries. Used by callers that build a
+        /// <see cref="RollResult"/> outside <see cref="RollEngine"/> (e.g.
+        /// <c>GameSession.CreateForcedFailResult</c>, test fixtures) so the
+        /// <c>Check</c> property is never null. Modifier bag is reconstructed as
+        /// <c>[stat, level]</c> from <paramref name="statModifier"/> /
+        /// <paramref name="levelBonus"/>; <paramref name="externalBonus"/> is folded
+        /// into <c>Total</c> the same way <see cref="RollEngine.ResolveCheck"/> would.
+        /// </summary>
+        /// <remarks>
+        /// <c>Tier</c> here is derived from <see cref="FailureTierLadder.FromMissMargin"/>
+        /// only — it can differ from the bespoke <see cref="RollResult.Tier"/> on a
+        /// nat-1 (Legendary in RollResult.Tier vs. Catastrophe here). This mirrors the
+        /// behaviour documented on <see cref="RollResult.Check"/>.
+        /// </remarks>
+        public static RollCheckResult Synthesise(
+            int dieRoll,
+            int? secondDieRoll,
+            int usedDieRoll,
+            int statModifier,
+            int levelBonus,
+            int dc,
+            int externalBonus = 0,
+            RollCheckKind kind = RollCheckKind.OptionRoll)
+        {
+            var modifiers = new NamedModifier[]
+            {
+                new NamedModifier("stat",  statModifier),
+                new NamedModifier("level", levelBonus),
+            };
+            int total       = usedDieRoll + statModifier + levelBonus + externalBonus;
+            bool isNatOne   = usedDieRoll == 1;
+            bool isNatTwenty = usedDieRoll == 20;
+            bool isSuccess  = total >= dc;
+            int missMargin  = isSuccess ? 0 : dc - total;
+            FailureTier tier = isSuccess
+                ? FailureTier.Success
+                : FailureTierLadder.FromMissMargin(missMargin);
+
+            return new RollCheckResult(
+                kind,
+                dieRoll,
+                secondDieRoll,
+                usedDieRoll,
+                modifiers,
+                modifierSum: statModifier + levelBonus,
+                total:       total,
+                dc:          dc,
+                isSuccess:   isSuccess,
+                isNatOne:    isNatOne,
+                isNatTwenty: isNatTwenty,
+                tier:        tier,
+                missMargin:  missMargin);
+        }
     }
 }

--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -97,6 +97,13 @@ namespace Pinder.Core.Rolls
         /// <summary>By how much the roll missed the DC (using FinalTotal). 0 on success.</summary>
         public int MissMargin => IsSuccess ? 0 : DC - FinalTotal;
 
+        /// <summary>
+        /// Primary constructor. <paramref name="check"/> is required and stored verbatim on
+        /// <see cref="Check"/>; callers outside <see cref="RollEngine"/> typically build it
+        /// via <see cref="RollCheckResult.Synthesise"/>. The parameter order matches the
+        /// pre-#920 signature so existing positional callers stay compatible — the only
+        /// change is that <paramref name="check"/> is now non-nullable and required.
+        /// </summary>
         public RollResult(
             int dieRoll,
             int? secondDieRoll,
@@ -106,9 +113,9 @@ namespace Pinder.Core.Rolls
             int levelBonus,
             int dc,
             FailureTier tier,
-            TrapDefinition? activatedTrap = null,
-            int externalBonus = 0,
-            RollCheckResult? check = null,
+            TrapDefinition? activatedTrap,
+            int externalBonus,
+            RollCheckResult check,
             StatType defendingStat = default)
         {
             DieRoll        = dieRoll;
@@ -127,7 +134,49 @@ namespace Pinder.Core.Rolls
             Tier           = IsSuccess ? FailureTier.Success : tier;
             ActivatedTrap  = activatedTrap;
             RiskTier       = ComputeRiskTier(dc, statModifier, levelBonus);
-            Check          = check!;
+            Check          = check ?? throw new System.ArgumentNullException(nameof(check));
+        }
+
+        /// <summary>
+        /// Convenience overload that synthesises <see cref="Check"/> from the bespoke fields
+        /// via <see cref="RollCheckResult.Synthesise"/>. Use this when you don't already have
+        /// a <see cref="RollCheckResult"/> from <see cref="RollEngine.ResolveCheck"/> — e.g.
+        /// <c>GameSession.CreateForcedFailResult</c> and test fixtures that exercise the
+        /// bespoke-field code paths without going through <see cref="RollEngine"/>.
+        /// </summary>
+        public RollResult(
+            int dieRoll,
+            int? secondDieRoll,
+            int usedDieRoll,
+            StatType stat,
+            int statModifier,
+            int levelBonus,
+            int dc,
+            FailureTier tier,
+            TrapDefinition? activatedTrap = null,
+            int externalBonus = 0,
+            StatType defendingStat = default)
+            : this(
+                dieRoll,
+                secondDieRoll,
+                usedDieRoll,
+                stat,
+                statModifier,
+                levelBonus,
+                dc,
+                tier,
+                activatedTrap,
+                externalBonus,
+                RollCheckResult.Synthesise(
+                    dieRoll,
+                    secondDieRoll,
+                    usedDieRoll,
+                    statModifier,
+                    levelBonus,
+                    dc,
+                    externalBonus),
+                defendingStat)
+        {
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/Rolls/Issue920_RollResultCheckNonNullTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue920_RollResultCheckNonNullTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Regression coverage for #920.
+    ///
+    /// After Phase 1 (#918) the <see cref="RollResult.Check"/> property became the
+    /// canonical wire-DTO source for d20 mechanics, but a forced-fail constructed via
+    /// <c>GameSession.CreateForcedFailResult</c> and ~12 test fixtures still passed
+    /// null for <c>check</c>, leaving <see cref="RollResult.Check"/> null at
+    /// construction time. The Phase 2 wire-DTO serializer would NRE on access.
+    ///
+    /// #920 fix:
+    ///   1. Added <see cref="RollCheckResult.Synthesise"/> — builds a canonical
+    ///      check from the bespoke fields a forced-fail <see cref="RollResult"/>
+    ///      carries.
+    ///   2. Tightened <see cref="RollResult"/>'s primary constructor: the
+    ///      <c>check</c> parameter is now required and non-nullable (no more
+    ///      <c>check!</c> null-suppression).
+    ///   3. The legacy convenience constructor (bespoke fields only) now auto-
+    ///      synthesises <see cref="RollCheckResult"/> so every code path
+    ///      produces a non-null <see cref="RollResult.Check"/>.
+    /// </summary>
+    public class Issue920_RollResultCheckNonNullTests
+    {
+        // ----------------------------------------------------------------
+        // Synthesise factory — bespoke→check field parity
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void Synthesise_BuildsForcedFailCheck_WithConsistentFields()
+        {
+            // A typical forced-fail input shape (cf. GameSession.CreateForcedFailResult).
+            int dc = 14;
+            int fakeDie = dc - 1; // 13 — just below DC, miss margin 1 → Fumble (FailureTierLadder)
+
+            RollCheckResult check = RollCheckResult.Synthesise(
+                dieRoll:       fakeDie,
+                secondDieRoll: null,
+                usedDieRoll:   fakeDie,
+                statModifier:  0,
+                levelBonus:    0,
+                dc:            dc);
+
+            Assert.Equal(RollCheckKind.OptionRoll, check.Kind);
+            Assert.Equal(fakeDie, check.DieRoll);
+            Assert.Equal(fakeDie, check.UsedDieRoll);
+            Assert.Null(check.SecondDieRoll);
+            Assert.Equal(dc, check.Dc);
+            Assert.Equal(fakeDie, check.Total);        // 13 + 0 + 0
+            Assert.False(check.IsSuccess);
+            Assert.False(check.IsNatOne);
+            Assert.False(check.IsNatTwenty);
+            Assert.Equal(1, check.MissMargin);          // 14 - 13
+            Assert.Equal(FailureTier.Fumble, check.Tier);
+            Assert.Equal(2, check.Modifiers.Count);     // [stat, level]
+            Assert.Contains(check.Modifiers, m => m.Key == "stat");
+            Assert.Contains(check.Modifiers, m => m.Key == "level");
+        }
+
+        [Fact]
+        public void Synthesise_NatTwentyOverDc_ReportsSuccessAndFlag()
+        {
+            RollCheckResult check = RollCheckResult.Synthesise(
+                dieRoll:       20,
+                secondDieRoll: null,
+                usedDieRoll:   20,
+                statModifier:  0,
+                levelBonus:    0,
+                dc:            50);
+
+            // RollCheckResult itself does not apply the nat-20 auto-success game rule;
+            // it just reports the raw mechanics. Here total < dc so success is false.
+            Assert.True(check.IsNatTwenty);
+            Assert.False(check.IsSuccess);
+            Assert.Equal(30, check.MissMargin);
+        }
+
+        [Fact]
+        public void Synthesise_FoldsExternalBonusIntoTotal()
+        {
+            // 10 + statMod 2 + level 1 + external 3 = 16 vs DC 14 → success
+            RollCheckResult check = RollCheckResult.Synthesise(
+                dieRoll:       10,
+                secondDieRoll: null,
+                usedDieRoll:   10,
+                statModifier:  2,
+                levelBonus:    1,
+                dc:            14,
+                externalBonus: 3);
+
+            Assert.Equal(16, check.Total);
+            Assert.True(check.IsSuccess);
+            Assert.Equal(0, check.MissMargin);
+            Assert.Equal(FailureTier.Success, check.Tier);
+        }
+
+        // ----------------------------------------------------------------
+        // RollResult — Check is non-null at construction time
+        // ----------------------------------------------------------------
+
+        [Fact]
+        public void ConvenienceCtor_AutoSynthesisesCheck_AndFieldsAgreeWithBespoke()
+        {
+            // Old-style call (no `check` argument) — must still produce a non-null Check.
+            var result = new RollResult(
+                dieRoll: 13,
+                secondDieRoll: null,
+                usedDieRoll: 13,
+                stat: StatType.Charm,
+                statModifier: 0,
+                levelBonus: 0,
+                dc: 14,
+                tier: FailureTier.Misfire);
+
+            Assert.NotNull(result.Check);
+            Assert.Equal(result.DieRoll,       result.Check.DieRoll);
+            Assert.Equal(result.UsedDieRoll,   result.Check.UsedDieRoll);
+            Assert.Equal(result.SecondDieRoll, result.Check.SecondDieRoll);
+            Assert.Equal(result.DC,            result.Check.Dc);
+            // Bespoke Total = die + statMod + level (no external) = 13.
+            // Check.Total folds externalBonus (0 here) — same value.
+            Assert.Equal(result.Total + result.ExternalBonus, result.Check.Total);
+            Assert.Equal(result.IsNatOne,      result.Check.IsNatOne);
+            Assert.Equal(result.IsNatTwenty,   result.Check.IsNatTwenty);
+        }
+
+        [Fact]
+        public void PrimaryCtor_RequiresNonNullCheck()
+        {
+            // The tightened primary ctor must throw ArgumentNullException on null.
+            Assert.Throws<ArgumentNullException>(() => new RollResult(
+                dieRoll:       10,
+                secondDieRoll: null,
+                usedDieRoll:   10,
+                stat:          StatType.Charm,
+                statModifier:  0,
+                levelBonus:    0,
+                dc:            12,
+                tier:          FailureTier.Misfire,
+                activatedTrap: null,
+                externalBonus: 0,
+                check:         null!));
+        }
+
+        [Fact]
+        public void PrimaryCtor_PreservesProvidedCheckVerbatim()
+        {
+            // When the caller supplies a Check (RollEngine path), it must be stored as-is.
+            var modifiers = new[] { new NamedModifier("stat", 3), new NamedModifier("level", 1) };
+            var supplied = new RollCheckResult(
+                RollCheckKind.OptionRoll,
+                dieRoll: 15, secondDieRoll: null, usedDieRoll: 15,
+                modifiers: modifiers,
+                modifierSum: 4, total: 19, dc: 12,
+                isSuccess: true, isNatOne: false, isNatTwenty: false,
+                tier: FailureTier.Success, missMargin: 0);
+
+            var result = new RollResult(
+                dieRoll:       15,
+                secondDieRoll: null,
+                usedDieRoll:   15,
+                stat:          StatType.Charm,
+                statModifier:  3,
+                levelBonus:    1,
+                dc:            12,
+                tier:          FailureTier.Success,
+                activatedTrap: null,
+                externalBonus: 0,
+                check:         supplied);
+
+            Assert.Same(supplied, result.Check);
+        }
+
+        // ----------------------------------------------------------------
+        // GameSession.CreateForcedFailResult — observed via the public flow
+        // ----------------------------------------------------------------
+
+        /// <summary>
+        /// CreateForcedFailResult is private; we mirror the exact synthesis call here and
+        /// assert the Check property is non-null + consistent. The mirror in
+        /// Issue399_HorninessShadowOrderingTests already documents the construction
+        /// pattern — this test guards the #920 invariant separately.
+        /// </summary>
+        [Fact]
+        public void CreateForcedFailResult_Mirror_ProducesNonNullConsistentCheck()
+        {
+            int dc = 14;
+            int fakeDie = dc - 1;
+
+            var check = RollCheckResult.Synthesise(
+                dieRoll: fakeDie, secondDieRoll: null, usedDieRoll: fakeDie,
+                statModifier: 0, levelBonus: 0, dc: dc);
+
+            var forced = new RollResult(
+                dieRoll:        fakeDie,
+                secondDieRoll:  null,
+                usedDieRoll:    fakeDie,
+                stat:           StatType.Charm,
+                statModifier:   0,
+                levelBonus:     0,
+                dc:             dc,
+                tier:           FailureTier.Catastrophe,
+                activatedTrap:  null,
+                externalBonus:  0,
+                check:          check,
+                defendingStat:  StatBlock.DefenceTable[StatType.Charm]);
+
+            Assert.NotNull(forced.Check);
+            Assert.Equal(forced.DieRoll,     forced.Check.DieRoll);
+            Assert.Equal(forced.UsedDieRoll, forced.Check.UsedDieRoll);
+            Assert.Equal(forced.DC,          forced.Check.Dc);
+            Assert.Equal(StatType.Charm,     forced.Stat);
+            Assert.False(forced.IsSuccess);
+            Assert.False(forced.Check.IsSuccess);
+
+            // bespoke vs Check.Tier divergence is expected here: bespoke Tier was
+            // passed in as Catastrophe (the shadow-tier override). Check.Tier is
+            // pure FailureTierLadder.FromMissMargin output → Fumble for miss-margin 1.
+            // This divergence is documented on RollResult.Check.
+            Assert.Equal(FailureTier.Catastrophe, forced.Tier);
+            Assert.Equal(FailureTier.Fumble,      forced.Check.Tier);
+        }
+    }
+}


### PR DESCRIPTION
Closes #920

## DoD Evidence

- [x] `RollCheckResult.Synthesise(...)` factory added (analogue of `ForForcedFail`; covers all bespoke-field synthesis paths, not just forced-fail).
- [x] `GameSession.CreateForcedFailResult` uses the factory and passes a non-null `check` to the primary `RollResult` ctor (no more implicit null).
- [x] All bespoke-field test constructors now go through the convenience `RollResult` overload, which auto-synthesises `Check` — no test-site churn required, but every fixture now produces a non-null `Check`.
- [x] `RollResult` constructor signature tightened: primary ctor takes `RollCheckResult check` (required, non-nullable); the `check!` null-suppression is gone. Primary ctor throws `ArgumentNullException` if `null` is passed.
- [x] New regression test file `tests/Pinder.Core.Tests/Rolls/Issue920_RollResultCheckNonNullTests.cs` (7 tests):
  - Synthesise field parity (Kind, DieRoll, DC, Total, MissMargin, Tier, Modifiers).
  - Nat-20 vs DC raw-mechanics behavior (RollCheckResult doesn't apply nat-20 auto-success).
  - `externalBonus` folding.
  - Convenience ctor produces non-null `Check` and bespoke ↔ Check parity (die roll, DC, total, nat flags).
  - Primary ctor rejects `null` for `check`.
  - Primary ctor preserves caller-supplied `Check` verbatim (RollEngine path).
  - Forced-fail mirror: `Check` non-null + consistent + documents legitimate `Tier` divergence (bespoke `Catastrophe` from shadow override vs `Check.Tier = Fumble` from `FailureTierLadder.FromMissMargin`).
- [x] `dotnet build Pinder.Core.sln`: clean (0 errors, 222 pre-existing warnings).
- [x] `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj`: **2797 passed, 0 failed, 18 skipped** (2815 total — was 2790 pre-#920; +7 new tests from this PR).
- [x] `dotnet test tests/Pinder.Rules.Tests/...`: same 46 pre-existing YAML-loader failures as origin/main (verified by checking out `origin/main -- .` and re-running one; pre-existing, unrelated to #920).

## Research Log

The null-passing sites lived in two places: `GameSession.CreateForcedFailResult` (one production site building a synthetic `RollResult` to compute a shadow-demote interest delta) and the bespoke-field convenience constructor of `RollResult` (which defaulted `RollCheckResult? check = null` and stored it via `check!`, leaving `Check` literally null for any call site that didn't pass one). The ~12 fixtures cited in the ticket were tests like `Issue474SnapshotEventsTests`, `RiskTierTests`, `Wave0SpecTests`, `RulesSpecValidationTests`, etc. that constructed `RollResult` directly without going through `RollEngine.ResolveCheck`. Phase 1 made `RollResult.Check` the canonical wire-DTO source for d20 mechanics, so leaving `Check` null would NRE the Phase 2 serializer.

I picked option 2 (synthesis) because option 1 (make `Check` nullable) would push the null-check burden out into every consumer — including the eventual wire DTO — and would block the Phase 3 goal of deleting the bespoke fields entirely (you can't delete a field that downstream consumers fall back to). The synthesised `RollCheckResult` mirrors the bespoke fields via a deterministic mapping: `usedDieRoll → DieRoll/UsedDieRoll`, modifier bag reconstructed as `[("stat", statMod), ("level", levelBonus)]`, `Total = usedDieRoll + statModifier + levelBonus + externalBonus`, `MissMargin = max(0, dc - total)`, `Tier = FailureTierLadder.FromMissMargin(missMargin)`. The one legitimate divergence — and one I tested explicitly — is that `RollResult.Tier` may differ from `Check.Tier` on a shadow-tier override (bespoke `Catastrophe` vs ladder-derived `Fumble`) and on nat-1 (`Legendary` vs `Catastrophe`); this is already documented on `RollResult.Check`'s docstring and is not unique to forced-fails.

To keep PR scope tight, I avoided rewriting the ~47 existing `new RollResult(...)` call sites: instead the convenience constructor (bespoke fields, no `check` parameter) chains to the primary ctor with `RollCheckResult.Synthesise(...)`. Net effect: the primary signature is tightened exactly as the ticket asks (no `RollCheckResult? = null`, no `check!`), every `RollResult` produced in the codebase now has a non-null `Check`, no wire-JSON shape changed, no bespoke field deleted — Phase 2 and Phase 3 stay independent.
