### PR TITLE
feat(781): expose TextingStyleLines on CharacterProfile from aggregation result

### DIFF
--- a/data/i18n/en/ui-character-sheet.yaml
+++ b/data/i18n/en/ui-character-sheet.yaml
@@ -26,3 +26,7 @@ strings:
   character_sheet.texting_style_sources_heading: "Sources"
   character_sheet.texting_style_no_fragments: "(no texting style fragments — the prompt block is empty)"
   character_sheet.texting_style_empty: "No texting style data is available for this session yet."
+  # #781: Final template section (admin-only)
+  character_sheet.texting_style_final_template_heading: "Final texting-style template (admin)"
+  character_sheet.texting_style_final_template_explainer: "Aggregated axis lines as computed by TextingStyleAggregator. Each line: axis: rule. Admin-facing only."
+  character_sheet.texting_style_final_template_empty: "(no aggregated lines — no items or anatomy configured for this character)"

--- a/src/Pinder.Core/Characters/CharacterProfile.cs
+++ b/src/Pinder.Core/Characters/CharacterProfile.cs
@@ -52,6 +52,19 @@ namespace Pinder.Core.Characters
         public string TextingStyleFragment { get; }
 
         /// <summary>
+        /// Issue #781: the final aggregated texting-style axis lines as
+        /// computed by <c>TextingStyleAggregator.AggregateWithAudit</c>.
+        /// Each line has the shape <c>&quot;axis: rule&quot;</c>
+        /// (e.g. <c>"emoji: ends every sentence with an emoji"</c>).
+        /// Lines are in canonical axis order (emoji, shorthand, grammar,
+        /// structure, length, tics, stance, register, pacing); missing
+        /// axes are dropped rather than back-filled.
+        /// Empty when the aggregator produced no output (no items / anatomy
+        /// configured for this character).
+        /// </summary>
+        public IReadOnlyList<string> TextingStyleLines { get; }
+
+        /// <summary>
         /// Issue #404: per-source breakdown of the texting-style fragments
         /// that were joined into <see cref="TextingStyleFragment"/>. Each
         /// entry pairs <c>(kind, source, fragment)</c>: kind is
@@ -116,7 +129,8 @@ namespace Pinder.Core.Characters
             ActiveArchetype activeArchetype = null,
             IReadOnlyList<string> equippedItemDisplayNames = null,
             IReadOnlyList<TextingStyleFragmentSource> textingStyleSources = null,
-            string genderIdentity = "")
+            string genderIdentity = "",
+            IReadOnlyList<string> textingStyleLines = null)
         {
             Stats = stats ?? throw new ArgumentNullException(nameof(stats));
             AssembledSystemPrompt = assembledSystemPrompt ?? throw new ArgumentNullException(nameof(assembledSystemPrompt));
@@ -132,6 +146,9 @@ namespace Pinder.Core.Characters
             // #562: optional, defaults to "" so existing test fixtures
             // and unit-test ctors work without modification.
             GenderIdentity = genderIdentity ?? string.Empty;
+            // #781: final aggregated texting-style lines. Defaults to empty
+            // list so existing callers (test fixtures) don't need to pass it.
+            TextingStyleLines = textingStyleLines ?? new System.Collections.Generic.List<string>();
         }
     }
 }

--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -200,7 +200,11 @@ namespace Pinder.SessionSetup
                 // the OpponentVisibleProfile DTO can surface it as a
                 // Tinder-card-equivalent field. Was previously read here
                 // and only used for the assembled system prompt.
-                genderIdentity: def.GenderIdentity);
+                genderIdentity: def.GenderIdentity,
+                // #781: expose the final aggregated texting-style lines
+                // so the admin-facing character sheet can show the full
+                // composed template without re-running the aggregator.
+                textingStyleLines: aggregationResult.Lines);
 
             // Issue #779: propagate the permanent stake from the definition
             // to the profile so setup can read it without an LLM call.

--- a/tests/Pinder.Core.Tests/Issue781_TextingStyleLinesOnProfileTests.cs
+++ b/tests/Pinder.Core.Tests/Issue781_TextingStyleLinesOnProfileTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Pinder.Core.Characters;
+using Pinder.Core.Data;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Prompts;
+using Pinder.Core.Stats;
+using Pinder.Core.Conversation;
+using Pinder.SessionSetup;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #781 — <c>CharacterProfile.TextingStyleLines</c> must carry
+    /// the final aggregated axis lines produced by
+    /// <c>TextingStyleAggregator.AggregateWithAudit</c> so the admin-facing
+    /// character sheet can surface them without re-running the aggregator.
+    /// </summary>
+    [Trait("Category", "Characters")]
+    public class Issue781_TextingStyleLinesOnProfileTests
+    {
+        private static string RepoRoot
+        {
+            get
+            {
+                string? dir = AppContext.BaseDirectory;
+                while (dir != null)
+                {
+                    if (Directory.Exists(Path.Combine(dir, "data")) &&
+                        Directory.Exists(Path.Combine(dir, "src")))
+                        return dir;
+                    dir = Directory.GetParent(dir)?.FullName;
+                }
+                throw new InvalidOperationException(
+                    "Cannot find repo root from " + AppContext.BaseDirectory);
+            }
+        }
+
+        private static IItemRepository LoadItemRepo()
+        {
+            string json = File.ReadAllText(
+                Path.Combine(RepoRoot, "data", "items", "starter-items.json"));
+            return new JsonItemRepository(json);
+        }
+
+        private static IAnatomyRepository LoadAnatomyRepo()
+        {
+            string json = File.ReadAllText(
+                Path.Combine(RepoRoot, "data", "anatomy", "anatomy-parameters.json"));
+            return new JsonAnatomyRepository(json);
+        }
+
+        // ── TextingStyleLines on CharacterProfile defaults to empty list ──────
+
+        [Fact]
+        public void CharacterProfile_DefaultConstructor_TextingStyleLinesIsEmpty()
+        {
+            // Existing callers that omit textingStyleLines must not break.
+            var stats = new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 0 }, { StatType.Rizz, 0 }, { StatType.Honesty, 0 },
+                    { StatType.Chaos, 0 }, { StatType.Wit, 0 }, { StatType.SelfAwareness, 0 },
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 },  { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 },   { ShadowStatType.Overthinking, 0 },
+                });
+            var timing = new TimingProfile(500, 0.1f, 3000f, "neutral");
+            var profile = new CharacterProfile(
+                stats,
+                "prompt",
+                "TestChar",
+                timing,
+                level: 1);
+
+            Assert.NotNull(profile.TextingStyleLines);
+            Assert.Empty(profile.TextingStyleLines);
+        }
+
+        // ── CharacterDefinitionLoader: TextingStyleLines populated on load ────
+
+        [Fact]
+        public void Load_GeraldDefinition_TextingStyleLinesIsNotNull()
+        {
+            var profile = CharacterDefinitionLoader.Load(
+                Path.Combine(RepoRoot, "data", "characters", "gerald.json"),
+                LoadItemRepo(), LoadAnatomyRepo());
+
+            Assert.NotNull(profile.TextingStyleLines);
+        }
+
+        [Fact]
+        public void Load_GeraldDefinition_TextingStyleLinesConsistentWithFragment()
+        {
+            // The joined fragment must equal the Lines joined with " | "
+            // (same guarantee as AggregateWithAudit → Aggregate).
+            var profile = CharacterDefinitionLoader.Load(
+                Path.Combine(RepoRoot, "data", "characters", "gerald.json"),
+                LoadItemRepo(), LoadAnatomyRepo());
+
+            string expectedJoined = profile.TextingStyleLines.Count == 0
+                ? string.Empty
+                : string.Join(" | ", profile.TextingStyleLines);
+
+            Assert.Equal(expectedJoined, profile.TextingStyleFragment);
+        }
+
+        [Fact]
+        public void Load_AllStarterCharacters_TextingStyleLinesConsistentWithFragment()
+        {
+            // Consistency check across every bundled character: Lines joined
+            // with " | " must always equal the Fragment string that feeds the
+            // LLM prompt. This guards against the two being computed independently
+            // and drifting apart.
+            var itemRepo   = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+            var slugs = new[] { "brick", "gerald", "reuben", "sable", "velvet", "zyx" };
+
+            foreach (var slug in slugs)
+            {
+                string path = Path.Combine(RepoRoot, "data", "characters", $"{slug}.json");
+                if (!File.Exists(path)) continue;
+
+                var profile = CharacterDefinitionLoader.Load(path, itemRepo, anatomyRepo);
+
+                string expectedJoined = profile.TextingStyleLines.Count == 0
+                    ? string.Empty
+                    : string.Join(" | ", profile.TextingStyleLines);
+
+                Assert.True(
+                    expectedJoined == profile.TextingStyleFragment,
+                    $"TextingStyleLines/Fragment mismatch for character '{slug}': " +
+                    $"expected='{expectedJoined}' actual='{profile.TextingStyleFragment}'");
+            }
+        }
+
+        [Fact]
+        public void Load_GeraldDefinition_TextingStyleLines_EachLineHasAxisColonFormat()
+        {
+            // Every emitted line from AggregateWithAudit has the shape "axis: rule".
+            var profile = CharacterDefinitionLoader.Load(
+                Path.Combine(RepoRoot, "data", "characters", "gerald.json"),
+                LoadItemRepo(), LoadAnatomyRepo());
+
+            foreach (var line in profile.TextingStyleLines)
+            {
+                Assert.True(line.Contains(':'),
+                    $"TextingStyleLines entry '{line}' should have 'axis: rule' format");
+                Assert.False(string.IsNullOrWhiteSpace(line.Substring(line.IndexOf(':') + 1).Trim()),
+                    $"TextingStyleLines entry '{line}' should have a non-empty rule after the colon");
+            }
+        }
+
+        // ── Minimal fixture: empty sources → empty Lines ──────────────────────
+
+        [Fact]
+        public void Parse_NoItems_NoAnatomy_TextingStyleLinesIsEmpty()
+        {
+            const string json = @"{
+                ""schema_version"": 1,
+                ""character_id"": ""550e8400-e29b-41d4-a716-446655440000"",
+                ""name"": ""TestChar"",
+                ""gender_identity"": ""they/them"",
+                ""bio"": ""test bio"",
+                ""level"": 1,
+                ""items"": [],
+                ""anatomy"": {},
+                ""allocation"": {
+                    ""spent"": {
+                        ""charm"": 1, ""rizz"": 1, ""honesty"": 1,
+                        ""chaos"": 1, ""wit"": 1, ""self_awareness"": 1
+                    },
+                    ""unspent_pool"": 0,
+                    ""shadows"": {
+                        ""madness"": 0, ""despair"": 0, ""denial"": 0,
+                        ""fixation"": 0, ""dread"": 0, ""overthinking"": 0
+                    }
+                }
+            }";
+
+            var itemRepo    = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+            var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
+
+            Assert.NotNull(profile.TextingStyleLines);
+            Assert.Empty(profile.TextingStyleLines);
+            Assert.Equal(string.Empty, profile.TextingStyleFragment);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #781 (pinder-core portion).

Add `TextingStyleLines` (`IReadOnlyList<string>`) to `CharacterProfile`, populated from `TextingStyleAggregator.AggregateWithAudit(..).Lines` in `CharacterDefinitionLoader.Assemble`.

## What changed
- **`CharacterProfile.cs`**: New `TextingStyleLines` property. Each line has shape `"axis: rule"` in canonical axis order; missing axes dropped. Defaults to empty list (backward-compatible—existing callers without the param compile and behave identically).
- **`CharacterDefinitionLoader.cs`**: Pass `aggregationResult.Lines` as `textingStyleLines` when constructing `CharacterProfile`. The aggregation result was already computed; this just threads the lines through.
- **`data/i18n/en/ui-character-sheet.yaml`**: Add 3 i18n strings for the admin-only final-template section in the Texting Style tab.
- **`Issue781_TextingStyleLinesOnProfileTests.cs`** (new): 6 tests covering default-empty, Gerald + all starter characters consistency (Lines joined == Fragment), axis:rule format, and empty-items case.

## How to test
```bash
dotnet test Pinder.Core.sln --filter "Issue781"
# Passed! - Failed: 0, Passed: 6, Skipped: 0
```

## Deviations from contract
None.