### PR TITLE
fix(#953): update YAML test parsing for expanded schema (244/244 passing)

### DIFF
--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.cs
@@ -34,7 +34,32 @@ namespace Pinder.Rules.Tests
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            return deserializer.Deserialize<Dictionary<string, string>>(content);
+            var raw = deserializer.Deserialize<Dictionary<string, object?>>(content);
+            var result = new Dictionary<string, string>();
+            foreach (var kvp in raw)
+            {
+                if (kvp.Value == null) continue;
+                if (kvp.Value is string s)
+                {
+                    result[kvp.Key] = s;
+                }
+                else if (kvp.Value is int i)
+                {
+                    result[kvp.Key] = i.ToString();
+                }
+                else if (kvp.Value is Dictionary<object, object> dict)
+                {
+                    var sb = new StringBuilder();
+                    foreach (var dk in dict.Values)
+                    {
+                        if (dk != null) sb.AppendLine(dk.ToString());
+                    }
+                    var flat = sb.ToString().TrimEnd();
+                    if (!string.IsNullOrEmpty(flat))
+                        result[kvp.Key] = flat;
+                }
+            }
+            return result;
         }
 
         // ===== AC1: File location and format =====
@@ -65,28 +90,44 @@ namespace Pinder.Rules.Tests
             }
         }
 
-        // Mutation: would catch if all 7 values aren't scalar strings (e.g. nested objects)
+        // Mutation: would catch if any content value is something other than string, int, or nested string/int dict
         [Fact]
-        public void YamlFile_AllValuesAreScalarStrings()
+        public void YamlFile_AllContentValuesAreStringIntOrNestedDict()
         {
             var content = LoadYamlContent();
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            // Parse as Dictionary<string, object> to detect non-string values
             var data = deserializer.Deserialize<Dictionary<string, object>>(content);
             foreach (var kvp in data)
             {
-                Assert.IsType<string>(kvp.Value);
+                if (kvp.Value is Dictionary<object, object> dict)
+                {
+                    foreach (var dkv in dict.Values)
+                    {
+                        if (dkv != null && dkv is not string && dkv is not int && dkv is not long)
+                            Assert.Fail($"Nested value in '{kvp.Key}' is not a string or integer: {dkv.GetType()}");
+                    }
+                }
+                else if (kvp.Value is not string && kvp.Value is not int && kvp.Value is not long)
+                {
+                    Assert.Fail($"Value for '{kvp.Key}' is not a string or integer: {kvp.Value?.GetType()}");
+                }
             }
         }
 
-        // Mutation: would catch if exactly 7 top-level keys aren't present
         [Fact]
-        public void YamlFile_HasExactly7Keys()
+        public void YamlFile_HasRequiredContentKeys()
         {
             var data = ParseYaml();
-            Assert.Equal(7, data.Count);
+            // The YAML now contains many more keys than the original 7;
+            // verify the core content sections are still present.
+            string[] required = { "name", "vision", "world_description", "player_role_description",
+                "opponent_role_description", "meta_contract", "writing_rules" };
+            foreach (var key in required)
+            {
+                Assert.True(data.ContainsKey(key), $"Missing required content key: {key}");
+            }
         }
 
         // ===== AC2 / AC4: Vision content requirements =====
@@ -190,18 +231,16 @@ namespace Pinder.Rules.Tests
 
         // ===== AC2 / AC4: Player role description content requirements =====
 
-        // Mutation: would catch if player role omits 4 dialogue options per turn
         [Fact]
         public void PlayerRole_MentionsDialogueOptionCount()
         {
             var data = ParseYaml();
             var player = data["player_role_description"];
+            // The count is now parameterized via max_dialogue_options rather than hardcoded; assert the concept is present.
             Assert.True(
-                player.Contains("4 option", StringComparison.OrdinalIgnoreCase) ||
-                player.Contains("four option", StringComparison.OrdinalIgnoreCase) ||
-                player.Contains("4 dialogue", StringComparison.OrdinalIgnoreCase) ||
-                player.Contains("four dialogue", StringComparison.OrdinalIgnoreCase),
-                "Player role must mention generating 4 dialogue options per turn");
+                player.Contains("dialogue options", StringComparison.OrdinalIgnoreCase) ||
+                player.Contains("max_dialogue_options", StringComparison.OrdinalIgnoreCase),
+                "Player role must mention generating dialogue options per turn");
         }
 
         // Mutation: would catch if player role omits texting style reference

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.cs
@@ -28,13 +28,38 @@ namespace Pinder.Rules.Tests
             return File.ReadAllText(Path.Combine(dir, "data", "game-definition.yaml"));
         }
 
+        /// <summary>
+        /// Recursively convert YamlDotNet's Dictionary&lt;object,object&gt; nodes
+        /// (and scalar integer values) into Dictionary&lt;string,object?&gt;.
+        /// Needed because Deserialize&lt;Dictionary&lt;string,object?&gt;&gt; fails when
+        /// nested mappings contain integer values (horniness_time_modifiers).
+        /// </summary>
+        private static object? ConvertYamlNode(object? node)
+        {
+            if (node == null) return null;
+            if (node is string s) return s;
+            if (node is int i) return i;
+            if (node is long l) return l;
+            if (node is Dictionary<object, object> dict)
+            {
+                var result = new Dictionary<string, object?>();
+                foreach (var kvp in dict)
+                    result[kvp.Key.ToString()!] = ConvertYamlNode(kvp.Value);
+                return result;
+            }
+            return node.ToString();
+        }
+
         private static Dictionary<string, string> ParseYaml()
         {
             var content = LoadYamlContent();
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            var raw = deserializer.Deserialize<Dictionary<string, object?>>(content);
+            var rawDict = deserializer.Deserialize<Dictionary<object, object>>(content);
+            var raw = new Dictionary<string, object?>();
+            foreach (var kvp in rawDict)
+                raw[kvp.Key.ToString()!] = ConvertYamlNode(kvp.Value);
             var result = new Dictionary<string, string>();
             foreach (var kvp in raw)
             {
@@ -47,7 +72,7 @@ namespace Pinder.Rules.Tests
                 {
                     result[kvp.Key] = i.ToString();
                 }
-                else if (kvp.Value is Dictionary<object, object> dict)
+                else if (kvp.Value is Dictionary<string, object?> dict)
                 {
                     var sb = new StringBuilder();
                     foreach (var dk in dict.Values)
@@ -98,10 +123,13 @@ namespace Pinder.Rules.Tests
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            var data = deserializer.Deserialize<Dictionary<string, object>>(content);
+            var dataRaw = deserializer.Deserialize<Dictionary<object, object>>(content);
+            var data = new Dictionary<string, object?>();
+            foreach (var kvp in dataRaw)
+                data[kvp.Key.ToString()!] = ConvertYamlNode(kvp.Value);
             foreach (var kvp in data)
             {
-                if (kvp.Value is Dictionary<object, object> dict)
+                if (kvp.Value is Dictionary<string, object?> dict)
                 {
                     foreach (var dkv in dict.Values)
                     {

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
@@ -14,7 +14,7 @@ namespace Pinder.Rules.Tests
     /// </summary>
     public class GameDefinitionYamlTests
     {
-        private static readonly string[] RequiredKeys = new[]
+        private static readonly string[] RequiredContentKeys = new[]
         {
             "name",
             "vision",
@@ -23,6 +23,32 @@ namespace Pinder.Rules.Tests
             "opponent_role_description",
             "meta_contract",
             "writing_rules"
+        };
+
+        /// <summary>All top-level keys expected in the current game-definition.yaml.</summary>
+        private static readonly string[] AllExpectedKeys = new[]
+        {
+            "name",
+            "max_turns",
+            "max_dialogue_options",
+            "vision",
+            "world_description",
+            "texting_psychology",
+            "player_role_description",
+            "opponent_role_description",
+            "opponent_friction",
+            "opponent_curiosity",
+            "player_probing",
+            "meta_contract",
+            "writing_rules",
+            "revelation_over_statement",
+            "delivery_rules",
+            "conversation_arc",
+            "dramatic_craft",
+            "improvement_prompt",
+            "global_dc_bias",
+            "horniness_time_modifiers",
+            "steering_prompt"
         };
 
         private static string LoadYamlContent()
@@ -38,13 +64,48 @@ namespace Pinder.Rules.Tests
             return File.ReadAllText(Path.Combine(dir, "data", "game-definition.yaml"));
         }
 
-        private static Dictionary<string, string> ParseYaml()
+        private static Dictionary<string, object?> ParseYamlRaw()
         {
             var content = LoadYamlContent();
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            return deserializer.Deserialize<Dictionary<string, string>>(content);
+            return deserializer.Deserialize<Dictionary<string, object?>>(content);
+        }
+
+        /// <summary>
+        /// Parse YAML and return string values for content-section keys.
+        /// Nested dicts are flattened by concatenating their values; integers are stringified.
+        /// Null-valued keys are omitted from the result.
+        /// </summary>
+        private static Dictionary<string, string> ParseYaml()
+        {
+            var raw = ParseYamlRaw();
+            var result = new Dictionary<string, string>();
+            foreach (var kvp in raw)
+            {
+                if (kvp.Value == null) continue;
+                if (kvp.Value is string s)
+                {
+                    result[kvp.Key] = s;
+                }
+                else if (kvp.Value is int i)
+                {
+                    result[kvp.Key] = i.ToString();
+                }
+                else if (kvp.Value is Dictionary<object, object> dict)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    foreach (var dk in dict.Values)
+                    {
+                        if (dk != null) sb.AppendLine(dk.ToString());
+                    }
+                    var flat = sb.ToString().TrimEnd();
+                    if (!string.IsNullOrEmpty(flat))
+                        result[kvp.Key] = flat;
+                }
+            }
+            return result;
         }
 
         [Fact]
@@ -58,19 +119,23 @@ namespace Pinder.Rules.Tests
         [Fact]
         public void YamlFile_ContainsAllRequiredKeys()
         {
-            var data = ParseYaml();
-            foreach (var key in RequiredKeys)
+            var raw = ParseYamlRaw();
+            foreach (var key in RequiredContentKeys)
             {
-                Assert.True(data.ContainsKey(key), $"Missing required key: {key}");
+                Assert.True(raw.ContainsKey(key), $"Missing required key: {key}");
             }
         }
 
         [Fact]
         public void YamlFile_HasNoExtraKeys()
         {
-            var data = ParseYaml();
-            var extraKeys = data.Keys.Except(RequiredKeys).ToList();
-            Assert.Empty(extraKeys);
+            var raw = ParseYamlRaw();
+            var extraKeys = raw.Keys.Except(AllExpectedKeys).ToList();
+            if (extraKeys.Count > 0)
+            {
+                Assert.Fail($"Unexpected top-level key(s): {string.Join(", ", extraKeys)}. " +
+                    "Update AllExpectedKeys if this addition is intentional.");
+            }
         }
 
         [Theory]
@@ -83,9 +148,10 @@ namespace Pinder.Rules.Tests
         [InlineData("writing_rules")]
         public void YamlFile_ValueIsNonEmpty(string key)
         {
-            var data = ParseYaml();
-            Assert.True(data.ContainsKey(key), $"Missing key: {key}");
-            Assert.False(string.IsNullOrWhiteSpace(data[key]), $"Value for '{key}' is empty or whitespace");
+            var raw = ParseYamlRaw();
+            Assert.True(raw.ContainsKey(key), $"Missing key: {key}");
+            Assert.True(raw[key] is string s && !string.IsNullOrWhiteSpace(s),
+                $"Value for '{key}' is not a non-empty string (type: {raw[key]?.GetType().Name ?? "null"})");
         }
 
         [Fact]
@@ -161,8 +227,9 @@ namespace Pinder.Rules.Tests
         {
             var data = ParseYaml();
             // Each content section should be substantial (> 200 chars)
-            foreach (var key in RequiredKeys.Where(k => k != "name"))
+            foreach (var key in RequiredContentKeys.Where(k => k != "name"))
             {
+                Assert.True(data.ContainsKey(key), $"Section '{key}' not found in parsed YAML");
                 Assert.True(data[key].Length > 200,
                     $"Section '{key}' is only {data[key].Length} chars — expected substantial content (>200)");
             }

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
@@ -64,13 +64,39 @@ namespace Pinder.Rules.Tests
             return File.ReadAllText(Path.Combine(dir, "data", "game-definition.yaml"));
         }
 
+        /// <summary>
+        /// Recursively convert YamlDotNet's Dictionary&lt;object,object&gt; nodes
+        /// (and scalar integer values) into Dictionary&lt;string,object?&gt;.
+        /// Needed because Deserialize&lt;Dictionary&lt;string,object?&gt;&gt; fails when
+        /// nested mappings contain integer values (horniness_time_modifiers).
+        /// </summary>
+        private static object? ConvertYamlNode(object? node)
+        {
+            if (node == null) return null;
+            if (node is string s) return s;
+            if (node is int i) return i;
+            if (node is long l) return l;
+            if (node is Dictionary<object, object> dict)
+            {
+                var result = new Dictionary<string, object?>();
+                foreach (var kvp in dict)
+                    result[kvp.Key.ToString()!] = ConvertYamlNode(kvp.Value);
+                return result;
+            }
+            return node.ToString();
+        }
+
         private static Dictionary<string, object?> ParseYamlRaw()
         {
             var content = LoadYamlContent();
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build();
-            return deserializer.Deserialize<Dictionary<string, object?>>(content);
+            var raw = deserializer.Deserialize<Dictionary<object, object>>(content);
+            var result = new Dictionary<string, object?>();
+            foreach (var kvp in raw)
+                result[kvp.Key.ToString()!] = ConvertYamlNode(kvp.Value);
+            return result;
         }
 
         /// <summary>
@@ -93,7 +119,7 @@ namespace Pinder.Rules.Tests
                 {
                     result[kvp.Key] = i.ToString();
                 }
-                else if (kvp.Value is Dictionary<object, object> dict)
+                else if (kvp.Value is Dictionary<string, object?> dict)
                 {
                     var sb = new System.Text.StringBuilder();
                     foreach (var dk in dict.Values)


### PR DESCRIPTION
## What
Fix 46 pre-existing test failures in `Pinder.Rules.Tests` caused by `game-definition.yaml` schema evolution (new integer keys, nested dicts) that broke the `Dictionary<string,string>` deserialization in `ParseYaml()`.

## Changes
- **ParseYaml()**: deserializes as `Dictionary<string,object?>`, then coerces strings/int/nested-dicts to strings for content-assertion compatibility
- **YamlFile_HasExactly7Keys** → **YamlFile_HasRequiredContentKeys**: validates the 7 core content sections exist rather than hardcoding an exact key count
- **YamlFile_HasNoExtraKeys**: updated with `AllExpectedKeys` matching all 21 current top-level YAML keys
- **YamlFile_AllValuesAreScalarStrings** → **YamlFile_AllContentValuesAreStringIntOrNestedDict**: permits nested string/int dicts like `horniness_time_modifiers`, `delivery_rules`, `conversation_arc`, `dramatic_craft`
- **PlayerRole_MentionsDialogueOptionCount**: assertion relaxed — count is now parameterized via `max_dialogue_options`

## Verification
- `dotnet test tests/Pinder.Rules.Tests/`: **244 passed, 0 failed, 0 skipped** (up from 198 passed, 46 failed)
- `dotnet build`: 0 errors

Closes #953