### PR TITLE
chore(#968): JsonPropertyName("defending_stat") on TurnSnapshot.DefendingStat

### DIFF
--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Pinder.SessionRunner.Snapshot
 {
@@ -157,6 +158,7 @@ namespace Pinder.SessionRunner.Snapshot
         /// name (<c>defending_stat</c>). Lives on a different class from
         /// <c>TurnDefenseEntry.DefendingStat</c>, so there is no collision.
         /// </summary>
+        [JsonPropertyName("defending_stat")]
         public string DefendingStat { get; set; } = string.Empty;
 
         /// <summary>


### PR DESCRIPTION
Adds `[JsonPropertyName("defending_stat")]` to `TurnSnapshot.DefendingStat` for wire-consistency hygiene.  
This is a debug-only surface — no test fixture or production wire DTO consumes the snapshot key today.

Closes #968

## DoD Evidence

**Build**: 0 errors, 0 warnings (session-runner). Full solution: 0 errors, 222 pre-existing warnings.
```
dotnet build session-runner/ → Build succeeded. 0 Warning(s) 0 Error(s)
```

**Tests**: Full solution suite — 3890 passed, 0 failed, 27 skipped (pre-existing).
```
Pinder.Core.Tests (net8.0)  — Passed! Failed: 0, Passed: 2810, Skipped: 18, Total: 2828, Duration: 10 s
Pinder.LlmAdapters.Tests (net8.0) — Passed! Failed: 0, Passed: 1080, Skipped: 9, Total: 1089, Duration: 23 s
```

**Commit**: `b7867df chore(#968): add JsonPropertyName("defending_stat") to TurnSnapshot.DefendingStat`

**Push**: Branch `chore/968-defending-stat-jsonpropertyname` pushed to `origin`.

**Deviations from contract**: none

## Research Log

| Topic | Source (URL) | Key finding |
|-------|-------------|-------------|
| JsonPropertyNameAttribute | https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonpropertynameattribute | Standard attribute for mapping C# property names to JSON wire names. `System.Text.Json` is available in .NET 8 without additional NuGet dependencies. |