### PR TITLE
Reapply #1089 — structural lead-in is RULES (GM-framing is architectural)

### DIFF
--- a/data/prompts/structural.yaml
+++ b/data/prompts/structural.yaml
@@ -1,22 +1,7 @@
 schema_version: 1
 prompts:
   structural-lead-in:
-    system_prompt: 'You are the game master a RPG similar to D&D, where you throw
-      dice to progress the game. You are steering two characters. The world & setting
-      are different though: one of the two characters is the "opponent"/monster who
-      is actually someone the first character wants to date in a satyrical dating
-      app that basically works like Tinder.  The character named {name} is actually
-      the Player. For the Player you create dialog options you choose from. The app
-      is called Pinder though, because you act like a sentient penis that is actually
-      a configurable plastic figure similar to the famous Potato Man. The goal is
-      to reveal all the weird things that happen in dating apps like these: most people
-      just want to get laid, people have the weirdest profiles, photos, looks, and
-      definitely the most weird ways of expressing their despair of not finding a
-      loved one. The dialogue that will play out by "fighting" should make the player
-      see themselves in a time when they were desparate enough to use something like
-      Tinder in the real world: it should be revealing, disarming, silly, embarrassing,
-      but also sometimes very honest and touching. Everything needs to be purely expressed
-      through what the two characters say though.'
+    system_prompt: 'RULES'
   structural-identity:
     system_prompt: IDENTITY
   structural-personality:

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -82,7 +82,6 @@ namespace Pinder.Core.Tests
             Assert.Equal(5, profile.Level);
             Assert.NotNull(profile.Stats);
             Assert.NotNull(profile.AssembledSystemPrompt);
-            Assert.Contains("Gerald_42", profile.AssembledSystemPrompt);
             Assert.Contains("PERSONALITY", profile.AssembledSystemPrompt);
             Assert.Contains("EFFECTIVE STATS", profile.AssembledSystemPrompt);
         }
@@ -349,7 +348,8 @@ namespace Pinder.Core.Tests
             var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
 
             // Should contain assembled fragments, not be empty
-            Assert.Contains("The character named Gerald_42 is actually the Player.", profile.AssembledSystemPrompt);
+            // Lead-in is now RULES token; character name no longer in character-level prompt (RULES migration).
+            Assert.Contains("RULES", profile.AssembledSystemPrompt);
             Assert.Contains("he/him", profile.AssembledSystemPrompt);
             Assert.Contains("BACKSTORY", profile.AssembledSystemPrompt);
             Assert.Contains("TEXTING STYLE", profile.AssembledSystemPrompt);

--- a/tests/Pinder.Core.Tests/CharacterSystemTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterSystemTests.cs
@@ -191,7 +191,6 @@ namespace Pinder.Core.Tests
             Assert.Contains("ACTIVE ARCHETYPE", prompt);
             Assert.DoesNotContain("ARCHETYPES (tendency order", prompt);
             Assert.Contains("EFFECTIVE STATS", prompt);
-            Assert.Contains("TestChar", prompt);
             Assert.Contains("she/her", prompt);
             Assert.Contains("A test bio.", prompt);
         }

--- a/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
@@ -168,12 +168,11 @@ namespace Pinder.Core.Tests
             var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
 
             Assert.False(string.IsNullOrWhiteSpace(profile.AssembledSystemPrompt));
-            // PromptBuilder produces sections like PERSONALITY, BACKSTORY, TEXTING STYLE, etc.
-            Assert.Contains("Gerald_42", profile.AssembledSystemPrompt);
+            // PromptBuilder produces sections like PERSONALITY, BACKSTORY, TEXTING STYLE, etc. (name removed from lead-in after RULES migration)
             Assert.Contains("PERSONALITY", profile.AssembledSystemPrompt);
         }
 
-        // Fails if: Name or gender_identity not passed to PromptBuilder
+        // Fails if: gender_identity not passed to PromptBuilder (name removed from lead-in after RULES migration)
         [Fact]
         public void AC4_Parse_SystemPrompt_ContainsNameAndGender()
         {
@@ -183,7 +182,6 @@ namespace Pinder.Core.Tests
             string json = BuildMinimalJson(name: "SpecialName", genderIdentity: "xe/xem");
             var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
 
-            Assert.Contains("SpecialName", profile.AssembledSystemPrompt);
             Assert.Contains("xe/xem", profile.AssembledSystemPrompt);
         }
 

--- a/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
@@ -109,8 +109,7 @@ namespace Pinder.Core.Tests
             var entry = catalog.Get("structural-lead-in");
 
             string fromYaml = entry.SystemPrompt!;
-            const string fromConst =
-                "You are the game master a RPG similar to D&D, where you throw dice to progress the game. You are steering two characters. The world & setting are different though: one of the two characters is the \"opponent\"/monster who is actually someone the first character wants to date in a satyrical dating app that basically works like Tinder.  The character named {name} is actually the Player. For the Player you create dialog options you choose from. The app is called Pinder though, because you act like a sentient penis that is actually a configurable plastic figure similar to the famous Potato Man. The goal is to reveal all the weird things that happen in dating apps like these: most people just want to get laid, people have the weirdest profiles, photos, looks, and definitely the most weird ways of expressing their despair of not finding a loved one. The dialogue that will play out by \"fighting\" should make the player see themselves in a time when they were desparate enough to use something like Tinder in the real world: it should be revealing, disarming, silly, embarrassing, but also sometimes very honest and touching. Everything needs to be purely expressed through what the two characters say though.";
+            const string fromConst = "RULES";
 
             Assert.Equal(fromConst, fromYaml);
         }
@@ -155,9 +154,8 @@ namespace Pinder.Core.Tests
                 Assert.Contains("TEXTING STYLE", prompt);
                 Assert.Contains("ACTIVE ARCHETYPE", prompt);
 
-                // Lead-in with substituted name.
-                Assert.Contains("The character named TestChar is actually the Player.", prompt);
-                Assert.Contains("The app is called Pinder though, because you act like a sentient penis that is actually", prompt);
+                // Lead-in is now the RULES token (structural.yaml structural-lead-in).
+                Assert.Contains("RULES", prompt);
             }
             finally
             {


### PR DESCRIPTION
Reapplies #1089 (reverts the erroneous revert #1092).

My revert was wrong. #1089 is an intended architectural change: the assembled system prompt should understand it is the GAME MASTER, not a game character. The old structural-lead-in prose re-asserted GM/{name}-as-Player framing at the per-character fragment layer, which is the wrong layer — the GM framing + WORLD RULES + doctrine belong in SessionSystemPromptBuilder / GameDefinition (what actually feeds the LLM via AnthropicLlmAdapter.BuildPlayer/BuildOpponent), not baked into each character fragment prompt. `RULES` as a section token in structural.yaml is correct, matching its sibling headings (IDENTITY/PERSONALITY/...). The guard tests that pinned the old prose were stale and are correctly removed/loosened. Full suite green locally (Core 2929 / LlmAdapters 1147 / Rules 243 / RemoteAssets 54, 0 failures) in dotnet sdk:8.0. Apologies for the churn.