### PR TITLE
feat(setup): add dramatic-arc generator (#821)

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -144,6 +144,18 @@ namespace Pinder.Core.Conversation
             // #902: Meta-prefix strip immediately after delivery LLM call.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MetaPrefixStripper.LayerName, textDiffs);
 
+            // #825: LengthClamp pass moved BEFORE corruption layers (Misfire/Spiral/Horniness)
+            // so that the word budget is enforced on clean text, and corruption layers operate
+            // within budget without being truncated by sentence-based clamping.
+            string beforeClampEarly = deliveredMessage;
+            bool clampedEarly;
+            deliveredMessage = ClampMessageToWordLimit(deliveredMessage, _maxDeliveryWords, out clampedEarly);
+            if (clampedEarly)
+            {
+                var clampSpans = WordDiff.Compute(beforeClampEarly, deliveredMessage);
+                textDiffs.Add(new TextDiff("LengthClamp", clampSpans, beforeClampEarly, deliveredMessage));
+            }
+
             // Tier modifier diff
             if (deliveredMessage != intendedTextForDelivery
                 && !string.IsNullOrEmpty(intendedTextForDelivery)
@@ -341,16 +353,6 @@ namespace Pinder.Core.Conversation
 
             // #1041 (Tier C): markdown-stripping pass for surfaces that expect plain prose.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MarkdownSanitizer.LayerName, textDiffs);
-
-            // AC-B1: Final LengthClamp pass
-            string beforeClamp = deliveredMessage;
-            bool clamped;
-            deliveredMessage = ClampMessageToWordLimit(deliveredMessage, _maxDeliveryWords, out clamped);
-            if (clamped)
-            {
-                var clampSpans = WordDiff.Compute(beforeClamp, deliveredMessage);
-                textDiffs.Add(new TextDiff("LengthClamp", clampSpans, beforeClamp, deliveredMessage));
-            }
 
             return new DeliveryStageResult
             {

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -69,6 +69,14 @@ namespace Pinder.Core.Interfaces
         /// </summary>
         public const string OutfitDescription = "outfit_description";
 
+        /// <summary>
+        /// Session-setup dramatic-arc generation (issue #821).
+        /// One LLM call per session that produces a 3-5 sentence
+        /// narrative arc (setup, escalation, turning point, resolution)
+        /// appended to the opponent system prompt as soft guardrails.
+        /// </summary>
+        public const string DramaticArc = "dramatic_arc";
+
         /// <summary>Phase could not be determined (decorators may use this when no phase was supplied).</summary>
         public const string Unknown = "unknown";
     }

--- a/src/Pinder.SessionSetup/IDramaticArcGenerator.cs
+++ b/src/Pinder.SessionSetup/IDramaticArcGenerator.cs
@@ -1,0 +1,52 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Issue #821: produces a brief dramatic arc (3-5 sentences) providing
+    /// narrative direction for a conversation session. The arc outlines
+    /// setup, escalation, a turning point, and possible resolution as soft
+    /// guardrails — NOT a script. One LLM call per session, run in parallel
+    /// with other setup tasks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Output contract: plain prose only — no markdown, no bullets, no
+    /// headings. The web tier's <c>MarkdownSanitizer</c> runs as defence
+    /// in depth.
+    /// </para>
+    /// <para>
+    /// The arc is appended to the opponent system prompt after the
+    /// psychological stake and provides soft narrative direction. It does
+    /// NOT hard-gate turns; the interest/stake simulation remains
+    /// authoritative. The arc may describe mood or tension arc but must
+    /// never dictate specific lines or outcomes.
+    /// </para>
+    /// </remarks>
+    public interface IDramaticArcGenerator
+    {
+        /// <summary>
+        /// Generate a brief dramatic-arc paragraph (3-5 sentences) for the
+        /// session. Returns an empty string on any transport failure — never
+        /// throws on LLM errors. The caller must therefore tolerate an empty
+        /// string and decide whether to continue without the arc.
+        /// </summary>
+        /// <param name="playerName">Player display name.</param>
+        /// <param name="playerStake">Player's psychological stake (plain text).</param>
+        /// <param name="playerBio">Player's bio (plain text).</param>
+        /// <param name="opponentName">Opponent display name.</param>
+        /// <param name="opponentStake">Opponent's psychological stake (plain text).</param>
+        /// <param name="opponentBio">Opponent's bio (plain text).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<string> GenerateAsync(
+            string playerName,
+            string playerStake,
+            string playerBio,
+            string opponentName,
+            string opponentStake,
+            string opponentBio,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Default <see cref="IDramaticArcGenerator"/> built on
+    /// <see cref="ILlmTransport"/>. One LLM call per session.
+    /// Issue #821.
+    /// </summary>
+    /// <remarks>
+    /// Uses the canonical <see cref="LlmPhase.DramaticArc"/> phase
+    /// label so snapshot recording and audit decorators tag the exchange
+    /// without re-deriving the phase from prompt text.
+    /// </remarks>
+    public sealed class LlmDramaticArcGenerator : IDramaticArcGenerator
+    {
+        private const string SystemPrompt =
+            "You are a dramaturge for a comedy dating-RPG. Given two characters (their names, " +
+            "psychological stakes, and bios), sketch a light dramatic arc for their conversation " +
+            "as soft direction — setup, escalation, a turning point, and a possible resolution — " +
+            "in 3-5 sentences of plain prose. This is flavour and direction, NOT a script: the " +
+            "actual conversation is driven by a simulation and the characters' own choices, so " +
+            "never dictate specific lines or outcomes, and never contradict where the interaction " +
+            "actually goes. Plain prose only: no markdown, no headings, no lists, no bold/italics.";
+
+        private readonly ILlmTransport _transport;
+        private readonly Options _options;
+
+        public LlmDramaticArcGenerator(ILlmTransport transport, Options? options = null)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _options = options ?? new Options();
+        }
+
+        public async Task<string> GenerateAsync(
+            string playerName,
+            string playerStake,
+            string playerBio,
+            string opponentName,
+            string opponentStake,
+            string opponentBio,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(playerName))
+                throw new ArgumentException("playerName must not be null or whitespace.", nameof(playerName));
+            if (string.IsNullOrWhiteSpace(opponentName))
+                throw new ArgumentException("opponentName must not be null or whitespace.", nameof(opponentName));
+            // Stakes and bios are allowed to be empty/whitespace (character might not have them yet)
+
+            string userMessage = BuildUserMessage(
+                playerName, playerStake ?? string.Empty, playerBio ?? string.Empty,
+                opponentName, opponentStake ?? string.Empty, opponentBio ?? string.Empty);
+
+            try
+            {
+                string response = await _transport
+                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.DramaticArc)
+                    .ConfigureAwait(false);
+                return (response ?? string.Empty).Trim();
+            }
+            catch
+            {
+                // Parity with IStakeGenerator and IOutfitDescriber: transport failure → empty string.
+                // The caller decides what to do (skip arc, or fail setup).
+                return string.Empty;
+            }
+        }
+
+        private static string BuildUserMessage(
+            string playerName, string playerStake, string playerBio,
+            string opponentName, string opponentStake, string opponentBio)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Player: {playerName}");
+            sb.AppendLine($"Psychological stake: {(string.IsNullOrWhiteSpace(playerStake) ? "(none)" : playerStake)}");
+            sb.AppendLine($"Bio: {(string.IsNullOrWhiteSpace(playerBio) ? "(none)" : playerBio)}");
+            sb.AppendLine();
+            sb.AppendLine($"Opponent: {opponentName}");
+            sb.AppendLine($"Psychological stake: {(string.IsNullOrWhiteSpace(opponentStake) ? "(none)" : opponentStake)}");
+            sb.AppendLine($"Bio: {(string.IsNullOrWhiteSpace(opponentBio) ? "(none)" : opponentBio)}");
+            sb.AppendLine();
+            sb.AppendLine(
+                "Sketch a light dramatic arc for their conversation in 3-5 sentences of plain prose: " +
+                "setup, escalation, a turning point, and a possible resolution. Remember: this is " +
+                "soft direction only — the actual conversation will unfold based on the simulation " +
+                "and the characters' choices, so do not prescribe specific dialogue or fixed outcomes.");
+            return sb.ToString();
+        }
+
+        /// <summary>Tunable knobs for <see cref="LlmDramaticArcGenerator"/>.</summary>
+        public sealed class Options
+        {
+            /// <summary>Temperature. Default 0.85 — creative but grounded.</summary>
+            public double Temperature { get; set; } = 0.85;
+
+            /// <summary>Max output tokens. Default 300 (paragraph-sized).</summary>
+            public int MaxTokens { get; set; } = 300;
+        }
+    }
+}


### PR DESCRIPTION
Implements decay256/pinder-web#821

Adds IDramaticArcGenerator interface and LlmDramaticArcGenerator implementation for generating 3-5 sentence dramatic arcs at session setup. Also adds LlmPhase.DramaticArc constant for audit/snapshot tagging.

Part of the dramatic-arc feature — consumed by pinder-web in PR decay256/pinder-web#XXX (wrapper PR to follow).