### PR TITLE
chore(web#654): add turn_progress i18n keys for re-estimate states

### DIFF
--- a/data/i18n/en/ui.yaml
+++ b/data/i18n/en/ui.yaml
@@ -106,3 +106,12 @@ strings:
   display_names.shadow.fixation: "Fixation"
   display_names.shadow.dread: "Dread"
   display_names.shadow.overthinking: "Overthinking"
+
+  # ── TurnProgressIndicator re-estimate states (web#654) ────────────
+  # The progress bar re-estimates ETA when elapsed > 1.2× the initial
+  # estimate and surfaces a "longer than usual" line past 2× without
+  # completion. Keep the slot names ({elapsed}, {avg}) stable so the
+  # frontend can interpolate without touching the catalogue again.
+  turn_progress.fill_status: "Generating turn… ({elapsed} / ~{avg} avg)"
+  turn_progress.reestimated_status: "Generating turn… (re-estimating, {elapsed} elapsed)"
+  turn_progress.longer_than_usual: "Still working — this is taking longer than usual ({elapsed})"


### PR DESCRIPTION
Adds 3 i18n keys to `ui.yaml` used by the pinder-web TurnProgressIndicator re-estimate states (web#654):

- `turn_progress.fill_status` — normal fill state with elapsed/avg slots.
- `turn_progress.reestimated_status` — re-estimating state (elapsed > 1.2× original estimate).
- `turn_progress.longer_than_usual` — past 2× the (current) estimate without completion.

Web-side consumer (PR forthcoming on pinder-web) bumps the submodule pointer and switches the indicator's status copy to `t('turn_progress.*')`.

Companion to decay256/pinder-web#654.