### PR TITLE
fix(#840): remove ALL message truncation — kill word-budget clamp + steering-budget gate

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -92,8 +92,7 @@ namespace Pinder.Core.Conversation
 
             string intendedTextForDelivery = originalIntendedText;
             DialogueOption deliveryOption = chosenOption;
-            var originalWords = originalIntendedText.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            if (steeringResult.SteeringSucceeded && steeringResult.SteeringQuestion != null && originalWords.Length < _maxDeliveryWords)
+            if (steeringResult.SteeringSucceeded && steeringResult.SteeringQuestion != null)
             {
                 intendedTextForDelivery = originalIntendedText.Length == 0
                     ? steeringResult.SteeringQuestion
@@ -143,18 +142,6 @@ namespace Pinder.Core.Conversation
 
             // #902: Meta-prefix strip immediately after delivery LLM call.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MetaPrefixStripper.LayerName, textDiffs);
-
-            // #825: LengthClamp pass moved BEFORE corruption layers (Misfire/Spiral/Horniness)
-            // so that the word budget is enforced on clean text, and corruption layers operate
-            // within budget without being truncated by sentence-based clamping.
-            string beforeClampEarly = deliveredMessage;
-            bool clampedEarly;
-            deliveredMessage = ClampMessageToWordLimit(deliveredMessage, _maxDeliveryWords, out clampedEarly);
-            if (clampedEarly)
-            {
-                var clampSpans = WordDiff.Compute(beforeClampEarly, deliveredMessage);
-                textDiffs.Add(new TextDiff("LengthClamp", clampSpans, beforeClampEarly, deliveredMessage));
-            }
 
             // Tier modifier diff
             if (deliveredMessage != intendedTextForDelivery
@@ -368,59 +355,5 @@ namespace Pinder.Core.Conversation
             };
         }
 
-        private string ClampMessageToWordLimit(string message, int maxWords, out bool clamped)
-        {
-            clamped = false;
-            if (string.IsNullOrWhiteSpace(message)) return message;
-            
-            var words = message.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            if (words.Length <= maxWords) return message;
-
-            // Split into sentences using punctuation markers
-            var sentences = new List<string>();
-            var currentSentence = new System.Text.StringBuilder();
-            
-            for (int i = 0; i < message.Length; i++)
-            {
-                char c = message[i];
-                currentSentence.Append(c);
-                if (c == '.' || c == '?' || c == '!')
-                {
-                    // Check if next char is whitespace or end of string to confirm sentence boundary
-                    if (i + 1 == message.Length || char.IsWhiteSpace(message[i + 1]))
-                    {
-                        sentences.Add(currentSentence.ToString().Trim());
-                        currentSentence.Clear();
-                    }
-                }
-            }
-            if (currentSentence.Length > 0)
-            {
-                sentences.Add(currentSentence.ToString().Trim());
-            }
-
-            var result = new System.Text.StringBuilder();
-            int currentWordCount = 0;
-            bool addedAny = false;
-
-            foreach (var sentence in sentences)
-            {
-                var sentenceWords = sentence.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                if (currentWordCount + sentenceWords.Length <= maxWords || !addedAny)
-                {
-                    if (addedAny) result.Append(" ");
-                    result.Append(sentence);
-                    currentWordCount += sentenceWords.Length;
-                    addedAny = true;
-                }
-                else
-                {
-                    clamped = true;
-                    break;
-                }
-            }
-
-            return result.ToString().Trim();
-        }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
+++ b/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue840_NoLengthClampTests
+    {
+        private static StatBlock MakeStats(
+            int charm = 2, int rizz = 2, int honesty = 2,
+            int chaos = 2, int wit = 2, int sa = 2)
+        {
+            var stats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm, charm },
+                { StatType.Rizz, rizz },
+                { StatType.Honesty, honesty },
+                { StatType.Chaos, chaos },
+                { StatType.Wit, wit },
+                { StatType.SelfAwareness, sa }
+            };
+            var shadow = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 },
+                { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 },
+                { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 },
+                { ShadowStatType.Overthinking, 0 }
+            };
+            return new StatBlock(stats, shadow);
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+        {
+            return new CharacterProfile(
+                stats,
+                $"You are {name}.",
+                name,
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        [Fact]
+        public async Task Long_message_delivered_intact_without_length_clamp()
+        {
+            var player = MakeProfile("Sable", MakeStats(charm: 5, wit: 5, sa: 5));
+            var opponent = MakeProfile("Brick", MakeStats(charm: 0, rizz: 0, honesty: 0, chaos: 0, wit: 0, sa: 0));
+
+            // Generate a 120-word string
+            var longWords = Enumerable.Range(1, 120).Select(i => $"word{i}").ToArray();
+            string longMessage = string.Join(" ", longWords);
+
+            // Game dice & steering RNG (steering fails so we only test the raw message delivery)
+            var dice = new FixedDice(1, 15, 50); // d20=15 (success)
+            var steeringRng = new FixedRandom(1); // fail steering
+
+            var llm = new CapturingLlmWithLongOutput(longMessage);
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(), 
+                steeringRng: steeringRng, 
+                maxDeliveryWords: 80 // Max words is 80, but message is 120!
+            );
+            var session = new GameSession(player, opponent, llm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // Assertions
+            Assert.Equal(longMessage, result.DeliveredMessage);
+            Assert.True(result.TextDiffs == null || !result.TextDiffs.Any(d => d.LayerName == "LengthClamp"), "Should not emit LengthClamp text diff.");
+            
+            // Verify word count is fully intact
+            var resultWordCount = result.DeliveredMessage.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
+            Assert.Equal(120, resultWordCount);
+        }
+
+        [Fact]
+        public async Task Steering_question_appended_even_when_intended_text_exceeds_max_delivery_words()
+        {
+            var player = MakeProfile("Sable", MakeStats(charm: 5, wit: 5, sa: 5));
+            var opponent = MakeProfile("Brick", MakeStats(charm: 0, rizz: 0, honesty: 0, chaos: 0, wit: 0, sa: 0));
+
+            // Intended text is 100 words (exceeds maxDeliveryWords of 80)
+            var longWords = Enumerable.Range(1, 100).Select(i => $"word{i}").ToArray();
+            string intendedText = string.Join(" ", longWords);
+
+            // Steering succeeds (roll 20)
+            var dice = new FixedDice(1, 15, 50);
+            var steeringRng = new FixedRandom(20);
+
+            var llm = new CapturingLlmWithLongOutput(intendedText, "how about now?");
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(), 
+                steeringRng: steeringRng, 
+                maxDeliveryWords: 80
+            );
+            var session = new GameSession(player, opponent, llm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // Assert steering succeeded
+            Assert.True(result.Steering.SteeringSucceeded);
+            Assert.Equal("how about now?", result.Steering.SteeringQuestion);
+
+            // Verify steering question was appended to the intended text despite being > 80 words
+            Assert.NotNull(llm.CapturedDeliveryContext);
+            string deliveryIntended = llm.CapturedDeliveryContext!.ChosenOption.IntendedText;
+            Assert.Contains("how about now?", deliveryIntended);
+            Assert.StartsWith("word1", deliveryIntended);
+        }
+
+        private sealed class CapturingLlmWithLongOutput : ILlmAdapter, IStatefulLlmAdapter
+        {
+            private readonly string _longMessage;
+            private readonly string _steeringQuestion;
+
+            public DeliveryContext? CapturedDeliveryContext { get; private set; }
+
+            public CapturingLlmWithLongOutput(string longMessage, string steeringQuestion = "how about now?")
+            {
+                _longMessage = longMessage;
+                _steeringQuestion = steeringQuestion;
+            }
+
+            public Task<StatefulOpponentResult> GetOpponentResponseAsync(
+                OpponentContext context,
+                System.Collections.Generic.IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulOpponentResult(
+                    new OpponentResponse("..."),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User(string.Empty),
+                        ConversationMessage.Assistant("..."),
+                    }));
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, _longMessage),
+                });
+            }
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
+            {
+                CapturedDeliveryContext = context;
+                return Task.FromResult(context.ChosenOption.IntendedText);
+            }
+
+            public Task<OpponentResponse> GetOpponentResponseAsync(OpponentContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new OpponentResponse("..."));
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? opponentContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(_steeringQuestion);
+        }
+
+        private sealed class FixedRandom : Random
+        {
+            private readonly Queue<int> _values;
+            public FixedRandom(params int[] values) { _values = new Queue<int>(values); }
+            public override int Next(int minValue, int maxValue) => _values.Count > 0 ? _values.Dequeue() : minValue;
+        }
+
+        private sealed class NullTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+    }
+}


### PR DESCRIPTION
This PR removes all message truncation from the delivery stage of the conversation pipeline, addressing the engine half of pinder-web#840.

### What was removed/changed:
1. **Word-Budget Clamp Removal**:
   - Removed the `ClampMessageToWordLimit` call site inside `ExecuteAsync`.
   - Removed the entire private `ClampMessageToWordLimit` helper method.
   - Removed the `LengthClamp` TextDiff emission. Long messages are now delivered 100% intact with their word count preserved.
2. **Steering-Budget Gate Removal**:
   - Removed the `&& originalWords.Length < _maxDeliveryWords` guard on the steering question.
   - Deleted the unused `originalWords` local variable. A steering question is now always appended whenever a steering roll succeeds, regardless of the original message's length.
3. **`_maxDeliveryWords` Disposition**:
   - Kept `_maxDeliveryWords` field, constructor parameter, and session plumbing untouched.
   - Repurposed it strictly as a **soft prompt hint** to the Horniness-overlay LLM call (at line 296), so no hard truncation occurs in code.

### Verification and Regression Tests:
Added a new test suite: `Issue840_NoLengthClampTests.cs` (under `tests/Pinder.Core.Tests/`) containing:
- `Long_message_delivered_intact_without_length_clamp`: Verifies a 120-word message is delivered intact without any `LengthClamp` diff.
- `Steering_question_appended_even_when_intended_text_exceeds_max_delivery_words`: Verifies steering questions are successfully appended even when the original text is 100 words (exceeding the soft limit of 80 words).

### Build/Test Evidence:
Verified with local dotnet builds and tests in the staging host's docker environment:
```bash
docker run --rm -v /tmp/wt-840:/src -w /src mcr.microsoft.com/dotnet/sdk:8.0 dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
```
**Output Tail:**
```
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 5 ms - Pinder.Core.Tests.dll (net8.0)
```
Full suite check results:
```
Failed!  - Failed:     3, Passed:  2933, Skipped:    18, Total:  2954, Duration: 4 s - Pinder.Core.Tests.dll (net8.0)
```
*(Note: The 3 failures are in RulesPipelineTests, which are pre-existing and happen because the .NET SDK container does not have `python3` installed; our new tests passed perfectly.)*

### Relationship with other PRs:
Supersedes core PR#1099 (its clamp regression suite is obsolete now the clamp is gone — close #1099).

Implements pinder-web#840 (engine half).
