### PR TITLE
fix: update stale test assertions from sprint 2026-06-04-ff2c74

### DIFF
--- a/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
+++ b/tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs
@@ -322,10 +322,10 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public async Task RealStarterFiles_ListIdsFindsAllEight()
+        public async Task RealStarterFiles_ListIdsFindsAllSix()
         {
             // Wire the store at the repo's data/characters directory and
-            // confirm we see all eight starter characters by their UUIDs.
+            // confirm we see all six starter characters by their UUIDs.
             string? dir = AppContext.BaseDirectory;
             while (dir != null)
             {
@@ -338,7 +338,7 @@ namespace Pinder.Core.Tests
             var store = new DirectoryCharacterStore(Path.Combine(dir!, "data", "characters"));
             var ids = await store.ListIdsAsync();
 
-            Assert.Equal(8, ids.Count);
+            Assert.Equal(6, ids.Count);
             Assert.All(ids, id => Assert.True(Guid.TryParseExact(id, "D", out _)));
         }
     }

--- a/tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs
@@ -46,7 +46,6 @@ namespace Pinder.LlmAdapters.Tests
             var prompt = SessionDocumentBuilder.BuildOpponentPrompt(ctx);
 
             Assert.Contains("400 characters", prompt);
-            Assert.Contains("200 characters", prompt);
         }
 
         // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes 2 stale test assertions left RED by sprint 2026-06-04-ff2c74.

## 1. DirectoryCharacterStoreTests.RealStarterFiles_ListIdsFindsAllSix

**Location:** tests/Pinder.Core.Tests/DirectoryCharacterStoreTests.cs line 341

**Problem:** Test asserted `Assert.Equal(8, ids.Count)` but ticket #829 intentionally DELETED 2 unloadable starter characters (marisol-tides, ozzie-pivot) via pinder-core#1100.

**Fix:**
- Updated assertion from 8 → 6
- Renamed test method from `RealStarterFiles_ListIdsFindsAllEight` to `RealStarterFiles_ListIdsFindsAllSix`
- Updated comment from "all eight starter characters" to "all six starter characters"
- Verified actual count: 6 character JSON files in data/characters/ (excluding character-schema.json)

**Reasoning:** This is intentional cleanup, not a regression.

---

## 2. Issue866_OpponentLengthCapTests.OpponentPrompt_200CharPlayer_HasCeiling400

**Location:** tests/Pinder.LlmAdapters.Tests/Issue866_OpponentLengthCapTests.cs line 42

**Problem:** Test asserted both `Assert.Contains("400 characters", prompt)` and `Assert.Contains("200 characters", prompt)`, but the prompt no longer includes the player message length (200).

**Investigation:** 
- Commit 2cc114f (pinder-core#1101) intentionally removed partner-length-mirroring instruction from opponent-response prompt
- This was part of #827 length-doctrine changes
- Before: prompt said "Aim for roughly {playerLen} characters (matching the player's message length)"
- After: prompt only says "Keep it to a natural text-message length. Do not exceed {ceiling} characters..."

**Fix:**
- Removed assertion for "200 characters" (player message length)
- Kept assertion for "400 characters" (ceiling)

**Reasoning:** This is a BY DESIGN change. The partner-length-mirroring instruction was intentionally removed. The test needed to be updated to match the new behavior.

---

## Test Results

Both targeted tests now pass:
- ✅ DirectoryCharacterStoreTests.RealStarterFiles_ListIdsFindsAllSix
- ✅ Issue866_OpponentLengthCapTests.OpponentPrompt_200CharPlayer_HasCeiling400

No new failures introduced.