### PR TITLE
feat(#869): capture raw LLM sessions in NarrativeHarness (core half)

### DIFF
--- a/src/Pinder.NarrativeHarness/HarnessRunResult.cs
+++ b/src/Pinder.NarrativeHarness/HarnessRunResult.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Tools.NarrativeHarness
+{
+    /// <summary>
+    /// The result returned by <see cref="HarnessRunner.RunAsync"/>.
+    ///
+    /// <para>
+    /// <b>Back-compat:</b> <see cref="Transcript"/> is byte-identical to what
+    /// <c>RunAsync</c> returned before this type was introduced (previously the
+    /// method returned <c>Task&lt;string&gt;</c>). Callers that only need the
+    /// markdown output access <c>result.Transcript</c>; callers that want the
+    /// structured LLM data access <c>result.RawSessions</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// <b><see cref="RawSessions"/>:</b> populated only when the
+    /// <see cref="HarnessRunner"/> was constructed with a transport that is (or is
+    /// wrapped in) a <see cref="RecordingLlmTransport"/>. When no recorder is
+    /// present the list is empty — this preserves the previous behaviour
+    /// transparently.
+    /// </para>
+    ///
+    /// <para>
+    /// netstandard2.0 / LangVersion 8.0 — intentionally a normal sealed class
+    /// (not a C# 9 <c>record</c>) for language-version compatibility.
+    /// </para>
+    /// </summary>
+    public sealed class HarnessRunResult
+    {
+        /// <summary>
+        /// The full annotated markdown transcript — identical to the string
+        /// previously returned by <c>RunAsync()</c>.
+        /// </summary>
+        public string Transcript { get; }
+
+        /// <summary>
+        /// Structured list of every raw LLM exchange captured during the run.
+        /// Empty when no <see cref="RecordingLlmTransport"/> was used.
+        /// </summary>
+        public IReadOnlyList<RawLlmSession> RawSessions { get; }
+
+        public HarnessRunResult(string transcript, IReadOnlyList<RawLlmSession> rawSessions)
+        {
+            Transcript  = transcript  ?? throw new ArgumentNullException(nameof(transcript));
+            RawSessions = rawSessions ?? throw new ArgumentNullException(nameof(rawSessions));
+        }
+    }
+}

--- a/src/Pinder.NarrativeHarness/HarnessRunner.cs
+++ b/src/Pinder.NarrativeHarness/HarnessRunner.cs
@@ -45,7 +45,7 @@ namespace Pinder.Tools.NarrativeHarness
             _narrativePrompt = NarrativePromptLoader.Load(AppContext.BaseDirectory);
         }
 
-        public async Task<string> RunAsync()
+        public async Task<HarnessRunResult> RunAsync()
         {
             var doc = new StringBuilder();
             var transcript = new List<(string Speaker, string Text)>();
@@ -142,7 +142,14 @@ namespace Pinder.Tools.NarrativeHarness
             }
             doc.AppendLine();
 
-            return doc.ToString();
+            // ── Collect raw sessions from a RecordingLlmTransport ────────────
+            IReadOnlyList<RawLlmSession> rawSessions;
+            if (_transport is RecordingLlmTransport rec)
+                rawSessions = rec.Sessions;
+            else
+                rawSessions = new RawLlmSession[0];
+
+            return new HarnessRunResult(doc.ToString(), rawSessions);
         }
 
         private void AppendTurnAnnotation(StringBuilder doc, int turn,

--- a/src/Pinder.NarrativeHarness/RawLlmSession.cs
+++ b/src/Pinder.NarrativeHarness/RawLlmSession.cs
@@ -1,0 +1,121 @@
+using System;
+
+namespace Pinder.Tools.NarrativeHarness
+{
+    /// <summary>
+    /// Captures one raw LLM exchange as driven by the Narrative Harness.
+    /// Populated by <see cref="RecordingLlmTransport"/> — one entry per
+    /// successful <c>SendAsync</c> call.
+    ///
+    /// <para>
+    /// <b>Speaker / Turn derivation from phase string:</b><br/>
+    ///   • <c>harness-turn-{n}</c>    → Speaker = "Character", Turn = n<br/>
+    ///   • <c>harness-pursuer-open</c> → Speaker = "Pursuer",   Turn = 0<br/>
+    ///   • <c>harness-pursuer-char-{n}</c> → Speaker = "Pursuer", Turn = n<br/>
+    ///   • <c>harness-pursuer-{n}</c>  → Speaker = "Pursuer",   Turn = n<br/>
+    ///   • anything else              → Speaker = "Unknown",   Turn = null<br/>
+    /// </para>
+    ///
+    /// <para>
+    /// netstandard2.0 / LangVersion 8.0 — intentionally a normal sealed class
+    /// (not a C# 9 <c>record</c>) to remain compatible with the project's
+    /// LangVersion constraint.
+    /// </para>
+    /// </summary>
+    public sealed class RawLlmSession
+    {
+        /// <summary>
+        /// Conversation turn number.  Null for phases that cannot be mapped to a
+        /// specific turn (e.g. unknown / future phase strings).
+        /// </summary>
+        public int? Turn { get; }
+
+        /// <summary>"Character", "Pursuer", or "Unknown".</summary>
+        public string Speaker { get; }
+
+        /// <summary>
+        /// Optional model label supplied to <see cref="RecordingLlmTransport"/>
+        /// at construction time.  Null when no label was provided.
+        /// </summary>
+        public string? Model { get; }
+
+        /// <summary>The system prompt sent to the LLM.</summary>
+        public string SystemPrompt { get; }
+
+        /// <summary>The user message sent to the LLM.</summary>
+        public string UserMessage { get; }
+
+        /// <summary>Sampling temperature used for this call.</summary>
+        public double Temperature { get; }
+
+        /// <summary>Max-tokens limit used for this call.</summary>
+        public int MaxTokens { get; }
+
+        /// <summary>The raw text response returned by the LLM.</summary>
+        public string RawResponse { get; }
+
+        public RawLlmSession(
+            int? turn,
+            string speaker,
+            string? model,
+            string systemPrompt,
+            string userMessage,
+            double temperature,
+            int maxTokens,
+            string rawResponse)
+        {
+            Turn        = turn;
+            Speaker     = speaker       ?? throw new ArgumentNullException(nameof(speaker));
+            Model       = model;
+            SystemPrompt = systemPrompt ?? throw new ArgumentNullException(nameof(systemPrompt));
+            UserMessage  = userMessage  ?? throw new ArgumentNullException(nameof(userMessage));
+            Temperature  = temperature;
+            MaxTokens    = maxTokens;
+            RawResponse  = rawResponse  ?? throw new ArgumentNullException(nameof(rawResponse));
+        }
+
+        // ── Phase-string parsing (internal helper, exercised by tests) ────────
+
+        public static (string Speaker, int? Turn) ParsePhase(string? phase)
+        {
+            if (phase == null)
+                return ("Unknown", null);
+
+            // harness-turn-{n}  →  Character, turn n
+            const string charPrefix = "harness-turn-";
+            if (phase.StartsWith(charPrefix, StringComparison.Ordinal))
+            {
+                string tail = phase.Substring(charPrefix.Length);
+                if (int.TryParse(tail, out int n))
+                    return ("Character", n);
+                return ("Character", null);
+            }
+
+            // harness-pursuer-open  →  Pursuer, turn 0
+            if (string.Equals(phase, "harness-pursuer-open", StringComparison.Ordinal))
+                return ("Pursuer", 0);
+
+            // harness-pursuer-char-{n}  →  Pursuer, turn n
+            const string pursuerCharPrefix = "harness-pursuer-char-";
+            if (phase.StartsWith(pursuerCharPrefix, StringComparison.Ordinal))
+            {
+                string tail = phase.Substring(pursuerCharPrefix.Length);
+                if (int.TryParse(tail, out int n))
+                    return ("Pursuer", n);
+                return ("Pursuer", null);
+            }
+
+            // harness-pursuer-{n}  →  Pursuer, turn n
+            const string pursuerPrefix = "harness-pursuer-";
+            if (phase.StartsWith(pursuerPrefix, StringComparison.Ordinal))
+            {
+                string tail = phase.Substring(pursuerPrefix.Length);
+                if (int.TryParse(tail, out int n))
+                    return ("Pursuer", n);
+                return ("Pursuer", null);
+            }
+
+            return ("Unknown", null);
+        }
+    }
+}

--- a/src/Pinder.NarrativeHarness/RecordingLlmTransport.cs
+++ b/src/Pinder.NarrativeHarness/RecordingLlmTransport.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.Tools.NarrativeHarness
+{
+    /// <summary>
+    /// <see cref="ILlmTransport"/> decorator that records every successful
+    /// <c>SendAsync</c> call as a <see cref="RawLlmSession"/>, additive to the
+    /// normal transport behaviour (the inner transport's response is returned
+    /// unchanged).
+    ///
+    /// <para>
+    /// <b>Speaker / Turn derivation:</b> the <c>phase</c> parameter is parsed by
+    /// <see cref="RawLlmSession.ParsePhase"/> to determine who spoke and on which
+    /// turn. See that method's documentation for the full mapping table.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Error behaviour:</b> if the inner transport throws, the exception is
+    /// propagated and <em>no session is recorded</em> for that call. The
+    /// HarnessRunner / PursuerActors already catch those exceptions and substitute
+    /// an error string; only successful responses enter the sessions list.
+    /// </para>
+    ///
+    /// <para>
+    /// Thread safety: the decorator is designed for the sequential harness loop.
+    /// The internal list is not synchronized; do not share across threads.
+    /// </para>
+    ///
+    /// <para>
+    /// netstandard2.0 / LangVersion 8.0 — normal sealed class, not a C# 9 record.
+    /// </para>
+    /// </summary>
+    public sealed class RecordingLlmTransport : ILlmTransport
+    {
+        private readonly ILlmTransport _inner;
+        private readonly string? _modelLabel;
+        private readonly List<RawLlmSession> _sessions = new List<RawLlmSession>();
+
+        /// <param name="inner">The real (or another decorator) transport to delegate to.</param>
+        /// <param name="modelLabel">
+        /// Optional model identifier to attach to every recorded session.
+        /// Pass <c>null</c> if the model is unknown or irrelevant.
+        /// </param>
+        public RecordingLlmTransport(ILlmTransport inner, string? modelLabel = null)
+        {
+            _inner      = inner      ?? throw new ArgumentNullException(nameof(inner));
+            _modelLabel = modelLabel;
+        }
+
+        /// <summary>Every session recorded so far, in call order.</summary>
+        public IReadOnlyList<RawLlmSession> Sessions => _sessions;
+
+        /// <inheritdoc />
+        public async Task<string> SendAsync(
+            string systemPrompt,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken ct = default)
+        {
+            // Delegate first — let exceptions propagate (no recording on error).
+            string response = await _inner.SendAsync(
+                systemPrompt, userMessage, temperature, maxTokens, phase, ct)
+                .ConfigureAwait(false);
+
+            var (speaker, turn) = RawLlmSession.ParsePhase(phase);
+
+            _sessions.Add(new RawLlmSession(
+                turn:         turn,
+                speaker:      speaker,
+                model:        _modelLabel,
+                systemPrompt: systemPrompt ?? string.Empty,
+                userMessage:  userMessage  ?? string.Empty,
+                temperature:  temperature,
+                maxTokens:    maxTokens,
+                rawResponse:  response     ?? string.Empty));
+
+            return response!;
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue869_RawLlmSessionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue869_RawLlmSessionTests.cs
@@ -1,0 +1,423 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Pinder.Tools.NarrativeHarness;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #869 (CORE half): the Narrative Harness collects and exposes a
+    /// structured list of every raw LLM exchange, additively, without changing
+    /// the existing markdown transcript.
+    ///
+    /// Coverage:
+    ///   A. <see cref="RawLlmSession.ParsePhase"/> derivation of Speaker + Turn
+    ///      from representative phase strings.
+    ///   B. <see cref="RecordingLlmTransport"/> records every successful
+    ///      SendAsync with correct fields, passes the response through unchanged,
+    ///      and does NOT record on error.
+    ///   C. <see cref="HarnessRunner.RunAsync"/> returns a non-null
+    ///      <see cref="HarnessRunResult"/> with RawSessions populated when the
+    ///      transport is a RecordingLlmTransport, and empty otherwise.
+    ///   D. The Transcript is byte-identical to the old Task&lt;string&gt; return
+    ///      value (verified by comparing two runs with identical stubs).
+    ///
+    /// Deterministic: all LLM calls are serviced by a canned-response stub —
+    /// no real network calls.
+    /// </summary>
+    public class Issue869_RawLlmSessionTests
+    {
+        // ─────────────────────────────────────────────────────────────────────
+        // A. RawLlmSession.ParsePhase
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("harness-turn-1",         "Character", 1)]
+        [InlineData("harness-turn-14",        "Character", 14)]
+        [InlineData("harness-pursuer-open",   "Pursuer",   0)]
+        [InlineData("harness-pursuer-char-1", "Pursuer",   1)]
+        [InlineData("harness-pursuer-char-7", "Pursuer",   7)]
+        [InlineData("harness-pursuer-3",      "Pursuer",   3)]
+        [InlineData("harness-pursuer-99",     "Pursuer",   99)]
+        public void ParsePhase_maps_known_phases_to_correct_speaker_and_turn(
+            string phase, string expectedSpeaker, int expectedTurn)
+        {
+            var (speaker, turn) = RawLlmSession.ParsePhase(phase);
+
+            Assert.Equal(expectedSpeaker, speaker);
+            Assert.Equal(expectedTurn, turn);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("dialogue_options")]
+        [InlineData("delivery")]
+        [InlineData("opponent_response")]
+        public void ParsePhase_unknown_phases_yield_Unknown_speaker_and_null_turn(string? phase)
+        {
+            var (speaker, turn) = RawLlmSession.ParsePhase(phase);
+
+            Assert.Equal("Unknown", speaker);
+            Assert.Null(turn);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // B. RecordingLlmTransport decorator
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task RecordingTransport_records_one_session_per_call()
+        {
+            var stub = new CannedTransport("hello");
+            var rec  = new RecordingLlmTransport(stub, modelLabel: "test-model");
+
+            await rec.SendAsync("sys", "usr", temperature: 0.5, maxTokens: 256, phase: "harness-turn-1");
+            await rec.SendAsync("sys2", "usr2", temperature: 0.8, maxTokens: 512, phase: "harness-pursuer-open");
+
+            Assert.Equal(2, rec.Sessions.Count);
+        }
+
+        [Fact]
+        public async Task RecordingTransport_session_fields_are_correct()
+        {
+            var stub = new CannedTransport("the-response");
+            var rec  = new RecordingLlmTransport(stub, modelLabel: "claude-test");
+
+            string returned = await rec.SendAsync(
+                "my-system", "my-user", temperature: 0.7, maxTokens: 128, phase: "harness-turn-3");
+
+            Assert.Equal("the-response", returned);            // response passed through
+
+            var s = rec.Sessions[0];
+            Assert.Equal("my-system",    s.SystemPrompt);
+            Assert.Equal("my-user",      s.UserMessage);
+            Assert.Equal(0.7,            s.Temperature);
+            Assert.Equal(128,            s.MaxTokens);
+            Assert.Equal("the-response", s.RawResponse);
+            Assert.Equal("claude-test",  s.Model);
+            Assert.Equal("Character",    s.Speaker);
+            Assert.Equal(3,              s.Turn);
+        }
+
+        [Fact]
+        public async Task RecordingTransport_pursuer_open_session_is_correct()
+        {
+            var stub = new CannedTransport("opening line");
+            var rec  = new RecordingLlmTransport(stub);
+
+            await rec.SendAsync("sp", "um", phase: "harness-pursuer-open");
+
+            var s = rec.Sessions[0];
+            Assert.Equal("Pursuer", s.Speaker);
+            Assert.Equal(0,         s.Turn);
+            Assert.Null(s.Model);   // no label supplied
+        }
+
+        [Fact]
+        public async Task RecordingTransport_does_not_record_on_inner_exception()
+        {
+            var stub = new ThrowingTransport(new InvalidOperationException("boom"));
+            var rec  = new RecordingLlmTransport(stub);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => rec.SendAsync("sp", "um", phase: "harness-turn-1"));
+
+            Assert.Empty(rec.Sessions);
+        }
+
+        [Fact]
+        public async Task RecordingTransport_model_label_null_by_default()
+        {
+            var stub = new CannedTransport("ok");
+            var rec  = new RecordingLlmTransport(stub);
+
+            await rec.SendAsync("sp", "um", phase: "harness-pursuer-1");
+
+            Assert.Null(rec.Sessions[0].Model);
+        }
+
+        [Fact]
+        public async Task RecordingTransport_passes_all_parameters_to_inner()
+        {
+            var spy = new SpyTransport();
+            var rec = new RecordingLlmTransport(spy);
+
+            await rec.SendAsync("SYS", "USR", temperature: 0.42, maxTokens: 333,
+                phase: "harness-turn-5");
+
+            Assert.Equal("SYS",  spy.LastSystemPrompt);
+            Assert.Equal("USR",  spy.LastUserMessage);
+            Assert.Equal(0.42,   spy.LastTemperature);
+            Assert.Equal(333,    spy.LastMaxTokens);
+            Assert.Equal("harness-turn-5", spy.LastPhase);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // C. HarnessRunner.RunAsync raw-session exposure
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// When the transport IS a RecordingLlmTransport, RunAsync returns a
+        /// HarnessRunResult whose RawSessions list is non-empty and contains at
+        /// least one entry per LLM call (character turn + pursuer lines).
+        /// A 1-turn run driven by the GenericLlmPursuerActor makes exactly 1
+        /// character-side call (harness-turn-1) — the generic pursuer skips the
+        /// LLM for the opening line (it uses a fixed fallback) and makes 0
+        /// subsequent calls after the last turn.
+        /// </summary>
+        [Fact]
+        public async Task HarnessRunner_with_RecordingTransport_exposes_raw_sessions()
+        {
+            var inner = new CannedTransport("canned reply");
+            var rec   = new RecordingLlmTransport(inner, modelLabel: "stub");
+
+            var runner = BuildRunner(rec, turns: 1, pursuerAssembledPrompt: null);
+            var result = await runner.RunAsync();
+
+            Assert.NotNull(result.RawSessions);
+            Assert.NotEmpty(result.RawSessions);
+
+            // The character-side call for turn 1 must be present.
+            var charSession = result.RawSessions.FirstOrDefault(
+                s => s.Speaker == "Character" && s.Turn == 1);
+            Assert.NotNull(charSession);
+            Assert.Equal("stub", charSession!.Model);
+        }
+
+        [Fact]
+        public async Task HarnessRunner_without_RecordingTransport_returns_empty_raw_sessions()
+        {
+            var plain = new CannedTransport("plain reply");
+
+            var runner = BuildRunner(plain, turns: 1, pursuerAssembledPrompt: null);
+            var result = await runner.RunAsync();
+
+            Assert.NotNull(result.RawSessions);
+            Assert.Empty(result.RawSessions);
+        }
+
+        [Fact]
+        public async Task HarnessRunner_with_CharacterPursuer_captures_pursuer_calls_too()
+        {
+            var inner = new CannedTransport("canned");
+            var rec   = new RecordingLlmTransport(inner, modelLabel: "stub");
+
+            // Use a real pursuer character so the pursuer makes LLM calls.
+            var runner = BuildRunner(rec, turns: 1,
+                pursuerAssembledPrompt: "You are Velvet_99, a romantic pursuer.");
+
+            var result = await runner.RunAsync();
+
+            // Should contain at least one Pursuer session (the opening line
+            // from CharacterPursuerActor goes via harness-pursuer-open).
+            bool hasPursuer = result.RawSessions.Any(s => s.Speaker == "Pursuer");
+            Assert.True(hasPursuer,
+                "Expected at least one Pursuer session in RawSessions when CharacterPursuerActor is used.");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // D. Transcript byte-identity
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Two runs with identical stubs and a plain (non-recording) transport
+        /// produce byte-identical Transcripts — proving that the transcript
+        /// generation is unaffected by the new code paths.
+        /// </summary>
+        [Fact]
+        public async Task HarnessRunner_transcript_is_byte_identical_across_identical_runs()
+        {
+            // Run 1
+            string t1;
+            {
+                var inner = new CannedTransport("stub-reply-A");
+                var runner = BuildRunner(inner, turns: 2, pursuerAssembledPrompt: null);
+                t1 = (await runner.RunAsync()).Transcript;
+            }
+
+            // Run 2 — identical stubs
+            string t2;
+            {
+                var inner = new CannedTransport("stub-reply-A");
+                var runner = BuildRunner(inner, turns: 2, pursuerAssembledPrompt: null);
+                t2 = (await runner.RunAsync()).Transcript;
+            }
+
+            Assert.Equal(t1, t2);
+        }
+
+        /// <summary>
+        /// The Transcript from a RecordingLlmTransport run is byte-identical to
+        /// the Transcript from a plain-transport run with the same canned
+        /// responses — the decorator is truly additive.
+        /// </summary>
+        [Fact]
+        public async Task HarnessRunner_transcript_same_with_and_without_recorder()
+        {
+            const string reply = "same-reply";
+
+            string plainTranscript;
+            {
+                var plain = new CannedTransport(reply);
+                var runner = BuildRunner(plain, turns: 1, pursuerAssembledPrompt: null);
+                plainTranscript = (await runner.RunAsync()).Transcript;
+            }
+
+            string recordingTranscript;
+            {
+                var inner = new CannedTransport(reply);
+                var rec   = new RecordingLlmTransport(inner);
+                var runner = BuildRunner(rec, turns: 1, pursuerAssembledPrompt: null);
+                recordingTranscript = (await runner.RunAsync()).Transcript;
+            }
+
+            Assert.Equal(plainTranscript, recordingTranscript);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Helpers
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Build a HarnessRunner with minimal wiring for unit tests.
+        /// Uses GameDefinition.PinderDefaults to avoid needing real game-def YAML.
+        /// Uses NarrativePromptLoader which the test module-init already wires.
+        /// </summary>
+        private static HarnessRunner BuildRunner(
+            ILlmTransport transport,
+            int turns,
+            string? pursuerAssembledPrompt)
+        {
+            var baseDef   = GameDefinition.PinderDefaults;
+            var character = MakeCharacter("TestChar");
+            var menu      = ConfessionMenu.Build(
+                "TestChar",
+                "Surface fear: [1] I want connection. [2] I push people away.",
+                "Background: grew up near the sea.");
+
+            var opts = MakeOptions(turns);
+
+            var pursuer = PursuerActorFactory.Create(
+                transport,
+                scriptedLines: null,
+                pursuerAssembledPrompt: pursuerAssembledPrompt,
+                pursuerDisplayName: pursuerAssembledPrompt != null ? "VelvetTest" : null,
+                pursuerSlug: pursuerAssembledPrompt != null ? "velvettest" : null,
+                baseDef: baseDef);
+
+            return new HarnessRunner(transport, character, menu, baseDef, opts, pursuer);
+        }
+
+        private static LoadedCharacter MakeCharacter(string name)
+        {
+            // CharacterProfile — mirrors Phase0Fixtures.MakeProfile pattern.
+            var stats   = MakeStatBlock();
+            var profile = new CharacterProfile(
+                stats: stats,
+                assembledSystemPrompt: $"You are {name}, a test character.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+
+            // CharacterDefinition — minimal valid construction.
+            var def = new CharacterDefinition(
+                schemaVersion: 1,
+                characterId: Guid.NewGuid(),
+                name: name,
+                genderIdentity: "they/them",
+                bio: "A test character.",
+                level: 1,
+                items: new List<string>(),
+                anatomy: new Dictionary<string, string>(),
+                allocation: new AllocationBlock(
+                    spent: new Dictionary<StatType, int>(),
+                    unspentPool: 0,
+                    shadows: new Dictionary<ShadowStatType, int>()),
+                psychologicalStake: "Surface fear: [1] I want connection. [2] I push people away.",
+                backgroundStory: "Grew up near the sea.");
+
+            return new LoadedCharacter(profile, def);
+        }
+
+        private static StatBlock MakeStatBlock()
+        {
+            var stats = new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 2 }, { StatType.Rizz, 2 }, { StatType.Honesty, 2 },
+                { StatType.Chaos, 2 }, { StatType.Wit, 2 },  { StatType.SelfAwareness, 2 }
+            };
+            var shadows = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial,  0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread,   0 }, { ShadowStatType.Overthinking, 0 }
+            };
+            return new StatBlock(stats, shadows);
+        }
+
+        /// <summary>
+        /// Build a HarnessOptions with the specified turn count. Because the
+        /// setters are private, we use the public Parse() pathway with a
+        /// hand-rolled arg array.
+        /// </summary>
+        private static HarnessOptions MakeOptions(int turns)
+            => HarnessOptions.Parse(new[] { "--turns", turns.ToString(), "--character", "testchar" });
+
+        // ── Stub transports ───────────────────────────────────────────────────
+
+        /// <summary>Returns the same canned response for every call.</summary>
+        private sealed class CannedTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public CannedTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+
+        /// <summary>Always throws the supplied exception.</summary>
+        private sealed class ThrowingTransport : ILlmTransport
+        {
+            private readonly Exception _ex;
+            public ThrowingTransport(Exception ex) => _ex = ex;
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromException<string>(_ex);
+        }
+
+        /// <summary>Records the last set of parameters for inspection.</summary>
+        private sealed class SpyTransport : ILlmTransport
+        {
+            public string? LastSystemPrompt { get; private set; }
+            public string? LastUserMessage  { get; private set; }
+            public double  LastTemperature  { get; private set; }
+            public int     LastMaxTokens    { get; private set; }
+            public string? LastPhase        { get; private set; }
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage,
+                double temperature = 0.9, int maxTokens = 1024, string? phase = null,
+                CancellationToken ct = default)
+            {
+                LastSystemPrompt = systemPrompt;
+                LastUserMessage  = userMessage;
+                LastTemperature  = temperature;
+                LastMaxTokens    = maxTokens;
+                LastPhase        = phase;
+                return Task.FromResult("ok");
+            }
+        }
+    }
+}

--- a/tools/NarrativeHarness/Program.cs
+++ b/tools/NarrativeHarness/Program.cs
@@ -105,7 +105,8 @@ namespace Pinder.Tools.NarrativeHarness
                 baseDef);
 
             var runner = new HarnessRunner(transport, character, menu, baseDef, opts, pursuer);
-            string transcript = await runner.RunAsync();
+            var result = await runner.RunAsync();
+            string transcript = result.Transcript;
 
             // ── Write out ─────────────────────────────────────────────────
             File.WriteAllText(opts.OutPath, transcript);


### PR DESCRIPTION
## Summary

CORE HALF of cross-repo ticket #869 — *capture + persist raw LLM sessions per turn*.

The pinder-web half (game-api controller, backend store, alembic 0007) is a separate PR done after this merges.

## Changes

| File | Change |
|------|--------|
| `src/Pinder.NarrativeHarness/RawLlmSession.cs` | NEW — public sealed class (netstandard2.0/LangVersion 8.0, not a C# 9 record). Fields: Turn, Speaker, Model, SystemPrompt, UserMessage, Temperature, MaxTokens, RawResponse. ParsePhase() static helper derives Speaker+Turn from the harness phase string. |
| `src/Pinder.NarrativeHarness/RecordingLlmTransport.cs` | NEW — public ILlmTransport decorator. Records every successful SendAsync call; passes response through unchanged. Only records on success (exception propagates, no recording — matches existing try/catch in HarnessRunner/PursuerActors). |
| `src/Pinder.NarrativeHarness/HarnessRunResult.cs` | NEW — public sealed class { Transcript, RawSessions }. Transcript is byte-identical to the old Task<string> return value. |
| `src/Pinder.NarrativeHarness/HarnessRunner.cs` | MODIFIED — RunAsync returns Task<HarnessRunResult>. RawSessions sourced from RecordingLlmTransport when _transport is one; empty list otherwise. Ctor and transcript logic unchanged. |
| `tools/NarrativeHarness/Program.cs` | MODIFIED — fix RunAsync caller to use .Transcript. |
| `tests/Pinder.LlmAdapters.Tests/Issue869_RawLlmSessionTests.cs` | NEW — 23 deterministic unit tests. |

## Design notes

- **Decorator pattern** — captures every SendAsync call transparently. No PursuerActor edits needed: the runner and pursuer share the same transport instance.
- **Back-compat** — no ctor signature change. Callers that don't wrap the transport in RecordingLlmTransport get empty RawSessions.
- **Transcript identity** — byte-identical to old return; proven by `HarnessRunner_transcript_same_with_and_without_recorder` test.
- **Error behaviour** — only records on success. The harness already catches transport errors; failed calls are never stored.

## Test results

Build: `dotnet build -c Release` → 0 errors  
Tests: `Passed: 1180, Skipped: 9, Total: 1189` (all green including 23 new #869 tests)