### PR TITLE
fix(#956): add typed ShadowGrowthEffects record list to GameEndedException

### DIFF
--- a/src/Pinder.Core/Conversation/GameEndedException.cs
+++ b/src/Pinder.Core/Conversation/GameEndedException.cs
@@ -1,8 +1,46 @@
 using System;
 using System.Collections.Generic;
+using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
 {
+    /// <summary>
+    /// Typed record for a single shadow growth event, carrying the same data as the
+    /// human-readable string in <see cref="GameEndedException.ShadowGrowthEvents"/>.
+    /// Callers that need to reapply growth (e.g. after catching a Ghosted throw)
+    /// should consume <see cref="GameEndedException.ShadowGrowthEffects"/> rather
+    /// than regex-parsing the string list.
+    /// </summary>
+    public sealed class ShadowGrowthEffect : IEquatable<ShadowGrowthEffect>
+    {
+        public ShadowStatType Stat { get; }
+        public int Amount { get; }
+        public string Reason { get; }
+
+        public ShadowGrowthEffect(ShadowStatType stat, int amount, string reason)
+        {
+            Stat = stat;
+            Amount = amount;
+            Reason = reason ?? throw new ArgumentNullException(nameof(reason));
+        }
+
+        public override bool Equals(object obj) => obj is ShadowGrowthEffect other && Equals(other);
+        public bool Equals(ShadowGrowthEffect other) =>
+            !(other is null) && Stat == other.Stat && Amount == other.Amount && Reason == other.Reason;
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 31 + Stat.GetHashCode();
+                hash = hash * 31 + Amount.GetHashCode();
+                hash = hash * 31 + (Reason?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+        public override string ToString() => $"{Stat} {Amount:+0;-#} ({Reason})";
+    }
+
     /// <summary>
     /// Thrown when an operation is attempted on a GameSession that has already ended.
     /// </summary>
@@ -14,11 +52,18 @@ namespace Pinder.Core.Conversation
         /// <summary>Shadow growth events that occurred when the game ended (e.g., ghost Dread +1). Empty if none.</summary>
         public IReadOnlyList<string> ShadowGrowthEvents { get; }
 
+        /// <summary>
+        /// Typed shadow growth effects parallel to <see cref="ShadowGrowthEvents"/>.
+        /// Same events, same order — callers can reapply mechanically without parsing strings.
+        /// </summary>
+        public IReadOnlyList<ShadowGrowthEffect> ShadowGrowthEffects { get; }
+
         public GameEndedException(GameOutcome outcome)
             : base($"Game has ended with outcome: {outcome}")
         {
             Outcome = outcome;
             ShadowGrowthEvents = Array.Empty<string>();
+            ShadowGrowthEffects = Array.Empty<ShadowGrowthEffect>();
         }
 
         public GameEndedException(GameOutcome outcome, string message)
@@ -26,6 +71,7 @@ namespace Pinder.Core.Conversation
         {
             Outcome = outcome;
             ShadowGrowthEvents = Array.Empty<string>();
+            ShadowGrowthEffects = Array.Empty<ShadowGrowthEffect>();
         }
 
         public GameEndedException(GameOutcome outcome, IReadOnlyList<string> shadowGrowthEvents)
@@ -33,6 +79,15 @@ namespace Pinder.Core.Conversation
         {
             Outcome = outcome;
             ShadowGrowthEvents = shadowGrowthEvents ?? Array.Empty<string>();
+            ShadowGrowthEffects = Array.Empty<ShadowGrowthEffect>();
+        }
+
+        public GameEndedException(GameOutcome outcome, IReadOnlyList<string> shadowGrowthEvents, IReadOnlyList<ShadowGrowthEffect> shadowGrowthEffects)
+            : base($"Game has ended with outcome: {outcome}")
+        {
+            Outcome = outcome;
+            ShadowGrowthEvents = shadowGrowthEvents ?? Array.Empty<string>();
+            ShadowGrowthEffects = shadowGrowthEffects ?? Array.Empty<ShadowGrowthEffect>();
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -768,7 +768,8 @@ namespace Pinder.Core.Conversation
                 if (_playerShadows != null)
                 {
                     var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents);
+                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
+                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
                 }
                 throw new GameEndedException(GameOutcome.Unmatched);
             }
@@ -790,7 +791,8 @@ namespace Pinder.Core.Conversation
                     if (_playerShadows != null)
                     {
                         var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
-                        throw new GameEndedException(GameOutcome.Ghosted, events);
+                        var effects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted") };
+                        throw new GameEndedException(GameOutcome.Ghosted, events, effects);
                     }
 
                     throw new GameEndedException(GameOutcome.Ghosted);
@@ -2077,7 +2079,8 @@ namespace Pinder.Core.Conversation
                 {
                     _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
                     var dreadEvents = _playerShadows.DrainGrowthEvents();
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents);
+                    var dreadEffects = _playerShadows.DrainGrowthEffects();
+                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
                 }
                 throw new GameEndedException(GameOutcome.Unmatched);
             }
@@ -2107,7 +2110,8 @@ namespace Pinder.Core.Conversation
                     {
                         _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Ghosted");
                         var events = _playerShadows.DrainGrowthEvents();
-                        throw new GameEndedException(GameOutcome.Ghosted, events);
+                        var effects = _playerShadows.DrainGrowthEffects();
+                        throw new GameEndedException(GameOutcome.Ghosted, events, effects);
                     }
 
                     throw new GameEndedException(GameOutcome.Ghosted);

--- a/src/Pinder.Core/Stats/SessionShadowTracker.cs
+++ b/src/Pinder.Core/Stats/SessionShadowTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Pinder.Core.Conversation;
 
 namespace Pinder.Core.Stats
 {
@@ -19,6 +20,7 @@ namespace Pinder.Core.Stats
         private readonly StatBlock _baseStats;
         private readonly Dictionary<ShadowStatType, int> _deltas;
         private readonly List<string> _growthEvents;
+        private readonly List<ShadowGrowthEffect> _growthEffects;
 
         /// <summary>
         /// Wraps an immutable StatBlock for mutable shadow tracking.
@@ -30,6 +32,7 @@ namespace Pinder.Core.Stats
             _baseStats = baseStats ?? throw new ArgumentNullException(nameof(baseStats));
             _deltas = new Dictionary<ShadowStatType, int>();
             _growthEvents = new List<string>();
+            _growthEffects = new List<ShadowGrowthEffect>();
         }
 
         /// <summary>
@@ -62,6 +65,7 @@ namespace Pinder.Core.Stats
 
             string description = $"{shadow} +{amount} ({reason})";
             _growthEvents.Add(description);
+            _growthEffects.Add(new ShadowGrowthEffect(shadow, amount, reason));
             return description;
         }
 
@@ -137,6 +141,7 @@ namespace Pinder.Core.Stats
                 ? $"{shadow} {sign} ({reason}) (floored)"
                 : $"{shadow} {sign} ({reason})";
             _growthEvents.Add(description);
+            _growthEffects.Add(new ShadowGrowthEffect(shadow, appliedDelta, floored ? $"{reason} (floored)" : reason));
             return description;
         }
 
@@ -156,6 +161,7 @@ namespace Pinder.Core.Stats
             if (targetValues == null) return;
             _deltas.Clear();
             _growthEvents.Clear();
+            _growthEffects.Clear();
 
             foreach (ShadowStatType shadow in System.Enum.GetValues(typeof(ShadowStatType)))
             {
@@ -184,6 +190,18 @@ namespace Pinder.Core.Stats
         }
 
         /// <summary>
+        /// Returns all typed shadow growth effects accumulated since last drain, then clears the internal log.
+        /// Parallel to <see cref="DrainGrowthEvents"/> — same events, same order, typed form.
+        /// Added per #956 for structured reapplication by callers.
+        /// </summary>
+        public IReadOnlyList<ShadowGrowthEffect> DrainGrowthEffects()
+        {
+            var effects = new List<ShadowGrowthEffect>(_growthEffects);
+            _growthEffects.Clear();
+            return effects;
+        }
+
+        /// <summary>
         /// #790 (Phase 4): deep clone for fast-gameplay engine forking. Returns
         /// an independent <see cref="SessionShadowTracker"/> wrapping the
         /// same immutable base <see cref="StatBlock"/> and carrying a copy
@@ -196,6 +214,7 @@ namespace Pinder.Core.Stats
             foreach (var kv in _deltas)
                 copy._deltas[kv.Key] = kv.Value;
             copy._growthEvents.AddRange(_growthEvents);
+            copy._growthEffects.AddRange(_growthEffects);
             return copy;
         }
     }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.cs
@@ -1157,6 +1157,56 @@ namespace Pinder.Core.Tests
             Assert.Equal(0, tracker.GetDelta(ShadowStatType.Overthinking));
         }
 
+        // #956: ShadowGrowthEffects typed record list must be populated and consistent
+        // with ShadowGrowthEvents on a Ghosted throw.
+        [Fact]
+        public async Task GhostedException_CarriesTypedShadowGrowthEffects()
+        {
+            var shadows = MakeTracker();
+            var session = BuildSession(dice: Dice(1), shadows: shadows, startingInterest: 1);
+
+            var ex = await Assert.ThrowsAsync<GameEndedException>(() => session.StartTurnAsync());
+
+            Assert.Equal(GameOutcome.Ghosted, ex.Outcome);
+            Assert.Equal(0, shadows.GetDelta(ShadowStatType.Dread));
+            Assert.Contains(ex.ShadowGrowthEvents, e => e.Contains("Ghosted") && e.Contains("Dread"));
+
+            Assert.NotNull(ex.ShadowGrowthEffects);
+            Assert.NotEmpty(ex.ShadowGrowthEffects);
+            Assert.Equal(ex.ShadowGrowthEvents.Count, ex.ShadowGrowthEffects.Count);
+
+            var effect = ex.ShadowGrowthEffects[0];
+            Assert.Equal(ShadowStatType.Dread, effect.Stat);
+            Assert.Equal(1, effect.Amount);
+            Assert.Equal("Ghosted", effect.Reason);
+        }
+
+        [Fact]
+        public void GameEndedException_DefaultCtor_HasEmptyEffects()
+        {
+            var ex = new GameEndedException(GameOutcome.Ghosted);
+            Assert.NotNull(ex.ShadowGrowthEffects);
+            Assert.Empty(ex.ShadowGrowthEffects);
+        }
+
+        [Fact]
+        public void GameEndedException_ThreeParamCtor_CarriesBothLists()
+        {
+            var events = new[] { "Dread +1 (Ghosted)", "Madness +1 (Nat 1)" };
+            var effects = new[]
+            {
+                new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted"),
+                new ShadowGrowthEffect(ShadowStatType.Madness, 1, "Nat 1")
+            };
+
+            var ex = new GameEndedException(GameOutcome.Ghosted, events, effects);
+
+            Assert.Equal(2, ex.ShadowGrowthEvents.Count);
+            Assert.Equal(2, ex.ShadowGrowthEffects.Count);
+            Assert.Equal(ShadowStatType.Dread, ex.ShadowGrowthEffects[0].Stat);
+            Assert.Equal(ShadowStatType.Madness, ex.ShadowGrowthEffects[1].Stat);
+        }
+
         // =====================================================================
         // Helpers — test-only utilities (no production code copied)
         // =====================================================================


### PR DESCRIPTION
Closes #956

Adds parallel typed list ShadowGrowthEffects: IReadOnlyList<ShadowGrowthEffect> on GameEndedException alongside the existing string ShadowGrowthEvents. Callers catching the exception (the web-side fix tracked under #942) can now reapply growth deltas mechanically instead of regex-parsing 'Dread +1 (Ghosted)'.

- New record: ShadowGrowthEffect(ShadowStatType, int Amount, string Reason)
- New constructor: GameEndedException(outcome, events, effects)
- All existing call sites in GameSession.cs updated to build both lists 1:1
- SessionShadowTracker exposes a helper for building the typed list parallel to events
- New regression test asserts both lists are populated and consistent on Ghosted

Tests: Pinder.Core.Tests 2822/0 passed (18 skipped). Build clean.

Implementer subagent stream-cut after running tests successfully; orchestrator squashed and pushed the on-disk work after build+test re-verification (zero_token_stats flake, work was complete on disk).