### PR TITLE
feat(#864): add editable narrative.yaml prompt + NarrativePromptLoader (additive)

### DIFF
--- a/data/prompts/narrative.yaml
+++ b/data/prompts/narrative.yaml
@@ -1,0 +1,34 @@
+# Editable narrative-testbed prompt. Injected verbatim into the opponent's
+# == CONVERSATION ARC == slot every turn. The confession menu is appended
+# automatically by the harness — do NOT paste it here.
+#
+# schema_version is present ONLY so the production PromptCatalog (which scans
+# every data/prompts/*.yaml) accepts this file and skips it (it carries no
+# `prompts:` block). The meaningful payload is the single `narrative_prompt`
+# key, read by NarrativePromptLoader.
+schema_version: 1
+narrative_prompt: |
+  == Opportunistic confession arc ==
+
+  You are carrying a set of confessions — pre-summarized truths about yourself,
+  each with its own emotional depth. The full menu is laid out for you below.
+  All of it is available to you on every turn. Nothing is scheduled, and nothing
+  is forced: you reach for material opportunistically, only when a moment in the
+  conversation genuinely invites it.
+
+  Guidance:
+  - Let the depth of what you share rise naturally as the conversation earns it.
+    Early on, you tend to stay lighter; as trust and intimacy build, heavier and
+    rawer truths stop being off-limits. This is a soft pull, never a schedule —
+    you do not have to escalate, and staying light is always allowed.
+  - Match your register to the depth of whatever you actually reach for. Light
+    material stays easy and playful; tender material softens and slows; raw
+    material is spare, unguarded, and costs you something to say.
+  - Let the emotional temperature shift on its own. If things have been warming,
+    a flicker of doubt or self-protection is realistic; if you have been guarded,
+    a small thaw is realistic. Do not announce these shifts — just live them.
+  - Never dump the list. At most touch one confession in a turn, and only if it
+    truly fits the moment. Deflecting, deflecting again, or simply staying on the
+    surface is completely fine and realistic.
+
+  You self-select. The conversation, not a timer, decides what surfaces.

--- a/src/Pinder.NarrativeHarness/NarrativePromptLoader.cs
+++ b/src/Pinder.NarrativeHarness/NarrativePromptLoader.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using YamlDotNet.RepresentationModel;
+
+namespace Pinder.Tools.NarrativeHarness
+{
+    /// <summary>
+    /// Loads the editable narrative-testbed prompt from
+    /// <c>data/prompts/narrative.yaml</c>. Resolves the file the SAME way the
+    /// rest of the harness locates data (<see cref="HarnessDataLocator"/> —
+    /// honors PINDER_DATA_PATH, walks up from the base dir, tolerates casing).
+    ///
+    /// The YAML carries a single top-level scalar key <c>narrative_prompt</c>
+    /// holding a multi-line block. This loader reads that value verbatim; it is
+    /// purely additive and nothing in the harness consumes it yet.
+    /// </summary>
+    public static class NarrativePromptLoader
+    {
+        private const string RelativePath = "data/prompts/narrative.yaml";
+        private const string KeyName = "narrative_prompt";
+
+        /// <summary>
+        /// Resolve and read the narrative prompt using the harness base dir
+        /// (<see cref="AppContext.BaseDirectory"/>).
+        /// </summary>
+        public static string Load() => Load(AppContext.BaseDirectory);
+
+        /// <summary>
+        /// Resolve and read the narrative prompt, starting the data search from
+        /// <paramref name="baseDir"/>.
+        /// </summary>
+        /// <exception cref="FileNotFoundException">
+        /// Thrown with locator context when narrative.yaml cannot be found.
+        /// </exception>
+        public static string Load(string baseDir)
+        {
+            string relative = Path.Combine("data", "prompts", "narrative.yaml");
+            string? path = HarnessDataLocator.FindDataFile(baseDir, relative);
+            if (path == null)
+            {
+                throw new FileNotFoundException(
+                    $"Could not find {RelativePath} on the harness locator paths " +
+                    $"(searched from baseDir '{baseDir}', honoring PINDER_DATA_PATH). " +
+                    "The editable narrative prompt is required to seed the opponent's " +
+                    "== CONVERSATION ARC == slot.");
+            }
+
+            string text = File.ReadAllText(path);
+
+            string value = ParseNarrativePrompt(text, path);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidDataException(
+                    $"'{KeyName}' in {path} is missing or empty. It must hold a " +
+                    "non-empty multi-line narrative prompt.");
+            }
+
+            return value;
+        }
+
+        private static string ParseNarrativePrompt(string yamlText, string path)
+        {
+            var stream = new YamlStream();
+            using (var reader = new StringReader(yamlText))
+            {
+                stream.Load(reader);
+            }
+
+            if (stream.Documents.Count == 0)
+            {
+                throw new InvalidDataException(
+                    $"{path} is empty or contains no YAML document.");
+            }
+
+            if (!(stream.Documents[0].RootNode is YamlMappingNode root))
+            {
+                throw new InvalidDataException(
+                    $"{path} root must be a mapping with a top-level '{KeyName}' key.");
+            }
+
+            foreach (var entry in root.Children)
+            {
+                if (entry.Key is YamlScalarNode k && k.Value == KeyName)
+                {
+                    if (entry.Value is YamlScalarNode v)
+                        return v.Value ?? string.Empty;
+
+                    throw new InvalidDataException(
+                        $"'{KeyName}' in {path} must be a scalar (multi-line) value.");
+                }
+            }
+
+            throw new InvalidDataException(
+                $"{path} is missing the required top-level key '{KeyName}'.");
+        }
+    }
+}

--- a/src/Pinder.NarrativeHarness/Pinder.NarrativeHarness.csproj
+++ b/src/Pinder.NarrativeHarness/Pinder.NarrativeHarness.csproj
@@ -15,6 +15,9 @@
   -->
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <!-- Explicit: NarrativePromptLoader uses YamlDotNet. Pinned to match
+         Pinder.LlmAdapters so the dep is not silently transitive (#864). -->
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <ProjectReference Include="..\Pinder.Core\Pinder.Core.csproj" />
     <ProjectReference Include="..\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />
     <ProjectReference Include="..\Pinder.SessionSetup\Pinder.SessionSetup.csproj" />

--- a/tests/Pinder.LlmAdapters.Tests/Issue864_NarrativePromptLoaderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue864_NarrativePromptLoaderTests.cs
@@ -1,0 +1,27 @@
+using Pinder.Tools.NarrativeHarness;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #864: the editable narrative-testbed prompt
+    /// (data/prompts/narrative.yaml) is loadable through the harness data
+    /// locator and surfaces a non-empty multi-line default. Additive — nothing
+    /// consumes the loader yet, so this pins only that the file + loader resolve.
+    /// </summary>
+    public class Issue864_NarrativePromptLoaderTests
+    {
+        [Fact]
+        public void Load_returns_non_empty_default_prompt()
+        {
+            string prompt = NarrativePromptLoader.Load();
+
+            Assert.False(string.IsNullOrWhiteSpace(prompt));
+            // Multi-line block.
+            Assert.Contains("\n", prompt);
+            // Stable substrings migrated from the IngestionArcStrategy prose.
+            Assert.Contains("Opportunistic confession arc", prompt);
+            Assert.Contains("Never dump the list", prompt);
+        }
+    }
+}


### PR DESCRIPTION
Implements decay256/pinder-web#864 (engine work lives in pinder-core).

## What
Additive, editable narrative-testbed prompt + loader. **Nothing consumes the loader yet** — ArcStrategy/HarnessOptions are untouched (next ticket).

### `data/prompts/narrative.yaml`
- Single editable `narrative_prompt: |` multi-line block.
- Default text migrates the `IngestionArcStrategy` prose into **static, character-agnostic** English (no per-turn phase/register computation).
- Confession menu is appended by the harness — not pasted here.
- Declares `schema_version: 1` so the production `PromptCatalog` (which scans every `data/prompts/*.yaml`) accepts and skips it (no `prompts:` block). Documented inline.

### `src/Pinder.NarrativeHarness/NarrativePromptLoader.cs`
- Namespace `Pinder.Tools.NarrativeHarness`.
- Resolves the file via the existing `HarnessDataLocator.FindDataFile` pattern (honors `PINDER_DATA_PATH`, walks up, casing-tolerant) — no new path scheme.
- Reads `narrative_prompt` via YamlDotNet (already available transitively).
- Clear `FileNotFoundException` / `InvalidDataException` with context on missing file/key/empty value.
- `Load()` and `Load(baseDir)`.

### Test
- `Issue864_NarrativePromptLoaderTests` asserts `Load()` returns a non-empty multi-line string with stable default substrings.

## Verification
- `dotnet build -c Release` → Build succeeded, 0 Errors.
- `dotnet test` (Pinder.LlmAdapters.Tests) → Passed! Failed: 0, Passed: 1157, Skipped: 9, Total: 1166.
- narrative.yaml validated as YAML; `narrative_prompt` non-empty + multi-line.