### PR TITLE
Refactor EngineInjectionBlockTests.cs to keep under 500 lines

### DIFF
--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public partial class EngineInjectionBlockTests
+    {
+        // Wire prompt catalog once for all tests (Phase 5 of #871: no const fallbacks).
+        static EngineInjectionBlockTests()
+        {
+            var dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 10; i++)
+            {
+                var candidate = System.IO.Path.Combine(dir, "data", "prompts");
+                if (System.IO.Directory.Exists(candidate))
+                {
+                    var catalog = Pinder.LlmAdapters.PromptCatalog.LoadFromDirectory(candidate);
+                    Pinder.LlmAdapters.PromptTemplates.Catalog = catalog;
+                    Pinder.Core.Prompts.PromptBuilder.StructuralFragmentLookup =
+                        key => catalog.TryGet(key)?.SystemPrompt;
+                    Pinder.LlmAdapters.ArchetypeYamlLoader.LoadFromPromptCatalog(catalog);
+                    return;
+                }
+                var parent = System.IO.Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+        }
+
+        // ── Helpers ──
+
+        private static DialogueContext MakeDialogueContext(
+            int currentTurn = 3,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            int currentInterest = 14,
+            IReadOnlyList<(string Sender, string Text)>? conversationHistory = null,
+            string opponentLastMessage = "hey",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            List<CallbackOpportunity>? callbackOpportunities = null,
+            int horninessLevel = 0,
+            bool requiresRizzOption = false,
+            string[]? activeTrapInstructions = null,
+            string[]? activeTraps = null,
+            string playerTextingStyle = "")
+        {
+            return new DialogueContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: conversationHistory ?? new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!"),
+                    ("Velvet", "how's your night going"),
+                    ("Sable", "so good lol")
+                },
+                opponentLastMessage: opponentLastMessage,
+                activeTraps: activeTraps ?? Array.Empty<string>(),
+                currentInterest: currentInterest,
+                shadowThresholds: shadowThresholds,
+                callbackOpportunities: callbackOpportunities,
+                horninessLevel: horninessLevel,
+                requiresRizzOption: requiresRizzOption,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                currentTurn: currentTurn,
+                playerTextingStyle: playerTextingStyle);
+        }
+
+        private static DeliveryContext MakeDeliveryContext(
+            DialogueOption? chosenOption = null,
+            FailureTier outcome = FailureTier.None,
+            int beatDcBy = 5,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null)
+        {
+            return new DeliveryContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!")
+                },
+                opponentLastMessage: "omg hi!!",
+                chosenOption: chosenOption ?? new DialogueOption(StatType.Wit, "you remind me of a song I can't quite place"),
+                outcome: outcome,
+                beatDcBy: beatDcBy,
+                activeTraps: Array.Empty<string>(),
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName);
+        }
+
+        private static OpponentContext MakeOpponentContext(
+            int interestBefore = 12,
+            int interestAfter = 14,
+            string playerDeliveredMessage = "you remind me of a song I can't quite place",
+            double responseDelayMinutes = 2.5,
+            string playerName = "Velvet",
+            string opponentName = "Sable",
+            Dictionary<ShadowStatType, int>? shadowThresholds = null,
+            string[]? activeTrapInstructions = null,
+            FailureTier deliveryTier = FailureTier.None)
+        {
+            return new OpponentContext(
+                playerPrompt: "velvet system prompt",
+                opponentPrompt: "sable system prompt",
+                conversationHistory: new List<(string, string)>
+                {
+                    ("Velvet", "hey there"),
+                    ("Sable", "omg hi!!")
+                },
+                opponentLastMessage: "omg hi!!",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: interestAfter,
+                playerDeliveredMessage: playerDeliveredMessage,
+                interestBefore: interestBefore,
+                interestAfter: interestAfter,
+                responseDelayMinutes: responseDelayMinutes,
+                shadowThresholds: shadowThresholds,
+                activeTrapInstructions: activeTrapInstructions,
+                playerName: playerName,
+                opponentName: opponentName,
+                deliveryTier: deliveryTier);
+        }
+
+        private static string? FindYamlPath(string relativePath)
+        {
+            string? dir = AppDomain.CurrentDomain.BaseDirectory;
+            while (dir != null)
+            {
+                string candidate = System.IO.Path.Combine(dir, relativePath);
+                if (System.IO.File.Exists(candidate)) return candidate;
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
@@ -11,132 +11,8 @@ namespace Pinder.LlmAdapters.Tests
     /// Tests for [ENGINE] injection block format in SessionDocumentBuilder.
     /// Verifies AC from Issue #544: options, delivery, and opponent injection formats.
     /// </summary>
-    public class EngineInjectionBlockTests
+    public partial class EngineInjectionBlockTests
     {
-        // Wire prompt catalog once for all tests (Phase 5 of #871: no const fallbacks).
-        static EngineInjectionBlockTests()
-        {
-            var dir = AppDomain.CurrentDomain.BaseDirectory;
-            for (int i = 0; i < 10; i++)
-            {
-                var candidate = System.IO.Path.Combine(dir, "data", "prompts");
-                if (System.IO.Directory.Exists(candidate))
-                {
-                    var catalog = Pinder.LlmAdapters.PromptCatalog.LoadFromDirectory(candidate);
-                    Pinder.LlmAdapters.PromptTemplates.Catalog = catalog;
-                    Pinder.Core.Prompts.PromptBuilder.StructuralFragmentLookup =
-                        key => catalog.TryGet(key)?.SystemPrompt;
-                    Pinder.LlmAdapters.ArchetypeYamlLoader.LoadFromPromptCatalog(catalog);
-                    return;
-                }
-                var parent = System.IO.Path.GetDirectoryName(dir);
-                if (parent == null || parent == dir) break;
-                dir = parent;
-            }
-        }
-
-        // ── Helpers ──
-
-        private static DialogueContext MakeDialogueContext(
-            int currentTurn = 3,
-            string playerName = "Velvet",
-            string opponentName = "Sable",
-            int currentInterest = 14,
-            IReadOnlyList<(string Sender, string Text)>? conversationHistory = null,
-            string opponentLastMessage = "hey",
-            Dictionary<ShadowStatType, int>? shadowThresholds = null,
-            List<CallbackOpportunity>? callbackOpportunities = null,
-            int horninessLevel = 0,
-            bool requiresRizzOption = false,
-            string[]? activeTrapInstructions = null,
-            string[]? activeTraps = null,
-            string playerTextingStyle = "")
-        {
-            return new DialogueContext(
-                playerPrompt: "velvet system prompt",
-                opponentPrompt: "sable system prompt",
-                conversationHistory: conversationHistory ?? new List<(string, string)>
-                {
-                    ("Velvet", "hey there"),
-                    ("Sable", "omg hi!!"),
-                    ("Velvet", "how's your night going"),
-                    ("Sable", "so good lol")
-                },
-                opponentLastMessage: opponentLastMessage,
-                activeTraps: activeTraps ?? Array.Empty<string>(),
-                currentInterest: currentInterest,
-                shadowThresholds: shadowThresholds,
-                callbackOpportunities: callbackOpportunities,
-                horninessLevel: horninessLevel,
-                requiresRizzOption: requiresRizzOption,
-                activeTrapInstructions: activeTrapInstructions,
-                playerName: playerName,
-                opponentName: opponentName,
-                currentTurn: currentTurn,
-                playerTextingStyle: playerTextingStyle);
-        }
-
-        private static DeliveryContext MakeDeliveryContext(
-            DialogueOption? chosenOption = null,
-            FailureTier outcome = FailureTier.None,
-            int beatDcBy = 5,
-            string playerName = "Velvet",
-            string opponentName = "Sable",
-            Dictionary<ShadowStatType, int>? shadowThresholds = null,
-            string[]? activeTrapInstructions = null)
-        {
-            return new DeliveryContext(
-                playerPrompt: "velvet system prompt",
-                opponentPrompt: "sable system prompt",
-                conversationHistory: new List<(string, string)>
-                {
-                    ("Velvet", "hey there"),
-                    ("Sable", "omg hi!!")
-                },
-                opponentLastMessage: "omg hi!!",
-                chosenOption: chosenOption ?? new DialogueOption(StatType.Wit, "you remind me of a song I can't quite place"),
-                outcome: outcome,
-                beatDcBy: beatDcBy,
-                activeTraps: Array.Empty<string>(),
-                shadowThresholds: shadowThresholds,
-                activeTrapInstructions: activeTrapInstructions,
-                playerName: playerName,
-                opponentName: opponentName);
-        }
-
-        private static OpponentContext MakeOpponentContext(
-            int interestBefore = 12,
-            int interestAfter = 14,
-            string playerDeliveredMessage = "you remind me of a song I can't quite place",
-            double responseDelayMinutes = 2.5,
-            string playerName = "Velvet",
-            string opponentName = "Sable",
-            Dictionary<ShadowStatType, int>? shadowThresholds = null,
-            string[]? activeTrapInstructions = null,
-            FailureTier deliveryTier = FailureTier.None)
-        {
-            return new OpponentContext(
-                playerPrompt: "velvet system prompt",
-                opponentPrompt: "sable system prompt",
-                conversationHistory: new List<(string, string)>
-                {
-                    ("Velvet", "hey there"),
-                    ("Sable", "omg hi!!")
-                },
-                opponentLastMessage: "omg hi!!",
-                activeTraps: Array.Empty<string>(),
-                currentInterest: interestAfter,
-                playerDeliveredMessage: playerDeliveredMessage,
-                interestBefore: interestBefore,
-                interestAfter: interestAfter,
-                responseDelayMinutes: responseDelayMinutes,
-                shadowThresholds: shadowThresholds,
-                activeTrapInstructions: activeTrapInstructions,
-                playerName: playerName,
-                opponentName: opponentName,
-                deliveryTier: deliveryTier);
-        }
-
         // ═══════════════════════════════════════════════════════════════
         // AC1: Options injection format — [ENGINE — Turn N]
         // ═══════════════════════════════════════════════════════════════
@@ -492,20 +368,6 @@ namespace Pinder.LlmAdapters.Tests
 
             int engineIdx = result.IndexOf("[ENGINE — OPPONENT]");
             Assert.True(engineIdx >= 0, "[ENGINE — OPPONENT] block must be present");
-        }
-
-        // ── Helper ──
-
-        private static string? FindYamlPath(string relativePath)
-        {
-            string? dir = AppDomain.CurrentDomain.BaseDirectory;
-            while (dir != null)
-            {
-                string candidate = System.IO.Path.Combine(dir, relativePath);
-                if (System.IO.File.Exists(candidate)) return candidate;
-                dir = System.IO.Path.GetDirectoryName(dir);
-            }
-            return null;
         }
     }
 }


### PR DESCRIPTION
Decomposes EngineInjectionBlockTests.cs into modular partial classes (splitting helpers out to EngineInjectionBlockTests.Helpers.cs) to keep all files strictly under 500 lines.

Closes #Refactor-78