### PR TITLE
fix(#1115): capture streaming token usage from message_start/message_delta SSE frames

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -63,9 +64,18 @@ namespace Pinder.LlmAdapters.Anthropic
     ///   <c>delta.type == "text_delta"</c> — the <c>delta.text</c> field, in
     ///   arrival order. Multi-chunk text reassembles by concatenation at the
     ///   call-site.</item>
-    ///   <item>All other event types (<c>message_start</c>,
-    ///   <c>content_block_start</c>, <c>ping</c>, <c>content_block_stop</c>,
-    ///   <c>message_delta</c>, <c>message_stop</c>, unknown) are silently
+    ///   <item><c>message_start</c> and <c>message_delta</c> frames are not
+    ///   yielded as text, but their <c>usage</c> blocks are captured for
+    ///   token/cost telemetry (issue #1115): <c>message_start</c> carries
+    ///   <c>usage.input_tokens</c>, <c>usage.cache_creation_input_tokens</c>
+    ///   and <c>usage.cache_read_input_tokens</c>; <c>message_delta</c>
+    ///   carries the final cumulative <c>usage.output_tokens</c>. The
+    ///   accumulated usage is exposed via
+    ///   <see cref="ITokenUsageProvider.GetSessionUsage"/> and
+    ///   <see cref="GetCallStats"/>, mirroring the non-streaming
+    ///   <c>AnthropicLlmAdapter</c>.</item>
+    ///   <item>All other event types (<c>content_block_start</c>, <c>ping</c>,
+    ///   <c>content_block_stop</c>, <c>message_stop</c>, unknown) are silently
     ///   ignored. The stream terminates when the underlying response stream
     ///   ends; no sentinel is required (Anthropic does not send <c>[DONE]</c>).</item>
     ///   <item>An open-time non-2xx HTTP response throws
@@ -81,7 +91,7 @@ namespace Pinder.LlmAdapters.Anthropic
     ///   <see cref="OperationCanceledException"/> (not a transport failure).</item>
     /// </list>
     /// </remarks>
-    public sealed class AnthropicStreamingTransport : IStreamingLlmTransport, IDisposable
+    public sealed class AnthropicStreamingTransport : IStreamingLlmTransport, ITokenUsageProvider, IDisposable
     {
         private const string ApiUrl = "https://api.anthropic.com/v1/messages";
         private const string AnthropicVersion = "2023-06-01";
@@ -91,6 +101,15 @@ namespace Pinder.LlmAdapters.Anthropic
         private readonly bool _ownsHttpClient;
         private readonly string _model;
         private bool _disposed;
+
+        // Issue #1115: token usage captured from message_start / message_delta
+        // SSE frames. One CallSummaryStat is committed per completed stream,
+        // mirroring how the non-streaming AnthropicDebugLogger records usage
+        // per call. Exposed via ITokenUsageProvider / GetCallStats so the same
+        // downstream telemetry path that consumes the non-streaming adapter
+        // sees real (non-zero) numbers for the streaming path.
+        private readonly List<CallSummaryStat> _callStats = new List<CallSummaryStat>();
+        private readonly object _statsLock = new object();
 
         /// <summary>
         /// Creates a transport with an internally-owned <see cref="HttpClient"/>.
@@ -182,6 +201,10 @@ namespace Pinder.LlmAdapters.Anthropic
                     "Anthropic streaming request failed before headers: " + ex.Message, LlmFailureKind.Network, ex);
             }
 
+            // Issue #1115: accumulate usage across this stream's SSE frames so
+            // we can commit one per-call telemetry row once the stream ends.
+            var usage = new StreamUsageAccumulator();
+            bool streamCompleted = false;
             try
             {
                 if (!response.IsSuccessStatusCode)
@@ -252,19 +275,29 @@ namespace Pinder.LlmAdapters.Anthropic
                     throw new LlmTransportException(message, failureKind);
                 }
 
-                await foreach (var fragment in ReadSseAsync(response, cancellationToken).ConfigureAwait(false))
+                await foreach (var fragment in ReadSseAsync(response, usage, cancellationToken).ConfigureAwait(false))
                 {
                     yield return fragment;
                 }
+                streamCompleted = true;
             }
             finally
             {
+                // Commit usage telemetry only when the stream ran to a clean
+                // completion (mirrors the non-streaming path, which records
+                // usage only on a successful response). On exceptions /
+                // cancellation we skip so we never record a partial/zero row.
+                if (streamCompleted && usage.HasUsage)
+                {
+                    CommitUsage(usage);
+                }
                 response.Dispose();
             }
         }
 
         private static async IAsyncEnumerable<string> ReadSseAsync(
             HttpResponseMessage response,
+            StreamUsageAccumulator usage,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             // Honour pre-cancellation deterministically before we touch the
@@ -332,7 +365,7 @@ namespace Pinder.LlmAdapters.Anthropic
                         // End of stream. If we have a buffered data line, dispatch it.
                         if (dataBuffer.Length > 0)
                         {
-                            var emitFinal = TryHandleDataFrame(dataBuffer.ToString(), out var frag, out var errMsg);
+                            var emitFinal = TryHandleDataFrame(dataBuffer.ToString(), usage, out var frag, out var errMsg);
                             dataBuffer.Clear();
                             if (errMsg != null)
                                 throw new LlmTransportException("Anthropic streaming error: " + errMsg);
@@ -347,7 +380,7 @@ namespace Pinder.LlmAdapters.Anthropic
                         // Frame boundary. Process whatever we accumulated.
                         if (dataBuffer.Length > 0)
                         {
-                            var emit = TryHandleDataFrame(dataBuffer.ToString(), out var frag, out var errMsg);
+                            var emit = TryHandleDataFrame(dataBuffer.ToString(), usage, out var frag, out var errMsg);
                             dataBuffer.Clear();
                             if (errMsg != null)
                                 throw new LlmTransportException("Anthropic streaming error: " + errMsg);
@@ -385,9 +418,12 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Parse one SSE data frame. Returns true when a text fragment should
         /// be yielded (with <paramref name="fragment"/> set). Sets
         /// <paramref name="errorMessage"/> when the frame represents an
-        /// Anthropic <c>error</c> event; the caller must throw.
+        /// Anthropic <c>error</c> event; the caller must throw. Side-effect:
+        /// folds any <c>usage</c> block on <c>message_start</c> /
+        /// <c>message_delta</c> frames into <paramref name="usage"/> (issue
+        /// #1115).
         /// </summary>
-        private static bool TryHandleDataFrame(string data, out string? fragment, out string? errorMessage)
+        private static bool TryHandleDataFrame(string data, StreamUsageAccumulator usage, out string? fragment, out string? errorMessage)
         {
             fragment = null;
             errorMessage = null;
@@ -429,6 +465,23 @@ namespace Pinder.LlmAdapters.Anthropic
                     }
                     return false;
                 }
+                case "message_start":
+                {
+                    // message_start carries the prompt-side usage:
+                    // input_tokens + cache_creation_input_tokens +
+                    // cache_read_input_tokens (and an initial output_tokens
+                    // value that message_delta later supersedes).
+                    var messageUsage = obj["message"]?["usage"] as JObject;
+                    usage.ApplyMessageStart(messageUsage);
+                    return false;
+                }
+                case "message_delta":
+                {
+                    // message_delta carries the final cumulative output_tokens.
+                    var deltaUsage = obj["usage"] as JObject;
+                    usage.ApplyMessageDelta(deltaUsage);
+                    return false;
+                }
                 case "error":
                 {
                     var err = obj["error"] as JObject;
@@ -440,10 +493,101 @@ namespace Pinder.LlmAdapters.Anthropic
                     return false;
                 }
                 default:
-                    // message_start, content_block_start, ping,
-                    // content_block_stop, message_delta, message_stop,
-                    // and any future event types — ignore.
+                    // content_block_start, ping, content_block_stop,
+                    // message_stop, and any future event types — ignore.
                     return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns a read-only snapshot of the per-stream token stats captured
+        /// during this transport's lifetime (issue #1115). Mirrors
+        /// <c>AnthropicLlmAdapter.GetCallStats</c> for the streaming path.
+        /// </summary>
+        public IReadOnlyList<CallSummaryStat> GetCallStats()
+        {
+            lock (_statsLock)
+            {
+                return _callStats.ToArray();
+            }
+        }
+
+        /// <inheritdoc />
+        public SessionTokenUsage GetSessionUsage()
+        {
+            lock (_statsLock)
+            {
+                return new SessionTokenUsage
+                {
+                    InputTokens              = _callStats.Sum(s => s.InputTokens),
+                    OutputTokens             = _callStats.Sum(s => s.OutputTokens),
+                    CacheReadInputTokens     = _callStats.Sum(s => s.CacheReadInputTokens),
+                    CacheCreationInputTokens = _callStats.Sum(s => s.CacheCreationInputTokens),
+                    CallCount                = _callStats.Count
+                };
+            }
+        }
+
+        private void CommitUsage(StreamUsageAccumulator usage)
+        {
+            var stat = new CallSummaryStat
+            {
+                Turn = 0,
+                Type = "stream",
+                InputTokens = usage.InputTokens,
+                OutputTokens = usage.OutputTokens,
+                CacheReadInputTokens = usage.CacheReadInputTokens,
+                CacheCreationInputTokens = usage.CacheCreationInputTokens
+            };
+            lock (_statsLock)
+            {
+                _callStats.Add(stat);
+            }
+        }
+
+        /// <summary>
+        /// Mutable accumulator for the usage fields scattered across an
+        /// Anthropic streaming response. Anthropic splits usage between the
+        /// <c>message_start</c> frame (prompt + cache tokens) and the final
+        /// <c>message_delta</c> frame (output tokens), so we fold both into a
+        /// single record (issue #1115).
+        /// </summary>
+        private sealed class StreamUsageAccumulator
+        {
+            public int InputTokens { get; private set; }
+            public int OutputTokens { get; private set; }
+            public int CacheReadInputTokens { get; private set; }
+            public int CacheCreationInputTokens { get; private set; }
+
+            /// <summary>True once any usage frame has contributed a value.</summary>
+            public bool HasUsage { get; private set; }
+
+            public void ApplyMessageStart(JObject? usage)
+            {
+                if (usage == null) return;
+                InputTokens = (int?)usage["input_tokens"] ?? InputTokens;
+                CacheCreationInputTokens = (int?)usage["cache_creation_input_tokens"] ?? CacheCreationInputTokens;
+                CacheReadInputTokens = (int?)usage["cache_read_input_tokens"] ?? CacheReadInputTokens;
+                // message_start also reports an initial output_tokens (usually 1);
+                // message_delta supersedes it with the final cumulative count.
+                OutputTokens = (int?)usage["output_tokens"] ?? OutputTokens;
+                HasUsage = true;
+            }
+
+            public void ApplyMessageDelta(JObject? usage)
+            {
+                if (usage == null) return;
+                // Anthropic emits the cumulative output_tokens on message_delta;
+                // take it as authoritative when present. Input/cache fields may
+                // also appear on later frames; fold them if present.
+                OutputTokens = (int?)usage["output_tokens"] ?? OutputTokens;
+                var input = (int?)usage["input_tokens"];
+                if (input.HasValue) InputTokens = input.Value;
+                var cacheCreate = (int?)usage["cache_creation_input_tokens"];
+                if (cacheCreate.HasValue) CacheCreationInputTokens = cacheCreate.Value;
+                var cacheRead = (int?)usage["cache_read_input_tokens"];
+                if (cacheRead.HasValue) CacheReadInputTokens = cacheRead.Value;
+                HasUsage = true;
             }
         }
 

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicStreamingTransportTests.Issue1115Usage.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicStreamingTransportTests.Issue1115Usage.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters.Anthropic;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    /// <summary>
+    /// Issue #1115 regression coverage: the Anthropic streaming transport
+    /// previously yielded only <c>content_block_delta</c> text frames and
+    /// silently discarded the <c>message_start</c> / <c>message_delta</c>
+    /// frames that carry token usage. As a result every streaming exchange
+    /// recorded all-zero usage (and a null cost). These tests pin that the
+    /// transport now captures usage from those frames and surfaces it via
+    /// <see cref="ITokenUsageProvider"/> — mirroring the non-streaming
+    /// <c>AnthropicLlmAdapter</c> path (see <c>Issue534_DebugFlagTests</c>
+    /// for the SSE/usage JSON shape this reuses).
+    /// </summary>
+    public partial class AnthropicStreamingTransportTests
+    {
+        // SSE frame factories reusing the JSON shape Anthropic actually emits
+        // (cf. the message_start / message_delta examples in the transport's
+        // own docstring and the usage block in Issue534_DebugFlagTests).
+        private static string MessageStartFrame(
+            int inputTokens, int cacheCreationInputTokens, int cacheReadInputTokens, int outputTokens = 1)
+        {
+            return "event: message_start\n" +
+                   "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"role\":\"assistant\"," +
+                   "\"content\":[],\"usage\":{" +
+                   "\"input_tokens\":" + inputTokens + "," +
+                   "\"cache_creation_input_tokens\":" + cacheCreationInputTokens + "," +
+                   "\"cache_read_input_tokens\":" + cacheReadInputTokens + "," +
+                   "\"output_tokens\":" + outputTokens + "}}}\n\n";
+        }
+
+        private static string MessageDeltaUsageFrame(int outputTokens)
+        {
+            return "event: message_delta\n" +
+                   "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null}," +
+                   "\"usage\":{\"output_tokens\":" + outputTokens + "}}\n\n";
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_CapturesUsage_FromMessageStartAndMessageDelta()
+        {
+            // What: a stream that carries usage in message_start (prompt + cache)
+            // and message_delta (output) must produce NON-ZERO usage on the
+            // ITokenUsageProvider path. Mutation: reverting the fix (ignoring
+            // those frames) yields all-zero usage and fails every assert below.
+            var frames = SsePayload(
+                MessageStartFrame(inputTokens: 25, cacheCreationInputTokens: 20, cacheReadInputTokens: 30),
+                "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+                TextDeltaFrame("Hello"),
+                TextDeltaFrame(", world!"),
+                "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+                MessageDeltaUsageFrame(outputTokens: 15),
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            );
+            var handler = new SseHandler(HttpStatusCode.OK, frames);
+            using var http = new HttpClient(handler);
+            using var transport = new AnthropicStreamingTransport(TestApiKey, TestModel, http);
+
+            // Consume the whole stream — usage is committed once the stream ends.
+            var fragments = new List<string>();
+            await foreach (var f in transport.SendStreamAsync("sys", "user"))
+                fragments.Add(f);
+
+            // Text path is unchanged.
+            Assert.Equal("Hello, world!", string.Concat(fragments));
+
+            // Usage path now carries real numbers (was all-zero pre-#1115).
+            var usage = transport.GetSessionUsage();
+            Assert.NotNull(usage);
+            Assert.Equal(25, usage.InputTokens);
+            Assert.Equal(15, usage.OutputTokens);
+            Assert.Equal(20, usage.CacheCreationInputTokens);
+            Assert.Equal(30, usage.CacheReadInputTokens);
+            Assert.Equal(1, usage.CallCount);
+
+            // TotalBilledInput = input + cache_creation (excludes cache_read).
+            Assert.Equal(45, usage.TotalBilledInput);
+
+            // The exchange is not zero — this is the crux of #1115.
+            Assert.True(usage.InputTokens > 0 && usage.OutputTokens > 0,
+                "Streaming usage must be non-zero so token_usages rows and cost_usd are populated.");
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_AsTokenUsageProvider_ExposesUsage()
+        {
+            // What: the transport implements ITokenUsageProvider so the same
+            // downstream telemetry that reads the non-streaming adapter can
+            // read the streaming transport. Mutation: dropping the interface
+            // (or returning zero) fails the cast/assert.
+            var frames = SsePayload(
+                MessageStartFrame(inputTokens: 100, cacheCreationInputTokens: 0, cacheReadInputTokens: 50),
+                TextDeltaFrame("hi"),
+                MessageDeltaUsageFrame(outputTokens: 42),
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            );
+            var handler = new SseHandler(HttpStatusCode.OK, frames);
+            using var http = new HttpClient(handler);
+            using var transport = new AnthropicStreamingTransport(TestApiKey, TestModel, http);
+
+            ITokenUsageProvider provider = transport;
+
+            await foreach (var _ in transport.SendStreamAsync("sys", "user")) { }
+
+            var usage = provider.GetSessionUsage();
+            Assert.Equal(100, usage.InputTokens);
+            Assert.Equal(42, usage.OutputTokens);
+            Assert.Equal(0, usage.CacheCreationInputTokens);
+            Assert.Equal(50, usage.CacheReadInputTokens);
+            Assert.Equal(1, usage.CallCount);
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_MultipleStreams_AccumulateUsage()
+        {
+            // What: usage from successive streams accumulates across calls,
+            // matching the per-call accumulation of the non-streaming adapter.
+            var firstFrames = SsePayload(
+                MessageStartFrame(inputTokens: 10, cacheCreationInputTokens: 5, cacheReadInputTokens: 0),
+                TextDeltaFrame("a"),
+                MessageDeltaUsageFrame(outputTokens: 3),
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            ).ToArray();
+            var secondFrames = SsePayload(
+                MessageStartFrame(inputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 7),
+                TextDeltaFrame("b"),
+                MessageDeltaUsageFrame(outputTokens: 4),
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            ).ToArray();
+
+            var handler = new TwoResponseSseHandler(firstFrames, secondFrames);
+            using var http = new HttpClient(handler);
+            using var transport = new AnthropicStreamingTransport(TestApiKey, TestModel, http);
+
+            await foreach (var _ in transport.SendStreamAsync("sys", "user1")) { }
+            await foreach (var _ in transport.SendStreamAsync("sys", "user2")) { }
+
+            var usage = transport.GetSessionUsage();
+            Assert.Equal(30, usage.InputTokens);   // 10 + 20
+            Assert.Equal(7, usage.OutputTokens);   // 3 + 4
+            Assert.Equal(5, usage.CacheCreationInputTokens);
+            Assert.Equal(7, usage.CacheReadInputTokens);
+            Assert.Equal(2, usage.CallCount);
+        }
+
+        [Fact]
+        public async Task SendStreamAsync_NoUsageFrames_LeavesUsageZeroWithNoCall()
+        {
+            // What: a degenerate stream with no usage frames records no call
+            // (so we never write an all-zero telemetry row). Mutation: always
+            // committing a row would make CallCount == 1 here.
+            var frames = SsePayload(
+                TextDeltaFrame("orphan"),
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            );
+            var handler = new SseHandler(HttpStatusCode.OK, frames);
+            using var http = new HttpClient(handler);
+            using var transport = new AnthropicStreamingTransport(TestApiKey, TestModel, http);
+
+            await foreach (var _ in transport.SendStreamAsync("sys", "user")) { }
+
+            var usage = transport.GetSessionUsage();
+            Assert.Equal(0, usage.InputTokens);
+            Assert.Equal(0, usage.OutputTokens);
+            Assert.Equal(0, usage.CallCount);
+        }
+
+        /// <summary>
+        /// Serves a different canned SSE body on each successive request, so a
+        /// single transport instance can drive two streams (for the
+        /// accumulation test).
+        /// </summary>
+        private sealed class TwoResponseSseHandler : HttpMessageHandler
+        {
+            private readonly byte[][] _first;
+            private readonly byte[][] _second;
+            private int _calls;
+
+            public TwoResponseSseHandler(byte[][] first, byte[][] second)
+            {
+                _first = first;
+                _second = second;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+            {
+                var chunks = _calls == 0 ? _first : _second;
+                _calls++;
+                var stream = new ChunkedStream(chunks, System.TimeSpan.Zero);
+                var content = new StreamContent(stream);
+                content.Headers.ContentType =
+                    new System.Net.Http.Headers.MediaTypeHeaderValue("text/event-stream");
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Token/cost telemetry recorded all-zero for every streaming turn. The Anthropic streaming transport structurally discarded token usage at the transport boundary, so each `LlmExchange.Usage` was zero, `token_usages` rows were all-zero, and `cost_usd` was null.

## Root cause
`src/Pinder.LlmAdapters/Anthropic/AnthropicStreamingTransport.cs` yielded only `content_block_delta` text frames and (per its own docstring) silently ignored all other SSE events — including `message_start` and `message_delta`. Anthropic delivers token usage ONLY in those ignored frames:
- `message_start` → `usage.input_tokens` + `cache_creation_input_tokens` + `cache_read_input_tokens`
- `message_delta` → cumulative `usage.output_tokens`

Because `SendStreamAsync` returns `IAsyncEnumerable<string>` (text only), usage was dropped.

## What changed
- `AnthropicStreamingTransport` now parses the `usage` blocks on `message_start`/`message_delta` into a per-stream accumulator and commits one `CallSummaryStat` per completed stream (only on clean completion, never on error/cancel — so no partial/zero rows).
- The transport now implements `ITokenUsageProvider`, exposing `GetSessionUsage()` + `GetCallStats()` — mirroring the non-streaming `AnthropicLlmAdapter`/`AnthropicDebugLogger` path so the same downstream telemetry consumers see real numbers.
- Text-yielding behaviour and all error/cancellation semantics are unchanged.

## Test added
`tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicStreamingTransportTests.Issue1115Usage.cs` — a mocked SSE stream with `message_start` + `message_delta` usage frames now produces NON-ZERO usage on the `ITokenUsageProvider` path (reuses the SSE/usage JSON shape from `Issue534_DebugFlagTests`). Covers: capture + TotalBilledInput, the `ITokenUsageProvider` cast, multi-stream accumulation, and the no-usage-frames degenerate case (records no call).

## Verification (local — no GitHub CI on this repo)
- `dotnet build -c Release` → 0 errors
- `dotnet test tests/Pinder.LlmAdapters.Tests` → 1184 passed
- `dotnet test tests/Pinder.Core.Tests` → 2936 passed

Scope is pinder-core only; the pinder-web consumers already read `exchange.Usage` correctly.

Fixes #1115
