### PR TITLE
fix(delivery-pipeline): move LengthClamp before corruption layers (#825)

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -144,6 +144,18 @@ namespace Pinder.Core.Conversation
             // #902: Meta-prefix strip immediately after delivery LLM call.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MetaPrefixStripper.LayerName, textDiffs);
 
+            // #825: LengthClamp pass moved BEFORE corruption layers (Misfire/Spiral/Horniness)
+            // so that the word budget is enforced on clean text, and corruption layers operate
+            // within budget without being truncated by sentence-based clamping.
+            string beforeClampEarly = deliveredMessage;
+            bool clampedEarly;
+            deliveredMessage = ClampMessageToWordLimit(deliveredMessage, _maxDeliveryWords, out clampedEarly);
+            if (clampedEarly)
+            {
+                var clampSpans = WordDiff.Compute(beforeClampEarly, deliveredMessage);
+                textDiffs.Add(new TextDiff("LengthClamp", clampSpans, beforeClampEarly, deliveredMessage));
+            }
+
             // Tier modifier diff
             if (deliveredMessage != intendedTextForDelivery
                 && !string.IsNullOrEmpty(intendedTextForDelivery)
@@ -341,16 +353,6 @@ namespace Pinder.Core.Conversation
 
             // #1041 (Tier C): markdown-stripping pass for surfaces that expect plain prose.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MarkdownSanitizer.LayerName, textDiffs);
-
-            // AC-B1: Final LengthClamp pass
-            string beforeClamp = deliveredMessage;
-            bool clamped;
-            deliveredMessage = ClampMessageToWordLimit(deliveredMessage, _maxDeliveryWords, out clamped);
-            if (clamped)
-            {
-                var clampSpans = WordDiff.Compute(beforeClamp, deliveredMessage);
-                textDiffs.Add(new TextDiff("LengthClamp", clampSpans, beforeClamp, deliveredMessage));
-            }
 
             return new DeliveryStageResult
             {


### PR DESCRIPTION
# Fix #825: LengthClamp pass now preserves corruption-layer content

## Problem

**Issue**: Turn 5 delivered message lacks ALL Misfire + Trap Spiral corruptions (game 23ce5845)

**Root Cause**: The `LengthClamp` pass in `DeliveryStage.cs` was running **AFTER** corruption layers (Misfire/Spiral/Horniness). The clamp uses sentence-based truncation and keeps whole sentences until the word budget is exceeded. When corrupted content landed after the first sentence boundary and the word budget was tight, all corrupted spans were deleted.

**Example**:
- Base delivered text (20 words): "I think you're really interesting and I like talking to you very much indeed because you're great."
- First sentence ends at: "...because that flinch?"
- Corruption layers add content AFTER that boundary
- LengthClamp (15-word budget) truncates at first sentence → all corruption deleted

## Solution (Option A - Preferred)

**Move the `LengthClamp` pass to run BEFORE corruption layers.**

### Changes Made

**File**: `pinder-core/src/Pinder.Core/Conversation/DeliveryStage.cs`

1. **Relocated LengthClamp block** from lines 345-353 (after corruption) to lines 147-159 (immediately after base LLM delivery, after meta-prefix strip, BEFORE corruption layers)

2. **Execution Order** (new):
   ```
   1. LLM delivers base message
   2. Meta-prefix strip (#902)
   3. → LengthClamp (NEW POSITION) ← enforces word budget on clean text
   4. Tier modifier diff
   5. Shadow corruption overlay
   6. Horniness overlay
   7. Callback phrase strip
   8. Markdown sanitizer
   ```

3. **Why This Works**:
   - Corruption instructions are **SAME-LENGTH-OR-SHORTER** by design (per `delivery-instructions.yaml`)
   - Clamping the base text ensures the final output stays within budget
   - Corruption layers operate on already-clamped text, so their content survives

## Verification Needed

### Manual Testing
1. **Replay problematic game**: https://pinder-prod.tail678fd2.ts.net/game/23ce5845-05d7-4002-99ea-d130c2c4964c
   - Navigate to turn 5 result
   - Delivered message box should NOW show red/orange corrupted spans
   - Previously: clean truncated text (all corruption deleted)

### Automated Testing
The ideal test would be:
- Set up tight `maxDeliveryWords` (e.g., 15)
- Deliver base message exceeding budget (20 words)
- Apply corruption layer that adds content
- Assert: final message is clamped BUT still contains corrupted spans
- Assert: `LengthClamp` diff appears BEFORE corruption diffs in `TextDiffs` list

(Note: Full integration test requires complex mocking of game state/engines - left for follow-up if needed)

## Build Status

✅ `dotnet build pinder-core/src/Pinder.Core` - **SUCCESS** (0 warnings, 0 errors)

## Related

- Corruption layer instructions: `pinder-core/data/delivery-instructions.yaml`
- All corruption tiers (fumble/misfire/trope_trap/catastrophe/nat1) are designed to be SAME LENGTH OR SHORTER
- No changes needed to corruption instructions themselves

## Checklist

- [x] Code compiles without errors
- [x] Core fix implemented (LengthClamp moved before corruption)
- [ ] Manual verification on game 23ce5845 turn 5
- [ ] Integration test added (complex setup - may defer)
- [x] Commit messages follow conventional commits
- [x] PR created in pinder-core
- [x] PR created in pinder-web (submodule update)

## Deployment Notes

This is a C# engine change in `pinder-core`. After merge:
1. Ensure `pinder-web` submodule points to merged commit
2. Redeploy backend services
3. Test with a few live games to verify corruption content appears
