### PR TITLE
feat(character): add BackgroundStory property and LLM generator

### DIFF
--- a/data/prompts/background.yaml
+++ b/data/prompts/background.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+# Pinder prompt catalog — background.yaml
+#
+# Issue #820: generate a cohesive narrative background story from a character's
+# assembled background fragments. Called once per character at creation time.
+#
+# Substitution: {token}-style. Single token in this file:
+#   {character_profile}  (the assembled system prompt containing background
+#                         fragments to weave into prose)
+#
+# Output: 3-5 sentences of cohesive narrative prose (no markdown, no bullets,
+# no section headers). Written in third person past tense.
+
+prompts:
+  background:
+    system_prompt: >-
+      You are a narrative synthesis engine for a comedy hookup-app simulator where the protagonists are sentient penises.
+      Read the character profile below and weave the character's background fragments into a single cohesive narrative paragraph (3-5 sentences).
+      Write in third person past tense. Make it read like a brief character biography: straightforward, specific, and grounded in the details given.
+      Do not add new facts, embellishments, or emotional commentary not present in the source material.
+      Output plain prose only — no markdown formatting, no bullet points, no section headers, no bold/italics.
+      Keep the absurd-yet-matter-of-fact tone: the character's world is ridiculous but they take it completely seriously.
+    user_template: |-
+      Read this character profile and synthesize the background fragments into a single narrative paragraph (3-5 sentences, third person past tense).
+      Use only the facts given. No embellishments. Plain prose only.
+
+      CHARACTER PROFILE:
+      {character_profile}

--- a/src/Pinder.Core/Characters/CharacterDefinition.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinition.cs
@@ -67,6 +67,13 @@ namespace Pinder.Core.Characters
         /// </summary>
         public string? PsychologicalStake { get; }
 
+        /// <summary>
+        /// Issue #820: cohesive narrative background story generated at
+        /// character-creation time from assembled background fragments.
+        /// 3-5 sentence prose. Null when absent (legacy files not yet regenerated).
+        /// </summary>
+        public string? BackgroundStory { get; }
+
         public CharacterDefinition(
             int schemaVersion,
             Guid characterId,
@@ -77,7 +84,8 @@ namespace Pinder.Core.Characters
             IReadOnlyList<string> items,
             IReadOnlyDictionary<string, string> anatomy,
             AllocationBlock allocation,
-            string? psychologicalStake = null)
+            string? psychologicalStake = null,
+            string? backgroundStory = null)
         {
             SchemaVersion = schemaVersion;
             CharacterId = characterId;
@@ -89,6 +97,7 @@ namespace Pinder.Core.Characters
             Anatomy = anatomy ?? throw new ArgumentNullException(nameof(anatomy));
             Allocation = allocation ?? throw new ArgumentNullException(nameof(allocation));
             PsychologicalStake = psychologicalStake;
+            BackgroundStory = backgroundStory;
         }
     }
 

--- a/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
@@ -139,6 +139,11 @@ namespace Pinder.Core.Characters
             if (!string.IsNullOrWhiteSpace(def.PsychologicalStake))
                 writer.WriteString("psychological_stake", def.PsychologicalStake);
 
+            // Issue #820: write the narrative background story if present.
+            // Omitted when absent, same hygiene as stake.
+            if (!string.IsNullOrWhiteSpace(def.BackgroundStory))
+                writer.WriteString("background_story", def.BackgroundStory);
+
             writer.WriteEndObject();
         }
 

--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -77,6 +77,14 @@ namespace Pinder.Core.Interfaces
         /// </summary>
         public const string DramaticArc = "dramatic_arc";
 
+        /// <summary>
+        /// Session-setup background-story generation (issue #820).
+        /// One LLM call per character at creation time that weaves
+        /// assembled background fragments into a 3-5 sentence cohesive
+        /// narrative stored on-disk and surfaced on the Character Sheet.
+        /// </summary>
+        public const string BackgroundStory = "background_story";
+
         /// <summary>Phase could not be determined (decorators may use this when no phase was supplied).</summary>
         public const string Unknown = "unknown";
     }

--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -102,6 +102,16 @@ namespace Pinder.SessionSetup
                         psychologicalStake = raw.Trim();
                 }
 
+                // Issue #820: optional narrative background story.
+                string? backgroundStory = null;
+                if (root.TryGetProperty("background_story", out var storyProp) &&
+                    storyProp.ValueKind == JsonValueKind.String)
+                {
+                    string raw = storyProp.GetString() ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(raw))
+                        backgroundStory = raw.Trim();
+                }
+
                 return new CharacterDefinition(
                     schemaVersion,
                     characterId,
@@ -112,7 +122,8 @@ namespace Pinder.SessionSetup
                     items,
                     anatomy,
                     allocation,
-                    psychologicalStake);
+                    psychologicalStake,
+                    backgroundStory);
             }
         }
 

--- a/src/Pinder.SessionSetup/IBackgroundGenerator.cs
+++ b/src/Pinder.SessionSetup/IBackgroundGenerator.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Generates a cohesive narrative background story from a character's
+    /// assembled background fragments. Called once per character at creation time.
+    /// </summary>
+    /// <remarks>
+    /// Issue #820: mirrors the <see cref="IStakeGenerator"/> pattern.
+    /// Output is 3-5 sentences of third-person past-tense prose synthesizing
+    /// the character's background fragments into a single narrative paragraph.
+    /// </remarks>
+    public interface IBackgroundGenerator
+    {
+        /// <summary>
+        /// Generate a narrative background story (3-5 sentence prose, third
+        /// person past tense) for <paramref name="characterName"/>. Returns
+        /// an empty string on transport failure — never throws.
+        /// </summary>
+        Task<string> GenerateAsync(
+            string characterName,
+            string assembledSystemPrompt,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.SessionSetup/LlmBackgroundGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmBackgroundGenerator.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Default <see cref="IBackgroundGenerator"/> built on <see cref="ILlmTransport"/>.
+    /// Generates a cohesive narrative background story (3-5 sentence prose) from
+    /// assembled background fragments.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #820: mirrors <see cref="LlmStakeGenerator"/>. Output is plain
+    /// third-person past-tense prose — no markdown, no bullets, no formatting.
+    /// The result is stored on-disk in the character definition and surfaced
+    /// on the Character Sheet alongside bio and stake.
+    /// </para>
+    /// <para>
+    /// Catalog-aware: when a <see cref="PromptCatalog"/> is supplied and
+    /// contains a <c>"background"</c> entry, system + user templates are read
+    /// from it; otherwise fallback constants are used.
+    /// </para>
+    /// </remarks>
+    public sealed class LlmBackgroundGenerator : IBackgroundGenerator
+    {
+        // Fallback constants when no PromptCatalog is supplied.
+        // These must stay byte-identical to data/prompts/background.yaml
+        // until the catalog is wired everywhere.
+        internal const string DefaultSystemPrompt =
+            "You are a narrative synthesis engine for a comedy hookup-app simulator where the protagonists are sentient penises. " +
+            "Read the character profile below and weave the character's background fragments into a single cohesive narrative paragraph (3-5 sentences). " +
+            "Write in third person past tense. Make it read like a brief character biography: straightforward, specific, and grounded in the details given. " +
+            "Do not add new facts, embellishments, or emotional commentary not present in the source material. " +
+            "Output plain prose only — no markdown formatting, no bullet points, no section headers, no bold/italics. " +
+            "Keep the absurd-yet-matter-of-fact tone: the character's world is ridiculous but they take it completely seriously.";
+
+        private readonly ILlmTransport _transport;
+        private readonly Options _options;
+        private readonly PromptCatalog? _catalog;
+
+        public LlmBackgroundGenerator(ILlmTransport transport, Options? options = null)
+            : this(transport, options, catalog: null)
+        {
+        }
+
+        /// <summary>
+        /// Catalog-aware constructor. When <paramref name="catalog"/> is
+        /// non-null and contains a <c>"background"</c> entry, system + user
+        /// templates are read from it; otherwise the embedded const defaults
+        /// are used.
+        /// </summary>
+        public LlmBackgroundGenerator(
+            ILlmTransport transport,
+            Options? options,
+            PromptCatalog? catalog)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _options = options ?? new Options();
+            _catalog = catalog;
+        }
+
+        /// <summary>
+        /// Effective system prompt for the background call — the catalog
+        /// entry if one is registered, otherwise the const default.
+        /// </summary>
+        private string SystemPrompt
+        {
+            get
+            {
+                var entry = _catalog?.TryGet("background");
+                if (entry != null && !string.IsNullOrWhiteSpace(entry.SystemPrompt))
+                    return entry.SystemPrompt!;
+                return DefaultSystemPrompt;
+            }
+        }
+
+        public async Task<string> GenerateAsync(
+            string characterName,
+            string assembledSystemPrompt,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateInputs(characterName, assembledSystemPrompt);
+            string userMessage = BuildUserMessage(assembledSystemPrompt, _catalog);
+
+            try
+            {
+                string response = await _transport
+                    .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.BackgroundStory)
+                    .ConfigureAwait(false);
+                return (response ?? string.Empty).Trim();
+            }
+            catch
+            {
+                // Mirror stake generator: transport failure → empty string.
+                return string.Empty;
+            }
+        }
+
+        // ── shared helpers ───────────────────────────────────────────────
+
+        private static void ValidateInputs(string characterName, string assembledSystemPrompt)
+        {
+            if (string.IsNullOrWhiteSpace(characterName))
+                throw new ArgumentException("characterName must not be null or whitespace.", nameof(characterName));
+            if (assembledSystemPrompt == null)
+                throw new ArgumentNullException(nameof(assembledSystemPrompt));
+        }
+
+        internal static string BuildUserMessage(
+            string assembledSystemPrompt,
+            PromptCatalog? catalog)
+        {
+            // Prefer the catalog template; fall back to const if absent.
+            var entry = catalog?.TryGet("background");
+            if (entry != null && !string.IsNullOrWhiteSpace(entry.UserTemplate))
+            {
+                return PromptCatalog.Substitute(
+                    entry.UserTemplate!,
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        { "character_profile", assembledSystemPrompt },
+                    });
+            }
+            return BuildUserMessageFromConstFallback(assembledSystemPrompt);
+        }
+
+        /// <summary>
+        /// Fallback user-message body when catalog is absent.
+        /// </summary>
+        internal static string BuildUserMessageFromConstFallback(string assembledSystemPrompt)
+        {
+            return
+                $@"Read this character profile and synthesize the background fragments into a single narrative paragraph (3-5 sentences, third person past tense).
+Use only the facts given. No embellishments. Plain prose only.
+
+CHARACTER PROFILE:
+{assembledSystemPrompt}";
+        }
+
+        /// <summary>Tunable knobs for <see cref="LlmBackgroundGenerator"/>.</summary>
+        public sealed class Options
+        {
+            /// <summary>Temperature. Default 0.8 (slightly lower than stake for more coherent prose).</summary>
+            public double Temperature { get; set; } = 0.8;
+
+            /// <summary>
+            /// Max output tokens. Default 350 (3-5 sentences of narrative
+            /// prose; allows ~250-300 tokens with a small safety margin).
+            /// </summary>
+            public int MaxTokens { get; set; } = 350;
+        }
+    }
+}


### PR DESCRIPTION
Implements decay256/pinder-web#820 (engine half). Adds CharacterDefinition.BackgroundStory property, IBackgroundGenerator interface, LlmBackgroundGenerator implementation, and background.yaml prompt. Part of the full-stack feature.