### PR TITLE
feat(#1095): shadow trap caps interest delta to 1, no longer fails the turn

### DIFF
--- a/data/delivery-instructions.yaml
+++ b/data/delivery-instructions.yaml
@@ -1,4 +1,7 @@
 delivery_instructions:
+  # Revision log:
+  #   2026-06-03 (#1095): shadow corruption is a "tainted, capped" message, not a
+  #   failed turn — the shadow-trap consequence reads neutral-to-slightly-negative.
   charm:
     clean: >-
       Check the character's observation style in their profile. Deliver the player's message as-written but

--- a/data/game-definition.yaml
+++ b/data/game-definition.yaml
@@ -1,4 +1,8 @@
 name: "Pinder"
+# Revision log:
+#   2026-06-03 (#1095): shadow trap caps a positive interest delta at +1 and is
+#   NOT a turn failure — DATEE reacts neutrally/slightly negatively, momentum
+#   continues; horniness then halves the post-shadow delta (floor).
 max_turns: 30
 max_dialogue_options: 3
 vision: |-
@@ -25,7 +29,11 @@ world_description: |
   then answer, aiming toward an enjoyable encounter. A message is intentional — what
   they send is what they chose to send — unless a game mechanic overrides that control.
   Session stats can CORRUPT messages (handled by separate corruption sessions): neediness,
-  desperation, etc. leaking out in the funniest, most cringe ways.
+  desperation, etc. leaking out in the funniest, most cringe ways. A "shadow trap" — when an
+  otherwise-good message is tainted by a missed shadow check — is NOT a failed turn: the message
+  still lands, the DATEE reacts neutrally or only slightly negatively (mild coolness, interest
+  barely moves), the positive interest gain is capped at +1, and momentum continues. It is a
+  small tainting, never a hard rejection.
 player_role_description: |
   The PLAYER AVATAR genuinely wants the date; their goal is to raise Interest to 25 ("Date Secured"). The human PLAYER also earns XP, but the character doesn't know about XP — they
   just want it to go well.
@@ -62,8 +70,9 @@ narrative_doctrine: |
   modifiers, the interest meter, shadow thresholds, failure tiers, or combo trackers. All of
   these exist beneath the conversation, never inside it, and manifest only through HOW
   characters speak — never through commentary. (A Trope Trap makes the character accidentally
-  use a cliche; a shadow at threshold makes messages sound slightly off; a Nat 20 just lands
-  perfectly.)
+  use a cliche; a shadow at threshold makes messages sound slightly off — a shadow trap lands a
+  little off and the DATEE responds neutrally or with mild coolness, never a hard rejection; a
+  Nat 20 just lands perfectly.)
 
   Never break character: always in-world, no narrator, no aside, no wink to the audience.
   [ENGINE] blocks are out-of-character and must never be quoted, referenced, or acknowledged

--- a/data/i18n/en/consequences.yaml
+++ b/data/i18n/en/consequences.yaml
@@ -19,6 +19,8 @@
 #   trap       — trap_activated
 schema_version: 1
 locale: en
+# Revision log:
+#   2026-06-03 (#1095): a shadow trap is a capped/tainted SUCCESS, not a failed turn.
 strings:
   # ── option_roll ───────────────────────────────────────────────────────────
   consequence.roll.pass: "Your {stat} roll landed — the message reads sincere and lands well."

--- a/data/i18n/en/glossary.yaml
+++ b/data/i18n/en/glossary.yaml
@@ -6,6 +6,9 @@
 # mirror that copy verbatim.
 schema_version: 1
 locale: en
+# Revision log:
+#   2026-06-03 (#1095): added glossary.shadow.trap — a shadow trap is a capped,
+#   tainted SUCCESS (interest gain ≤ +1, momentum continues), NOT a failed turn.
 strings:
   # Foundation samples (Phase 1 — kept for the i18n pipeline self-test).
   glossary.charm: "Charm"
@@ -45,6 +48,9 @@ strings:
   # ── Combo lookup fallbacks (#186) ────────────────────────────────
   glossary.combo.fallback_sequence: "Unknown combo sequence."
   glossary.combo.fallback_reward: "+1 Interest if success"
+
+  # ── Shadow trap (#1095) ───────────────────────────────────────────
+  glossary.shadow.trap: "A shadow trap is a successful message tainted by a missed shadow check. It is NOT a failed turn: the roll still counts as a success and momentum keeps building, but the message lands a little off — the DATEE reacts neutrally or with mild coolness — and the interest gain is capped at +1 (horniness may halve that to 0)."
 
   # ── Shadow reason explanations (#186 / mirrors PlaytestFormatter) ─
   # Brief plain-English explanation paired with each shadow-growth

--- a/data/i18n/en/ui-turn-result.yaml
+++ b/data/i18n/en/ui-turn-result.yaml
@@ -1,5 +1,9 @@
 # TurnResultDisplay — resolved-turn breakdown card.
 # Migrated #440 Phase 5.
+# Revision log:
+#   2026-06-03 (#1095): shadow check explainer + override line reworded — a shadow
+#   trap taints the message and caps a success's interest gain at +1; it does NOT
+#   force a success to fail.
 schema_version: 1
 locale: en
 strings:
@@ -17,12 +21,12 @@ strings:
   turn_result.horniness_check_explainer: "Per-turn d20 vs DC {dc}: a miss may trigger a horniness overlay on the delivered message."
 
   turn_result.shadow_check_heading: "Shadow check"
-  turn_result.shadow_check_explainer: "Per-turn d20 vs DC {dc}: a miss may force a successful action to fail via a shadow overlay."
+  turn_result.shadow_check_explainer: "Per-turn d20 vs DC {dc}: a miss taints the delivered message via a shadow overlay and caps a successful action's interest gain at +1 (it does NOT fail the turn)."
   turn_result.shadow_check_line: "⚫ Shadow check ({shadow}): d20 = {die} + 0 = {die} vs DC {dc} →"
   turn_result.shadow_check_miss: "MISS ({tier})"
   turn_result.shadow_check_miss_corruption: "MISS ({tier}) — corruption applied"
   turn_result.shadow_check_success: "SUCCESS"
-  turn_result.shadow_override_line: "↳ Shadow override ({shadow} {tier}): success forced to fail"
+  turn_result.shadow_override_line: "↳ Shadow trap ({shadow} {tier}): success tainted, interest capped at +1"
 
   turn_result.timeline_intended: "Intended"
   turn_result.timeline_delivered: "Delivered"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,11 +171,11 @@ A single turn flows through two phases: `StartTurnAsync` (generate options) and 
 
 10. **Horniness check (roll only)** — Separate RNG. DC = 20 − session horniness. On miss, records the overlay instruction via `HorninessEngine.PeekAsync()` but defers the text rewrite until after shadow corruption (#899).
 
-10a. **Shadow corruption** — If the chosen stat has an active paired shadow and the shadow check misses, calls `ILlmAdapter.ApplyShadowCorruptionAsync()` to rewrite the message with shadow flavor. On a successful main roll, also demotes the interest delta to the shadow-tier failure delta (#365).
+10a. **Shadow corruption** — If the chosen stat has an active paired shadow and the shadow check misses, calls `ILlmAdapter.ApplyShadowCorruptionAsync()` to rewrite the message with shadow flavor. On a successful main roll (a "shadow trap"), the turn is **NOT** demoted to a failure: instead the positive interest delta is **truncated to a maximum of 1** (`finalDelta = min(positiveDelta, 1)`, #1095). The roll verdict stays SUCCESS — `ApplyFinalOverride(Miss, …)` is **not** called for the shadow-trap case — so momentum keeps incrementing and success-gated downstream stays on the success path. The DATEE reacts neutrally / slightly negatively to the tainted message (a tone nuance, not a failure beat). *(Superseded #365, which previously demoted the success to a shadow-tier failure delta.)*
 
 10b. **Horniness text overlay** — Applies the pre-fetched horniness overlay instruction (step 10) via `ILlmAdapter.ApplyHorninessOverlayAsync()`. Runs AFTER shadow corruption so horniness has final say over the delivered text (#899). If no overlay instruction, skipped.
 
-10c. **Horniness §15 interest-delta halving** — When the horniness overlay fired and the post-shadow interest delta is strictly positive, the delta is halved (floor). This is deferred to operate on the post-shadow-demote delta (#743/#399).
+10c. **Horniness §15 interest-delta halving** — When the horniness overlay fired and the post-shadow interest delta is strictly positive, the delta is halved (floor). This is deferred to operate on the post-shadow (truncated) delta (#743/#399). Worked shadow-trap interaction (#1095): a success with base delta = e.g. 4 → shadow trap truncates to **1** → horniness halves `floor(1/2) = 0`. Net interest delta is **0**, but the turn is **STILL NOT a failure** — the verdict stays SUCCESS and the momentum streak still increments.
 
 11. **Shadow growth** — `EvaluatePerTurnShadowGrowth()` evaluates 15+ triggers: Nat 1 → paired shadow +1, same stat 3× → Fixation +1, Charm 3× → Madness +1, RIZZ failures → Despair, etc. Also evaluates reductions (combo success → Madness −1, Honesty success at high interest → Denial −1).
 
@@ -478,7 +478,7 @@ Called only on successful steering roll via `IStatefulLlmAdapter`. Receives play
 
 Called on failed horniness check. Receives the delivered message + tier-specific overlay instruction. Returns the rewritten message with involuntary heat. Runs AFTER shadow corruption (#899) so horniness has final say over the delivered text.
 
-> When a horniness overlay fires, if the post-shadow-demote interest delta is > 0, it is halved (floor, §15). This represents the character losing track of the connection in the heat of arousal.
+> When a horniness overlay fires, if the post-shadow interest delta is > 0, it is halved (floor, §15). This represents the character losing track of the connection in the heat of arousal. Note (#1095): the shadow trap first truncates a positive delta to 1, so on a shadow-trap success that also fires horniness the net is `floor(1/2) = 0` — but the turn is still a SUCCESS (verdict not demoted) and momentum still increments.
 
 ## 7. Constraints & Best Practices
 

--- a/docs/modules/game-session.md
+++ b/docs/modules/game-session.md
@@ -53,7 +53,7 @@ public sealed class GameSession
 
 ### Momentum System (rules §15)
 
-Momentum is tracked as a streak counter (`_momentumStreak`) that increments on each consecutive success and resets to 0 on any failure.
+Momentum is tracked as a streak counter (`_momentumStreak`) that increments on each consecutive success and resets to 0 on any failure. A **shadow trap** on a *successful* roll (#1095) is **not** a failure for momentum purposes — the roll verdict stays SUCCESS even though the message is shadow-tainted and the interest delta is capped at 1, so the streak continues to increment.
 
 **Bonus computation** (`GetMomentumBonus`):
 
@@ -115,3 +115,4 @@ Interest is clamped to [0, 25] by `GameSession` / `InterestMeter`. Individual de
 | 2026-04-03 | #312 | Bug fix: Triple combo bonus (+1) now actually applied to Read/Recover rolls. Previously `ConsumeTripleBonus()` was called but the bonus value was never passed to `RollEngine.ResolveFixedDC`. Now `HasTripleBonus` is captured before consumption and passed as `externalBonus`. Two new test files: `TripleBonusReadRecoverTests.cs` and `TripleBonusReadRecoverEdgeCaseTests.cs` (486 lines total). |
 | 2026-04-03 | #308 | Shadow threshold wiring: confirmed `GameSession` routes player shadows to `DeliveryContext` and opponent shadows to `OpponentContext`. `GameSessionConfig` accepts `opponentShadows` parameter. New test file `Issue308_ShadowThresholdWiringSpecTests.cs` (443 lines, 13 tests). |
 | 2026-04-03 | #315 | Vision concern — added tier boundary tests for Triple combo bonus on Read/Recover. Tests verify +1 external bonus softens every failure tier boundary: Catastrophe→TropeTrap (miss 10→9), Misfire→Fumble (miss 3→2), Fumble→Success (miss 1→0), plus Recover path equivalents. New test file `Issue315_VisionTierBoundaryTests.cs` (242 lines, 10 tests). Test-only change; no production code modified. |
+| 2026-06-03 | #1095 | Shadow trap rule change: a shadow trap (success roll + paired-shadow MISS with overlay) NO LONGER demotes the turn to a forced failure. The positive interest delta is truncated to a max of 1; the roll verdict stays SUCCESS and the momentum streak keeps incrementing. Horniness §15 halving then runs on the truncated delta (shadow→1, floor(1/2)=0), still not a failure. Momentum section clarified. |

--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -244,10 +244,18 @@ namespace Pinder.Core.Conversation
                     {
                         if (shadowOverlayApplied && rollResult.IsSuccess)
                         {
-                            var forcedFailResult = TurnOrchestratorHelpers.CreateForcedFailResult(rollResult, shadowTier);
-                            int shadowFailDelta = TurnOrchestratorHelpers.ResolveFailureInterestDelta(forcedFailResult, _rules);
-                            shadowCorrection = shadowFailDelta - interestDelta;
-                            interestDelta = shadowFailDelta;
+                            // #1095: A shadow trap (success roll + paired-shadow MISS with overlay)
+                            // no longer demotes the turn to a forced FAILURE. Instead it TRUNCATES
+                            // the positive interest delta to a maximum of 1 ("tainted, capped").
+                            // The roll verdict stays SUCCESS (no ApplyFinalOverride to Miss in
+                            // TurnOrchestrator), momentum keeps incrementing, and success-gated
+                            // downstream effects stay on the success path. The DATEE reacts
+                            // neutrally / slightly negatively, not with a hard-rejection failure beat.
+                            // shadowCorrection stays the signed adjustment so the central
+                            // state.Interest.Apply(ShadowCorrection) remains correct.
+                            int truncated = Math.Min(interestDelta, 1);
+                            shadowCorrection = truncated - interestDelta;
+                            interestDelta = truncated;
                         }
 
                         shadowCheckResult = new ShadowCheckResult(

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs
@@ -54,10 +54,11 @@ namespace Pinder.Core.Conversation
             // Centrally apply proposed state mutations from DeliveryStage
             if (deliveryStage.ShadowCorrection != 0)
             {
+                // #1095: A shadow trap caps the positive interest delta at 1; it is NOT a
+                // turn failure. Apply the (signed) truncation adjustment to interest, but do
+                // NOT override the roll verdict to Miss — the verdict/momentum stay SUCCESS.
+                // (Previously this called ApplyFinalOverride(Miss, tier), demoting the turn.)
                 state.Interest.Apply(deliveryStage.ShadowCorrection);
-                rollStage.RollResult.Check.ApplyFinalOverride(
-                    Pinder.Core.Rolls.RollVerdict.Miss,
-                    deliveryStage.ShadowCheckResult.Tier);
             }
             if (deliveryStage.HorninessInterestPenalty != 0)
             {

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -1,0 +1,301 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// #1095 — Rule change: a "shadow trap" (a SUCCESSFUL main roll paired with a
+    /// shadow check MISS that applies the shadow overlay) NO LONGER demotes the
+    /// turn to a forced failure. Instead it TRUNCATES the positive interest delta
+    /// to a maximum of 1 ("tainted, capped"). The roll verdict stays SUCCESS,
+    /// momentum keeps incrementing, and success-gated downstream stays on the
+    /// success path. Horniness halving (floor, delta>0) runs AFTER the shadow
+    /// truncation, so shadow→1 then floor(1/2)=0 nets 0 but is STILL not a failure.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1095_ShadowTrapTruncateTests
+    {
+        private static StatDeliveryInstructions LoadYaml()
+        {
+            string dir = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 10; i++)
+            {
+                string candidate = Path.Combine(dir, "data", "delivery-instructions.yaml");
+                if (File.Exists(candidate))
+                    return StatDeliveryInstructions.LoadFrom(File.ReadAllText(candidate));
+                dir = Path.GetDirectoryName(dir)!;
+                if (dir == null) break;
+            }
+            string fallback = "/tmp/work-W1b/pinder-core/data/delivery-instructions.yaml";
+            return StatDeliveryInstructions.LoadFrom(File.ReadAllText(fallback));
+        }
+
+        private static StatBlock MakeStats(int allStats = 2, int shadowOnPair = 0, ShadowStatType pairStat = ShadowStatType.Despair)
+        {
+            var stats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm, allStats },
+                { StatType.Rizz, allStats },
+                { StatType.Honesty, allStats },
+                { StatType.Chaos, allStats },
+                { StatType.Wit, allStats },
+                { StatType.SelfAwareness, allStats }
+            };
+            var shadow = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            shadow[pairStat] = shadowOnPair;
+            return new StatBlock(stats, shadow);
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+        {
+            return new CharacterProfile(
+                stats, $"You are {name}.", name,
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), level: 1);
+        }
+
+        private static int FindIndex(DialogueOption[] options, StatType stat)
+        {
+            for (int i = 0; i < options.Length; i++)
+                if (options[i].Stat == stat) return i;
+            return 0;
+        }
+
+        private static (GameSession session, ShadowTrapLlm llm) MakeSession(int horninessDie = 0)
+        {
+            var instructions = LoadYaml();
+            var playerStats = MakeStats(allStats: 5, shadowOnPair: 10, pairStat: ShadowStatType.Despair);
+            var player = MakeProfile("Sable", playerStats);
+            var opponent = MakeProfile("Brick", MakeStats(allStats: 0));
+
+            // Game dice (consumed in order): horniness 1d10, main d20, timing.
+            //  - horninessDie == 0  → SessionHorniness = 0 → horniness overlay does NOT
+            //    fire (PeekAsync returns NotPerformed), isolating the pure shadow
+            //    truncation (delta → 1). This is the default for the shadow-only cases.
+            //  - horninessDie  > 0  → SessionHorniness > 0 → horniness overlay fires and
+            //    halves the post-shadow delta (floor), used by the combined case.
+            // main d20 = 20 (Nat 20 → guaranteed success), timing = 50.
+            var dice = new FixedDice(horninessDie, 20, 50);
+            // Steering RNG: steering roll 1 (fail steering), shadow roll 1 (miss → DC=10).
+            var steeringRng = new FixedRandom(1, 1);
+
+            var llm = new ShadowTrapLlm();
+            var playerShadows = new SessionShadowTracker(playerStats);
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                steeringRng: steeringRng,
+                statDeliveryInstructions: instructions,
+                playerShadows: playerShadows);
+            var session = new GameSession(player, opponent, llm, dice, new NullTrapRegistry(), config);
+            return (session, llm);
+        }
+
+        /// <summary>
+        /// Case 1: shadow trap on a success — a positive base delta (Nat 20 success
+        /// → ≥ 4) is truncated to exactly 1. The roll verdict stays SUCCESS and the
+        /// momentum streak increments through the trap turn. (No horniness here:
+        /// SessionHorniness defaults to 0, so no overlay fires.)
+        /// </summary>
+        [Fact]
+        public async Task ShadowTrap_OnSuccess_TruncatesToOne_VerdictSuccess_MomentumIncrements()
+        {
+            var (session, llm) = MakeSession();
+
+            await session.StartTurnAsync();
+            int rizzIdx = FindIndex(llm.LastOptions, StatType.Rizz);
+            int momentumBefore = session.CreateSnapshot().MomentumStreak;
+            var result = await session.ResolveTurnAsync(rizzIdx);
+            int momentumAfter = session.CreateSnapshot().MomentumStreak;
+
+            // Shadow trap actually fired.
+            Assert.True(result.Roll.IsSuccess);
+            Assert.True(result.ShadowCheck.OverlayApplied);
+            Assert.True(llm.ShadowCorruptionCalled);
+
+            // #1095: positive delta truncated to exactly 1 (no horniness → no further halving).
+            Assert.Equal(1, result.InterestDelta);
+
+            // #1095: base (pre-shadow) delta is the positive success delta and is ≥ 1.
+            Assert.True(result.BaseInterestDelta >= 1,
+                $"base success delta should be positive; got {result.BaseInterestDelta}");
+
+            // #1095: verdict stays SUCCESS — NOT demoted to Miss.
+            Assert.Equal(RollVerdict.Success, result.Roll.Check.FinalVerdict);
+            Assert.Equal(FailureTier.Success, result.Roll.Check.FinalTier);
+
+            // #1095: momentum streak keeps incrementing through the shadow-trap turn.
+            Assert.Equal(momentumBefore + 1, momentumAfter);
+        }
+
+        /// <summary>
+        /// Case 5: the #942 invariant (IsSuccess && BaseInterestDelta &lt; 0 ⇒ throw)
+        /// is NOT tripped by a shadow trap — only the FINAL delta is truncated;
+        /// BaseInterestDelta stays the positive success delta. Completing the turn
+        /// without an InvariantViolationException proves the invariant holds.
+        /// </summary>
+        [Fact]
+        public async Task ShadowTrap_OnSuccess_DoesNotTrip942Invariant()
+        {
+            var (session, llm) = MakeSession();
+
+            await session.StartTurnAsync();
+            int rizzIdx = FindIndex(llm.LastOptions, StatType.Rizz);
+
+            // Must not throw InvariantViolationException (#942).
+            var result = await session.ResolveTurnAsync(rizzIdx);
+
+            Assert.True(result.Roll.IsSuccess);
+            // #942: a success roll keeps a non-negative base interest delta.
+            Assert.True(result.BaseInterestDelta >= 0,
+                $"#942: success roll must keep BaseInterestDelta ≥ 0; got {result.BaseInterestDelta}");
+            // The truncation lives only in the FINAL delta.
+            Assert.Equal(1, result.InterestDelta);
+        }
+
+        /// <summary>
+        /// Audit invariant: interest before + final delta == interest after, for the
+        /// shadow-trap (capped) path. Guards the centrally-applied ShadowCorrection.
+        /// </summary>
+        [Fact]
+        public async Task ShadowTrap_OnSuccess_InterestAuditBalances()
+        {
+            var (session, llm) = MakeSession();
+
+            await session.StartTurnAsync();
+            int rizzIdx = FindIndex(llm.LastOptions, StatType.Rizz);
+            int interestBefore = session.CreateSnapshot().Interest;
+            var result = await session.ResolveTurnAsync(rizzIdx);
+            int interestAfter = session.CreateSnapshot().Interest;
+
+            Assert.True(result.ShadowCheck.OverlayApplied);
+            Assert.Equal(interestBefore + result.InterestDelta, interestAfter);
+        }
+
+        /// <summary>
+        /// Case 2 (the headline worked example): shadow trap on a success FOLLOWED by
+        /// horniness halving. Base positive delta (Nat 20 → ≥ 4) is first truncated by
+        /// the shadow trap to 1, then horniness (floor, delta &gt; 0) halves it:
+        /// floor(1 / 2) = 0. Net final interest delta == 0 — BUT the turn is STILL NOT
+        /// a failure: the roll verdict stays SUCCESS and the momentum streak still
+        /// increments. (horninessDie = 5 → SessionHorniness = 5 → overlay fires.)
+        /// </summary>
+        [Fact]
+        public async Task ShadowTrap_ThenHorniness_NetsZero_ButStillSuccess_MomentumIncrements()
+        {
+            var (session, llm) = MakeSession(horninessDie: 5);
+
+            await session.StartTurnAsync();
+            int rizzIdx = FindIndex(llm.LastOptions, StatType.Rizz);
+            int momentumBefore = session.CreateSnapshot().MomentumStreak;
+            var result = await session.ResolveTurnAsync(rizzIdx);
+            int momentumAfter = session.CreateSnapshot().MomentumStreak;
+
+            // Shadow trap fired AND horniness overlay fired (it is what drives the halving).
+            Assert.True(result.Roll.IsSuccess);
+            Assert.True(result.ShadowCheck.OverlayApplied);
+            Assert.True(result.HorninessCheck.OverlayApplied);
+
+            // #1095 worked example: shadow → 1, then horniness floor(1/2) = 0.
+            Assert.Equal(0, result.InterestDelta);
+
+            // Still a success: verdict NOT demoted to Miss despite the net-zero delta.
+            Assert.Equal(RollVerdict.Success, result.Roll.Check.FinalVerdict);
+            Assert.Equal(FailureTier.Success, result.Roll.Check.FinalTier);
+
+            // Base (pre-shadow) delta stays the positive success delta (≥ 1) — #942 holds.
+            Assert.True(result.BaseInterestDelta >= 1,
+                $"base success delta should be positive; got {result.BaseInterestDelta}");
+
+            // Momentum streak still increments through the net-zero shadow+horniness turn.
+            Assert.Equal(momentumBefore + 1, momentumAfter);
+        }
+
+        private sealed class ShadowTrapLlm : ILlmAdapter, IStatefulLlmAdapter
+        {
+            public bool ShadowCorruptionCalled { get; private set; }
+            public DialogueOption[] LastOptions { get; private set; } = System.Array.Empty<DialogueOption>();
+
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("..."),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User(string.Empty),
+                        ConversationMessage.Assistant("..."),
+                    }));
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
+            {
+                LastOptions = new[]
+                {
+                    new DialogueOption(StatType.Charm, "Hey there"),
+                    new DialogueOption(StatType.Rizz, "Nice vibes"),
+                    new DialogueOption(StatType.Wit, "Clever remark"),
+                    new DialogueOption(StatType.Honesty, "Real talk")
+                };
+                return Task.FromResult(LastOptions);
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
+            {
+                string intended = context.ChosenOption.IntendedText;
+                return Task.FromResult(context.Outcome == FailureTier.Success
+                    ? intended
+                    : $"[{context.Outcome}] {intended}");
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new OpponentResponse("..."));
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+            {
+                ShadowCorruptionCalled = true;
+                return Task.FromResult(message + " [shadow:" + shadow + "]");
+            }
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult("steering question");
+        }
+
+        private sealed class FixedRandom : System.Random
+        {
+            private readonly Queue<int> _values;
+            public FixedRandom(params int[] values) { _values = new Queue<int>(values); }
+            public override int Next(int minValue, int maxValue) => _values.Count > 0 ? _values.Dequeue() : minValue;
+        }
+
+        private sealed class NullTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -170,12 +170,13 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// AC: On a SUCCESS roll + shadow miss, the existing override behavior
-        /// still kicks in — interest delta is replaced with the failure delta.
-        /// (#365 fix preserves this on success rolls.)
+        /// #1095: On a SUCCESS roll + shadow miss (a "shadow trap"), the turn is
+        /// NO LONGER demoted to a forced failure. The positive interest delta is
+        /// truncated to a maximum of 1 (then horniness may floor it to 0), but the
+        /// roll stays a SUCCESS — the verdict is not overridden to Miss.
         /// </summary>
         [Fact]
-        public async Task SuccessRoll_ShadowMiss_StillOverridesInterestDeltaToFailure()
+        public async Task SuccessRoll_ShadowMiss_TruncatesInterestDeltaToOne_StaysSuccess()
         {
             var instructions = LoadYaml();
 
@@ -204,9 +205,13 @@ namespace Pinder.Core.Tests
             Assert.True(result.Roll.IsSuccess);
             Assert.True(result.ShadowCheck.OverlayApplied);
             Assert.True(llm.ShadowCorruptionCalled);
-            // The success was demoted to a failure delta — non-positive.
-            Assert.True(result.InterestDelta <= 0,
-                $"Success demoted by shadow should yield non-positive delta; got {result.InterestDelta}");
+
+            // #1095: the success is NOT demoted — the FINAL verdict stays Success.
+            Assert.Equal(Pinder.Core.Rolls.RollVerdict.Success, result.Roll.Check.FinalVerdict);
+
+            // #1095: the positive delta is truncated to a max of 1 (horniness may
+            // floor it further to 0), so the final delta is in [0, 1].
+            Assert.InRange(result.InterestDelta, 0, 1);
         }
 
         private static int FindIndex(DialogueOption[] options, StatType stat)

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -76,24 +76,6 @@ namespace Pinder.Core.Tests
                 new TimingProfile(5, 0.0f, 0.0f, "neutral"), level: 1);
         }
 
-        // Mirror of GameSession.CreateForcedFailResult so the test can derive
-        // the post-demote delta the engine will produce for a given shadow tier.
-        private static RollResult MakeForcedFailRollResult(RollResult original, FailureTier tier)
-        {
-            int fakeDie = original.DC > 1 ? original.DC - 1 : 1;
-            return new RollResult(
-                dieRoll: fakeDie,
-                secondDieRoll: null,
-                usedDieRoll: fakeDie,
-                stat: original.Stat,
-                statModifier: 0,
-                levelBonus: 0,
-                dc: original.DC,
-                tier: tier,
-                activatedTrap: null,
-                externalBonus: 0);
-        }
-
         private static int FindIndex(DialogueOption[] options, StatType stat)
         {
             for (int i = 0; i < options.Length; i++)
@@ -102,11 +84,17 @@ namespace Pinder.Core.Tests
         }
 
         // -----------------------------------------------------------------
-        // Test 1 — Honesty success + horniness miss + Denial demote → final
-        // delta NEGATIVE. §15 must NOT charge a penalty (rule premise fails).
+        // Test 1 — Honesty success + horniness miss + Denial shadow trap.
+        //
+        // #1095 rule change: a shadow trap (success roll + paired-shadow MISS
+        // with overlay) NO LONGER demotes the turn to a forced failure. It
+        // TRUNCATES the positive interest delta to a max of 1, then horniness
+        // halves (floor) the post-shadow delta: floor(1/2) = 0. Net delta = 0,
+        // but the turn is STILL a SUCCESS (verdict not Miss) and momentum keeps
+        // incrementing.
         // -----------------------------------------------------------------
         [Fact]
-        public async Task HonestySuccess_HorninessMiss_DenialDemote_NegativeFinal_NoHorninessPenalty()
+        public async Task HonestySuccess_HorninessMiss_DenialShadowTrap_CapsToOneThenHorninessToZero_StaysSuccess()
         {
             var instructions = LoadYaml();
 
@@ -114,13 +102,8 @@ namespace Pinder.Core.Tests
             // (paired with Honesty — moderate shadow).  Opponent: weak.
             //
             // shadow check DC = 20 - 10 = 10 → miss when shadow d20 < 10.
-            // We force shadow d20 = 1 → missMargin = 9 → TropeTrap tier
-            // (per HorninessEngine.DetermineHorninessTier: missMargin 6..9 → TropeTrap).
-            // TropeTrap failure delta = -2 (FailureScale).
-            //
-            // Honesty success on a Nat 20 → success delta = 4 (per SuccessScale)
-            // + risk bonus (Nat 20 → +0 unless RiskTierBonus says otherwise).
-            // Either way pre-demote delta is positive; post-demote is -2.
+            // We force shadow d20 = 1 → missMargin = 9 → TropeTrap tier.
+            // Honesty success on a Nat 20 → positive pre-shadow delta.
             var playerStats = MakeStats(allStats: 5,
                 pairStat: ShadowStatType.Denial, shadowOnPair: 10);
             var player = MakeProfile("PlayerH", playerStats);
@@ -130,13 +113,8 @@ namespace Pinder.Core.Tests
             // (Nat 20 success), timing = 50.
             var dice = new FixedDice(5, 20, 50);
 
-            // SteeringRng feeds: steering d20 (we don't care — just non-zero),
-            // horniness d20 (force MISS: roll < 15), shadow d20 (force MISS: < 10).
-            //   1st = steering: 1 (fail steering)
-            //   2nd = horniness: 1 (DC=15, miss, missMargin=14 → Catastrophe;
-            //                     either tier triggers an overlay instruction
-            //                     in the YAML so OverlayApplied=true)
-            //   3rd = shadow: 1 (DC=10, miss, missMargin=9 → TropeTrap)
+            // SteeringRng feeds: steering d20, horniness d20 (force MISS: < 15),
+            // shadow d20 (force MISS: < 10).
             var steeringRng = new FixedRandom(1, 1, 1);
 
             var llm = new HorninessShadowCapturingLlm();
@@ -152,8 +130,10 @@ namespace Pinder.Core.Tests
             int honestyIdx = FindIndex(llm.LastOptions, StatType.Honesty);
 
             int interestBefore = session.CreateSnapshot().Interest;
+            int momentumBefore = session.CreateSnapshot().MomentumStreak;
             var result = await session.ResolveTurnAsync(honestyIdx);
             int interestAfter = session.CreateSnapshot().Interest;
+            int momentumAfter = session.CreateSnapshot().MomentumStreak;
 
             // Sanity: roll succeeded, horniness fired, shadow check fired and missed,
             // shadow corruption ran (overlay applied).
@@ -165,21 +145,17 @@ namespace Pinder.Core.Tests
             Assert.True(result.ShadowCheck.OverlayApplied,
                 "Shadow corruption overlay must apply on Honesty/Denial TropeTrap");
 
-            // The shadow demote rewrites interestDelta to the failure delta
-            // for the resolved shadow tier. That tier-specific delta is
-            // negative (Fumble/-1, Misfire/-1, TropeTrap/-2, Catastrophe/-3,
-            // Legendary/-4 per FailureScale). Therefore §15 must NOT have
-            // applied any penalty (rule premise: delta > 0 fails).
-            int expectedFailureDelta = FailureScale.GetInterestDelta(
-                MakeForcedFailRollResult(result.Roll, result.ShadowCheck.Tier));
-            Assert.True(expectedFailureDelta < 0,
-                $"shadow tier {result.ShadowCheck.Tier} must yield negative failure delta");
-            Assert.Equal(expectedFailureDelta, result.InterestDelta);
-            Assert.Equal(0, result.HorninessInterestPenalty);
+            // #1095: shadow trap truncates the positive delta to 1, then horniness
+            // halves (floor) → floor(1/2) = 0. Net final delta == 0.
+            Assert.Equal(0, result.InterestDelta);
 
-            // Audit invariant: before + final_delta == after. Since
-            // HorninessInterestPenalty == 0, delta_from_roll (the natural
-            // pre-§15 delta after any shadow demote) == delta_total == -2.
+            // #1095: the turn is STILL a success — the FINAL verdict is NOT a miss.
+            Assert.Equal(Pinder.Core.Rolls.RollVerdict.Success, result.Roll.Check.FinalVerdict);
+
+            // #1095: momentum keeps incrementing through a shadow-trap success.
+            Assert.Equal(momentumBefore + 1, momentumAfter);
+
+            // Audit invariant: before + final_delta == after (net 0 here).
             Assert.Equal(interestBefore + result.InterestDelta, interestAfter);
         }
 

--- a/tests/Pinder.Core.Tests/Issue907_TextingStyleConflictMatrixTests.cs
+++ b/tests/Pinder.Core.Tests/Issue907_TextingStyleConflictMatrixTests.cs
@@ -159,10 +159,16 @@ conflicts:
         public void RealConflictsYaml_ContainsCanonicalConflicts()
         {
             var c = LoadRealConflicts();
+            // #1094 (commit 8d054c7) retired the "minimum 80 words per message" length
+            // floor in favour of a brevity-compatible "compact but layered" axis and
+            // updated the conflict matrix accordingly. The canonical length×length
+            // conflict is now 5-word-cap vs. "compact but layered", not vs. the old
+            // 80-word floor. (This assertion was left stale by #1094, which shipped
+            // without CI — see #1095 PR notes.)
             Assert.True(c.AreConflicting(
                 ("length", "never sends more than 5 words"),
-                ("length", "minimum 80 words per message, no exceptions")),
-                "Missing: length:5words vs length:80words");
+                ("length", "compact but layered — 1-2 sentences, several ideas packed in, never padded")),
+                "Missing: length:5words vs length:compact-but-layered");
             Assert.True(c.AreConflicting(
                 ("structure", "wall-of-text (one paragraph, no breaks, comma splices throughout)"),
                 ("length", "never sends more than 5 words")),

--- a/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
@@ -101,10 +101,12 @@ namespace Pinder.Core.Tests
         // ─── Integration-level: GameSession shadow-corruption populates fields ─
 
         [Fact]
-        public async Task GameSession_SuccessDemotedByShadow_PopulatesFinalMissAndFinalTier()
+        public async Task GameSession_SuccessShadowTrap_FinalVerdictStaysSuccess()
         {
-            // Mirrors Issue365_ShadowOnFailedRollTests.SuccessRoll_ShadowMiss…
-            // — d20=20 success demoted by shadow miss.
+            // #1095: a shadow trap (success roll + paired-shadow MISS with overlay)
+            // NO LONGER demotes the turn to a forced Miss. The overlay still fires
+            // (the message is tainted, the delta is capped at 1), but FinalVerdict /
+            // FinalTier stay on the SUCCESS path — the turn is not a failure.
             var instructions = LoadYaml();
 
             var playerStats = MakeStats(allStats: 5, shadowOnPair: 10, pairStat: ShadowStatType.Despair);
@@ -129,21 +131,23 @@ namespace Pinder.Core.Tests
             int rizzIdx = FindIndex(llm.LastOptions, StatType.Rizz);
             var result = await session.ResolveTurnAsync(rizzIdx);
 
-            // Pre-demotion fields stay TRUE / Success (back-compat).
+            // Pre-shadow fields stay TRUE / Success (back-compat).
             Assert.True(result.Roll.IsSuccess);
             Assert.Equal(FailureTier.Success, result.Roll.Tier);
             Assert.True(result.Roll.Check.IsSuccess);
             Assert.Equal(FailureTier.Success, result.Roll.Check.Tier);
 
-            // Shadow overlay fired.
+            // Shadow overlay fired (message tainted, delta capped).
             Assert.True(result.ShadowCheck.OverlayApplied);
 
-            // #927: FinalVerdict / FinalTier on the option-roll's Check reflect
-            // the post-shadow demotion. The shadow tier is whatever the shadow
-            // ladder produced for missMargin=9 (DC=10 - roll=1 = 9 → TropeTrap).
-            Assert.Equal(RollVerdict.Miss, result.Roll.Check.FinalVerdict);
-            Assert.Equal(result.ShadowCheck.Tier, result.Roll.Check.FinalTier);
-            Assert.NotEqual(FailureTier.Success, result.Roll.Check.FinalTier);
+            // #1095: FinalVerdict / FinalTier are NOT demoted — the verdict stays
+            // Success because a shadow trap is no longer a turn failure.
+            Assert.Equal(RollVerdict.Success, result.Roll.Check.FinalVerdict);
+            Assert.Equal(FailureTier.Success, result.Roll.Check.FinalTier);
+
+            // The interest delta is capped at a maximum of 1 (a positive success
+            // delta, truncated by the shadow trap; horniness may floor it further).
+            Assert.InRange(result.InterestDelta, 0, 1);
         }
 
         [Fact]
@@ -224,11 +228,11 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public async Task GameSession_MultipleTurns_OnlyTurnWithOverlayHasFinalDemoted()
+        public async Task GameSession_MultipleTurns_ShadowTrapTurnStaysSuccess()
         {
             // Run two consecutive turns. Turn 1: success with no shadow.
-            // Turn 2: success demoted by shadow. The two turns' RollCheckResult
-            // instances are independent — only turn 2 has FinalVerdict=Miss.
+            // Turn 2: success + shadow trap. #1095: the shadow trap no longer
+            // demotes turn 2 to a Miss — both turns' FinalVerdict stay Success.
             var instructions = LoadYaml();
 
             // Player starts WITHOUT shadow; we'll bump shadow between turns.
@@ -255,12 +259,15 @@ namespace Pinder.Core.Tests
             // Turn 1.
             await session.StartTurnAsync();
             int rizzIdx1 = FindIndex(llm.LastOptions, StatType.Rizz);
+            int momentumBefore = session.CreateSnapshot().MomentumStreak;
             var turn1 = await session.ResolveTurnAsync(rizzIdx1);
+            int momentumAfterTurn1 = session.CreateSnapshot().MomentumStreak;
 
             Assert.True(turn1.Roll.IsSuccess);
             Assert.False(turn1.ShadowCheck.OverlayApplied);
             Assert.Equal(RollVerdict.Success, turn1.Roll.Check.FinalVerdict);
             Assert.Equal(FailureTier.Success, turn1.Roll.Check.FinalTier);
+            Assert.Equal(momentumBefore + 1, momentumAfterTurn1);
 
             // Bump shadow so turn 2 has an active paired shadow.
             playerShadows.ApplyGrowth(ShadowStatType.Despair, +10, "test setup");
@@ -269,11 +276,16 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             int rizzIdx2 = FindIndex(llm.LastOptions, StatType.Rizz);
             var turn2 = await session.ResolveTurnAsync(rizzIdx2);
+            int momentumAfterTurn2 = session.CreateSnapshot().MomentumStreak;
 
             Assert.True(turn2.Roll.IsSuccess);
             Assert.True(turn2.ShadowCheck.OverlayApplied);
-            Assert.Equal(RollVerdict.Miss, turn2.Roll.Check.FinalVerdict);
-            Assert.Equal(turn2.ShadowCheck.Tier, turn2.Roll.Check.FinalTier);
+
+            // #1095: a shadow trap is NOT a turn failure — verdict stays Success
+            // and momentum continues to increment through the trap turn.
+            Assert.Equal(RollVerdict.Success, turn2.Roll.Check.FinalVerdict);
+            Assert.Equal(FailureTier.Success, turn2.Roll.Check.FinalTier);
+            Assert.Equal(momentumAfterTurn1 + 1, momentumAfterTurn2);
 
             // Turn 1's Check is independent — was NOT retroactively mutated.
             Assert.Equal(RollVerdict.Success, turn1.Roll.Check.FinalVerdict);


### PR DESCRIPTION
Closes #1095.

## Rule change
A **shadow trap** (successful main roll + paired shadow check MISS that applies the shadow overlay) **no longer demotes the turn to a forced failure**. Instead it **truncates the positive interest delta to a maximum of 1** ("tainted, capped"):
- Roll verdict stays **SUCCESS** (no `ApplyFinalOverride(Miss, …)` for the capped-success path).
- Momentum streak **keeps incrementing**.
- Success-gated downstream effects stay on the success path.
- DATEE reacts **neutrally / slightly negatively** (tone nuance, not a failure beat).

Horniness halving runs **after** the shadow truncation, on the post-shadow delta, floor, only when delta > 0. Worked example: base 4 → shadow trap → 1 → horniness `floor(1/2) = 0`. Net delta **0**, but the turn is **still a success** and momentum still increments.

## Engine
- `src/Pinder.Core/Conversation/DeliveryStage.cs` — shadow block: `int truncated = Math.Min(interestDelta, 1); shadowCorrection = truncated - interestDelta; interestDelta = truncated;` (signed `shadowCorrection` preserved so the central `state.Interest.Apply(ShadowCorrection)` stays correct). `ShadowCheckResult` still records miss/tier/overlayApplied for display.
- `src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs` — removed the `ApplyFinalOverride(RollVerdict.Miss, …)` call for the shadow-correction path so verdict/momentum stay success; `state.Interest.Apply(ShadowCorrection)` retained.
- Horniness block already correct (floor, delta>0); now operates on the truncated value (ordering unchanged).

## Tests (local only — no GitHub CI)
- **New** `Issue1095_ShadowTrapTruncateTests` (4 cases): shadow-trap on success → delta 1 / verdict Success / momentum++; **worked example** shadow+horniness → 0 but still success + momentum++; interest audit balances; #942 invariant holds.
- Re-pointed `Issue365`, `Issue399`, `Issue927` from the old forced-fail semantics to the new capped-success semantics (no coverage deleted).
- **Also fixes a pre-existing RED test**: `Issue907_TextingStyleConflictMatrixTests.RealConflictsYaml_ContainsCanonicalConflicts` was left stale by **#1094** (commit `8d054c7`, current `main` HEAD), which retired the `minimum 80 words` length floor → `compact but layered` but didn't update the assertion. Since there's no CI, that landed red on `main`; re-pointed to the new canonical conflict.

## Docs / data
`docs/ARCHITECTURE.md` (steps 10a/10c + horniness blockquote), `docs/modules/game-session.md` (momentum), `data/game-definition.yaml`, `data/delivery-instructions.yaml`, `data/i18n/en/{consequences,glossary,ui-turn-result}.yaml` — shadow-trap now described as "capped/tainted, neutral-to-slightly-negative", not a failed turn.

## Verification
```
dotnet build  → clean
dotnet test   → Passed! Failed: 0, Passed: 2933, Skipped: 18, Total: 2951
```
