### PR TITLE
feat: split SessionDocumentBuilder

### DIFF
--- a/src/Pinder.LlmAdapters/HistoryFormatter.cs
+++ b/src/Pinder.LlmAdapters/HistoryFormatter.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Pinder.Core.Conversation;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Helper for formatting conversation history for LLM prompts.
+    /// </summary>
+    public static class HistoryFormatter
+    {
+        /// <summary>
+        /// Formats conversation history with [T{n}|PLAYER|name] markers.
+        /// Full history — never truncated.
+        /// </summary>
+        public static void Format(
+            StringBuilder sb,
+            IReadOnlyList<(string Sender, string Text)> history,
+            string playerName)
+        {
+            if (sb == null) throw new ArgumentNullException(nameof(sb));
+            if (history == null) throw new ArgumentNullException(nameof(history));
+
+            sb.AppendLine("[CONVERSATION_START]");
+
+            // #951: turn index must count only real conversational entries.
+            // Scene entries (sender == "[scene]") must never appear in the
+            // LLM context — GameSession.BuildHistoryForLlmContext() normally
+            // filters them, but a defense-in-depth guard here prevents any
+            // caller from accidentally passing an unfiltered list and having
+            // the LLM confuse "[scene]" for the opponent's character name.
+            int filteredIndex = 0;
+            for (int i = 0; i < history.Count; i++)
+            {
+                var entry = history[i];
+                if (Senders.IsScene(entry.Sender)) continue;
+                int turn = (filteredIndex / 2) + 1;
+                string role = entry.Sender == playerName ? "PLAYER" : "OPPONENT";
+                sb.AppendLine($"[T{turn}|{role}|{entry.Sender}] \"{entry.Text}\"");
+                filteredIndex++;
+            }
+
+            sb.AppendLine("[CURRENT_TURN]");
+        }
+
+        /// <summary>
+        /// Formats recent conversation history without turn numbers for context.
+        /// Filters scene entries and takes the last 6 entries.
+        /// </summary>
+        public static void FormatRecent(
+            StringBuilder sb,
+            IReadOnlyList<(string Sender, string Text)> history,
+            string? playerName)
+        {
+            if (sb == null) throw new ArgumentNullException(nameof(sb));
+            if (history == null) throw new ArgumentNullException(nameof(history));
+
+            // #951: skip scene entries (sender == "[scene]") before computing
+            // the last-6 window so turn-0 bios and outfit descriptions never
+            // appear as [OPPONENT] lines that confuse the LLM about the
+            // opponent's character name.
+            var filtered = new List<(string Sender, string Text)>(history.Count);
+            foreach (var e in history)
+            {
+                if (!Senders.IsScene(e.Sender))
+                {
+                    filtered.Add(e);
+                }
+            }
+
+            int start = Math.Max(0, filtered.Count - 6);
+            for (int i = start; i < filtered.Count; i++)
+            {
+                var entry = filtered[i];
+                string role = (!string.IsNullOrEmpty(playerName) && entry.Sender == playerName) ? "PLAYER" : "OPPONENT";
+                sb.AppendLine($"[{role}] \"{entry.Text}\"");
+            }
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.cs
@@ -40,7 +40,7 @@ namespace Pinder.LlmAdapters
             }
 
             // Conversation history
-            AppendConversationHistory(sb, context.ConversationHistory, playerName);
+            HistoryFormatter.Format(sb, context.ConversationHistory, playerName);
             sb.AppendLine();
 
             // Game state summary for the ENGINE block
@@ -202,7 +202,7 @@ namespace Pinder.LlmAdapters
             var sb = new StringBuilder();
 
             // Conversation history
-            AppendConversationHistory(sb, context.ConversationHistory, playerName);
+            HistoryFormatter.Format(sb, context.ConversationHistory, playerName);
 
             string deliveryTaint = BuildShadowTaintBlock(context.ShadowThresholds);
             if (!string.IsNullOrEmpty(deliveryTaint))
@@ -343,7 +343,7 @@ namespace Pinder.LlmAdapters
             var sb = new StringBuilder();
 
             // Conversation history
-            AppendConversationHistory(sb, context.ConversationHistory, playerName);
+            HistoryFormatter.Format(sb, context.ConversationHistory, playerName);
             sb.AppendLine();
 
             // Player's last message with failure context if applicable
@@ -472,20 +472,7 @@ namespace Pinder.LlmAdapters
             if (conversationHistory != null && conversationHistory.Count > 0)
             {
                 sb.AppendLine("RECENT CONVERSATION (for context — reference specific details in your response):");
-                // #951: skip scene entries (sender == "[scene]") before computing
-                // the last-6 window so turn-0 bios and outfit descriptions never
-                // appear as [OPPONENT] lines that confuse the LLM about the
-                // opponent's character name.
-                var filtered = new System.Collections.Generic.List<(string Sender, string Text)>(conversationHistory.Count);
-                foreach (var e in conversationHistory)
-                    if (!Senders.IsScene(e.Sender)) filtered.Add(e);
-                int start = Math.Max(0, filtered.Count - 6);
-                for (int i = start; i < filtered.Count; i++)
-                {
-                    var entry = filtered[i];
-                    string role = (!string.IsNullOrEmpty(playerName) && entry.Sender == playerName) ? "PLAYER" : "OPPONENT";
-                    sb.AppendLine($"[{role}] \"{entry.Text}\"");
-                }
+                HistoryFormatter.FormatRecent(sb, conversationHistory, playerName);
                 sb.AppendLine();
             }
 
@@ -498,36 +485,7 @@ namespace Pinder.LlmAdapters
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Formats conversation history with [T{n}|PLAYER|name] markers.
-        /// Full history — never truncated.
-        /// </summary>
-        private static void AppendConversationHistory(
-            StringBuilder sb,
-            IReadOnlyList<(string Sender, string Text)> history,
-            string playerName)
-        {
-            sb.AppendLine("[CONVERSATION_START]");
 
-            // #951: turn index must count only real conversational entries.
-            // Scene entries (sender == "[scene]") must never appear in the
-            // LLM context — GameSession.BuildHistoryForLlmContext() normally
-            // filters them, but a defense-in-depth guard here prevents any
-            // caller from accidentally passing an unfiltered list and having
-            // the LLM confuse "[scene]" for the opponent's character name.
-            int filteredIndex = 0;
-            for (int i = 0; i < history.Count; i++)
-            {
-                var entry = history[i];
-                if (Senders.IsScene(entry.Sender)) continue;
-                int turn = (filteredIndex / 2) + 1;
-                string role = entry.Sender == playerName ? "PLAYER" : "OPPONENT";
-                sb.AppendLine($"[T{turn}|{role}|{entry.Sender}] \"{entry.Text}\"");
-                filteredIndex++;
-            }
-
-            sb.AppendLine("[CURRENT_TURN]");
-        }
 
         /// <summary>
         /// Returns a stat-specific note on what success with that stat sounds and feels like.

--- a/tests/Pinder.LlmAdapters.Tests/HistoryFormatterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/HistoryFormatterTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class HistoryFormatterTests
+    {
+        [Fact]
+        public void Format_CorrectlyConstructsFullHistory()
+        {
+            // Arrange
+            var sb = new StringBuilder();
+            var history = new List<(string Sender, string Text)>
+            {
+                ("O", "Hello, how are you?"),
+                ("P", "I am good!"),
+                ("[scene]", "A scenic backdrop rolls in.")
+            };
+            var playerName = "P";
+
+            // Act
+            HistoryFormatter.Format(sb, history, playerName);
+            var result = sb.ToString();
+
+            // Assert
+            Assert.Contains("[CONVERSATION_START]", result);
+            Assert.Contains("[T1|OPPONENT|O] \"Hello, how are you?\"", result);
+            Assert.Contains("[T1|PLAYER|P] \"I am good!\"", result);
+            Assert.DoesNotContain("[scene]", result);
+            Assert.Contains("[CURRENT_TURN]", result);
+        }
+
+        [Fact]
+        public void FormatRecent_CorrectlyFormatsRecentHistory()
+        {
+            // Arrange
+            var sb = new StringBuilder();
+            var history = new List<(string Sender, string Text)>
+            {
+                ("[scene]", "Outfit context: fancy dress"),
+                ("O", "Hi"),
+                ("P", "Hey"),
+                ("O", "How's your day?"),
+                ("P", "Good, you?"),
+                ("O", "Great"),
+                ("P", "Awesome"),
+                ("O", "Are you free?")
+            };
+            var playerName = "P";
+
+            // Act
+            HistoryFormatter.FormatRecent(sb, history, playerName);
+            var result = sb.ToString();
+
+            // Assert
+            // It should only take up to 6 non-scene entries
+            // The filtered entries would be: O:Hi, P:Hey, O:How's your day, P:Good, O:Great, P:Awesome, O:Are you free? (total 7 entries)
+            // The last 6 would be: P:Hey, O:How's your day, P:Good, O:Great, P:Awesome, O:Are you free?
+            Assert.DoesNotContain("Outfit context", result);
+            Assert.DoesNotContain("[OPPONENT] \"Hi\"", result); // First entry is truncated
+            Assert.Contains("[PLAYER] \"Hey\"", result);
+            Assert.Contains("[OPPONENT] \"How's your day?\"", result);
+            Assert.Contains("[PLAYER] \"Good, you?\"", result);
+            Assert.Contains("[OPPONENT] \"Great\"", result);
+            Assert.Contains("[PLAYER] \"Awesome\"", result);
+            Assert.Contains("[OPPONENT] \"Are you free?\"", result);
+        }
+    }
+}


### PR DESCRIPTION
Extract the list formatting of historical messages into a standalone static helper class HistoryFormatter.

Closes #4