### PR TITLE
test(anthropic): add regression tests for opus-4.8 model-id translation (#1068)

### DIFF
--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicRequestBuildersTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicRequestBuildersTests.cs
@@ -1,0 +1,60 @@
+using System;
+using Pinder.LlmAdapters.Anthropic;
+using Pinder.LlmAdapters.Anthropic.Dto;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    public sealed class AnthropicRequestBuildersTests
+    {
+        [Theory]
+        [InlineData("claude-opus-4.8")]
+        [InlineData("claude-opus-4.8-thinking-low")]
+        [InlineData("claude-opus-4.8-thinking-mid")]
+        [InlineData("claude-opus-4.8-thinking-high")]
+        public void BuildMessagesRequest_MapsOpus48ToDashedApiModelId(string modelSpec)
+        {
+            // Arrange
+            var systemBlocks = Array.Empty<ContentBlock>();
+            string userContent = "hello";
+
+            // Act
+            var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                modelSpec,
+                maxTokens: 1024,
+                systemBlocks,
+                userContent,
+                temperature: 0.7);
+
+            // Assert
+            Assert.Equal("claude-opus-4-8", request.Model);
+            Assert.NotEqual("claude-opus-4.8", request.Model);
+            Assert.NotEqual("claude-3-opus-20240229", request.Model);
+        }
+
+        [Theory]
+        [InlineData("claude-opus-4.8-thinking-low", 2048)]
+        [InlineData("claude-opus-4.8-thinking-mid", 4096)]
+        [InlineData("claude-opus-4.8-thinking-high", 8192)]
+        public void BuildMessagesRequest_ConfiguresThinkingBudgetCorrectly(string modelSpec, int expectedBudget)
+        {
+            // Arrange
+            var systemBlocks = Array.Empty<ContentBlock>();
+            string userContent = "hello";
+
+            // Act
+            var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                modelSpec,
+                maxTokens: 1024,
+                systemBlocks,
+                userContent,
+                temperature: 0.7);
+
+            // Assert
+            Assert.NotNull(request.Thinking);
+            Assert.Equal(expectedBudget, request.Thinking.BudgetTokens);
+            Assert.Equal(1.0, request.Temperature);
+            Assert.True(request.MaxTokens >= expectedBudget + 1024);
+        }
+    }
+}


### PR DESCRIPTION
Adds regression tests verifying that all opus-4.8 variants successfully map to the dashed API model id claude-opus-4-8 with correct thinking budget configurations.