### PR TITLE
chore: broaden TierLadderAuditTest regex to flag bare numeric ladders

### DIFF
--- a/tests/Pinder.Core.Tests/Rolls/TierLadderAuditTest.cs
+++ b/tests/Pinder.Core.Tests/Rolls/TierLadderAuditTest.cs
@@ -14,6 +14,29 @@ namespace Pinder.Core.Tests
         private static readonly Regex LadderPattern =
             new Regex(@"miss(Margin|)\s*<=\s*\d", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        private static readonly Regex NumericComparisonPattern =
+            new Regex(@"<=\s*(\d+)\b", RegexOptions.Compiled);
+
+        private static bool IsBareNumericLadder(string content, out int lineCount)
+        {
+            var lines = content.Split(new[] { "\r\n", "\r", "\n" }, System.StringSplitOptions.None);
+            var matchedNumbers = new System.Collections.Generic.HashSet<string>();
+            int matchedLineCount = 0;
+
+            foreach (var line in lines)
+            {
+                var match = NumericComparisonPattern.Match(line);
+                if (match.Success)
+                {
+                    matchedLineCount++;
+                    matchedNumbers.Add(match.Groups[1].Value);
+                }
+            }
+
+            lineCount = matchedLineCount;
+            return matchedLineCount >= 3 && matchedNumbers.Count >= 2;
+        }
+
         [Fact]
         public void NoDuplicateMissMarginLadders_InRollsFolder_OutsideFailureTierLadder()
         {
@@ -52,6 +75,44 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
+        public void NoBareNumericLadders_InRollsFolder_OutsideFailureTierLadder()
+        {
+            var testAssemblyDir = Path.GetDirectoryName(typeof(TierLadderAuditTest).Assembly.Location)!;
+            var dir = new DirectoryInfo(testAssemblyDir);
+            string? srcDir = null;
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "src", "Pinder.Core", "Rolls");
+                if (Directory.Exists(candidate))
+                {
+                    srcDir = candidate;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            Assert.True(srcDir != null, "Could not locate src/Pinder.Core/Rolls from test assembly path");
+
+            var violations = new System.Collections.Generic.List<string>();
+            foreach (var file in Directory.EnumerateFiles(srcDir!, "*.cs", SearchOption.AllDirectories))
+            {
+                var fileName = Path.GetFileName(file);
+                if (fileName == "FailureTierLadder.cs" || fileName == "RollResult.cs")
+                    continue;
+
+                var content = File.ReadAllText(file);
+                if (IsBareNumericLadder(content, out int lineCount))
+                {
+                    violations.Add($"{fileName} ({lineCount} matches)");
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Bare numeric ladder detected in: {string.Join(", ", violations)}. " +
+                "Use FailureTierLadder.FromMissMargin instead.");
+        }
+
+        [Fact]
         public void NoDuplicateMissMarginLadders_InConversationFolder()
         {
             var testAssemblyDir = Path.GetDirectoryName(typeof(TierLadderAuditTest).Assembly.Location)!;
@@ -80,6 +141,44 @@ namespace Pinder.Core.Tests
 
             Assert.True(violations.Count == 0,
                 $"Duplicate miss-margin ladder detected in: {string.Join(", ", violations)}. " +
+                "Use FailureTierLadder.FromMissMargin instead.");
+        }
+
+        [Fact]
+        public void NoBareNumericLadders_InConversationFolder()
+        {
+            var testAssemblyDir = Path.GetDirectoryName(typeof(TierLadderAuditTest).Assembly.Location)!;
+            var dir = new DirectoryInfo(testAssemblyDir);
+            string? srcDir = null;
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "src", "Pinder.Core", "Conversation");
+                if (Directory.Exists(candidate))
+                {
+                    srcDir = candidate;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            Assert.True(srcDir != null, "Could not locate src/Pinder.Core/Conversation from test assembly path");
+
+            var violations = new System.Collections.Generic.List<string>();
+            foreach (var file in Directory.EnumerateFiles(srcDir!, "*.cs", SearchOption.AllDirectories))
+            {
+                var fileName = Path.GetFileName(file);
+                if (fileName == "GameClock.cs" || fileName == "InterestMeter.cs" || fileName == "SessionXpRecorder.cs")
+                    continue;
+
+                var content = File.ReadAllText(file);
+                if (IsBareNumericLadder(content, out int lineCount))
+                {
+                    violations.Add($"{fileName} ({lineCount} matches)");
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Bare numeric ladder detected in: {string.Join(", ", violations)}. " +
                 "Use FailureTierLadder.FromMissMargin instead.");
         }
     }


### PR DESCRIPTION
Broadens the TierLadderAuditTest regex to detect bare numeric ladders of 3 or more <= \d literal-integer comparisons appearing in the same source file. Excludes already known ladders.

Closes #921