### PR TITLE
feat(#855): two in-character actors in NarrativeHarness (real pursuer character)

### DIFF
--- a/src/Pinder.NarrativeHarness/HarnessOptions.cs
+++ b/src/Pinder.NarrativeHarness/HarnessOptions.cs
@@ -7,6 +7,7 @@ namespace Pinder.Tools.NarrativeHarness
     public sealed class HarnessOptions
     {
         public string CharacterSlug { get; private set; } = "brick";
+        public string? PursuerCharacterSlug { get; private set; }     // --pursuer-character (opt; real 2nd char)
         public string ArcShape { get; private set; } = "ingestion"; // ingestion | romcom
         public bool PolarityOn { get; private set; } = false;        // --polarity on|off
         public int Turns { get; private set; } = 14;                 // resolved from <n|range>
@@ -20,7 +21,13 @@ namespace Pinder.Tools.NarrativeHarness
 @"NarrativeHarness — rules-free narrative testbed (#843)
 
 Usage:
-  --character <slug>        Character to load (e.g. brick, velvet). Default: brick
+  --character <slug>        Opponent character to load (e.g. brick, velvet). Default: brick
+  --pursuer-character <slug> OPTIONAL second real character driven as the pursuer
+                            through the SAME production prompt path (BuildOpponent).
+                            When set, the pursuer stays in character for the whole
+                            transcript (REACTIVE — no arc injection). When omitted,
+                            the pursuer falls back to --player-script (if given) or
+                            the generic lightweight LLM persona.
   --arc-shape <shape>       ingestion | romcom. Default: ingestion
   --polarity <on|off>       Enforce per-beat direction-of-change. Default: off
   --turns <n|range>         Turn count, e.g. 14 or 10-20 (range picks the high end,
@@ -42,6 +49,7 @@ Usage:
             }
 
             if (Get("--character") is string c) o.CharacterSlug = c;
+            if (Get("--pursuer-character") is string pc) o.PursuerCharacterSlug = pc;
 
             if (Get("--arc-shape") is string shape)
             {

--- a/src/Pinder.NarrativeHarness/HarnessRunner.cs
+++ b/src/Pinder.NarrativeHarness/HarnessRunner.cs
@@ -15,17 +15,20 @@ namespace Pinder.Tools.NarrativeHarness
     /// </summary>
     public sealed class HarnessRunner
     {
+        /// <summary>Speaker key used for the pursuer side in the transcript.</summary>
+        public const string PursuerSpeaker = "Pursuer";
+
         private readonly ILlmTransport _transport;
         private readonly LoadedCharacter _character;
         private readonly ConfessionMenu _menu;
         private readonly GameDefinition _baseDef;
         private readonly IArcStrategy _strategy;
         private readonly HarnessOptions _opts;
-        private readonly List<string>? _scripted;
+        private readonly IPursuerActor _pursuer;
 
         public HarnessRunner(ILlmTransport transport, LoadedCharacter character,
             ConfessionMenu menu, GameDefinition baseDef, IArcStrategy strategy,
-            HarnessOptions opts, List<string>? scripted)
+            HarnessOptions opts, IPursuerActor pursuer)
         {
             _transport = transport;
             _character = character;
@@ -33,7 +36,7 @@ namespace Pinder.Tools.NarrativeHarness
             _baseDef = baseDef;
             _strategy = strategy;
             _opts = opts;
-            _scripted = scripted;
+            _pursuer = pursuer ?? throw new ArgumentNullException(nameof(pursuer));
         }
 
         public async Task<string> RunAsync()
@@ -45,11 +48,11 @@ namespace Pinder.Tools.NarrativeHarness
             // ── Header ────────────────────────────────────────────────────
             doc.AppendLine($"# Narrative Harness Transcript — {_character.Name}");
             doc.AppendLine();
-            doc.AppendLine($"- **Character:** {_opts.CharacterSlug} ({_character.Name})");
+            doc.AppendLine($"- **Opponent character:** {_opts.CharacterSlug} ({_character.Name}) — replies via SessionSystemPromptBuilder.BuildOpponent (arc-injected)");
+            doc.AppendLine($"- **Pursuer side:** {_pursuer.HeaderLabel}");
             doc.AppendLine($"- **Arc shape:** {_strategy.Name}");
             doc.AppendLine($"- **Polarity:** {(_opts.PolarityOn ? "on" : "off")}");
             doc.AppendLine($"- **Turns:** {_opts.Turns}");
-            doc.AppendLine($"- **Pursuer:** {(_scripted != null ? "scripted (--player-script)" : "LLM")}");
             doc.AppendLine($"- **Model:** claude-opus-4-8 (real Anthropic adapter)");
             doc.AppendLine($"- **Rule paths:** NONE — SessionSystemPromptBuilder → AnthropicTransport only (no Pinder.Rules).");
             doc.AppendLine($"- **Generated:** {DateTime.UtcNow:yyyy-MM-dd HH:mm}Z");
@@ -73,10 +76,9 @@ namespace Pinder.Tools.NarrativeHarness
             doc.AppendLine("## Conversation");
             doc.AppendLine();
 
-            // Pursuer opens with a neutral hook.
-            string pursuerLine = _scripted != null && _scripted.Count > 0
-                ? _scripted[0]
-                : "hey — your profile actually made me laugh out loud, which never happens. so what's the most ridiculous thing that's happened to you this week?";
+            // Pursuer opens with its own opening line (character / scripted / generic).
+            string pursuerLine = await _pursuer.OpeningLineAsync()
+                ?? "hey — your profile actually made me laugh out loud, which never happens. so what's the most ridiculous thing that's happened to you this week?";
 
             for (int turn = 1; turn <= _opts.Turns; turn++)
             {
@@ -84,7 +86,7 @@ namespace Pinder.Tools.NarrativeHarness
                 ArcDirective directive = _strategy.DirectiveFor(ctx);
 
                 // ── PURSUER turn (record the line we're sending in) ───────
-                transcript.Add(("Pursuer", pursuerLine));
+                transcript.Add((PursuerSpeaker, pursuerLine));
 
                 // ── CHARACTER turn via REAL builder + REAL transport ──────
                 GameDefinition turnDef = GameDefinitionArcInjector.WithArc(_baseDef, directive.ArcText);
@@ -116,16 +118,10 @@ namespace Pinder.Tools.NarrativeHarness
 
                 if (turn >= _opts.Turns) break;
 
-                // ── Next pursuer line: scripted or LLM ────────────────────
-                if (_scripted != null)
-                {
-                    if (turn < _scripted.Count) pursuerLine = _scripted[turn];
-                    else break; // ran out of scripted lines
-                }
-                else
-                {
-                    pursuerLine = await GeneratePursuerLineAsync(transcript, turn);
-                }
+                // ── Next pursuer line: character / scripted / generic LLM ──
+                string? next = await _pursuer.NextLineAsync(transcript, turn);
+                if (next == null) break; // pursuer has nothing more (e.g. scripted ran out)
+                pursuerLine = next;
             }
 
             // ── Footer summary ────────────────────────────────────────────
@@ -196,59 +192,23 @@ namespace Pinder.Tools.NarrativeHarness
         }
 
         /// <summary>
-        /// User-message turn the character model answers: the running conversation
-        /// rendered as a chat log, ending on the pursuer's latest line. This is
-        /// the only "state" — no engine state, no rolls.
+        /// User-message turn the character (opponent) model answers: the running
+        /// conversation rendered as a chat log, ending on the pursuer's latest
+        /// line. This is the only "state" — no engine state, no rolls. The
+        /// pursuer side mirrors this in <see cref="CharacterPursuerActor"/>.
         /// </summary>
-        private string BuildCharacterUserMessage(List<(string Speaker, string Text)> transcript, string latestPursuer)
+        internal string BuildCharacterUserMessage(List<(string Speaker, string Text)> transcript, string latestPursuer)
         {
             var sb = new StringBuilder();
             sb.AppendLine("You are texting on a dating app. This is the conversation so far. "
                 + "Reply ONLY as yourself, in one natural text message (1-4 sentences). "
                 + "Do not narrate or use stage directions.");
             sb.AppendLine();
-            // Replay everything except the just-added latest pursuer line, which
-            // we present as the prompt to answer.
-            var history = transcript.Take(transcript.Count).ToList();
-            foreach (var (speaker, text) in history)
+            foreach (var (speaker, text) in transcript)
                 sb.AppendLine($"{speaker}: {text}");
             sb.AppendLine();
             sb.AppendLine($"{_character.Name}:");
             return sb.ToString();
-        }
-
-        /// <summary>
-        /// Simulated pursuer: a lightweight standalone persona (NOT the real
-        /// builder — only the CHARACTER side must go through the production
-        /// builder). Keeps the conversation dynamic.
-        /// </summary>
-        private async Task<string> GeneratePursuerLineAsync(List<(string Speaker, string Text)> transcript, int turn)
-        {
-            string pursuerSystem =
-                "You are a witty, curious person texting someone on a dating app. You find them "
-                + "intriguing and you gently dig deeper — ask real questions, share a little, tease, "
-                + "and follow the emotional thread. Reply ONLY as yourself in one short text message "
-                + "(1-2 sentences). No narration, no stage directions.";
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Conversation so far:");
-            foreach (var (speaker, text) in transcript)
-                sb.AppendLine($"{speaker}: {text}");
-            sb.AppendLine();
-            sb.AppendLine("Pursuer:");
-
-            try
-            {
-                string line = await _transport.SendAsync(
-                    pursuerSystem, sb.ToString(), temperature: 0.95, maxTokens: 200,
-                    phase: $"harness-pursuer-{turn}");
-                line = (line ?? "").Trim();
-                return line.Length > 0 ? line : "tell me more — i mean it.";
-            }
-            catch (Exception ex)
-            {
-                return $"[pursuer transport error: {ex.Message}]";
-            }
         }
     }
 }

--- a/src/Pinder.NarrativeHarness/PursuerActor.cs
+++ b/src/Pinder.NarrativeHarness/PursuerActor.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+
+namespace Pinder.Tools.NarrativeHarness
+{
+    /// <summary>
+    /// The pursuer side of the harness conversation, factored out of
+    /// <see cref="HarnessRunner"/> so the runner stays small and so each pursuer
+    /// strategy is independently testable (#855).
+    ///
+    /// Three implementations exist:
+    ///   • <see cref="CharacterPursuerActor"/> — a REAL Pinder character driven
+    ///     through the SAME production prompt path the opponent uses
+    ///     (<see cref="SessionSystemPromptBuilder.BuildOpponent"/>), staying in
+    ///     character for the whole transcript.
+    ///   • <see cref="ScriptedPursuerActor"/> — fixed lines from --player-script.
+    ///   • <see cref="GenericLlmPursuerActor"/> — the legacy lightweight standalone
+    ///     persona (NOT a real character); the single-character fallback.
+    ///
+    /// ZERO rule paths: identical contract to the opponent side
+    /// (build-prompt -&gt; SendAsync -&gt; record). Nothing here references
+    /// Pinder.Rules.
+    /// </summary>
+    public interface IPursuerActor
+    {
+        /// <summary>One-line description for the transcript header (which side / which character).</summary>
+        string HeaderLabel { get; }
+
+        /// <summary>The pursuer's opening line. Null means "no opening available" (caller supplies a default).</summary>
+        Task<string?> OpeningLineAsync();
+
+        /// <summary>
+        /// Produce the pursuer's next line given the running transcript. Returns
+        /// null to signal the pursuer has nothing more to say (e.g. a scripted
+        /// run ran out of lines), which ends the conversation.
+        /// </summary>
+        Task<string?> NextLineAsync(IReadOnlyList<(string Speaker, string Text)> transcript, int turn);
+    }
+
+    /// <summary>
+    /// REAL second character. Driven through the production opponent prompt path
+    /// (BuildOpponent) with its OWN assembled system prompt, so it stays in
+    /// character across the whole transcript. It maintains its own conversation
+    /// view: its own opponent-style system prompt, with the OTHER side's lines
+    /// fed in as the inbound messages — mirroring the opponent side exactly.
+    ///
+    /// ARC DESIGN DECISION (#855): the pursuer is REACTIVE — it gets NO separate
+    /// arc / confession-menu injection. It is built from the BASE GameDefinition
+    /// (no <c>== CONVERSATION ARC ==</c> slot populated), so only the OPPONENT
+    /// carries the experiment's arc. This is the cleanest REVERSIBLE default:
+    /// the opponent's arc remains the single independent variable (no confound
+    /// from two simultaneously-driven arcs), and a symmetric pursuer arc can be
+    /// added later by passing an arc-injected GameDefinition here instead of the
+    /// base one — a one-line change. See the PR body for the full rationale.
+    /// </summary>
+    public sealed class CharacterPursuerActor : IPursuerActor
+    {
+        private readonly ILlmTransport _transport;
+        private readonly string _assembledSystemPrompt;
+        private readonly string _displayName;
+        private readonly string _slug;
+        private readonly GameDefinition _baseDef;
+
+        public CharacterPursuerActor(ILlmTransport transport, string assembledSystemPrompt,
+            string displayName, string slug, GameDefinition baseDef)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _assembledSystemPrompt = assembledSystemPrompt ?? throw new ArgumentNullException(nameof(assembledSystemPrompt));
+            _displayName = displayName;
+            _slug = slug;
+            _baseDef = baseDef ?? throw new ArgumentNullException(nameof(baseDef));
+        }
+
+        public string HeaderLabel =>
+            $"LLM character — {_slug} ({_displayName}) via SessionSystemPromptBuilder.BuildOpponent (REACTIVE, no arc injection)";
+
+        /// <summary>
+        /// The opponent-style system prompt for the pursuer character. Built from
+        /// the BASE game definition (no arc text) — see the arc design note above.
+        /// </summary>
+        private string SystemPrompt() =>
+            SessionSystemPromptBuilder.BuildOpponent(_assembledSystemPrompt, _baseDef);
+
+        public async Task<string?> OpeningLineAsync()
+        {
+            string userMessage =
+                "You are texting on a dating app and you are sending the FIRST message to "
+                + "someone whose profile you just saw and liked. Open the conversation in one "
+                + "natural text message (1-2 sentences), fully in character. Do not narrate or "
+                + "use stage directions.\n\n" + _displayName + ":";
+            return await SendAsync(userMessage, "harness-pursuer-open").ConfigureAwait(false);
+        }
+
+        public async Task<string?> NextLineAsync(IReadOnlyList<(string Speaker, string Text)> transcript, int turn)
+        {
+            string userMessage = BuildPursuerUserMessage(transcript);
+            return await SendAsync(userMessage, $"harness-pursuer-char-{turn}").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// The pursuer's conversation view: the running transcript rendered as a
+        /// chat log from the pursuer's perspective (its own "Pursuer"-keyed lines
+        /// relabelled to its name; the opponent's lines kept as the inbound
+        /// messages), ending on the pursuer's name prompt. Mirrors the opponent
+        /// side's <see cref="HarnessRunner.BuildCharacterUserMessage"/>.
+        /// </summary>
+        private string BuildPursuerUserMessage(IReadOnlyList<(string Speaker, string Text)> transcript)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("You are texting on a dating app. This is the conversation so far. "
+                + "Reply ONLY as yourself, in one natural text message (1-4 sentences). "
+                + "Do not narrate or use stage directions.");
+            sb.AppendLine();
+            foreach (var (speaker, text) in transcript)
+            {
+                string who = speaker == HarnessRunner.PursuerSpeaker ? _displayName : speaker;
+                sb.AppendLine($"{who}: {text}");
+            }
+            sb.AppendLine();
+            sb.AppendLine($"{_displayName}:");
+            return sb.ToString();
+        }
+
+        private async Task<string?> SendAsync(string userMessage, string phase)
+        {
+            try
+            {
+                string reply = await _transport.SendAsync(
+                    SystemPrompt(), userMessage, temperature: 0.9, maxTokens: 512, phase: phase)
+                    .ConfigureAwait(false);
+                reply = (reply ?? "").Trim();
+                return reply.Length > 0 ? reply : null;
+            }
+            catch (Exception ex)
+            {
+                return $"[pursuer transport error: {ex.Message}]";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scripted pursuer: fixed lines supplied via --player-script. Kept working
+    /// as an alternative to a pursuer character (#855 back-compat requirement).
+    /// </summary>
+    public sealed class ScriptedPursuerActor : IPursuerActor
+    {
+        private readonly List<string> _lines;
+
+        public ScriptedPursuerActor(List<string> lines)
+        {
+            _lines = lines ?? new List<string>();
+        }
+
+        public string HeaderLabel => "scripted (--player-script)";
+
+        public Task<string?> OpeningLineAsync() =>
+            Task.FromResult(_lines.Count > 0 ? _lines[0] : null);
+
+        public Task<string?> NextLineAsync(IReadOnlyList<(string Speaker, string Text)> transcript, int turn)
+        {
+            // turn is 1-based; line index for the *next* turn is `turn`.
+            return Task.FromResult(turn < _lines.Count ? _lines[turn] : null);
+        }
+    }
+
+    /// <summary>
+    /// Legacy lightweight standalone persona — NOT a real character. This is the
+    /// single-character fallback (no --pursuer-character given) and preserves the
+    /// pre-#855 behaviour verbatim so nothing regresses.
+    /// </summary>
+    public sealed class GenericLlmPursuerActor : IPursuerActor
+    {
+        private readonly ILlmTransport _transport;
+
+        private const string PursuerSystem =
+            "You are a witty, curious person texting someone on a dating app. You find them "
+            + "intriguing and you gently dig deeper — ask real questions, share a little, tease, "
+            + "and follow the emotional thread. Reply ONLY as yourself in one short text message "
+            + "(1-2 sentences). No narration, no stage directions.";
+
+        public GenericLlmPursuerActor(ILlmTransport transport)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        }
+
+        public string HeaderLabel => "generic LLM persona (NOT a real character)";
+
+        public Task<string?> OpeningLineAsync() =>
+            Task.FromResult<string?>(
+                "hey — your profile actually made me laugh out loud, which never happens. "
+                + "so what's the most ridiculous thing that's happened to you this week?");
+
+        public async Task<string?> NextLineAsync(IReadOnlyList<(string Speaker, string Text)> transcript, int turn)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Conversation so far:");
+            foreach (var (speaker, text) in transcript)
+                sb.AppendLine($"{speaker}: {text}");
+            sb.AppendLine();
+            sb.AppendLine("Pursuer:");
+
+            try
+            {
+                string line = await _transport.SendAsync(
+                    PursuerSystem, sb.ToString(), temperature: 0.95, maxTokens: 200,
+                    phase: $"harness-pursuer-{turn}").ConfigureAwait(false);
+                line = (line ?? "").Trim();
+                return line.Length > 0 ? line : "tell me more — i mean it.";
+            }
+            catch (Exception ex)
+            {
+                return $"[pursuer transport error: {ex.Message}]";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Selects the pursuer strategy. Precedence (#855):
+    ///   1. a real pursuer CHARACTER (when its assembled prompt is supplied),
+    ///   2. else a SCRIPTED pursuer (--player-script),
+    ///   3. else the GENERIC LLM persona (single-character fallback).
+    /// Pure selection — no file IO — so it is unit-testable.
+    /// </summary>
+    public static class PursuerActorFactory
+    {
+        public static IPursuerActor Create(
+            ILlmTransport transport,
+            List<string>? scriptedLines,
+            string? pursuerAssembledPrompt,
+            string? pursuerDisplayName,
+            string? pursuerSlug,
+            GameDefinition baseDef)
+        {
+            if (pursuerAssembledPrompt != null)
+                return new CharacterPursuerActor(
+                    transport, pursuerAssembledPrompt,
+                    pursuerDisplayName ?? pursuerSlug ?? "Pursuer",
+                    pursuerSlug ?? "pursuer", baseDef);
+
+            if (scriptedLines != null)
+                return new ScriptedPursuerActor(scriptedLines);
+
+            return new GenericLlmPursuerActor(transport);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue855_TwoCharacterHarnessTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue855_TwoCharacterHarnessTests.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Pinder.Tools.NarrativeHarness;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #855: the Narrative harness can drive BOTH sides as real Pinder
+    /// characters that stay in character for the whole conversation. These
+    /// regression tests pin the pursuer-side wiring:
+    ///   • two-character mode → the pursuer is a real character driven through
+    ///     the SAME production prompt path as the opponent (BuildOpponent);
+    ///   • single-character fallback → the generic lightweight LLM persona
+    ///     (NOT a real character) is used, exactly as before;
+    ///   • scripted mode (--player-script) → fixed lines, no transport calls.
+    ///
+    /// Deterministic: the LLM is stubbed by <see cref="RecordingTransport"/>
+    /// (same pattern as #340/#831) — no real network calls.
+    /// </summary>
+    public class Issue855_TwoCharacterHarnessTests
+    {
+        // A small but recognizable "assembled system prompt" for the pursuer
+        // character — its presence in the system prompt proves the production
+        // BuildOpponent path was used.
+        private const string PursuerAssembledPrompt =
+            "You are Velvet_99, a velvet-voiced romantic who never breaks character.";
+
+        // ── 1. Two-character mode: pursuer uses the BuildOpponent path ────────
+
+        [Fact]
+        public void Factory_with_pursuer_character_returns_character_actor()
+        {
+            var transport = new RecordingTransport("reply");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: PursuerAssembledPrompt,
+                pursuerDisplayName: "Velvet_99", pursuerSlug: "velvet",
+                baseDef: GameDefinition.PinderDefaults);
+
+            Assert.IsType<CharacterPursuerActor>(actor);
+            Assert.Contains("velvet", actor.HeaderLabel);
+            Assert.Contains("BuildOpponent", actor.HeaderLabel);
+        }
+
+        [Fact]
+        public async Task Character_pursuer_drives_BuildOpponent_system_prompt_with_its_own_profile()
+        {
+            var transport = new RecordingTransport("hey, I noticed you too.");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: PursuerAssembledPrompt,
+                pursuerDisplayName: "Velvet_99", pursuerSlug: "velvet",
+                baseDef: GameDefinition.PinderDefaults);
+
+            var transcript = new List<(string, string)>
+            {
+                ("Pursuer", "opening"),
+                ("Opponent", "a reply from the opponent"),
+            };
+            string? line = await actor.NextLineAsync(transcript, turn: 1);
+
+            Assert.Equal("hey, I noticed you too.", line);
+            // The system prompt is the REAL production opponent prompt for the
+            // pursuer character — proven by the OPPONENT CHARACTER section and
+            // the pursuer's own assembled profile text appearing in it.
+            Assert.NotNull(transport.LastSystem);
+            Assert.Contains("== OPPONENT CHARACTER ==", transport.LastSystem!);
+            Assert.Contains(PursuerAssembledPrompt, transport.LastSystem!);
+            // It is NOT the generic-persona prompt.
+            Assert.DoesNotContain("witty, curious person texting", transport.LastSystem!);
+        }
+
+        [Fact]
+        public async Task Character_pursuer_is_reactive_no_arc_injection()
+        {
+            // ARC DESIGN DECISION (#855): the pursuer is REACTIVE — built from the
+            // BASE game definition with NO arc text, so its system prompt carries
+            // no "== CONVERSATION ARC ==" section. Only the opponent carries the
+            // experiment's arc. This pins that reversible default.
+            var transport = new RecordingTransport("reactive line");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: PursuerAssembledPrompt,
+                pursuerDisplayName: "Velvet_99", pursuerSlug: "velvet",
+                baseDef: GameDefinition.PinderDefaults);
+
+            await actor.NextLineAsync(new List<(string, string)> { ("Pursuer", "hi") }, turn: 1);
+
+            Assert.NotNull(transport.LastSystem);
+            Assert.DoesNotContain("== CONVERSATION ARC ==", transport.LastSystem!);
+        }
+
+        [Fact]
+        public async Task Character_pursuer_relabels_its_own_lines_to_its_name_in_its_view()
+        {
+            // Each side maintains its OWN conversation view: the pursuer sees its
+            // own "Pursuer"-keyed lines under its display name, the opponent's
+            // lines as the inbound messages.
+            var transport = new RecordingTransport("ok");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: PursuerAssembledPrompt,
+                pursuerDisplayName: "Velvet_99", pursuerSlug: "velvet",
+                baseDef: GameDefinition.PinderDefaults);
+
+            var transcript = new List<(string, string)>
+            {
+                ("Pursuer", "my earlier line"),
+                ("Brick_77", "the opponent answered"),
+            };
+            await actor.NextLineAsync(transcript, turn: 2);
+
+            Assert.NotNull(transport.LastUser);
+            Assert.Contains("Velvet_99: my earlier line", transport.LastUser!);
+            Assert.Contains("Brick_77: the opponent answered", transport.LastUser!);
+            Assert.DoesNotContain("Pursuer: my earlier line", transport.LastUser!);
+        }
+
+        // ── 2. Single-character fallback: generic LLM persona ────────────────
+
+        [Fact]
+        public void Factory_without_pursuer_or_script_returns_generic_actor()
+        {
+            var transport = new RecordingTransport("reply");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: null, pursuerDisplayName: null,
+                pursuerSlug: null, baseDef: GameDefinition.PinderDefaults);
+
+            Assert.IsType<GenericLlmPursuerActor>(actor);
+            Assert.Contains("NOT a real character", actor.HeaderLabel);
+        }
+
+        [Fact]
+        public async Task Generic_pursuer_uses_lightweight_standalone_persona()
+        {
+            var transport = new RecordingTransport("tell me more");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: null,
+                pursuerAssembledPrompt: null, pursuerDisplayName: null,
+                pursuerSlug: null, baseDef: GameDefinition.PinderDefaults);
+
+            string? line = await actor.NextLineAsync(
+                new List<(string, string)> { ("Pursuer", "hi"), ("Opponent", "hey") }, turn: 1);
+
+            Assert.Equal("tell me more", line);
+            // The generic persona — NOT a production character prompt.
+            Assert.NotNull(transport.LastSystem);
+            Assert.Contains("witty, curious person texting", transport.LastSystem!);
+            Assert.DoesNotContain("== OPPONENT CHARACTER ==", transport.LastSystem!);
+        }
+
+        // ── 3. Scripted mode still works ─────────────────────────────────────
+
+        [Fact]
+        public void Factory_with_script_and_no_pursuer_character_returns_scripted_actor()
+        {
+            var transport = new RecordingTransport("unused");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: new List<string> { "a", "b" },
+                pursuerAssembledPrompt: null, pursuerDisplayName: null,
+                pursuerSlug: null, baseDef: GameDefinition.PinderDefaults);
+
+            Assert.IsType<ScriptedPursuerActor>(actor);
+            Assert.Contains("scripted", actor.HeaderLabel);
+        }
+
+        [Fact]
+        public async Task Scripted_pursuer_returns_lines_in_order_then_ends_with_no_transport_calls()
+        {
+            var transport = new RecordingTransport("SHOULD NOT BE CALLED");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: new List<string> { "line one", "line two" },
+                pursuerAssembledPrompt: null, pursuerDisplayName: null,
+                pursuerSlug: null, baseDef: GameDefinition.PinderDefaults);
+
+            var transcript = new List<(string, string)>();
+            Assert.Equal("line one", await actor.OpeningLineAsync());
+            Assert.Equal("line two", await actor.NextLineAsync(transcript, turn: 1));
+            // Ran out of lines → null ends the conversation.
+            Assert.Null(await actor.NextLineAsync(transcript, turn: 2));
+            Assert.Equal(0, transport.CallCount);
+        }
+
+        // ── 4. Precedence: pursuer character beats a script if both given ────
+
+        [Fact]
+        public void Factory_pursuer_character_takes_precedence_over_script()
+        {
+            var transport = new RecordingTransport("reply");
+            IPursuerActor actor = PursuerActorFactory.Create(
+                transport, scriptedLines: new List<string> { "scripted" },
+                pursuerAssembledPrompt: PursuerAssembledPrompt,
+                pursuerDisplayName: "Velvet_99", pursuerSlug: "velvet",
+                baseDef: GameDefinition.PinderDefaults);
+
+            Assert.IsType<CharacterPursuerActor>(actor);
+        }
+
+        // ── Recording transport (mirror of #340/#831 pattern) ────────────────
+
+        private sealed class RecordingTransport : ILlmTransport
+        {
+            private readonly string _response;
+
+            public string? LastSystem { get; private set; }
+            public string? LastUser { get; private set; }
+            public int CallCount { get; private set; }
+
+            public RecordingTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
+            {
+                CallCount++;
+                LastSystem = systemPrompt;
+                LastUser = userMessage;
+                return Task.FromResult(_response);
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
+++ b/tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
+    <ProjectReference Include="..\..\src\Pinder.NarrativeHarness\Pinder.NarrativeHarness.csproj" />
     <ProjectReference Include="..\..\src\Pinder.Rules\Pinder.Rules.csproj" />
     <ProjectReference Include="..\Pinder.Core.TestCommon\Pinder.Core.TestCommon.csproj" />
   </ItemGroup>

--- a/tools/NarrativeHarness/Program.cs
+++ b/tools/NarrativeHarness/Program.cs
@@ -85,7 +85,31 @@ namespace Pinder.Tools.NarrativeHarness
                     .ToList();
             }
 
-            var runner = new HarnessRunner(transport, character, menu, baseDef, strategy, opts, scriptedLines);
+            // ── Optional REAL pursuer character (#855) ────────────────────
+            // When --pursuer-character is set, the pursuer is a real Pinder
+            // character driven through the SAME production prompt path as the
+            // opponent (BuildOpponent). It takes precedence over both the
+            // scripted and the generic-LLM pursuer.
+            LoadedCharacter? pursuerCharacter = null;
+            if (opts.PursuerCharacterSlug != null)
+            {
+                try { pursuerCharacter = HarnessCharacterLoader.Load(opts.PursuerCharacterSlug); }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine("[ERROR] Pursuer character load failed: " + ex.Message);
+                    return 1;
+                }
+            }
+
+            IPursuerActor pursuer = PursuerActorFactory.Create(
+                transport,
+                scriptedLines,
+                pursuerCharacter?.AssembledSystemPrompt,
+                pursuerCharacter?.Name,
+                opts.PursuerCharacterSlug,
+                baseDef);
+
+            var runner = new HarnessRunner(transport, character, menu, baseDef, strategy, opts, pursuer);
             string transcript = await runner.RunAsync();
 
             // ── Write out ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Replaces the generic "simulated pursuer" in `Pinder.NarrativeHarness` with a pluggable pursuer abstraction so the testbed can drive a **real second Pinder character** that stays in character for the whole transcript. Engine portion of decay256/pinder-web#855.

- New `IPursuerActor` abstraction (`PursuerActor.cs`) with three implementations:
  - `CharacterPursuerActor` — a real character driven through the SAME production prompt path as the opponent (`SessionSystemPromptBuilder.BuildOpponent` with that character's assembled system prompt). Stays in character every turn.
  - `ScriptedPursuerActor` — `--player-script` lines (unchanged behaviour, now isolated).
  - `GenericLlmPursuerActor` — the prior lightweight LLM persona (single-character fallback, nothing regresses).
- `PursuerActorFactory.Create` picks precedence: **pursuer-character > scripted > generic**.
- New CLI flag `--pursuer-character <slug>` (`--character` stays the opponent, back-compat).
- Transcript header now names BOTH sides (opponent slug + pursuer side label).
- `HarnessRunner` no longer owns pursuer logic — it consumes `IPursuerActor` (`OpeningLineAsync` / `NextLineAsync`).

## Design decision (reversible default)
**Pursuer is REACTIVE and gets NO arc/confession injection** — only the opponent side receives the per-beat arc directive. This is the cleanest reversible default: it keeps a single arc "spine" for the conversation and avoids two arcs fighting. The `CharacterPursuerActor.HeaderLabel` states this explicitly in every transcript. Adding a symmetric pursuer arc later is a localized change (give the actor its own `IArcStrategy`).

## ZERO Pinder.Rules invariant
Preserved. `Pinder.NarrativeHarness.csproj` still carries the "deliberately does NOT reference Pinder.Rules" guard comment and gains no new reference.

## DoD Evidence (local — NO GitHub CI)
- `dotnet build src/Pinder.NarrativeHarness` → **Build succeeded. 0 Warning(s), 0 Error(s)**.
- `dotnet build tests/Pinder.LlmAdapters.Tests` → 0 Errors (155 pre-existing nullable/xUnit-analyzer warnings only).
- `dotnet test --filter Issue855` → **Passed! Failed: 0, Passed: 9, Skipped: 0**.
- `dotnet test tests/Pinder.LlmAdapters.Tests` (full) → **Passed! Failed: 0, Passed: 1156, Skipped: 9, Total: 1165** (no regression).

## Research Log
- Read HarnessRunner.cs / HarnessOptions.cs / Program.cs / SessionSystemPromptBuilder.cs.
- Confirmed `BuildOpponent` is the production prompt path; mirrored it for the pursuer side (each side maintains its own conversation view, the other side's lines fed in as inbound).
- Tests stub the LLM transport (no network) following existing harness test patterns.

Part of decay256/pinder-web#855 (engine portion). pinder-web consumption (controller + proxy + admin second-dropdown + submodule bump) follows in a separate pinder-web PR.
