### PR TITLE
feat(core): Split GameSession end-of-game checks and ghost trigger evaluation to GameSessionRulesEvaluator

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -914,11 +914,8 @@ namespace Pinder.Core.Conversation
             if (_ended)
                 throw new GameEndedException(_outcome!.Value);
 
-            // 2. Check interest end conditions (transactional — #957)
-            CheckInterestEndConditions();
-
-            // 3. Ghost trigger check (transactional — #957)
-            CheckGhostTrigger();
+            // 2 & 3. Check interest end conditions and ghost trigger (transactional — #957)
+            GameSessionRulesEvaluator.EvaluateEndState(_interest, _playerShadows, _dice, _rules);
 
             // 4. Clear pending Speak options and weakness window (#49)
             _currentOptions = null;
@@ -938,71 +935,10 @@ namespace Pinder.Core.Conversation
             _turnNumber++;
 
             // 8. Check end conditions after interest change (transactional — #957)
-            if (_interest.IsZero)
-            {
-                if (_playerShadows != null)
-                {
-                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
-                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
-                }
-                throw new GameEndedException(GameOutcome.Unmatched);
-            }
+            GameSessionRulesEvaluator.CheckInterestEndConditions(_interest, _playerShadows);
         }
 
-        /// <summary>
-        /// Checks interest-based end conditions and throws GameEndedException if triggered.
-        /// </summary>
-        /// <remarks>
-        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
-        /// before throwing. The caller (Wait()) catches and calls MarkEnded + reapplies
-        /// shadow growth from ex.ShadowGrowthEffects.
-        /// </remarks>
-        private void CheckInterestEndConditions()
-        {
-            if (_interest.IsZero)
-            {
-                if (_playerShadows != null)
-                {
-                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
-                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
-                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
-                }
-                throw new GameEndedException(GameOutcome.Unmatched);
-            }
 
-            if (_interest.IsMaxed)
-            {
-                throw new GameEndedException(GameOutcome.DateSecured);
-            }
-        }
-
-        /// <summary>
-        /// Checks ghost trigger: if Bored state, 25% chance (dice.Roll(4)==1) to ghost.
-        /// </summary>
-        /// <remarks>
-        /// #957: transactional — no observable state mutation (_ended, _outcome, shadow)
-        /// before throwing. The caller (Wait() and StartTurnAsync()) catches and calls
-        /// MarkEnded + reapplies shadow growth from ex.ShadowGrowthEffects.
-        /// </remarks>
-        private void CheckGhostTrigger()
-        {
-            if (ResolveInterestState() == InterestState.Bored)
-            {
-                int ghostRoll = _dice.Roll(4);
-                if (ghostRoll == 1)
-                {
-                    if (_playerShadows != null)
-                    {
-                        var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
-                        var effects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted") };
-                        throw new GameEndedException(GameOutcome.Ghosted, events, effects);
-                    }
-
-                    throw new GameEndedException(GameOutcome.Ghosted);
-                }
-            }
-        }
 
         /// <summary>
         /// Returns the shadow stat paired with the given positive stat, or null if unrecognised.

--- a/src/Pinder.Core/Conversation/GameSessionRulesEvaluator.cs
+++ b/src/Pinder.Core/Conversation/GameSessionRulesEvaluator.cs
@@ -1,0 +1,88 @@
+using System;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Offloads end-of-game checks and rules evaluation from GameSession.
+    /// </summary>
+    public static class GameSessionRulesEvaluator
+    {
+        /// <summary>
+        /// Evaluates end-of-game rules (interest end conditions and ghost triggers).
+        /// </summary>
+        /// <exception cref="GameEndedException">Thrown if game has ended or ghost trigger fires.</exception>
+        public static void EvaluateEndState(
+            InterestMeter interest,
+            SessionShadowTracker? playerShadows,
+            IDiceRoller dice,
+            IRuleResolver? rules)
+        {
+            CheckInterestEndConditions(interest, playerShadows);
+            CheckGhostTrigger(interest, playerShadows, dice, rules);
+        }
+
+        /// <summary>
+        /// Checks interest-based end conditions and throws GameEndedException if triggered.
+        /// </summary>
+        public static void CheckInterestEndConditions(
+            InterestMeter interest,
+            SessionShadowTracker? playerShadows)
+        {
+            if (interest.IsZero)
+            {
+                if (playerShadows != null)
+                {
+                    var dreadEvents = new[] { $"{ShadowStatType.Dread} +1 (Conversation ended without date)" };
+                    var dreadEffects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Conversation ended without date") };
+                    throw new GameEndedException(GameOutcome.Unmatched, dreadEvents, dreadEffects);
+                }
+                throw new GameEndedException(GameOutcome.Unmatched);
+            }
+
+            if (interest.IsMaxed)
+            {
+                throw new GameEndedException(GameOutcome.DateSecured);
+            }
+        }
+
+        /// <summary>
+        /// Checks ghost trigger: if Bored state, 25% chance (dice.Roll(4)==1) to ghost.
+        /// </summary>
+        public static void CheckGhostTrigger(
+            InterestMeter interest,
+            SessionShadowTracker? playerShadows,
+            IDiceRoller dice,
+            IRuleResolver? rules)
+        {
+            InterestState interestState = ResolveInterestState(interest, rules);
+            if (interestState == InterestState.Bored)
+            {
+                int ghostRoll = dice.Roll(4);
+                if (ghostRoll == 1)
+                {
+                    if (playerShadows != null)
+                    {
+                        var events = new[] { $"{ShadowStatType.Dread} +1 (Ghosted)" };
+                        var effects = new[] { new ShadowGrowthEffect(ShadowStatType.Dread, 1, "Ghosted") };
+                        throw new GameEndedException(GameOutcome.Ghosted, events, effects);
+                    }
+
+                    throw new GameEndedException(GameOutcome.Ghosted);
+                }
+            }
+        }
+
+        private static InterestState ResolveInterestState(InterestMeter interest, IRuleResolver? rules)
+        {
+            if (rules != null)
+            {
+                var resolved = rules.GetInterestState(interest.Current);
+                if (resolved.HasValue)
+                    return resolved.Value;
+            }
+            return interest.GetState();
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/GameSessionRulesEvaluatorTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/GameSessionRulesEvaluatorTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    [Collection("GameSession")]
+    [Trait("Category", "Core")]
+    public class GameSessionRulesEvaluatorTests
+    {
+        // Simple stub dice for predictable ghost rolls
+        private sealed class PredictableDice : IDiceRoller
+        {
+            private readonly int _value;
+            public PredictableDice(int value) => _value = value;
+            public int Roll(int sides) => _value;
+        }
+
+        [Fact]
+        public void CheckInterestEndConditions_InterestZero_ThrowsUnmatched()
+        {
+            var interest = new InterestMeter(0); // IsZero = true
+            var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2, 0));
+
+            var ex = Assert.Throws<GameEndedException>(() =>
+                GameSessionRulesEvaluator.CheckInterestEndConditions(interest, shadows)
+            );
+
+            Assert.Equal(GameOutcome.Unmatched, ex.Outcome);
+            Assert.NotEmpty(ex.ShadowGrowthEvents);
+            Assert.Contains("Dread +1 (Conversation ended without date)", ex.ShadowGrowthEvents[0]);
+        }
+
+        [Fact]
+        public void CheckInterestEndConditions_InterestMaxed_ThrowsDateSecured()
+        {
+            var interest = new InterestMeter(25); // IsMaxed = true
+
+            var ex = Assert.Throws<GameEndedException>(() =>
+                GameSessionRulesEvaluator.CheckInterestEndConditions(interest, null)
+            );
+
+            Assert.Equal(GameOutcome.DateSecured, ex.Outcome);
+        }
+
+        [Fact]
+        public void CheckGhostTrigger_BoredAndRollOne_ThrowsGhosted()
+        {
+            var interest = new InterestMeter(2); // Bored state (interest 1-4)
+            var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2, 0));
+            var dice = new PredictableDice(1); // will trigger ghost
+
+            var ex = Assert.Throws<GameEndedException>(() =>
+                GameSessionRulesEvaluator.CheckGhostTrigger(interest, shadows, dice, null)
+            );
+
+            Assert.Equal(GameOutcome.Ghosted, ex.Outcome);
+            Assert.NotEmpty(ex.ShadowGrowthEvents);
+            Assert.Contains("Dread +1 (Ghosted)", ex.ShadowGrowthEvents[0]);
+        }
+
+        [Fact]
+        public void CheckGhostTrigger_BoredAndRollTwo_DoesNotThrow()
+        {
+            var interest = new InterestMeter(2); // Bored state
+            var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2, 0));
+            var dice = new PredictableDice(2); // will not trigger ghost
+
+            // Should complete successfully without throwing
+            GameSessionRulesEvaluator.CheckGhostTrigger(interest, shadows, dice, null);
+        }
+    }
+}


### PR DESCRIPTION
Refactored GameSession.cs by offloading end-of-game checks (interest end conditions and ghost triggers) to a new GameSessionRulesEvaluator class. Added unit tests for validation.

Closes #1