### PR TITLE
Update stale prompt/vision assertions and fix clone constructor (#1072)

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.Clone.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Clone.cs
@@ -82,6 +82,7 @@ namespace Pinder.Core.Conversation
             _statDeliveryInstructions = src._statDeliveryInstructions;
             _onTextLayerNoop = src._onTextLayerNoop;
             _consequenceCatalog = src._consequenceCatalog;
+            _maxDialogueOptions = src._maxDialogueOptions;
 
             // ── Mutable engine state — deep copies (Category A) ──
             _state           = src._state.Clone();

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -349,7 +349,7 @@ namespace Pinder.Core.Tests
             var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
 
             // Should contain assembled fragments, not be empty
-            Assert.Contains("You are playing the role of Gerald_42", profile.AssembledSystemPrompt);
+            Assert.Contains("The character named Gerald_42 is actually the Player.", profile.AssembledSystemPrompt);
             Assert.Contains("he/him", profile.AssembledSystemPrompt);
             Assert.Contains("BACKSTORY", profile.AssembledSystemPrompt);
             Assert.Contains("TEXTING STYLE", profile.AssembledSystemPrompt);

--- a/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
@@ -110,7 +110,7 @@ namespace Pinder.Core.Tests
 
             string fromYaml = entry.SystemPrompt!;
             const string fromConst =
-                "You are playing the role of {name}, a sentient penis on the dating app Pinder.";
+                "You are the game master a RPG similar to D&D, where you throw dice to progress the game. You are steering two characters. The world & setting are different though: one of the two characters is the \"opponent\"/monster who is actually someone the first character wants to date in a satyrical dating app that basically works like Tinder.  The character named {name} is actually the Player. For the Player you create dialog options you choose from. The app is called Pinder though, because you act like a sentient penis that is actually a configurable plastic figure similar to the famous Potato Man. The goal is to reveal all the weird things that happen in dating apps like these: most people just want to get laid, people have the weirdest profiles, photos, looks, and definitely the most weird ways of expressing their despair of not finding a loved one. The dialogue that will play out by \"fighting\" should make the player see themselves in a time when they were desparate enough to use something like Tinder in the real world: it should be revealing, disarming, silly, embarrassing, but also sometimes very honest and touching. Everything needs to be purely expressed through what the two characters say though.";
 
             Assert.Equal(fromConst, fromYaml);
         }
@@ -156,8 +156,8 @@ namespace Pinder.Core.Tests
                 Assert.Contains("ACTIVE ARCHETYPE", prompt);
 
                 // Lead-in with substituted name.
-                Assert.Contains("You are playing the role of TestChar", prompt);
-                Assert.Contains("a sentient penis on the dating app Pinder.", prompt);
+                Assert.Contains("The character named TestChar is actually the Player.", prompt);
+                Assert.Contains("The app is called Pinder though, because you act like a sentient penis that is actually", prompt);
             }
             finally
             {

--- a/tests/Pinder.Core.Tests/Phase4/Phase4_GameSessionCloneTests.cs
+++ b/tests/Pinder.Core.Tests/Phase4/Phase4_GameSessionCloneTests.cs
@@ -364,6 +364,21 @@ namespace Pinder.Core.Tests.Phase4
             Assert.Equal(originalHorniness, clone.SessionHorniness);
         }
 
+        [Fact]
+        public void Clone_MaxDialogueOptions_PreservedExactly()
+        {
+            var (parent, _) = MakeFreshSessionWithTurnsQueued(turnsToQueue: 0);
+            var clone = parent.Clone();
+
+            var field = typeof(GameSession).GetField("_maxDialogueOptions", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            var parentVal = (int)field.GetValue(parent)!;
+            var cloneVal = (int)field.GetValue(clone)!;
+
+            Assert.Equal(parentVal, cloneVal);
+            Assert.True(cloneVal > 0, "maxDialogueOptions should be positive");
+        }
+
         // ---- helpers --------------------------------------------------------------
         //
         // Reuses Phase0Fixtures (canned LLM transport, deterministic dice

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.Opponent_Meta_Writing.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.Opponent_Meta_Writing.cs
@@ -213,7 +213,7 @@ namespace Pinder.Rules.Tests
         {
             var data = ParseYaml();
             // All content sections should be multi-line (contain newlines)
-            foreach (var key in new[] { "vision", "world_description", "player_role_description",
+            foreach (var key in new[] { "world_description", "player_role_description",
                                         "opponent_role_description", "meta_contract", "writing_rules" })
             {
                 Assert.Contains("\n", data[key]);

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.Vision_World_Player.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlContentTests.Vision_World_Player.cs
@@ -17,6 +17,7 @@ namespace Pinder.Rules.Tests
             Assert.True(
                 vision.Contains("player", StringComparison.OrdinalIgnoreCase) &&
                 (vision.Contains("opponent", StringComparison.OrdinalIgnoreCase) ||
+                 vision.Contains("DATEE", StringComparison.OrdinalIgnoreCase) ||
                  vision.Contains("other player", StringComparison.OrdinalIgnoreCase) ||
                  vision.Contains("multiplayer", StringComparison.OrdinalIgnoreCase) ||
                  vision.Contains("uploaded", StringComparison.OrdinalIgnoreCase)),
@@ -33,7 +34,11 @@ namespace Pinder.Rules.Tests
                 vision.Contains("emotional", StringComparison.OrdinalIgnoreCase) ||
                 vision.Contains("tension", StringComparison.OrdinalIgnoreCase) ||
                 vision.Contains("stakes", StringComparison.OrdinalIgnoreCase) ||
-                vision.Contains("feel", StringComparison.OrdinalIgnoreCase),
+                vision.Contains("feel", StringComparison.OrdinalIgnoreCase) ||
+                vision.Contains("honest", StringComparison.OrdinalIgnoreCase) ||
+                vision.Contains("touching", StringComparison.OrdinalIgnoreCase) ||
+                vision.Contains("despair", StringComparison.OrdinalIgnoreCase) ||
+                vision.Contains("desparate", StringComparison.OrdinalIgnoreCase),
                 "Vision must mention emotional stakes beneath absurdity");
         }
 
@@ -87,9 +92,10 @@ namespace Pinder.Rules.Tests
         {
             var data = ParseYaml();
             var world = data["world_description"];
+            var player = data["player_role_description"];
             // Must mention 0 and 25 as the interest range boundaries
             Assert.Contains("0", world);
-            Assert.Contains("25", world);
+            Assert.Contains("25", player);
         }
 
         // Mutation: would catch if world description omits ghosting/Bored state risk
@@ -98,9 +104,12 @@ namespace Pinder.Rules.Tests
         {
             var data = ParseYaml();
             var world = data["world_description"];
+            var opponent = data["opponent_role_description"];
             Assert.True(
                 world.Contains("Bored", StringComparison.Ordinal) ||
-                world.Contains("ghost", StringComparison.OrdinalIgnoreCase),
+                opponent.Contains("Bored", StringComparison.Ordinal) ||
+                world.Contains("ghost", StringComparison.OrdinalIgnoreCase) ||
+                opponent.Contains("ghost", StringComparison.OrdinalIgnoreCase),
                 "World description must mention Bored state or ghosting risk");
         }
 

--- a/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
+++ b/tests/Pinder.Rules.Tests/GameDefinitionYamlTests.cs
@@ -193,10 +193,10 @@ namespace Pinder.Rules.Tests
             var data = ParseYaml();
             var vision = data["vision"];
             // Must reference the core premise
-            Assert.Contains("sentient peni", vision, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("dating", vision, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("comedy", vision, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("shadow", vision, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("sentient penis", vision, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("game master", vision, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("RPG", vision, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("dialogue", vision, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -224,10 +224,12 @@ namespace Pinder.Rules.Tests
         {
             var data = ParseYaml();
             var world = data["world_description"];
-            Assert.Contains("Interest", world);
-            Assert.Contains("25", world);
-            Assert.Contains("Bored", world);
-            Assert.Contains("Date Secured", world);
+            var playerRole = data["player_role_description"];
+            var opponentRole = data["opponent_role_description"];
+            Assert.Contains("Interest", world, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("25", playerRole);
+            Assert.Contains("Bored", opponentRole);
+            Assert.Contains("Date Secured", playerRole);
         }
 
         [Fact]


### PR DESCRIPTION
### What was implemented
- Updated the assertions and expectations in various test files to match the new creative direction (specifically, the rewrites in `structural.yaml` and `game-definition.yaml`).
- Fixed the private `GameSession` clone constructor in `GameSession.Clone.cs` to copy `_maxDialogueOptions` from the source.
- Added a regression test `Clone_MaxDialogueOptions_PreservedExactly` to ensure copy behavior is pinned.

### How to test it
- Run `dotnet test` to verify all tests are completely green.
- Run `bash scripts/check-prompt-content.sh` to verify that no forbidden prompt content was reintroduced to `src/`.

### Deviations from contract
- None