### PR TITLE
chore(#964): nullable consequence wire field on RollCheckResult / ShadowCheckResult / HorninessCheckResult

### DIFF
--- a/src/Pinder.Core/Conversation/HorninessCheckResult.cs
+++ b/src/Pinder.Core/Conversation/HorninessCheckResult.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Pinder.Core.Rolls;
 
 namespace Pinder.Core.Conversation
@@ -35,6 +36,24 @@ namespace Pinder.Core.Conversation
         /// Null only for the <see cref="NotPerformed"/> sentinel.
         /// </summary>
         public RollCheckResult? Check { get; }
+
+        /// <summary>
+        /// Human-readable consequence text for this horniness check (#964).
+        /// Population deferred to follow-up. SPA falls back to client-side i18n catalogue when null.
+        /// </summary>
+        [JsonPropertyName("consequence")]
+        public string? Consequence { get; private set; }
+
+        /// <summary>
+        /// Apply an engine-populated consequence string. Idempotent — throws
+        /// <see cref="System.InvalidOperationException"/> if already set (#964).
+        /// </summary>
+        public void ApplyConsequence(string consequence)
+        {
+            if (Consequence != null)
+                throw new System.InvalidOperationException("Consequence already applied");
+            Consequence = consequence;
+        }
 
         public HorninessCheckResult(
             int roll, int modifier, int total, int dc,

--- a/src/Pinder.Core/Conversation/ShadowCheckResult.cs
+++ b/src/Pinder.Core/Conversation/ShadowCheckResult.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
@@ -40,6 +41,24 @@ namespace Pinder.Core.Conversation
         /// Null only for the <see cref="NotPerformed"/> sentinel.
         /// </summary>
         public RollCheckResult? Check { get; }
+
+        /// <summary>
+        /// Human-readable consequence text for this shadow check (#964).
+        /// Population deferred to follow-up. SPA falls back to client-side i18n catalogue when null.
+        /// </summary>
+        [JsonPropertyName("consequence")]
+        public string? Consequence { get; private set; }
+
+        /// <summary>
+        /// Apply an engine-populated consequence string. Idempotent — throws
+        /// <see cref="System.InvalidOperationException"/> if already set (#964).
+        /// </summary>
+        public void ApplyConsequence(string consequence)
+        {
+            if (Consequence != null)
+                throw new System.InvalidOperationException("Consequence already applied");
+            Consequence = consequence;
+        }
 
         public ShadowCheckResult(
             bool checkPerformed,

--- a/src/Pinder.Core/Rolls/RollCheckResult.cs
+++ b/src/Pinder.Core/Rolls/RollCheckResult.cs
@@ -139,6 +139,24 @@ namespace Pinder.Core.Rolls
         }
 
         /// <summary>
+        /// Human-readable consequence text for this check result (#964).
+        /// Population deferred to follow-up. SPA falls back to client-side i18n catalogue when null.
+        /// </summary>
+        [JsonPropertyName("consequence")]
+        public string? Consequence { get; private set; }
+
+        /// <summary>
+        /// Apply an engine-populated consequence string. Idempotent — throws
+        /// <see cref="System.InvalidOperationException"/> if already set (#964).
+        /// </summary>
+        public void ApplyConsequence(string consequence)
+        {
+            if (Consequence != null)
+                throw new System.InvalidOperationException("Consequence already applied");
+            Consequence = consequence;
+        }
+
+        /// <summary>
         /// Synthesise a <see cref="RollCheckResult"/> from the bespoke fields a
         /// <see cref="RollResult"/> already carries. Used by callers that build a
         /// <see cref="RollResult"/> outside <see cref="RollEngine"/> (e.g.

--- a/tests/Pinder.Core.Tests/Conversation/HorninessCheckResultTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/HorninessCheckResultTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="HorninessCheckResult.Consequence"/> (#964).
+    /// </summary>
+    public class HorninessCheckResultTests
+    {
+        private static HorninessCheckResult CreateSample()
+        {
+            return new HorninessCheckResult(
+                roll: 5, modifier: 3, total: 8, dc: 10,
+                isMiss: true, tier: FailureTier.Fumble, overlayApplied: false);
+        }
+
+        [Fact]
+        public void Consequence_DefaultIsNull()
+        {
+            var result = CreateSample();
+            Assert.Null(result.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SetsProperty()
+        {
+            var result = CreateSample();
+            result.ApplyConsequence("Hormones surge.");
+            Assert.Equal("Hormones surge.", result.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SecondCallThrows()
+        {
+            var result = CreateSample();
+            result.ApplyConsequence("first");
+            var ex = Assert.Throws<InvalidOperationException>(() => result.ApplyConsequence("second"));
+            Assert.Equal("Consequence already applied", ex.Message);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/ShadowCheckResultTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/ShadowCheckResultTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ShadowCheckResult.Consequence"/> (#964).
+    /// </summary>
+    public class ShadowCheckResultTests
+    {
+        private static ShadowCheckResult CreateSample()
+        {
+            return new ShadowCheckResult(
+                checkPerformed: true,
+                shadow: ShadowStatType.Madness,
+                roll: 8,
+                dc: 12,
+                isMiss: true,
+                tier: FailureTier.Fumble,
+                overlayApplied: false);
+        }
+
+        [Fact]
+        public void Consequence_DefaultIsNull()
+        {
+            var result = CreateSample();
+            Assert.Null(result.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SetsProperty()
+        {
+            var result = CreateSample();
+            result.ApplyConsequence("Your mind clouds with madness.");
+            Assert.Equal("Your mind clouds with madness.", result.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SecondCallThrows()
+        {
+            var result = CreateSample();
+            result.ApplyConsequence("first");
+            var ex = Assert.Throws<InvalidOperationException>(() => result.ApplyConsequence("second"));
+            Assert.Equal("Consequence already applied", ex.Message);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Rolls/RollCheckResultTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/RollCheckResultTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Pinder.Core.Rolls;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="RollCheckResult.Consequence"/> (#964).
+    /// </summary>
+    public class RollCheckResultTests
+    {
+        private static RollCheckResult CreateSampleCheck()
+        {
+            return new RollCheckResult(
+                RollCheckKind.OptionRoll, 15, null, 15,
+                new List<NamedModifier>(), 0, 15, 10,
+                isSuccess: true, isNatOne: false, isNatTwenty: false,
+                FailureTier.Success, missMargin: 0);
+        }
+
+        [Fact]
+        public void Consequence_DefaultIsNull()
+        {
+            var check = CreateSampleCheck();
+            Assert.Null(check.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SetsProperty()
+        {
+            var check = CreateSampleCheck();
+            check.ApplyConsequence("You feel a dark presence.");
+            Assert.Equal("You feel a dark presence.", check.Consequence);
+        }
+
+        [Fact]
+        public void ApplyConsequence_SecondCallThrows()
+        {
+            var check = CreateSampleCheck();
+            check.ApplyConsequence("first");
+            var ex = Assert.Throws<InvalidOperationException>(() => check.ApplyConsequence("second"));
+            Assert.Equal("Consequence already applied", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Closes #964

Adds nullable `Consequence` property (`string?`, default `null`) with
`[JsonPropertyName("consequence")]` on `RollCheckResult`, `ShadowCheckResult`,
and `HorninessCheckResult`. Each class receives an `ApplyConsequence(string)`
method with an idempotent guard — second call throws `InvalidOperationException`.
SPA falls back to client-side i18n catalogue when `consequence` is null.

## Out of scope
- Engine-side population (loading yaml catalogue, slot substitution, locale handling) → follow-up **#976**
- `TropeTrapResult`: no separate class exists. `TropeTrap` is a `FailureTier`, captured on
  `RollCheckResult` when `Tier == FailureTier.TropeTrap`. The `Consequence` field on
  `RollCheckResult` covers the TropeTrap case.

## DoD Evidence
- `dotnet build` clean (0 errors)
- `dotnet test` — all 9 new tests pass (3 per class: default-null, setter, idempotent guard)
- `consequence` key serialises as snake_case via `[JsonPropertyName]`
- Existing tests unaffected

## Research Log
- Audited `FailureTier` enum values before writing tests (initially used non-existent `Near`; corrected to `Fumble`)
- Confirmed `TropeTrapResult` does not exist in the codebase — `TropeTrap` is a `FailureTier` value, not a separate result class