### PR TITLE
fix(#1117): parse full dialogue option text with inner quotes + reject truncated fragments

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
@@ -36,9 +36,24 @@ namespace Pinder.LlmAdapters.Anthropic
             @"\[TELL_BONUS:\s*(\w+)\]",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // Captures the FULL intended text of an option (issue #1117).
+        // The previous pattern @"""([^""]+)""" stopped at the first inner
+        // double-quote, so an option that quotes the opponent back
+        // (e.g. the model writes:  said "it's a lot")  got truncated to a
+        // leading fragment. Because each per-option section (split out by the
+        // OPTION_N header) only ever contains this single quoted block followed
+        // by bracketed [CALLBACK]/[COMBO]/[TELL_BONUS] metadata tags — none of
+        // which contain double-quotes — a greedy capture to the LAST quote on
+        // the line reconstructs the complete text, inner quotes included.
         private static readonly Regex QuotedTextRegex = new Regex(
-            @"""([^""]+)""",
+            @"""(.+)""",
             RegexOptions.Compiled);
+
+        // Minimum length (after meta-prefix stripping/trim) for a parsed option
+        // to be treated as a playable dialogue line. Degenerate stubs such as
+        // "the" or "..." that slip through are dropped here so they are never
+        // surfaced; PadDialogueOptionsToFour then backfills a proper placeholder.
+        private const int MinPlayableOptionLength = 4;
 
 
 
@@ -87,6 +102,11 @@ namespace Pinder.LlmAdapters.Anthropic
 
                         var text = MetaPrefixStripper.Strip(textMatch.Groups[1].Value.Trim());
                         if (string.IsNullOrEmpty(text)) continue;
+
+                        // Issue #1117 sanity guard: reject sub-threshold/degenerate
+                        // fragments (e.g. "the", "...") so they are never surfaced as
+                        // playable options. PadDialogueOptionsToFour backfills instead.
+                        if (text.Length < MinPlayableOptionLength) continue;
 
                         // Parse optional metadata
                         int? callbackTurn = null;

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.DialogueOptions.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.DialogueOptions.cs
@@ -311,17 +311,19 @@ OPTION_2
             Assert.All(result, o => Assert.False(o.HasWeaknessWindow));
         }
 
-        // What: Spec edge case — multiple quoted strings, first one used
-        // Mutation: Would catch if last quoted string is used instead of first
+        // What: Spec edge case — inner quotes within a single option are preserved (issue #1117)
+        // Mutation: Would catch if the option text is truncated at the first inner quote
         [Fact]
-        public void ParseDialogueOptions_MultipleQuotedStrings_UsesFirst()
+        public void ParseDialogueOptions_MultipleQuotedStrings_CapturesFullText()
         {
             var input = @"OPTION_1
 [STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""First quote"" and then ""second quote""";
 
             var result = AnthropicLlmAdapter.ParseDialogueOptions(input);
-            Assert.Equal("First quote", result[0].IntendedText);
+            // Issue #1117: full text captured including inner quotes, not the
+            // leading fragment ("First quote") the old regex produced.
+            Assert.Equal(@"First quote"" and then ""second quote", result[0].IntendedText);
         }
 
         // What: Spec edge case — padding skips stats already present

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.DialogueOptions.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.DialogueOptions.cs
@@ -72,10 +72,10 @@ OPTION_2
             }
         }
 
-        // What: AC4 Spec edge - Multiple quoted strings: first one is used
-        // Mutation: Would catch if last quoted string is used instead of first
+        // What: AC4 Spec edge - inner quotes within a single option are preserved (issue #1117)
+        // Mutation: Would catch if the option text is truncated at the first inner quote
         [Fact]
-        public void ParseDialogueOptions_MultipleQuotedStrings_UsesFirst()
+        public void ParseDialogueOptions_MultipleQuotedStrings_CapturesFullText()
         {
             var input = @"OPTION_1
 [STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
@@ -83,18 +83,22 @@ OPTION_2
 
 OPTION_2
 [STAT: RIZZ] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""text""
+""text option two""
 
 OPTION_3
 [STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""text""
+""text option three""
 
 OPTION_4
 [STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""text""";
+""text option four""";
 
             var result = AnthropicLlmAdapter.ParseDialogueOptions(input);
-            Assert.Equal("First quoted string", result[0].IntendedText);
+            // Issue #1117: the full text (inner quotes included) is captured,
+            // not just the leading fragment up to the first inner quote.
+            Assert.Equal(
+                @"First quoted string"" and then ""second quoted string",
+                result[0].IntendedText);
         }
 
         // What: AC4 Spec edge - HasWeaknessWindow always false from adapter parsing

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ParseDialogueOptions.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ParseDialogueOptions.cs
@@ -111,24 +111,24 @@ OPTION_4
         {
             var input = @"OPTION_1
 [STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""One""
+""Option one""
 OPTION_2
 [STAT: RIZZ] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""Two""
+""Option two""
 OPTION_3
 [STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""Three""
+""Option three""
 OPTION_4
 [STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""Four""
+""Option four""
 OPTION_5
 [STAT: CHAOS] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
-""Five""";
+""Option five""";
 
             var result = AnthropicLlmAdapter.ParseDialogueOptions(input);
             Assert.Equal(4, result.Length);
-            Assert.Equal("One", result[0].IntendedText);
-            Assert.Equal("Four", result[3].IntendedText);
+            Assert.Equal("Option one", result[0].IntendedText);
+            Assert.Equal("Option four", result[3].IntendedText);
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
@@ -115,5 +115,57 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
             var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
             Assert.Equal(StatType.SelfAwareness, result[0].Stat);
         }
+
+        // --- Issue #1117 regression coverage ---
+
+        [Fact]
+        public void ParseDialogueOptionsText_InnerDoubleQuotes_ParsesFullText()
+        {
+            // The model quotes the opponent back inside the option's intended text.
+            // Previously the leading-fragment regex truncated this at the first
+            // inner double-quote (observed fragments like "see you said it's").
+            var input = @"OPTION_1 [STAT: Wit] ""Interesting that you said ""it's a lot"" earlier — care to unpack that?"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+
+            Assert.Equal(StatType.Wit, result[0].Stat);
+            Assert.Equal(
+                @"Interesting that you said ""it's a lot"" earlier — care to unpack that?",
+                result[0].IntendedText);
+        }
+
+        [Fact]
+        public void ParseDialogueOptionsText_MultipleOptions_OneWithInnerQuotes_AllParseFully()
+        {
+            var input = @"OPTION_1 [STAT: Charm] ""Hey there, looking good!"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_2 [STAT: Honesty] ""You literally said ""I never text first"" two minutes ago."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_3 [STAT: Wit] ""Bold of you to assume I read."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+
+            Assert.Equal(4, result.Length);
+            Assert.Equal("Hey there, looking good!", result[0].IntendedText);
+            Assert.Equal(
+                @"You literally said ""I never text first"" two minutes ago.",
+                result[1].IntendedText);
+            Assert.Equal("Bold of you to assume I read.", result[2].IntendedText);
+        }
+
+        [Fact]
+        public void ParseDialogueOptionsText_DegenerateFragment_NotSurfacedAsPlayableOption()
+        {
+            // A truncated tiny stub ("the") must NOT be surfaced as a playable
+            // option — it is dropped and the slot is backfilled by padding.
+            var input = @"OPTION_1 [STAT: Charm] ""the"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_2 [STAT: Wit] ""That's a genuinely funny take, I'll give you that."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+
+            Assert.Equal(4, result.Length);
+            // The degenerate "the" fragment must not appear as any option's text.
+            Assert.DoesNotContain(result, o => o.IntendedText == "the");
+            // The real option is still parsed and surfaced.
+            Assert.Contains(result, o => o.IntendedText == "That's a genuinely funny take, I'll give you that.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Dialogue options were being truncated to a leading fragment whenever the model's intended text contained an inner double-quote (e.g. quoting the opponent back). This PR captures the full option text and adds a guard so degenerate stubs are never surfaced as playable options.

## Root cause
`src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs` extracted each option's text with `QuotedTextRegex = new Regex("\"([^\"]+)\"")`. The character class `[^"]+` stops at the **first** inner double-quote, so an option whose text quotes the opponent (e.g. `said "it's a lot"`) was truncated to the leading fragment. Real observed fragments in prod: `the`, `...`, `see you said it's`, `interesting that you said`. The only post-extraction guard was `if (string.IsNullOrEmpty(text)) continue;` — no minimum-length/completeness check, so 3-char stubs were accepted as valid options.

## What changed
- **Greedy quoted-text capture:** `QuotedTextRegex` is now `"\"(.+)\""`, capturing to the **last** quote within the per-option section. Each section (split by the `OPTION_N` header) contains exactly one quoted block followed by bracketed `[CALLBACK]`/`[COMBO]`/`[TELL_BONUS]` metadata that never contains double-quotes, so a greedy capture safely reconstructs the full text including inner quotes. `.` does not match newlines, so multi-option responses keep parsing per-section correctly.
- **Sanity guard:** new `MinPlayableOptionLength = 4` — sub-threshold/degenerate fragments are dropped after stripping/trim and before being added, so they are never surfaced. `PadDialogueOptionsToFour` backfills the slot, keeping option count/format correct (least-surprising, matches existing padding behavior).
- **JSON tool path** (`ParseDialogueOptionsTool`) reads `text` directly from JSON and is **unaffected** — confirmed by existing + regression tests.

## Tests
- New regression coverage in `DialogueOptionParsersTests`:
  - an option whose intended text contains inner double-quotes parses to the **full** string (not the leading fragment);
  - a degenerate tiny fragment (`"the"`) is **not** surfaced as a playable option;
  - a multi-option response with inner quotes has all options parse fully.
- Updated two pre-existing tests that encoded the old buggy "first quote wins" truncation to assert the corrected full-text behavior, and refreshed a 5→4 truncation fixture to use realistic (≥4 char) strings.

## Local verification (no CI on this repo — local gate)
- `dotnet build -c Release` → 0 errors
- `Pinder.LlmAdapters.Tests` → **1183 passed**, 0 failed
- `Pinder.Core.Tests` → **2936 passed**, 0 failed

Fixes #1117