### PR TITLE
chore(#947): wire Anthropic prompt cache on OpenRouter Sonnet-4.6 path

### DIFF
--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiCacheControl.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiCacheControl.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Pinder.LlmAdapters.OpenAi
+{
+    /// <summary>
+    /// Builds the <c>content</c> field of an OpenAI-compatible
+    /// <c>messages[i]</c> entry in one of two shapes:
+    /// <list type="bullet">
+    ///   <item><description>Plain string — the legacy shape, used when prompt
+    ///   caching is disabled or when the upstream provider does not honour
+    ///   Anthropic-style <c>cache_control</c> markers.</description></item>
+    ///   <item><description>Single-element <c>text</c> content-block array with
+    ///   an inline <c>cache_control: { type: "ephemeral" }</c> breakpoint — the
+    ///   shape required by Anthropic prompt caching and by OpenRouter when
+    ///   routing to Anthropic-family models.</description></item>
+    /// </list>
+    ///
+    /// <para>
+    /// Issue #947: the OpenAI-compatible request path was sending a plain string
+    /// for the (large, byte-stable) system prompt, so the upstream Anthropic
+    /// cache layer never saw a breakpoint and <c>cache_read_input_tokens</c>
+    /// stayed at zero across multi-turn sessions. Wrapping the system prompt in
+    /// a content block with <c>cache_control: ephemeral</c> makes the prefix
+    /// cacheable on the Anthropic / OpenRouter→Anthropic path while remaining
+    /// a no-op (OpenAI accepts content-block arrays but ignores unknown fields)
+    /// on the OpenAI native path, which uses automatic caching anyway.
+    /// </para>
+    ///
+    /// <para>
+    /// OpenRouter explicitly documents per-block <c>cache_control</c> as the
+    /// supported way to enable Anthropic prompt caching for Claude models on
+    /// their platform (see
+    /// <c>https://openrouter.ai/docs/guides/best-practices/prompt-caching</c>).
+    /// Sonnet-4.6 requires a stable prefix of ≥2,048 tokens; the assembled
+    /// session system prompt is well above that threshold.
+    /// </para>
+    /// </summary>
+    internal static class OpenAiCacheControl
+    {
+        /// <summary>
+        /// Build the <c>content</c> value for a system message.
+        /// </summary>
+        /// <param name="systemPrompt">The system prompt text.</param>
+        /// <param name="useCacheControl">
+        /// When true, return a single-element content-block array with
+        /// <c>cache_control: ephemeral</c>. When false, return the plain string.
+        /// </param>
+        public static object BuildSystemContent(string systemPrompt, bool useCacheControl)
+        {
+            if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
+
+            if (!useCacheControl)
+                return systemPrompt;
+
+            return new object[]
+            {
+                new
+                {
+                    type = "text",
+                    text = systemPrompt,
+                    cache_control = new { type = "ephemeral" }
+                }
+            };
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -212,14 +212,21 @@ namespace Pinder.LlmAdapters.OpenAi
 
         private string BuildRequestJson(string systemPrompt, string userContent, double temperature)
         {
+            // #947: wrap the (byte-stable, large) system prompt in a content
+            // block with cache_control: ephemeral so the Anthropic /
+            // OpenRouter→Anthropic path can register a prompt-cache breakpoint.
+            // OpenAI accepts the content-block shape and ignores the marker.
+            var systemContent = OpenAiCacheControl.BuildSystemContent(
+                systemPrompt, _options.UseAnthropicCacheControl);
+
             var request = new
             {
                 model = _options.Model,
                 max_tokens = _options.MaxTokens,
                 temperature = temperature,
-                messages = new[]
+                messages = new object[]
                 {
-                    new { role = "system", content = systemPrompt },
+                    new { role = "system", content = systemContent },
                     new { role = "user", content = userContent }
                 }
             };
@@ -237,8 +244,14 @@ namespace Pinder.LlmAdapters.OpenAi
             string currentUserContent,
             double temperature)
         {
+            // #947: same cache_control wrapping as BuildRequestJson — the
+            // stateful path is the one used for multi-turn opponent-response
+            // exchanges, which is exactly where prompt-cache hits matter most.
+            var systemContent = OpenAiCacheControl.BuildSystemContent(
+                systemPrompt, _options.UseAnthropicCacheControl);
+
             var messages = new List<object>();
-            messages.Add(new { role = "system", content = systemPrompt });
+            messages.Add(new { role = "system", content = systemContent });
 
             for (int i = 0; i < priorHistory.Count; i++)
             {

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiOptions.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiOptions.cs
@@ -26,5 +26,19 @@ namespace Pinder.LlmAdapters.OpenAi
         /// When set, overrides the hardcoded tier instructions in SessionDocumentBuilder.
         /// </summary>
         public StatDeliveryInstructions? StatDeliveryInstructions { get; set; }
+
+        /// <summary>
+        /// Issue #947 — when true (default), emits the system prompt as a
+        /// single-element <c>text</c> content-block with an inline
+        /// <c>cache_control: { type: "ephemeral" }</c> breakpoint. This is the
+        /// shape Anthropic prompt-caching requires and that OpenRouter passes
+        /// through verbatim to Anthropic-family models (Sonnet 4.6 included).
+        ///
+        /// Set to false when routing to a provider that rejects unknown fields
+        /// on content blocks. Native OpenAI tolerates the marker (uses automatic
+        /// caching regardless), so leaving this on is safe for the common
+        /// OpenAI / OpenRouter-Anthropic / OpenRouter-OpenAI routes.
+        /// </summary>
+        public bool UseAnthropicCacheControl { get; set; } = true;
     }
 }

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiStreamingTransport.cs
@@ -57,10 +57,11 @@ namespace Pinder.LlmAdapters.OpenAi
         private readonly string _model;
         private readonly HttpClient _httpClient;
         private readonly bool _ownsHttpClient;
+        private readonly bool _useAnthropicCacheControl;
         private bool _disposed;
 
         /// <summary>Creates transport with internally-owned HttpClient.</summary>
-        public OpenAiStreamingTransport(string apiKey, string baseUrl, string model)
+        public OpenAiStreamingTransport(string apiKey, string baseUrl, string model, bool useAnthropicCacheControl = true)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
@@ -73,10 +74,11 @@ namespace Pinder.LlmAdapters.OpenAi
                 Timeout = Timeout.InfiniteTimeSpan,
             };
             _ownsHttpClient = true;
+            _useAnthropicCacheControl = useAnthropicCacheControl;
         }
 
         /// <summary>Creates transport with an externally-provided HttpClient (for testing).</summary>
-        public OpenAiStreamingTransport(string apiKey, string baseUrl, string model, HttpClient httpClient)
+        public OpenAiStreamingTransport(string apiKey, string baseUrl, string model, HttpClient httpClient, bool useAnthropicCacheControl = true)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
@@ -85,6 +87,7 @@ namespace Pinder.LlmAdapters.OpenAi
             _baseUrl = (baseUrl ?? "https://api.openai.com").TrimEnd('/');
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _ownsHttpClient = false;
+            _useAnthropicCacheControl = useAnthropicCacheControl;
         }
 
         /// <inheritdoc />
@@ -101,15 +104,22 @@ namespace Pinder.LlmAdapters.OpenAi
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 
+            // #947: see OpenAiCacheControl. Wrap the system prompt in a
+            // content-block with cache_control: ephemeral so the OpenRouter
+            // → Anthropic streaming path can register a prompt-cache
+            // breakpoint. Plain string content cannot carry the marker.
+            var systemContent = OpenAiCacheControl.BuildSystemContent(
+                systemPrompt, _useAnthropicCacheControl);
+
             var request = new
             {
                 model = _model,
                 max_tokens = maxTokens,
                 temperature = temperature,
                 stream = true,
-                messages = new[]
+                messages = new object[]
                 {
-                    new { role = "system", content = systemPrompt },
+                    new { role = "system", content = systemContent },
                     new { role = "user", content = userMessage }
                 }
             };

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiTransport.cs
@@ -17,24 +17,27 @@ namespace Pinder.LlmAdapters.OpenAi
     {
         private readonly OpenAiClient _client;
         private readonly string _model;
+        private readonly bool _useAnthropicCacheControl;
         private bool _disposed;
 
         /// <summary>Creates transport with internally-owned OpenAiClient.</summary>
-        public OpenAiTransport(string apiKey, string baseUrl, string model)
+        public OpenAiTransport(string apiKey, string baseUrl, string model, bool useAnthropicCacheControl = true)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
             _model = model ?? throw new ArgumentNullException(nameof(model));
             _client = new OpenAiClient(apiKey, baseUrl);
+            _useAnthropicCacheControl = useAnthropicCacheControl;
         }
 
         /// <summary>Creates transport with externally-provided HttpClient (for testing).</summary>
-        public OpenAiTransport(string apiKey, string baseUrl, string model, System.Net.Http.HttpClient httpClient)
+        public OpenAiTransport(string apiKey, string baseUrl, string model, System.Net.Http.HttpClient httpClient, bool useAnthropicCacheControl = true)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("API key must not be null, empty, or whitespace.", nameof(apiKey));
             _model = model ?? throw new ArgumentNullException(nameof(model));
             _client = new OpenAiClient(apiKey, baseUrl, httpClient);
+            _useAnthropicCacheControl = useAnthropicCacheControl;
         }
 
         /// <inheritdoc />
@@ -45,14 +48,21 @@ namespace Pinder.LlmAdapters.OpenAi
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
 
+            // #947: emit the system prompt as a content-block with
+            // cache_control: ephemeral so OpenRouter→Anthropic / direct
+            // Anthropic-compatible routes can hit the prompt cache. See
+            // OpenAiCacheControl for the rationale.
+            var systemContent = OpenAiCacheControl.BuildSystemContent(
+                systemPrompt, _useAnthropicCacheControl);
+
             var request = new
             {
                 model = _model,
                 max_tokens = maxTokens,
                 temperature = temperature,
-                messages = new[]
+                messages = new object[]
                 {
-                    new { role = "system", content = systemPrompt },
+                    new { role = "system", content = systemContent },
                     new { role = "user", content = userMessage }
                 }
             };

--- a/tests/Pinder.LlmAdapters.Tests/OpenAi/Issue947_PromptCacheControlTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OpenAi/Issue947_PromptCacheControlTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Pinder.LlmAdapters.OpenAi;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.OpenAi
+{
+    /// <summary>
+    /// Issue #947 — Anthropic prompt cache must hit on the OpenRouter Sonnet
+    /// path. The fix wraps the (byte-stable) system prompt in a content-block
+    /// array with <c>cache_control: { type: "ephemeral" }</c>. These tests
+    /// assert request-side payload shape (which is what determines whether
+    /// the upstream Anthropic cache layer actually registers a breakpoint).
+    /// A full end-to-end <c>cache_read_input_tokens &gt; 0</c> assertion
+    /// requires a real Anthropic API key and is out of scope for unit tests.
+    /// </summary>
+    public class Issue947_PromptCacheControlTests
+    {
+        // ---------------------------------------------------------------
+        // OpenAiCacheControl — pure unit
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void BuildSystemContent_WhenDisabled_ReturnsPlainString()
+        {
+            var content = OpenAiCacheControl.BuildSystemContent(
+                "SYS", useCacheControl: false);
+
+            Assert.Equal("SYS", content);
+        }
+
+        [Fact]
+        public void BuildSystemContent_WhenEnabled_ReturnsContentBlockArrayWithEphemeralMarker()
+        {
+            var content = OpenAiCacheControl.BuildSystemContent(
+                "SYS", useCacheControl: true);
+
+            // Serialize through Newtonsoft to inspect the shape — the test is
+            // shape-of-payload, not type-identity, since we serialize anyway.
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(content);
+            var arr = JArray.Parse(json);
+
+            Assert.Single(arr);
+            Assert.Equal("text", (string?)arr[0]["type"]);
+            Assert.Equal("SYS", (string?)arr[0]["text"]);
+            Assert.Equal("ephemeral", (string?)arr[0]["cache_control"]?["type"]);
+        }
+
+        // ---------------------------------------------------------------
+        // OpenAiTransport — request body carries cache_control by default
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public async Task OpenAiTransport_ByDefault_SendsSystemAsContentBlockArrayWithCacheControl()
+        {
+            string? capturedBody = null;
+            var handler = new CaptureChatCompletionsHandler(
+                responseBody: "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}",
+                capture: req => capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult());
+            using var http = new HttpClient(handler);
+            using var transport = new OpenAiTransport(
+                "sk-test", "https://example.test", "test-model", http);
+
+            _ = await transport.SendAsync(
+                systemPrompt: "STABLE-PREFIX-SYS",
+                userMessage: "TURN-1-USER",
+                temperature: 0.5,
+                maxTokens: 32);
+
+            Assert.NotNull(capturedBody);
+            var json = JObject.Parse(capturedBody!);
+            var messages = (JArray)json["messages"]!;
+
+            Assert.Equal(2, messages.Count);
+            Assert.Equal("system", (string?)messages[0]["role"]);
+
+            // The system content must be an array of content blocks (not a
+            // plain string) so the cache_control marker can travel inline.
+            var systemContent = messages[0]["content"];
+            Assert.NotNull(systemContent);
+            Assert.Equal(JTokenType.Array, systemContent!.Type);
+            var blocks = (JArray)systemContent;
+            Assert.Single(blocks);
+            Assert.Equal("text", (string?)blocks[0]["type"]);
+            Assert.Equal("STABLE-PREFIX-SYS", (string?)blocks[0]["text"]);
+            Assert.Equal("ephemeral", (string?)blocks[0]["cache_control"]?["type"]);
+
+            // The user message stays a plain string — only the prefix is
+            // a cache breakpoint.
+            Assert.Equal("user", (string?)messages[1]["role"]);
+            Assert.Equal("TURN-1-USER", (string?)messages[1]["content"]);
+        }
+
+        [Fact]
+        public async Task OpenAiTransport_WhenCacheControlDisabled_SendsSystemAsPlainString()
+        {
+            string? capturedBody = null;
+            var handler = new CaptureChatCompletionsHandler(
+                responseBody: "{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}",
+                capture: req => capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult());
+            using var http = new HttpClient(handler);
+            using var transport = new OpenAiTransport(
+                "sk-test", "https://example.test", "test-model", http,
+                useAnthropicCacheControl: false);
+
+            _ = await transport.SendAsync("SYS", "USR");
+
+            Assert.NotNull(capturedBody);
+            var json = JObject.Parse(capturedBody!);
+            var messages = (JArray)json["messages"]!;
+            Assert.Equal("system", (string?)messages[0]["role"]);
+            Assert.Equal(JTokenType.String, messages[0]["content"]!.Type);
+            Assert.Equal("SYS", (string?)messages[0]["content"]);
+            Assert.DoesNotContain("cache_control", capturedBody);
+        }
+
+        // ---------------------------------------------------------------
+        // OpenAiStreamingTransport — same shape on the streaming path
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public async Task OpenAiStreamingTransport_ByDefault_SendsSystemAsContentBlockArrayWithCacheControl()
+        {
+            string? capturedBody = null;
+            var sse = "data: " + ChunkContent("ok") + "\n\ndata: [DONE]\n\n";
+            var handler = new CaptureChatCompletionsHandler(
+                responseBody: sse,
+                contentType: "text/event-stream",
+                capture: req => capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult());
+            using var http = new HttpClient(handler);
+            using var transport = new OpenAiStreamingTransport(
+                "sk-test", "https://example.test", "test-model", http);
+
+            await foreach (var _ in transport.SendStreamAsync("SYS-STREAM", "USR-STREAM"))
+            {
+                // drain
+            }
+
+            Assert.NotNull(capturedBody);
+            var json = JObject.Parse(capturedBody!);
+            var messages = (JArray)json["messages"]!;
+            Assert.Equal(2, messages.Count);
+
+            var systemContent = messages[0]["content"];
+            Assert.NotNull(systemContent);
+            Assert.Equal(JTokenType.Array, systemContent!.Type);
+            var blocks = (JArray)systemContent;
+            Assert.Single(blocks);
+            Assert.Equal("SYS-STREAM", (string?)blocks[0]["text"]);
+            Assert.Equal("ephemeral", (string?)blocks[0]["cache_control"]?["type"]);
+        }
+
+        [Fact]
+        public async Task OpenAiStreamingTransport_WhenCacheControlDisabled_OmitsMarker()
+        {
+            string? capturedBody = null;
+            var sse = "data: " + ChunkContent("ok") + "\n\ndata: [DONE]\n\n";
+            var handler = new CaptureChatCompletionsHandler(
+                responseBody: sse,
+                contentType: "text/event-stream",
+                capture: req => capturedBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult());
+            using var http = new HttpClient(handler);
+            using var transport = new OpenAiStreamingTransport(
+                "sk-test", "https://example.test", "test-model", http,
+                useAnthropicCacheControl: false);
+
+            await foreach (var _ in transport.SendStreamAsync("SYS", "USR"))
+            {
+                // drain
+            }
+
+            Assert.NotNull(capturedBody);
+            Assert.DoesNotContain("cache_control", capturedBody);
+        }
+
+        // ---------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------
+
+        private static string ChunkContent(string content)
+        {
+            var escaped = content.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            return "{\"id\":\"c1\",\"object\":\"chat.completion.chunk\","
+                + "\"choices\":[{\"index\":0,\"delta\":{\"content\":\"" + escaped + "\"}}]}";
+        }
+
+        private sealed class CaptureChatCompletionsHandler : HttpMessageHandler
+        {
+            private readonly byte[] _body;
+            private readonly string _contentType;
+            private readonly Action<HttpRequestMessage>? _capture;
+
+            public CaptureChatCompletionsHandler(
+                string responseBody,
+                string contentType = "application/json",
+                Action<HttpRequestMessage>? capture = null)
+            {
+                _body = Encoding.UTF8.GetBytes(responseBody);
+                _contentType = contentType;
+                _capture = capture;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _capture?.Invoke(request);
+                var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_body),
+                };
+                resp.Content.Headers.ContentType = new MediaTypeHeaderValue(_contentType);
+                return Task.FromResult(resp);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #947

## Diagnosis findings

- **Stable prefix token count (turn 2):** ~4-5k tokens (delivery system = 16,774 chars; opponent-response system = 17,539 chars). Both well above Sonnet-4.6's 2,048-token minimum cacheable prefix.
- **Stable prefix was interleaved:** no. Per `/tmp/staging-test-review/turn-{1,2,3}.json`, the `system_prompt` content for each phase is **byte-identical** across all three turns. The growing input tokens come entirely from the appended `user_prompt` (conversation history accumulates), not from system-prompt drift.
- **`cache_control` markers present before this PR:** no on the OpenAI-shape path (`OpenAiLlmAdapter`, `OpenAiTransport`, `OpenAiStreamingTransport`). The Anthropic-direct path (`AnthropicLlmAdapter` via `CacheBlockBuilder`) has carried the markers since #206 — staging hits that path differently.
- **OpenRouter Sonnet-4.6 `cache_control` pass-through:** confirmed-supports. Per OpenRouter docs (`/docs/guides/best-practices/prompt-caching`), Sonnet 4.6 is listed as a prompt-cache-supported model with a 2,048-token minimum, and per-block `cache_control: { type: "ephemeral" }` is the documented method for explicit breakpoints.

## DoD Evidence

- [x] Stable prefix already contiguous + ≥1024 tokens — no restructure needed.
- [x] `cache_control: ephemeral` markers now emitted on the OpenAI/OpenRouter path for the system block (the natural stable prefix). The Anthropic-direct path was already wired.
- [x] OpenRouter path: forwards markers natively for Sonnet-4.6 (and the entire Claude family per OpenRouter docs).
- [x] New regression tests (`Issue947_PromptCacheControlTests`, 6 tests, mock-based) assert the constructed payload carries the marker on both transports; disabling the gate (`UseAnthropicCacheControl=false`) reverts to plain-string content.
- [x] `dotnet build`: clean (0 errors, pre-existing warnings unchanged).
- [x] `dotnet test`:
  - `Pinder.LlmAdapters.Tests`: 1080/1080 pass (9 pre-existing skips).
  - `Pinder.Core.Tests`: 2810/2810 pass (18 pre-existing skips).
  - `Pinder.RemoteAssets.Tests`: 54/54 pass.
  - `Pinder.Rules.Tests`: 46 pre-existing failures verified against origin/main (YAML-deserialization unrelated to this change).

## Research Log

The staging-test review for session `b79b6331-...` (3 turns on `openrouter/anthropic/claude-sonnet-4.6`) showed `cache_read=0` and `cache_creation=0` on every turn while input grew 12.9→14.8→17.0k tokens — a textbook "prefix caching never engaged" pattern. The ticket flagged three plausible root causes (sub-1024-token prefix, missing `cache_control`, OpenRouter not passing markers through). Phase-A diagnosis ruled out the first and third: the per-phase `system_prompt` in the staging dumps is byte-identical across turns and 16-17k characters long (well past the 2,048-token Sonnet-4.6 minimum), and OpenRouter explicitly documents per-block `cache_control` as the supported Anthropic pass-through for Sonnet 4.6. That left root cause #2 as the entire fix.

The actual gap is narrow: `AnthropicLlmAdapter` has had `cache_control: ephemeral` on its system blocks since #206 (via `CacheBlockBuilder`), but the OpenAI-shape transports (`OpenAiLlmAdapter.BuildRequestJson`/`BuildStatefulRequestJson`, `OpenAiTransport.SendAsync`, `OpenAiStreamingTransport.SendStreamAsync`) all emit the system prompt as a plain string. Anthropic's API requires `cache_control` to live on a content-block object — plain string content cannot carry the marker. The fix wraps the system prompt in a single-element `text` content-block array with the marker inline. OpenAI native accepts the content-block shape and ignores `cache_control` (automatic caching covers them anyway); OpenRouter forwards the marker verbatim to Anthropic.

A `OpenAiOptions.UseAnthropicCacheControl` flag (default `true`) is the config gate the ticket asked for. If a future route appears that rejects unknown content-block fields, set it to `false` per-adapter without touching message structure. The new helper `OpenAiCacheControl.BuildSystemContent` is one place to find the toggle and is internal-only — call sites are the three transport entry points.

Deferred / out of scope for this PR: a full end-to-end `cache_read_input_tokens > 0` smoke test requires a real Anthropic or OpenRouter key and a multi-turn live session, which the ticket explicitly calls out as out-of-scope for a chore-level fix. Mock-based regression tests cover the request-side shape, which is the precondition the upstream cache layer keys off. Next sprint's staging-test review should confirm `cache_read` is non-zero on turn 2+ of a real session — that's the definitive landing signal.
