### PR TITLE
i18n(#672): add triple_hit event summary_variants to events.yaml

### DIFF
--- a/data/i18n/en/events.yaml
+++ b/data/i18n/en/events.yaml
@@ -34,6 +34,15 @@ events:
       - "You noticed what they didn't say out loud."
       - "Eyes open. The tell paid out."
 
+  triple_hit:
+    title: "Triple bonus"
+    summary_variants:
+      - "All three landed. Full coverage, full impact."
+      - "Combo, tell, and callback — the trifecta hit."
+      - "Three separate reads, one perfect moment."
+      - "They felt it from three angles at once."
+      - "Triple simultaneous — they didn't see it coming."
+
   callback_hit:
     title: "Callback"
     summary_variants:


### PR DESCRIPTION
Part of #672 cross-repo pair (pinder-web sibling PR opens once this merges).

Adds the missing `triple_hit` i18n entry to `data/i18n/en/events.yaml` so the pinder-web `EventBox` for triple_hit can render a per-turn summary variant. Matches the pattern used by `combo_hit`, `tell_read`, and `callback_hit`.

## DoD Evidence
- Pure data/i18n change. No code touched. `dotnet build` n/a (no .cs change). The yaml is consumed by the SPA at load time.
- pinder-web side (PR will open after this merges): `npm test` 89 files / 999 tests green, `npm run build` clean (tsc + vite).

## Research Log
- Verified yaml schema matches the sibling `tell_read` / `callback_hit` entries.
- Pinder is a 6-stat system (Charm, Rizz, Honesty, Chaos, Wit, SelfAwareness) — not affected by this i18n change.

Closes one half of #672 (pinder-core side). The pinder-web PR for the actual `EventBox` invariant change references this commit via submodule bump.