### PR TITLE
fix(anthropic): omit `temperature` for claude-opus-4-8 (HTTP 400)

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicModelIds.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicModelIds.cs
@@ -65,5 +65,24 @@ namespace Pinder.LlmAdapters.Anthropic
                     return processed.Replace('.', '-');
             }
         }
+
+        /// <summary>
+        /// Returns true if the given model rejects the `temperature` request parameter.
+        /// Anthropic deprecated `temperature` for claude-opus-4-8 (and later opus models);
+        /// sending it yields HTTP 400 invalid_request_error. Accepts either an internal
+        /// spec or an already-dashed API id.
+        /// </summary>
+        public static bool RejectsTemperature(string modelSpecOrApiId)
+        {
+            if (string.IsNullOrEmpty(modelSpecOrApiId)) return false;
+            string apiId = ToApiId(modelSpecOrApiId);
+            switch (apiId.ToLowerInvariant())
+            {
+                case "claude-opus-4-8":
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicRequestBuilders.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicRequestBuilders.cs
@@ -62,6 +62,14 @@ namespace Pinder.LlmAdapters.Anthropic
                 request.Temperature = 1.0;
                 request.MaxTokens = Math.Max(request.MaxTokens, budget + 1024);
             }
+
+            // Some models (e.g. claude-opus-4-8) reject the `temperature` parameter
+            // with HTTP 400. Omit it entirely for those. This runs after id resolution
+            // so it also covers the thinking-variant temperature set above.
+            if (AnthropicModelIds.RejectsTemperature(request.Model))
+            {
+                request.Temperature = null;
+            }
         }
 
         /// <summary>

--- a/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesRequest.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/Dto/MessagesRequest.cs
@@ -23,8 +23,10 @@ namespace Pinder.LlmAdapters.Anthropic.Dto
         [JsonProperty("max_tokens")]
         public int MaxTokens { get; set; } = 1024;
 
-        [JsonProperty("temperature")]
-        public double Temperature { get; set; } = 0.9;
+        // Nullable + omitted when null: some models (e.g. claude-opus-4-8) reject
+        // the `temperature` parameter outright with a 400 invalid_request_error.
+        [JsonProperty("temperature", NullValueHandling = NullValueHandling.Ignore)]
+        public double? Temperature { get; set; } = 0.9;
 
         [JsonProperty("system")]
         public ContentBlock[] System { get; set; } = Array.Empty<ContentBlock>();

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.HttpAndError.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.HttpAndError.cs
@@ -30,7 +30,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             await adapter.GetOpponentResponseAsync(MakeOpponentContext());
 
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.RequestBodies[0]);
-            Assert.Equal(0.6, body!.Temperature, 2);
+            Assert.Equal(0.6, body!.Temperature!.Value, 2);
         }
 
         // What: AC7 - Temperature override for InterestChangeBeat method
@@ -48,7 +48,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             await adapter.GetInterestChangeBeatAsync(ctx);
 
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.RequestBodies[0]);
-            Assert.Equal(0.4, body!.Temperature, 2);
+            Assert.Equal(0.4, body!.Temperature!.Value, 2);
         }
 
         // What: AC7 - Temperature override for DeliverMessage method
@@ -65,7 +65,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             await adapter.DeliverMessageAsync(MakeDeliveryContext());
 
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.RequestBodies[0]);
-            Assert.Equal(0.3, body!.Temperature, 2);
+            Assert.Equal(0.3, body!.Temperature!.Value, 2);
         }
 
         // What: AC7 - When no override set, default temperatures are used
@@ -87,7 +87,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
 
             await adapter.GetDialogueOptionsAsync(MakeDialogueContext());
             var dialogueBody = JsonConvert.DeserializeObject<MessagesRequest>(handler.RequestBodies[0]);
-            Assert.Equal(0.9, dialogueBody!.Temperature, 2);
+            Assert.Equal(0.9, dialogueBody!.Temperature!.Value, 2);
         }
 
         // ==============================================================================

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.AdapterMethods.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.AdapterMethods.cs
@@ -44,7 +44,7 @@ OPTION_4
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
             Assert.NotNull(body);
             Assert.Equal("claude-sonnet-4-20250514", body!.Model);
-            Assert.Equal(0.9, body.Temperature, 2);
+            Assert.Equal(0.9, body.Temperature!.Value, 2);
             // Only player prompt in system (fix for voice bleed #487)
             Assert.Single(body.System);
             Assert.Equal("ephemeral", body.System[0].CacheControl?.Type);
@@ -69,7 +69,7 @@ OPTION_4
 
             Assert.Equal("Delivered message text", result);
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
-            Assert.Equal(0.7, body!.Temperature, 2);
+            Assert.Equal(0.7, body!.Temperature!.Value, 2);
             Assert.Equal(1, body.System.Length); // Player-only prompt cached
         }
 
@@ -88,7 +88,7 @@ OPTION_4
 
             Assert.Equal("That's sweet, tell me more", result.MessageText);
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
-            Assert.Equal(0.85, body!.Temperature, 2);
+            Assert.Equal(0.85, body!.Temperature!.Value, 2);
             // Only 1 system block — opponent only
             Assert.Single(body.System);
             Assert.Contains("Velvet", body.System[0].Text);
@@ -111,7 +111,7 @@ OPTION_4
 
             Assert.Equal("Velvet leans closer to her phone.", result);
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
-            Assert.Equal(0.8, body!.Temperature, 2);
+            Assert.Equal(0.8, body!.Temperature!.Value, 2);
             Assert.Empty(body.System); // No system blocks
         }
 
@@ -157,7 +157,7 @@ OPTION_4
             await adapter.GetDialogueOptionsAsync(MakeDialogueContext());
 
             var body = JsonConvert.DeserializeObject<MessagesRequest>(handler.CapturedRequestBody!);
-            Assert.Equal(0.5, body!.Temperature, 2);
+            Assert.Equal(0.5, body!.Temperature!.Value, 2);
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicRequestBuildersTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicRequestBuildersTests.cs
@@ -53,8 +53,46 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             // Assert
             Assert.NotNull(request.Thinking);
             Assert.Equal(expectedBudget, request.Thinking.BudgetTokens);
-            Assert.Equal(1.0, request.Temperature);
+            // opus-4-8 rejects `temperature`; even the thinking path must omit it.
+            Assert.Null(request.Temperature);
             Assert.True(request.MaxTokens >= expectedBudget + 1024);
+        }
+
+        [Theory]
+        [InlineData("claude-opus-4.8")]
+        [InlineData("anthropic/claude-opus-4.8")]
+        [InlineData("claude-opus-4.8-thinking-mid")]
+        public void BuildMessagesRequest_OmitsTemperature_ForOpus48(string modelSpec)
+        {
+            var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                modelSpec, maxTokens: 1024, Array.Empty<ContentBlock>(), "hello", temperature: 0.7);
+
+            // Temperature must be null so it serializes out of the request body entirely
+            // (claude-opus-4-8 returns HTTP 400 `temperature is deprecated for this model`).
+            Assert.Null(request.Temperature);
+        }
+
+        [Theory]
+        [InlineData("claude-sonnet-4.6")]
+        [InlineData("anthropic/claude-opus-4.7")]
+        public void BuildMessagesRequest_KeepsTemperature_ForModelsThatAcceptIt(string modelSpec)
+        {
+            var request = AnthropicRequestBuilders.BuildMessagesRequest(
+                modelSpec, maxTokens: 1024, Array.Empty<ContentBlock>(), "hello", temperature: 0.7);
+
+            Assert.Equal(0.7, request.Temperature);
+        }
+
+        [Theory]
+        [InlineData("claude-opus-4.8", true)]
+        [InlineData("anthropic/claude-opus-4.8", true)]
+        [InlineData("claude-opus-4-8", true)]
+        [InlineData("claude-opus-4.7", false)]
+        [InlineData("claude-sonnet-4.6", false)]
+        [InlineData("", false)]
+        public void RejectsTemperature_ClassifiesModelsCorrectly(string modelSpec, bool expected)
+        {
+            Assert.Equal(expected, AnthropicModelIds.RejectsTemperature(modelSpec));
         }
     }
 }


### PR DESCRIPTION
## Problem
Staging stake generation fails on `anthropic/claude-opus-4.8`:
`HTTP 400 invalid_request_error: \`temperature\` is deprecated for this model.` → `stake_llm_failed`.

The model id now resolves correctly (#1069), so requests reach Anthropic and trip this. `MessagesRequest.Temperature` was a non-nullable double, always serialized.

## Fix
- `MessagesRequest.Temperature` → `double?` with `NullValueHandling.Ignore`.
- `AnthropicModelIds.RejectsTemperature(spec)` — single source classifying models that reject temperature (claude-opus-4-8).
- `AnthropicRequestBuilders` nulls temperature for those after id resolution (covers thinking path).

## Tests
- New: omit-for-opus48, keep-for-others, RejectsTemperature classification. Updated thinking test (opus-4-8 omits temp) + nullable assertion sites.
- Full solution green: 4341 passed / 0 failed.

Closes #1078