### PR TITLE
refactor(sanitize): centralize text sanitization and strip diff computation into TextSanitizer

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -1468,17 +1468,7 @@ namespace Pinder.Core.Conversation
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryCompleted, deliveredMessage));
 
             // #902: Meta-prefix strip immediately after delivery LLM call.
-            {
-                string rawDelivered = deliveredMessage;
-                deliveredMessage = MetaPrefixStripper.Strip(rawDelivered);
-                if (deliveredMessage != rawDelivered)
-                {
-                    var stripSpans = WordDiff.Compute(rawDelivered, deliveredMessage);
-                    textDiffs.Add(new TextDiff(
-                        MetaPrefixStripper.LayerName, stripSpans,
-                        rawDelivered, deliveredMessage));
-                }
-            }
+            deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MetaPrefixStripper.LayerName, textDiffs);
 
             // Tier modifier diff (SECOND per #364): intended+steering text vs
             // delivered-after-LLM rewrite. The LLM now degrades the combined
@@ -1529,16 +1519,7 @@ namespace Pinder.Core.Conversation
                     progress?.Report(new TurnProgressEvent(TurnProgressStage.TrapOverlayCompleted, rawTrapOutput));
 
                     // Immediately run MetaPrefixStripper.Strip to sanitize any non-narrative prefixes
-                    string sanitizedTrapOutput = MetaPrefixStripper.Strip(rawTrapOutput);
-                    if (sanitizedTrapOutput != rawTrapOutput)
-                    {
-                        var stripSpans = WordDiff.Compute(rawTrapOutput, sanitizedTrapOutput);
-                        textDiffs.Add(new TextDiff(
-                            MetaPrefixStripper.LayerName, stripSpans,
-                            rawTrapOutput, sanitizedTrapOutput));
-                    }
-
-                    deliveredMessage = sanitizedTrapOutput;
+                    deliveredMessage = TextSanitizer.Sanitize(rawTrapOutput, MetaPrefixStripper.LayerName, textDiffs);
 
                     if (deliveredMessage != beforeTrap)
                     {
@@ -1644,16 +1625,7 @@ namespace Pinder.Core.Conversation
                             progress?.Report(new TurnProgressEvent(TurnProgressStage.ShadowCorruptionCompleted, rawShadowOutput));
 
                             // Immediately run MetaPrefixStripper.Strip to sanitize any non-narrative prefixes
-                            string sanitizedShadowOutput = MetaPrefixStripper.Strip(rawShadowOutput);
-                            if (sanitizedShadowOutput != rawShadowOutput)
-                            {
-                                var stripSpans = WordDiff.Compute(rawShadowOutput, sanitizedShadowOutput);
-                                textDiffs.Add(new TextDiff(
-                                    MetaPrefixStripper.LayerName, stripSpans,
-                                    rawShadowOutput, sanitizedShadowOutput));
-                            }
-
-                            deliveredMessage = sanitizedShadowOutput;
+                            deliveredMessage = TextSanitizer.Sanitize(rawShadowOutput, MetaPrefixStripper.LayerName, textDiffs);
 
                             if (deliveredMessage != beforeShadow)
                             {
@@ -1719,16 +1691,7 @@ namespace Pinder.Core.Conversation
                 progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, rawHorninessOutput));
 
                 // Immediately run MetaPrefixStripper.Strip to sanitize any non-narrative prefixes
-                string sanitizedHorninessOutput = MetaPrefixStripper.Strip(rawHorninessOutput);
-                if (sanitizedHorninessOutput != rawHorninessOutput)
-                {
-                    var stripSpans = WordDiff.Compute(rawHorninessOutput, sanitizedHorninessOutput);
-                    textDiffs.Add(new TextDiff(
-                        MetaPrefixStripper.LayerName, stripSpans,
-                        rawHorninessOutput, sanitizedHorninessOutput));
-                }
-
-                deliveredMessage = sanitizedHorninessOutput;
+                deliveredMessage = TextSanitizer.Sanitize(rawHorninessOutput, MetaPrefixStripper.LayerName, textDiffs);
 
                 if (deliveredMessage != beforeHorniness)
                 {
@@ -1779,19 +1742,7 @@ namespace Pinder.Core.Conversation
             // text. Emits a TextDiff layer when it actually changes the
             // message so the audit log / replay tool / UI can render the
             // before/after just like Steering / Horniness / Shadow.
-            {
-                string beforeCallbackStrip = deliveredMessage;
-                string strippedMessage = CallbackStripper.Strip(beforeCallbackStrip);
-                if (!ReferenceEquals(strippedMessage, beforeCallbackStrip)
-                    && strippedMessage != beforeCallbackStrip)
-                {
-                    deliveredMessage = strippedMessage;
-                    var stripSpans = WordDiff.Compute(beforeCallbackStrip, deliveredMessage);
-                    textDiffs.Add(new TextDiff(
-                        CallbackStripper.LayerName, stripSpans,
-                        beforeCallbackStrip, deliveredMessage));
-                }
-            }
+            deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, CallbackStripper.LayerName, textDiffs);
 
             _history.Add((_player.DisplayName, deliveredMessage));
 

--- a/src/Pinder.Core/Text/TextSanitizer.cs
+++ b/src/Pinder.Core/Text/TextSanitizer.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Text
+{
+    /// <summary>
+    /// Issue #988: Centralized sanitizer that coordinates post-process passes
+    /// like callback stripping and meta-prefix stripping.
+    /// </summary>
+    public static class TextSanitizer
+    {
+        /// <summary>
+        /// Sanitizes raw text using the specified pass layer (e.g. MetaPrefixStripper or CallbackStripper).
+        /// If a change is made, computes a word-level diff and adds it to the provided list.
+        /// </summary>
+        public static string Sanitize(string rawText, string layerName, List<TextDiff> diffList)
+        {
+            if (rawText == null) return string.Empty;
+            if (diffList == null) throw new ArgumentNullException(nameof(diffList));
+
+            string sanitizedText;
+
+            if (layerName == MetaPrefixStripper.LayerName)
+            {
+                sanitizedText = MetaPrefixStripper.Strip(rawText);
+            }
+            else if (layerName == CallbackStripper.LayerName)
+            {
+                sanitizedText = CallbackStripper.Strip(rawText);
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown sanitization layer: '{layerName}'", nameof(layerName));
+            }
+
+            if (sanitizedText != rawText)
+            {
+                var stripSpans = WordDiff.Compute(rawText, sanitizedText);
+                diffList.Add(new TextDiff(layerName, stripSpans, rawText, sanitizedText));
+            }
+
+            return sanitizedText;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/TextSanitizerTests.cs
+++ b/tests/Pinder.Core.Tests/TextSanitizerTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Pinder.Core.Text;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    public class TextSanitizerTests
+    {
+        [Fact]
+        public void Sanitize_MetaPrefix_StripsAndAddsDiff()
+        {
+            var diffs = new List<TextDiff>();
+            string raw = "CONTEXT: this is a test";
+            string result = TextSanitizer.Sanitize(raw, MetaPrefixStripper.LayerName, diffs);
+
+            Assert.Equal("this is a test", result);
+            Assert.Single(diffs);
+            Assert.Equal("Meta-Prefix Strip", diffs[0].LayerName);
+            Assert.Equal(raw, diffs[0].Before);
+            Assert.Equal("this is a test", diffs[0].After);
+        }
+
+        [Fact]
+        public void Sanitize_Callback_StripsAndAddsDiff()
+        {
+            var diffs = new List<TextDiff>();
+            string raw = "As you just said, this is a test";
+            string result = TextSanitizer.Sanitize(raw, CallbackStripper.LayerName, diffs);
+
+            Assert.Equal("This is a test", result);
+            Assert.Single(diffs);
+            Assert.Equal("Callback Strip", diffs[0].LayerName);
+            Assert.Equal(raw, diffs[0].Before);
+            Assert.Equal("This is a test", diffs[0].After);
+        }
+
+        [Fact]
+        public void Sanitize_NoChange_DoesNotAddDiff()
+        {
+            var diffs = new List<TextDiff>();
+            string raw = "Just a normal sentence.";
+            string result = TextSanitizer.Sanitize(raw, MetaPrefixStripper.LayerName, diffs);
+
+            Assert.Equal(raw, result);
+            Assert.Empty(diffs);
+        }
+
+        [Fact]
+        public void Sanitize_NullInput_ReturnsEmptyAndDoesNotAddDiff()
+        {
+            var diffs = new List<TextDiff>();
+            string result = TextSanitizer.Sanitize(null!, MetaPrefixStripper.LayerName, diffs);
+
+            Assert.Equal(string.Empty, result);
+            Assert.Empty(diffs);
+        }
+    }
+}


### PR DESCRIPTION
Issue #988: Extracted MetaPrefixStripper and CallbackStripper coordination from GameSession.cs. Created TextSanitizer helper class to eliminate duplicated inline regex matching, stripping, and WordDiff computations. Added unit tests for TextSanitizer.
