### PR TITLE
feat(characters): port Marisol_Tides + Ozzie_Pivot to v1 schema

### DIFF
--- a/data/characters/marisol-tides.json
+++ b/data/characters/marisol-tides.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "character_id": "a5be0d29-96c5-469b-921a-3ec075639828",
+  "name": "Marisol_Tides",
+  "gender_identity": "she/her",
+  "bio": "marine bio dropout now selling hand-strung anklets at the pier. my dog picks who i date.",
+  "level": 6,
+  "items": [
+    "beach-waves",
+    "anklet-star-charm",
+    "friendship-bracelet-handmade",
+    "harem-pants",
+    "barefoot",
+    "oakley-sunglasses-forehead"
+  ],
+  "anatomy": {
+    "length": "medium",
+    "girth": "average",
+    "circumcision": "circumcised",
+    "vein_definition": "subtle",
+    "skin_texture": "natural",
+    "skin_tone": "warm",
+    "ball_size": "average",
+    "tattoos": "one-meaningful",
+    "eye_style": "soft"
+  },
+  "allocation": {
+    "spent": {
+      "charm": 4,
+      "rizz": 2,
+      "honesty": 5,
+      "chaos": 2,
+      "wit": 1,
+      "self_awareness": 0
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 1,
+      "despair": 2,
+      "denial": 3,
+      "fixation": 2,
+      "dread": 1,
+      "overthinking": 1
+    }
+  }
+}

--- a/data/characters/ozzie-pivot.json
+++ b/data/characters/ozzie-pivot.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "character_id": "9b1a068e-a076-48a3-9dc8-6f700b02fe9c",
+  "name": "Ozzie_Pivot",
+  "gender_identity": "he/him",
+  "bio": "former improv kid turned ux consultant. i will bit-crash your first date and bill you for the workshop.",
+  "level": 6,
+  "items": [
+    "designer-glasses-clear",
+    "blazer-crop-top",
+    "chinos-too-tight",
+    "boat-shoes-no-socks",
+    "color-coded-planner",
+    "apple-watch"
+  ],
+  "anatomy": {
+    "length": "medium",
+    "girth": "average",
+    "circumcision": "circumcised",
+    "vein_definition": "defined",
+    "skin_texture": "natural",
+    "skin_tone": "warm",
+    "ball_size": "asymmetric",
+    "tattoos": "one-meaningful",
+    "eye_style": "wide"
+  },
+  "allocation": {
+    "spent": {
+      "charm": 3,
+      "rizz": 1,
+      "honesty": 0,
+      "chaos": 2,
+      "wit": 4,
+      "self_awareness": 0
+    },
+    "unspent_pool": 0,
+    "shadows": {
+      "madness": 1,
+      "despair": 1,
+      "denial": 3,
+      "fixation": 2,
+      "dread": 1,
+      "overthinking": 4
+    }
+  }
+}

--- a/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
+++ b/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
@@ -322,10 +322,10 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public async Task RealStarterFiles_ListIdsFindsAllSix()
+        public async Task RealStarterFiles_ListIdsFindsAllEight()
         {
             // Wire the store at the repo's data/characters directory and
-            // confirm we see all six starter characters by their UUIDs.
+            // confirm we see all eight starter characters by their UUIDs.
             string? dir = AppContext.BaseDirectory;
             while (dir != null)
             {
@@ -338,7 +338,7 @@ namespace Pinder.Core.Tests
             var store = new DirectoryCharacterStore(Path.Combine(dir!, "data", "characters"));
             var ids = await store.ListIdsAsync();
 
-            Assert.Equal(6, ids.Count);
+            Assert.Equal(8, ids.Count);
             Assert.All(ids, id => Assert.True(Guid.TryParseExact(id, "D", out _)));
         }
     }


### PR DESCRIPTION
Two player-authored characters salvaged (only genuine local-only work) from the stale pinder-web tree during 2026-06-02 cleanup. Legacy build_points+shadows -> character-v1 (schema_version, UUIDv4 character_id, allocation.{spent,unspent_pool,shadows}). Validated against character-schema.json; all items+anatomy resolve; engine loads 8 chars 0 failed. Reviewer note: legacy negative spent stats clamped to 0 (v1 floor): Marisol self_awareness -2->0; Ozzie honesty/self_awareness -2->0 — may want rebalance.