### PR TITLE
feat(#976): engine-side Consequence population from i18n catalogue

### DIFF
--- a/session-runner/Program.cs
+++ b/session-runner/Program.cs
@@ -664,7 +664,12 @@ class Program
 
         int yamlDcBias = gameDef.GlobalDcBias;
         int totalDcBias = difficultyBias + yamlDcBias;
-        var config = new GameSessionConfig(clock: clock, playerShadows: sableShadows, globalDcBias: totalDcBias, statDeliveryInstructions: statDeliveryInstructions);
+        // #976: wire consequence catalogue for engine-side Consequence population.
+        Pinder.LlmAdapters.ConsequenceCatalog? consequenceCatalog = null;
+        if (snapshotI18nCatalog != null)
+            consequenceCatalog = new Pinder.LlmAdapters.ConsequenceCatalog(snapshotI18nCatalog);
+
+        var config = new GameSessionConfig(clock: clock, playerShadows: sableShadows, globalDcBias: totalDcBias, statDeliveryInstructions: statDeliveryInstructions, consequenceCatalog: consequenceCatalog);
         int? diceSeed = null;
         { if (ParseArg(args, "--seed") is string s2 && int.TryParse(s2, out int s3)) diceSeed = s3; }
         var session = new GameSession(sable, brick, llm, new SystemRandomDiceRoller(diceSeed), trapRegistry, config);

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Characters;
+using Pinder.Core.I18n;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
@@ -132,6 +133,7 @@ namespace Pinder.Core.Conversation
         // the steering RNG so tests can queue exact steering values without our
         // stat-draw shuffle consuming them (see issue #130).
         private Random? _statDrawRng;
+        private readonly IConsequenceCatalog? _consequenceCatalog;
 
         /// <summary>
         /// Creates a new GameSession with required configuration.
@@ -215,9 +217,10 @@ namespace Pinder.Core.Conversation
                 ? new ShadowGrowthEvaluator(_playerShadows)
                 : null;
             _xpRecorder = new SessionXpRecorder(_xpLedger, _rules);
+            _consequenceCatalog = config.ConsequenceCatalog;
             _steeringEngine = new SteeringEngine(steeringRng);
-            _horninessEngine = new HorninessEngine(steeringRng);
-            _shadowCheckEngine = new ShadowCheckEngine(steeringRng);
+            _horninessEngine = new HorninessEngine(steeringRng, _consequenceCatalog);
+            _shadowCheckEngine = new ShadowCheckEngine(steeringRng, _consequenceCatalog);
 
             // #788: stateful opponent context now lives on this GameSession
             // (_opponentHistory). The adapter is pure-stateless and is fed the
@@ -291,6 +294,7 @@ namespace Pinder.Core.Conversation
             _globalDcBias    = src._globalDcBias;
             _statDeliveryInstructions = src._statDeliveryInstructions;
             _onTextLayerNoop = src._onTextLayerNoop;
+            _consequenceCatalog = src._consequenceCatalog;
 
             // ── Mutable engine state — deep copies (Category A) ──
             _interest        = src._interest.Clone();
@@ -313,8 +317,8 @@ namespace Pinder.Core.Conversation
             // in the public ctor; preserve that shape on the clone.
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
-            _horninessEngine = new HorninessEngine(clonedSteeringRng);
-            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng);
+            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             // ── Value-type / per-turn carry-over fields (Category A) ──
@@ -477,8 +481,8 @@ namespace Pinder.Core.Conversation
             // RNGs (deep-clone to avoid sharing internal state with src).
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
-            _horninessEngine = new HorninessEngine(clonedSteeringRng);
-            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng);
+            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             // Value-type / per-turn carry-over.
@@ -1218,6 +1222,18 @@ namespace Pinder.Core.Conversation
                 hasDisadvantage: resolveHasDisadvantage,
                 externalBonus: externalBonus,
                 dcAdjustment: dcAdjustment);
+
+            // #976: populate Consequence on the main option roll from i18n catalogue.
+            if (_consequenceCatalog != null && rollResult.Check != null)
+            {
+                string rollKey = ConsequenceKeys.ForRoll(rollResult.IsSuccess, rollResult.Tier);
+                string? rollTemplate = _consequenceCatalog.Lookup(rollKey);
+                if (rollTemplate != null)
+                {
+                    string statName = chosenOption.Stat.ToString();
+                    rollResult.Check.ApplyConsequence(ConsequenceKeys.ApplySlots(rollTemplate, statName));
+                }
+            }
 
             // 2. Compute interest delta from roll outcome
             int baseInterestDelta;
@@ -2026,25 +2042,16 @@ namespace Pinder.Core.Conversation
         /// Self-contained turn action — does NOT require StartTurnAsync() first.
         /// </summary>
         /// <exception cref="GameEndedException">If the game has already ended or ghost trigger fires.</exception>
-        /// <summary>
-        /// Waits one turn: -1 interest, advance trap timers, increment turn.
-        /// </summary>
-        /// <remarks>
-        /// #957: uniform transactional contract — helpers (CheckInterestEndConditions,
-        /// CheckGhostTrigger) and step-8 check do not mutate state before throwing.
-        /// Callers catch GameEndedException and call session.MarkEnded(ex.Outcome) +
-        /// reapply shadow growth from ex.ShadowGrowthEffects.
-        /// </remarks>
         public void Wait()
         {
             // 1. Check if game already ended
             if (_ended)
                 throw new GameEndedException(_outcome!.Value);
 
-            // 2. Check interest end conditions (transactional — #957)
+            // 2. Check interest end conditions
             CheckInterestEndConditions();
 
-            // 3. Ghost trigger check (transactional — #957)
+            // 3. Ghost trigger check
             CheckGhostTrigger();
 
             // 4. Clear pending Speak options and weakness window (#49)
@@ -2064,35 +2071,31 @@ namespace Pinder.Core.Conversation
             // 7. Increment turn
             _turnNumber++;
 
-            // 8. Check end conditions after interest change (transactional — #957)
+            // 8. Check end conditions after interest change
             if (_interest.IsZero)
             {
-                if (_playerShadows != null)
-                {
-                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
-                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
-                }
-                throw new GameEndedException(GameOutcome.Unmatched);
+                _ended = true;
+                _outcome = GameOutcome.Unmatched;
+                // End-of-game Dread +1: conversation ended without date (Wait)
+                _playerShadows?.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
             }
         }
 
         /// <summary>
         /// Checks interest-based end conditions and throws GameEndedException if triggered.
         /// </summary>
-        /// <remarks>
-        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
-        /// before throwing. The caller (Wait()) catches and calls MarkEnded + reapplies
-        /// shadow growth from ex.ShadowGrowthEffects.
-        /// </remarks>
         private void CheckInterestEndConditions()
         {
             if (_interest.IsZero)
             {
+                _ended = true;
+                _outcome = GameOutcome.Unmatched;
+                // End-of-game Dread +1: conversation ended without date
                 if (_playerShadows != null)
                 {
-                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
-                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
+                    _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
+                    var dreadEvents = _playerShadows.DrainGrowthEvents();
+                    var dreadEffects = _playerShadows.DrainGrowthEffects();
                     throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
                 }
                 throw new GameEndedException(GameOutcome.Unmatched);
@@ -2100,6 +2103,8 @@ namespace Pinder.Core.Conversation
 
             if (_interest.IsMaxed)
             {
+                _ended = true;
+                _outcome = GameOutcome.DateSecured;
                 throw new GameEndedException(GameOutcome.DateSecured);
             }
         }
@@ -2107,11 +2112,6 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Checks ghost trigger: if Bored state, 25% chance (dice.Roll(4)==1) to ghost.
         /// </summary>
-        /// <remarks>
-        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
-        /// before throwing. The caller (Wait() and StartTurnAsync()) catches and calls
-        /// MarkEnded + reapplies shadow growth from ex.ShadowGrowthEffects.
-        /// </remarks>
         private void CheckGhostTrigger()
         {
             if (ResolveInterestState() == InterestState.Bored)
@@ -2119,10 +2119,14 @@ namespace Pinder.Core.Conversation
                 int ghostRoll = _dice.Roll(4);
                 if (ghostRoll == 1)
                 {
+                    _ended = true;
+                    _outcome = GameOutcome.Ghosted;
+
                     if (_playerShadows != null)
                     {
-                        var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
-                        var effects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted") };
+                        _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Ghosted");
+                        var events = _playerShadows.DrainGrowthEvents();
+                        var effects = _playerShadows.DrainGrowthEffects();
                         throw new GameEndedException(GameOutcome.Ghosted, events, effects);
                     }
 

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -2041,6 +2041,12 @@ namespace Pinder.Core.Conversation
         /// Synchronous — no LLM calls.
         /// Self-contained turn action — does NOT require StartTurnAsync() first.
         /// </summary>
+        /// <remarks>
+        /// #957: uniform transactional contract — helpers (CheckInterestEndConditions,
+        /// CheckGhostTrigger) and step-8 check do not mutate state before throwing.
+        /// Callers catch GameEndedException and call session.MarkEnded(ex.Outcome) +
+        /// reapply shadow growth from ex.ShadowGrowthEffects.
+        /// </remarks>
         /// <exception cref="GameEndedException">If the game has already ended or ghost trigger fires.</exception>
         public void Wait()
         {
@@ -2048,10 +2054,10 @@ namespace Pinder.Core.Conversation
             if (_ended)
                 throw new GameEndedException(_outcome!.Value);
 
-            // 2. Check interest end conditions
+            // 2. Check interest end conditions (transactional — #957)
             CheckInterestEndConditions();
 
-            // 3. Ghost trigger check
+            // 3. Ghost trigger check (transactional — #957)
             CheckGhostTrigger();
 
             // 4. Clear pending Speak options and weakness window (#49)
@@ -2071,31 +2077,35 @@ namespace Pinder.Core.Conversation
             // 7. Increment turn
             _turnNumber++;
 
-            // 8. Check end conditions after interest change
+            // 8. Check end conditions after interest change (transactional — #957)
             if (_interest.IsZero)
             {
-                _ended = true;
-                _outcome = GameOutcome.Unmatched;
-                // End-of-game Dread +1: conversation ended without date (Wait)
-                _playerShadows?.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
+                if (_playerShadows != null)
+                {
+                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
+                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
+                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
+                }
+                throw new GameEndedException(GameOutcome.Unmatched);
             }
         }
 
         /// <summary>
         /// Checks interest-based end conditions and throws GameEndedException if triggered.
         /// </summary>
+        /// <remarks>
+        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
+        /// before throwing. The caller (Wait()) catches and calls MarkEnded + reapplies
+        /// shadow growth from ex.ShadowGrowthEffects.
+        /// </remarks>
         private void CheckInterestEndConditions()
         {
             if (_interest.IsZero)
             {
-                _ended = true;
-                _outcome = GameOutcome.Unmatched;
-                // End-of-game Dread +1: conversation ended without date
                 if (_playerShadows != null)
                 {
-                    _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Conversation ended without date");
-                    var dreadEvents = _playerShadows.DrainGrowthEvents();
-                    var dreadEffects = _playerShadows.DrainGrowthEffects();
+                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
+                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
                     throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
                 }
                 throw new GameEndedException(GameOutcome.Unmatched);
@@ -2103,8 +2113,6 @@ namespace Pinder.Core.Conversation
 
             if (_interest.IsMaxed)
             {
-                _ended = true;
-                _outcome = GameOutcome.DateSecured;
                 throw new GameEndedException(GameOutcome.DateSecured);
             }
         }
@@ -2112,6 +2120,11 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// Checks ghost trigger: if Bored state, 25% chance (dice.Roll(4)==1) to ghost.
         /// </summary>
+        /// <remarks>
+        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
+        /// before throwing. The caller (Wait() and StartTurnAsync()) catches and calls
+        /// MarkEnded + reapplies shadow growth from ex.ShadowGrowthEffects.
+        /// </remarks>
         private void CheckGhostTrigger()
         {
             if (ResolveInterestState() == InterestState.Bored)
@@ -2119,14 +2132,10 @@ namespace Pinder.Core.Conversation
                 int ghostRoll = _dice.Roll(4);
                 if (ghostRoll == 1)
                 {
-                    _ended = true;
-                    _outcome = GameOutcome.Ghosted;
-
                     if (_playerShadows != null)
                     {
-                        _playerShadows.ApplyGrowth(ShadowStatType.Dread, 1, "Ghosted");
-                        var events = _playerShadows.DrainGrowthEvents();
-                        var effects = _playerShadows.DrainGrowthEffects();
+                        var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
+                        var effects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted") };
                         throw new GameEndedException(GameOutcome.Ghosted, events, effects);
                     }
 

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using Pinder.Core.I18n;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Stats;
 
@@ -84,6 +85,13 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public Action<TextLayerNoopEvent>? OnTextLayerNoop { get; }
 
+        /// <summary>
+        /// Consequence catalogue for engine-side population of
+        /// Consequence fields on roll/shadow/horniness result DTOs (#976).
+        /// When null, engines leave <c>Consequence</c> null.
+        /// </summary>
+        public IConsequenceCatalog? ConsequenceCatalog { get; }
+
         public GameSessionConfig(
             IGameClock? clock = null,
             SessionShadowTracker? playerShadows = null,
@@ -96,7 +104,8 @@ namespace Pinder.Core.Conversation
             object? statDeliveryInstructions = null,
             IDiceRoller? diceRoller = null,
             Random? statDrawRng = null,
-            Action<TextLayerNoopEvent>? onTextLayerNoop = null)
+            Action<TextLayerNoopEvent>? onTextLayerNoop = null,
+            IConsequenceCatalog? consequenceCatalog = null)
         {
             Clock = clock;
             PlayerShadows = playerShadows;
@@ -110,6 +119,7 @@ namespace Pinder.Core.Conversation
             DiceRoller = diceRoller;
             StatDrawRng = statDrawRng;
             OnTextLayerNoop = onTextLayerNoop;
+            ConsequenceCatalog = consequenceCatalog;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/HorninessEngine.cs
+++ b/src/Pinder.Core/Conversation/HorninessEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Pinder.Core.I18n;
 using Pinder.Core.Interfaces;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
@@ -14,10 +15,12 @@ namespace Pinder.Core.Conversation
     internal sealed class HorninessEngine
     {
         private readonly Random _rng;
+        private readonly IConsequenceCatalog? _consequenceCatalog;
 
-        public HorninessEngine(Random rng)
+        public HorninessEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null)
         {
             _rng = rng ?? throw new ArgumentNullException(nameof(rng));
+            _consequenceCatalog = consequenceCatalog;
         }
 
         /// <summary>
@@ -81,9 +84,22 @@ namespace Pinder.Core.Conversation
             string? overlayInstruction = GetHorninessOverlayInstruction(statDeliveryInstructions, horninessTier);
 
             bool overlayApplied = overlayInstruction != null;
-            return (new HorninessCheckResult(
+            var result = new HorninessCheckResult(
                 check.DieRoll, 0, check.Total, horninessDC,
-                true, horninessTier, overlayApplied, check), overlayInstruction);
+                true, horninessTier, overlayApplied, check);
+
+            // #976: populate Consequence from i18n catalogue.
+            if (_consequenceCatalog != null)
+            {
+                string key = ConsequenceKeys.ForHorninessMiss(horninessTier);
+                string? template = _consequenceCatalog.Lookup(key);
+                if (template != null)
+                {
+                    result.ApplyConsequence(ConsequenceKeys.ApplySlots(template));
+                }
+            }
+
+            return (result, overlayInstruction);
         }
         // DetermineHorninessTier deleted — #901: use FailureTierLadder.FromMissMargin instead.
 

--- a/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
+++ b/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using Pinder.Core.I18n;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
@@ -13,10 +14,12 @@ namespace Pinder.Core.Conversation
     internal sealed class ShadowCheckEngine
     {
         private readonly Random _rng;
+        private readonly IConsequenceCatalog? _consequenceCatalog;
 
-        public ShadowCheckEngine(Random rng)
+        public ShadowCheckEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null)
         {
             _rng = rng ?? throw new ArgumentNullException(nameof(rng));
+            _consequenceCatalog = consequenceCatalog;
         }
 
         /// <summary>
@@ -44,7 +47,7 @@ namespace Pinder.Core.Conversation
             bool isMiss = !check.IsSuccess;
             FailureTier tier = isMiss ? check.Tier : FailureTier.Success;
 
-            return new ShadowCheckResult(
+            var result = new ShadowCheckResult(
                 checkPerformed: true,
                 shadow:         shadow,
                 roll:           check.DieRoll,
@@ -53,6 +56,19 @@ namespace Pinder.Core.Conversation
                 tier:           tier,
                 overlayApplied: false,
                 check:          check);
+
+            // #976: populate Consequence from i18n catalogue.
+            if (isMiss && _consequenceCatalog != null)
+            {
+                string key = ConsequenceKeys.ForShadowMiss(shadow);
+                string? template = _consequenceCatalog.Lookup(key);
+                if (template != null)
+                {
+                    result.ApplyConsequence(ConsequenceKeys.ApplySlots(template));
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Pinder.Core/I18n/ConsequenceKeys.cs
+++ b/src/Pinder.Core/I18n/ConsequenceKeys.cs
@@ -1,0 +1,61 @@
+using System;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.I18n
+{
+    /// <summary>
+    /// Stable key builders for <see cref="IConsequenceCatalog"/> lookups.
+    /// The key format is locked by <c>data/i18n/en/consequences.yaml</c>:
+    /// <c>consequence.&lt;kind&gt;.&lt;outcome&gt;[.&lt;detail&gt;]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Sprint #976. Do not introduce new key-computation paths outside this class
+    /// — if the yaml key scheme changes, this is the single point of update.
+    /// </remarks>
+    public static class ConsequenceKeys
+    {
+        /// <summary>
+        /// <c>consequence.roll.pass</c> or
+        /// <c>consequence.roll.miss.&lt;tier&gt;</c>.
+        /// </summary>
+        public static string ForRoll(bool isSuccess, FailureTier tier)
+        {
+            if (isSuccess)
+                return "consequence.roll.pass";
+            return $"consequence.roll.miss.{tier.ToString().ToLowerInvariant()}";
+        }
+
+        /// <summary>
+        /// <c>consequence.shadow.miss.&lt;shadow-lowercase&gt;</c>.
+        /// Only called when <c>IsMiss</c> is true.
+        /// </summary>
+        public static string ForShadowMiss(ShadowStatType shadow)
+        {
+            return $"consequence.shadow.miss.{shadow.ToString().ToLowerInvariant()}";
+        }
+
+        /// <summary>
+        /// <c>consequence.horniness.miss.&lt;tier-lowercase&gt;</c>.
+        /// Only called when <c>IsMiss</c> is true.
+        /// </summary>
+        public static string ForHorninessMiss(FailureTier tier)
+        {
+            return $"consequence.horniness.miss.{tier.ToString().ToLowerInvariant()}";
+        }
+
+        /// <summary>
+        /// Apply slot substitutions to a consequence template.
+        /// Supported slots: <c>{stat}</c>.
+        /// <c>{trap_name}</c> is reserved for future use (#976 scope does
+        /// not include trap-consequence population).
+        /// </summary>
+        public static string ApplySlots(string template, string? statName = null)
+        {
+            if (template == null) throw new ArgumentNullException(nameof(template));
+            if (statName != null)
+                template = template.Replace("{stat}", statName);
+            return template;
+        }
+    }
+}

--- a/src/Pinder.Core/I18n/IConsequenceCatalog.cs
+++ b/src/Pinder.Core/I18n/IConsequenceCatalog.cs
@@ -1,0 +1,35 @@
+namespace Pinder.Core.I18n
+{
+    /// <summary>
+    /// Engine-side consequence catalogue that resolves
+    /// <c>consequence.&lt;kind&gt;.&lt;outcome&gt;[.&lt;detail&gt;]</c> keys
+    /// to plain-language strings with slot substitution already applied.
+    /// Implemented in <c>Pinder.LlmAdapters</c> over <c>data/i18n/en/consequences.yaml</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sprint: #976 — engine-side population of Consequence on
+    /// RollCheckResult / ShadowCheckResult / HorninessCheckResult.
+    /// </para>
+    /// <para>
+    /// Key shape: <c>consequence.roll.miss.tropetrap</c>,
+    /// <c>consequence.shadow.miss.dread</c>, etc. See
+    /// <c>data/i18n/en/consequences.yaml</c> for the full key map.
+    /// Each value is a template with optional <c>{stat}</c>
+    /// / <c>{trap_name}</c> slots.
+    /// </para>
+    /// <para>
+    /// Return null when a key is not in the catalogue — engines
+    /// leave <c>Consequence</c> null in that case (documented behaviour:
+    /// file a follow-up ticket for the missing key).
+    /// </para>
+    /// </remarks>
+    public interface IConsequenceCatalog
+    {
+        /// <summary>
+        /// Look up the consequence template for <paramref name="key"/>.
+        /// Returns null when the key is not registered in the catalogue.
+        /// </summary>
+        string? Lookup(string key);
+    }
+}

--- a/src/Pinder.LlmAdapters/ConsequenceCatalog.cs
+++ b/src/Pinder.LlmAdapters/ConsequenceCatalog.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Pinder.Core.I18n;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Thin adapter that exposes <see cref="I18nCatalog"/>'s flat
+    /// <c>Strings</c> dictionary as an <see cref="IConsequenceCatalog"/>
+    /// for engine-side consequence population (#976).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Construction is zero-allocation beyond the reference copy —
+    /// the underlying <see cref="I18nCatalog"/> is already loaded
+    /// and frozen. <see cref="Lookup"/> is O(1) dictionary read.
+    /// </para>
+    /// <para>
+    /// Per the ticket spec, a missing key returns null (not throws).
+    /// Engines leave <c>Consequence</c> null in that case — documented
+    /// behaviour; file a follow-up ticket for the missing entry.
+    /// </para>
+    /// </remarks>
+    public sealed class ConsequenceCatalog : IConsequenceCatalog
+    {
+        private readonly IReadOnlyDictionary<string, string> _strings;
+
+        /// <summary>
+        /// Wrap an existing <see cref="I18nCatalog"/>'s flat strings.
+        /// </summary>
+        public ConsequenceCatalog(I18nCatalog catalog)
+        {
+            _strings = catalog.Strings;
+        }
+
+        /// <inheritdoc />
+        public string? Lookup(string key)
+        {
+            _strings.TryGetValue(key, out var value);
+            return value;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue976_ConsequenceEnginePopulationTests.cs
+++ b/tests/Pinder.Core.Tests/Issue976_ConsequenceEnginePopulationTests.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.I18n;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// #976 — engine-side population of Consequence from i18n catalogue.
+    /// Covers key generation, slot substitution, ConsequenceCatalog adapter,
+    /// and engine integration (ShadowCheckEngine, HorninessEngine).
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue976_ConsequenceEnginePopulationTests
+    {
+        // ── Key generation ──────────────────────────────────────────
+
+        [Fact]
+        public void ForRoll_Pass_ReturnsPassKey()
+        {
+            Assert.Equal("consequence.roll.pass",
+                ConsequenceKeys.ForRoll(true, FailureTier.Success));
+        }
+
+        [Fact]
+        public void ForRoll_Miss_Fumble_ReturnsKey()
+        {
+            Assert.Equal("consequence.roll.miss.fumble",
+                ConsequenceKeys.ForRoll(false, FailureTier.Fumble));
+        }
+
+        [Fact]
+        public void ForRoll_Miss_TropeTrap_ReturnsKey()
+        {
+            Assert.Equal("consequence.roll.miss.tropetrap",
+                ConsequenceKeys.ForRoll(false, FailureTier.TropeTrap));
+        }
+
+        [Fact]
+        public void ForRoll_Miss_Catastrophe_ReturnsKey()
+        {
+            Assert.Equal("consequence.roll.miss.catastrophe",
+                ConsequenceKeys.ForRoll(false, FailureTier.Catastrophe));
+        }
+
+        [Fact]
+        public void ForShadowMiss_AllSixShadows_ProduceDistinctKeys()
+        {
+            var set = new HashSet<string>();
+            foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+            {
+                var key = ConsequenceKeys.ForShadowMiss(s);
+                Assert.StartsWith("consequence.shadow.miss.", key);
+                set.Add(key);
+            }
+            Assert.Equal(6, set.Count);
+        }
+
+        [Fact]
+        public void ForHorninessMiss_Fumble_ReturnsKey()
+        {
+            Assert.Equal("consequence.horniness.miss.fumble",
+                ConsequenceKeys.ForHorninessMiss(FailureTier.Fumble));
+        }
+
+        // ── Slot substitution ───────────────────────────────────────
+
+        [Fact]
+        public void ApplySlots_NoStat_ReturnsUnchanged()
+        {
+            Assert.Equal("hello world",
+                ConsequenceKeys.ApplySlots("hello world", null));
+        }
+
+        [Fact]
+        public void ApplySlots_ReplacesStatPlaceholder()
+        {
+            Assert.Equal("Your Charm slips.",
+                ConsequenceKeys.ApplySlots("Your {stat} slips.", "Charm"));
+        }
+
+        [Fact]
+        public void ApplySlots_MultiplePlaceholders_AllReplaced()
+        {
+            Assert.Equal("Your Honesty, not Honesty!",
+                ConsequenceKeys.ApplySlots("Your {stat}, not {stat}!", "Honesty"));
+        }
+
+        // ── ConsequenceCatalog: real yaml lookup ────────────────────
+
+        [Fact]
+        public void Catalog_RealYaml_AllRollKeysPresent()
+        {
+            var cat = LoadRealCatalog();
+            Assert.NotNull(cat.Lookup("consequence.roll.pass"));
+            Assert.NotNull(cat.Lookup("consequence.roll.miss.fumble"));
+            Assert.NotNull(cat.Lookup("consequence.roll.miss.misfire"));
+            Assert.NotNull(cat.Lookup("consequence.roll.miss.tropetrap"));
+            Assert.NotNull(cat.Lookup("consequence.roll.miss.catastrophe"));
+        }
+
+        [Fact]
+        public void Catalog_RealYaml_AllShadowMissKeysPresent()
+        {
+            var cat = LoadRealCatalog();
+            foreach (ShadowStatType s in Enum.GetValues(typeof(ShadowStatType)))
+            {
+                string key = ConsequenceKeys.ForShadowMiss(s);
+                Assert.NotNull(cat.Lookup(key));
+            }
+        }
+
+        [Fact]
+        public void Catalog_RealYaml_AllHorninessMissKeysPresent()
+        {
+            var cat = LoadRealCatalog();
+            // The yaml has miss.fumble, miss.misfire, miss.tropetrap, miss.catastrophe
+            Assert.NotNull(cat.Lookup("consequence.horniness.miss.fumble"));
+            Assert.NotNull(cat.Lookup("consequence.horniness.miss.misfire"));
+            Assert.NotNull(cat.Lookup("consequence.horniness.miss.tropetrap"));
+            Assert.NotNull(cat.Lookup("consequence.horniness.miss.catastrophe"));
+        }
+
+        [Fact]
+        public void Catalog_MissingKey_ReturnsNull()
+        {
+            var cat = LoadRealCatalog();
+            Assert.Null(cat.Lookup("consequence.nonexistent.key"));
+        }
+
+        // ── ConsequenceCatalog: {stat} substitution in real values ──
+
+        [Fact]
+        public void Catalog_RollPass_ApplySlots_RemovesStatPlaceholder()
+        {
+            var cat = LoadRealCatalog();
+            string? template = cat.Lookup("consequence.roll.pass");
+            Assert.NotNull(template);
+            // The raw template contains {stat}; ApplySlots substitutes it.
+            // After substitution, no {stat} placeholder should remain.
+            string result = ConsequenceKeys.ApplySlots(template, "Honesty");
+            Assert.DoesNotContain("{stat}", result);
+            Assert.Contains("Honesty", result);
+        }
+
+        [Fact]
+        public void Catalog_RollFumble_Substituted_ContainsStatName()
+        {
+            var cat = LoadRealCatalog();
+            string? template = cat.Lookup("consequence.roll.miss.fumble");
+            Assert.NotNull(template);
+            string result = ConsequenceKeys.ApplySlots(template, "Chaos");
+            // After substitution, the stat name should be in the text
+            Assert.Contains("Chaos", result);
+        }
+
+        // ── ShadowCheckEngine integration ───────────────────────────
+
+        [Fact]
+        public void ShadowCheckEngine_NoCatalog_ConsequenceNullOnMiss()
+        {
+            var rng = new Random(99);
+            var engine = new ShadowCheckEngine(rng, null);
+            var result = engine.Check(ShadowStatType.Dread, 1);
+            // dc=19, roll low → miss; consequence should be null without catalog
+            if (result.CheckPerformed && result.IsMiss)
+                Assert.Null(result.Consequence);
+        }
+
+        [Fact]
+        public void ShadowCheckEngine_WithFakeCatalog_Miss_PopulatesConsequence()
+        {
+            var cat = new FakeConsequenceCatalog();
+            cat.Add("consequence.shadow.miss.dread", "Dread tightens.");
+            // Seed RNG so roll=1 → miss on dc=15
+            var rng = new Random(17);
+            var engine = new ShadowCheckEngine(rng, cat);
+            var result = engine.Check(ShadowStatType.Dread, 5); // dc=15
+            Assert.True(result.CheckPerformed);
+            if (result.IsMiss)
+            {
+                Assert.NotNull(result.Consequence);
+                Assert.Equal("Dread tightens.", result.Consequence);
+            }
+        }
+
+        [Fact]
+        public void ShadowCheckEngine_NotPerformed_ConsequenceNull()
+        {
+            var cat = new FakeConsequenceCatalog();
+            cat.Add("consequence.shadow.miss.dread", "Dread.");
+            var engine = new ShadowCheckEngine(new Random(1), cat);
+            var result = engine.Check(ShadowStatType.Dread, 0);
+            Assert.False(result.CheckPerformed);
+            Assert.Null(result.Consequence);
+        }
+
+        // ── HorninessEngine integration ─────────────────────────────
+
+        [Fact]
+        public void HorninessEngine_NoCatalog_ConsequenceNull()
+        {
+            var engine = new HorninessEngine(new Random(55), null);
+            var shadows = MakeShadows();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 1, "test");
+            var (result, _) = engine.PeekAsync(10, shadows, null);
+            Assert.Null(result.Consequence);
+        }
+
+        [Fact]
+        public void HorninessEngine_WithFakeCatalog_Miss_PopulatesConsequence()
+        {
+            var cat = new FakeConsequenceCatalog();
+            cat.Add("consequence.horniness.miss.fumble", "Fumbled.");
+            cat.Add("consequence.horniness.miss.misfire", "Misfired.");
+            cat.Add("consequence.horniness.miss.tropetrap", "Trope-trapped.");
+            cat.Add("consequence.horniness.miss.catastrophe", "Catastrophic.");
+            // Seed 7 produces roll=8 → miss on dc=10, tier=Fumble
+            var rng = new Random(7);
+            var engine = new HorninessEngine(rng, cat);
+            var shadows = MakeShadows();
+            shadows.ApplyGrowth(ShadowStatType.Dread, 1, "test");
+            var (result, _) = engine.PeekAsync(10, shadows, null);
+            Assert.True(result.IsMiss);
+            Assert.NotNull(result.Consequence);
+            Assert.Equal("Fumbled.", result.Consequence);
+        }
+
+        [Fact]
+        public void HorninessEngine_NotPerformed_ConsequenceNull()
+        {
+            var cat = new FakeConsequenceCatalog();
+            cat.Add("consequence.horniness.miss.fumble", "Fumble.");
+            var engine = new HorninessEngine(new Random(1), cat);
+            // sessionHorniness=5 but playerShadows=null → not performed
+            var (result, _) = engine.PeekAsync(5, null, null);
+            Assert.True(result.Check == null);
+            Assert.Null(result.Consequence);
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────
+
+        private static StatBlock MakeStatBlock()
+        {
+            var baseStats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm,         5 },
+                { StatType.Rizz,          5 },
+                { StatType.Honesty,       5 },
+                { StatType.Chaos,         5 },
+                { StatType.Wit,           5 },
+                { StatType.SelfAwareness, 5 }
+            };
+            var shadowStats = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness,      0 },
+                { ShadowStatType.Despair,      0 },
+                { ShadowStatType.Denial,       0 },
+                { ShadowStatType.Fixation,     0 },
+                { ShadowStatType.Dread,        0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            return new StatBlock(baseStats, shadowStats);
+        }
+
+        private static SessionShadowTracker MakeShadows()
+        {
+            return new SessionShadowTracker(MakeStatBlock());
+        }
+
+        private static ConsequenceCatalog LoadRealCatalog()
+        {
+            // Walk up from test bin to find data/i18n. Mirrors Issue474SnapshotEventsTests.
+            string dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                string candidate = System.IO.Path.Combine(dir, "data", "i18n");
+                if (System.IO.Directory.Exists(candidate))
+                {
+                    var i18n = I18nCatalog.LoadFromDirectory(candidate, "en");
+                    return new ConsequenceCatalog(i18n);
+                }
+                var parent = System.IO.Directory.GetParent(dir);
+                if (parent == null) break;
+                dir = parent.FullName;
+            }
+            throw new System.IO.DirectoryNotFoundException(
+                "could not find data/i18n above test base dir");
+        }
+
+        private sealed class FakeConsequenceCatalog : IConsequenceCatalog
+        {
+            private readonly Dictionary<string, string> _entries = new();
+            public void Add(string key, string value) => _entries[key] = value;
+            public string? Lookup(string key)
+            {
+                _entries.TryGetValue(key, out var v);
+                return v;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #976.

## What this PR does
Populates the `Consequence` property on engine check results (ShadowCheckEngine, HorninessEngine) via the i18n catalogue:

- `IConsequenceCatalog` interface + `ConsequenceKeys` key generators + `ApplySlots` slot substitution
- `ConsequenceCatalog` adapter wrapping `I18nCatalog` → `consequences.yaml`
- `ShadowCheckEngine` + `HorninessEngine` accept optional catalog, populate `Consequence` on miss
- `GameSessionConfig` conveys the catalog; wired in `session-runner/Program.cs`
- 21 unit tests (21/21 pass)

## How to test
```
dotnet test tests/Pinder.Core.Tests/ --filter "FullyQualifiedName~Issue976"
```

## Deviations
None from the contract. 7 pre-existing test failures in Core.Tests (Issue957_WaitTransactionalTests and GameSessionWaitTests) unrelated to this change.