### PR TITLE
chore(#924): consistent JsonStringEnumConverter + JsonPropertyName on RollResult enums

### DIFF
--- a/src/Pinder.Core/Rolls/RollResult.cs
+++ b/src/Pinder.Core/Rolls/RollResult.cs
@@ -19,6 +19,8 @@ namespace Pinder.Core.Rolls
         public int UsedDieRoll { get; }
 
         /// <summary>The stat used for the roll.</summary>
+        [JsonPropertyName("stat")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public StatType Stat { get; }
 
         /// <summary>
@@ -71,6 +73,8 @@ namespace Pinder.Core.Rolls
         public bool IsNatTwenty { get; }
 
         /// <summary>Failure tier. None on success.</summary>
+        [JsonPropertyName("tier")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public FailureTier Tier { get; }
 
         /// <summary>
@@ -92,6 +96,8 @@ namespace Pinder.Core.Rolls
         /// Risk tier derived from the "need" value (dc - statMod - levelBonus).
         /// Safe (≤5), Medium (6–10), Hard (11–15), Bold (≥16).
         /// </summary>
+        [JsonPropertyName("risk_tier")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public RiskTier RiskTier { get; }
 
         /// <summary>By how much the roll missed the DC (using FinalTotal). 0 on success.</summary>

--- a/tests/Pinder.Core.Tests/Rolls/Issue924_EnumSerializationShapeTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue924_EnumSerializationShapeTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Issue924
+{
+    /// <summary>
+    /// Issue #924: direct <see cref="JsonSerializer.Serialize"/> of a
+    /// <see cref="RollResult"/> must emit a consistently snake_case + string-enum
+    /// shape across every enum property (no mixed int/string, no mixed casing).
+    ///
+    /// NOT a wire-DTO test — the production wire path goes through
+    /// <c>RollResultDto.From()</c> in pinder-web. This test pins the latent
+    /// direct-serialization shape so test/debug/refactor callers see a
+    /// predictable JSON.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue924_EnumSerializationShapeTests
+    {
+        private static RollResult MakeResult()
+        {
+            // Hit-success path; tier ends up Success on success but we
+            // verify the property still serializes as a string.
+            return new RollResult(
+                dieRoll: 14,
+                secondDieRoll: null,
+                usedDieRoll: 14,
+                stat: StatType.Wit,
+                statModifier: 3,
+                levelBonus: 1,
+                dc: 12,
+                tier: FailureTier.Success,
+                activatedTrap: null,
+                externalBonus: 0,
+                defendingStat: StatType.Charm);
+        }
+
+        private static RollResult MakeMissResult()
+        {
+            // Force a real failure tier so we pin the string form of a
+            // non-default FailureTier value.
+            return new RollResult(
+                dieRoll: 2,
+                secondDieRoll: null,
+                usedDieRoll: 2,
+                stat: StatType.Chaos,
+                statModifier: 0,
+                levelBonus: 0,
+                dc: 25,
+                tier: FailureTier.Catastrophe,
+                activatedTrap: null,
+                externalBonus: 0,
+                defendingStat: StatType.Honesty);
+        }
+
+        [Fact]
+        public void Stat_serialises_as_snake_case_string_enum()
+        {
+            var json = JsonSerializer.Serialize(MakeResult());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("stat", out var stat),
+                "expected snake_case 'stat' property");
+            Assert.Equal(JsonValueKind.String, stat.ValueKind);
+            Assert.Equal("Wit", stat.GetString());
+            // The old PascalCase, int-valued shape must be gone.
+            Assert.False(root.TryGetProperty("Stat", out _),
+                "did not expect legacy PascalCase 'Stat' property");
+        }
+
+        [Fact]
+        public void DefendingStat_serialises_as_snake_case_string_enum()
+        {
+            var json = JsonSerializer.Serialize(MakeResult());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("defending_stat", out var ds));
+            Assert.Equal(JsonValueKind.String, ds.ValueKind);
+            Assert.Equal("Charm", ds.GetString());
+        }
+
+        [Fact]
+        public void Tier_serialises_as_snake_case_string_enum()
+        {
+            var json = JsonSerializer.Serialize(MakeMissResult());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("tier", out var tier),
+                "expected snake_case 'tier' property");
+            Assert.Equal(JsonValueKind.String, tier.ValueKind);
+            Assert.Equal("Catastrophe", tier.GetString());
+            Assert.False(root.TryGetProperty("Tier", out _),
+                "did not expect legacy PascalCase 'Tier' property");
+        }
+
+        [Fact]
+        public void RiskTier_serialises_as_snake_case_string_enum()
+        {
+            var json = JsonSerializer.Serialize(MakeMissResult());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("risk_tier", out var rt),
+                "expected snake_case 'risk_tier' property");
+            Assert.Equal(JsonValueKind.String, rt.ValueKind);
+            // dc=25, statMod=0, levelBonus=0 → need=25 → Reckless.
+            Assert.Equal("Reckless", rt.GetString());
+            Assert.False(root.TryGetProperty("RiskTier", out _),
+                "did not expect legacy PascalCase 'RiskTier' property");
+        }
+
+        [Fact]
+        public void All_four_enum_props_share_one_consistent_shape()
+        {
+            // Pin field-by-field that every enum property on RollResult uses
+            // the same snake_case + string-enum convention. This is the
+            // regression guard against the #924 mixed-shape footgun.
+            var json = JsonSerializer.Serialize(MakeMissResult());
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            foreach (var name in new[] { "stat", "defending_stat", "tier", "risk_tier" })
+            {
+                Assert.True(root.TryGetProperty(name, out var prop),
+                    $"missing snake_case property '{name}'");
+                Assert.Equal(JsonValueKind.String, prop.ValueKind);
+            }
+
+            // And the legacy PascalCase forms must all be absent.
+            foreach (var legacy in new[] { "Stat", "DefendingStat", "Tier", "RiskTier" })
+            {
+                Assert.False(root.TryGetProperty(legacy, out _),
+                    $"unexpected legacy PascalCase property '{legacy}'");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #924

## DoD Evidence
- [x] `[JsonConverter(typeof(JsonStringEnumConverter))]` on every enum prop of `RollResult` (`Stat`, `Tier`, `RiskTier`, `DefendingStat`)
- [x] `[JsonPropertyName("snake_case")]` on every prop: `stat`, `tier`, `risk_tier`, `defending_stat`
- [x] New regression test `Issue924_EnumSerializationShapeTests` — direct `JsonSerializer.Serialize(RollResult)` produces a fully consistent snake_case + string-enum shape, pinned field-by-field (and asserts the legacy PascalCase forms are absent)
- [x] `dotnet build`: clean (0 errors)
- [x] `dotnet test Pinder.Core.Tests`: 2802/2802 pass, 18 skipped (5 of the 2802 are new)

## Research Log
Per the #906 follow-up, only `DefendingStat` on `RollResult` carried `[JsonConverter(JsonStringEnumConverter)]` + a snake_case `[JsonPropertyName]`; `Stat`, `Tier`, and `RiskTier` had neither, so direct `JsonSerializer.Serialize(rollResult)` produced mixed `"Stat":1` (int / PascalCase) alongside `"defending_stat":"Wit"` (string / snake_case). I went with option (2) from the ticket (consistent application) rather than dropping the attribute from `DefendingStat`, because consistent self-serializability is the direction the codebase is heading post-#920 and the wire DTO (`RollResultDto.From()` in pinder-web) is unaffected either way — it calls `.ToString()` on enum values manually. Snake_case names match the ticket's recommended canonical form (`stat`, `tier`, `risk_tier`); they are intentionally _not_ aligned with the wire DTO's renamed `FailureTier` field, since that rename is a wire-shape concern owned by `RollResultDto`, not by `RollResult` itself. No production serialization path changes; no other enum-holding result types (`ShadowCheckResult`, `HorninessCheckResult`) were touched — those are out of scope per the spawn template.
