### PR TITLE
fix(#1123): symmetric two-session GM — stateful + cached + bleed-isolated avatar session

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -2036,3 +2036,6 @@ started
 {"ts": "2026-06-13T09:17:08Z", "agent": "orchestrator", "action": "merged", "sprint_id": "2026-06-13-e33d7d", "ticket": "1122", "pr": 1132, "commit": "aa87956ff04320154009ab6f173337023ae63c4b", "closed_issues": [1122]}
 {"ts": "2026-06-13T09:17:08Z", "agent": "orchestrator", "action": "docs-not-required", "sprint_id": "2026-06-13-e33d7d", "ticket": "1122", "pr": 1132, "rationale": "Rename internal to engine; prompt-string surface already PLAYER AVATAR. Comprehensive docs sweep is ticket #1130."}
 {"ts": "2026-06-13T09:17:08Z", "agent": "orchestrator", "action": "followup-filed", "sprint_id": "2026-06-13-e33d7d", "ticket": "1122", "followup": 1133, "detail": "deferred yaml-key alignment player_role_description->player_avatar_role_description"}
+{"ts":"2026-06-13T09:38:22Z","agent":"backend-engineer","action":"start","detail":"begin #1123 symmetric two-session GM"}
+{"ts":"2026-06-13T10:21:21Z","ticket":1123,"event":"started","agent":"backend-engineer-subagent"}
+{"event":"started","ticket":1123,"agent":"backend-engineer-cont","ts":"2026-06-13T11:02:07Z","branch":"fix/1123-symmetric-two-session-gm"}

--- a/agent.log
+++ b/agent.log
@@ -2039,3 +2039,4 @@ started
 {"ts":"2026-06-13T09:38:22Z","agent":"backend-engineer","action":"start","detail":"begin #1123 symmetric two-session GM"}
 {"ts":"2026-06-13T10:21:21Z","ticket":1123,"event":"started","agent":"backend-engineer-subagent"}
 {"event":"started","ticket":1123,"agent":"backend-engineer-cont","ts":"2026-06-13T11:02:07Z","branch":"fix/1123-symmetric-two-session-gm"}
+{"event":"completed","ticket":1123,"agent":"backend-engineer-cont","ts":"2026-06-13T11:14:34Z","pr":"https://github.com/decay256/pinder-core/pull/1134","sha":"ad3dbba9af27410030b88f45df2bf9c3ccf671d0","build":"0 errors","tests":"4431 passed / 0 failed / 27 skipped"}

--- a/session-runner/Program.Snapshot.cs
+++ b/session-runner/Program.Snapshot.cs
@@ -157,6 +157,13 @@ partial class Program
             .Select(m => new DateeHistoryEntry { Role = m.Role, Content = m.Content })
             .ToList();
 
+        // #1123: project the engine-owned avatar history into the wire shape
+        // (symmetric to the datee history). Sourced from the post-turn snapshot
+        // so it reflects the avatar entry appended during this turn's delivery.
+        var avatarHistoryEntries = (state.AvatarHistory ?? new List<Pinder.Core.Conversation.ConversationMessage>())
+            .Select(m => new DateeHistoryEntry { Role = m.Role, Content = m.Content })
+            .ToList();
+
         // Issue #474: detect canonical event kinds fired this turn and
         // resolve their interpretation strings via the (optional) i18n
         // catalog. Empty list when no event-class condition was met,
@@ -183,6 +190,7 @@ partial class Program
             RizzCumulativeFailureCount = rizzCumulativeFailureCount,
             ConversationHistory = convEntries,
             DateeHistory = dateeHistoryEntries,
+            AvatarHistory = avatarHistoryEntries,
             Events = events,
             DefendingStat = result.Roll.DefendingStat.ToString(),
             GhostProbabilityPerTurn = state.GhostProbabilityPerTurn,
@@ -245,6 +253,7 @@ partial class Program
         snap.HighestPctHistory ??= new List<bool>();
         snap.ConversationHistory ??= new List<ConversationEntry>();
         snap.DateeHistory ??= new List<DateeHistoryEntry>();
+        snap.AvatarHistory ??= new List<DateeHistoryEntry>();
 
         void Assume(string field, string defaultValue)
         {
@@ -298,6 +307,9 @@ partial class Program
             PendingTripleBonus   = snap.PendingTripleBonus,
             RizzCumulativeFailureCount = snap.RizzCumulativeFailureCount,
             DateeHistory      = (snap.DateeHistory ?? new List<DateeHistoryEntry>())
+                                     .Select(e => (e.Role, e.Content))
+                                     .ToList(),
+            AvatarHistory     = (snap.AvatarHistory ?? new List<DateeHistoryEntry>())
                                      .Select(e => (e.Role, e.Content))
                                      .ToList(),
         };

--- a/session-runner/Snapshot/SessionSnapshot.cs
+++ b/session-runner/Snapshot/SessionSnapshot.cs
@@ -200,6 +200,18 @@ namespace Pinder.SessionRunner.Snapshot
         public List<DateeHistoryEntry> DateeHistory { get; set; } = new List<DateeHistoryEntry>();
 
         /// <summary>
+        /// Issue #1123: engine-owned avatar-LLM conversation history at the time
+        /// of snapshot — the symmetric sibling of <see cref="DateeHistory"/>.
+        /// Each entry's <see cref="DateeHistoryEntry.Role"/> is <c>"user"</c> or
+        /// <c>"assistant"</c>. Empty when no avatar calls have resolved yet.
+        ///
+        /// <para>New persisted field added with NO back-compat (deploy/data wipe
+        /// owned by #1129, per the #1121 convention). Pre-#1123 snapshots
+        /// deserialise this as empty.</para>
+        /// </summary>
+        public List<DateeHistoryEntry> AvatarHistory { get; set; } = new List<DateeHistoryEntry>();
+
+        /// <summary>
         /// Issue #474: events fired on this turn, with their deterministic
         /// human-readable interpretation strings from the i18n catalog.
         /// Empty list when no event-class condition was met (a fully

--- a/src/Pinder.Core/Characters/PublicProfileCard.cs
+++ b/src/Pinder.Core/Characters/PublicProfileCard.cs
@@ -1,0 +1,117 @@
+using System.Text;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Issue #1123: the minimal, public "dating-app card" view of a character —
+    /// the only thing the OTHER session's Game-Master is allowed to see about a
+    /// character it is not playing.
+    ///
+    /// <para>
+    /// Strict bleed-isolation contract. Each two-session GM session
+    /// (<see cref="Pinder.Core.Conversation.DateeContext"/> and the avatar
+    /// delivery path) carries ONLY its own character's private stake in its
+    /// system prompt. The opposing character appears solely as (a) this public
+    /// card and (b) sent messages in the labelled transcript. The full assembled
+    /// system prompt (psychological stake, full stat block, archetype
+    /// directives, voice spec) of the opposing character is NEVER carried across
+    /// the session boundary.
+    /// </para>
+    ///
+    /// <para>
+    /// This is the symmetric sibling of <see cref="DateeVisibleProfile"/> (the
+    /// dialogue-options "YOU ARE TALKING TO" card). Where
+    /// <see cref="DateeVisibleProfile"/> renders the datee for the avatar's
+    /// option-generation prompt, <see cref="PublicProfileCard"/> is the neutral
+    /// cross-session card carried on the per-call context DTOs so neither
+    /// session leaks the other's private spec.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// Mirrors a single Tinder-style profile view: display name, self-reported
+    /// gender identity, player-written bio, and an outfit/scene signal (LLM
+    /// description when available, equipped-item display names as a degraded
+    /// fallback). Deliberately excludes everything private: stake, stats,
+    /// archetype, the full §3.1 system prompt.
+    /// </remarks>
+    public sealed class PublicProfileCard
+    {
+        /// <summary>Display name (e.g. "Sable_xo").</summary>
+        public string DisplayName { get; }
+
+        /// <summary>Self-reported gender identity (e.g. "she/her"). May be empty.</summary>
+        public string GenderIdentity { get; }
+
+        /// <summary>Player-written bio. May be empty.</summary>
+        public string Bio { get; }
+
+        /// <summary>
+        /// LLM-generated outfit / scene description — the "what the photo looks
+        /// like" signal. Empty when no describer was wired or the call failed;
+        /// the renderer then falls back to
+        /// <see cref="EquippedItemDisplayNamesFallback"/>.
+        /// </summary>
+        public string OutfitDescription { get; }
+
+        /// <summary>
+        /// Display names of equipped items. Used as a fallback "outfit" signal
+        /// only when <see cref="OutfitDescription"/> is empty. May itself be
+        /// empty when neither signal is available.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<string> EquippedItemDisplayNamesFallback { get; }
+
+        public PublicProfileCard(
+            string displayName,
+            string genderIdentity,
+            string bio,
+            string outfitDescription,
+            System.Collections.Generic.IReadOnlyList<string> equippedItemDisplayNamesFallback)
+        {
+            DisplayName    = displayName    ?? string.Empty;
+            GenderIdentity = genderIdentity ?? string.Empty;
+            Bio            = bio            ?? string.Empty;
+            OutfitDescription = outfitDescription ?? string.Empty;
+            EquippedItemDisplayNamesFallback =
+                equippedItemDisplayNamesFallback
+                ?? new System.Collections.Generic.List<string>();
+        }
+
+        /// <summary>An empty card (no public info). Used when a character is unavailable.</summary>
+        public static PublicProfileCard Empty { get; } =
+            new PublicProfileCard(string.Empty, string.Empty, string.Empty, string.Empty,
+                new System.Collections.Generic.List<string>());
+
+        /// <summary>
+        /// Render the public card as a single string suitable for dropping into
+        /// the opposing session's system prompt as a dating-app card.
+        ///
+        /// Format:
+        ///   <c>{DisplayName} ({GenderIdentity}): "{Bio}" | {OutfitDescription or fallback}</c>
+        ///
+        /// Each segment is omitted when its source is empty so the rendered
+        /// string is well-formed even for partial data.
+        /// </summary>
+        public string Render()
+        {
+            var sb = new StringBuilder();
+            sb.Append(DisplayName);
+            if (!string.IsNullOrWhiteSpace(GenderIdentity))
+                sb.Append(" (").Append(GenderIdentity).Append(')');
+            if (!string.IsNullOrWhiteSpace(Bio))
+                sb.Append(": \"").Append(Bio).Append('"');
+
+            if (!string.IsNullOrWhiteSpace(OutfitDescription))
+            {
+                sb.Append(" | Outfit: ").Append(OutfitDescription);
+            }
+            else if (EquippedItemDisplayNamesFallback != null
+                     && EquippedItemDisplayNamesFallback.Count > 0)
+            {
+                sb.Append(" | Wearing: ").Append(
+                    string.Join(", ", EquippedItemDisplayNamesFallback));
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/DateeContext.cs
+++ b/src/Pinder.Core/Conversation/DateeContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Pinder.Core.Characters;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
@@ -9,10 +10,17 @@ namespace Pinder.Core.Conversation
     /// </summary>
     public sealed class DateeContext
     {
-        /// <summary>Assembled system prompt for the player character.</summary>
-        public string PlayerAvatarPrompt { get; }
+        /// <summary>
+        /// Issue #1123 — strict bleed isolation. The datee session carries ONLY
+        /// the avatar's PUBLIC dating-app card (name + public profile fields),
+        /// never the avatar's full assembled system prompt (private stake, stat
+        /// block, archetype directives, voice spec). The avatar otherwise
+        /// appears only as sent messages in the labelled transcript. Never null;
+        /// <see cref="PublicProfileCard.Empty"/> when no card is supplied.
+        /// </summary>
+        public PublicProfileCard PlayerAvatarCard { get; }
 
-        /// <summary>Assembled system prompt for the datee character.</summary>
+        /// <summary>Assembled system prompt for the datee character (this session's own character — not a bleed).</summary>
         public string DateePrompt { get; }
 
         /// <summary>Conversation history as (sender, text) pairs in order.</summary>
@@ -61,7 +69,6 @@ namespace Pinder.Core.Conversation
         public string ActiveArchetypeDirective { get; }
 
         public DateeContext(
-            string playerAvatarPrompt,
             string dateePrompt,
             IReadOnlyList<(string Sender, string Text)> conversationHistory,
             string dateeLastMessage,
@@ -77,9 +84,10 @@ namespace Pinder.Core.Conversation
             string dateeName = "",
             int currentTurn = 0,
             FailureTier deliveryTier = FailureTier.Success,
-            string activeArchetypeDirective = null)
+            string activeArchetypeDirective = null,
+            PublicProfileCard? playerAvatarCard = null)
         {
-            PlayerAvatarPrompt = playerAvatarPrompt ?? throw new System.ArgumentNullException(nameof(playerAvatarPrompt));
+            PlayerAvatarCard = playerAvatarCard ?? PublicProfileCard.Empty;
             DateePrompt = dateePrompt ?? throw new System.ArgumentNullException(nameof(dateePrompt));
             ConversationHistory = conversationHistory ?? throw new System.ArgumentNullException(nameof(conversationHistory));
             DateeLastMessage = dateeLastMessage ?? throw new System.ArgumentNullException(nameof(dateeLastMessage));

--- a/src/Pinder.Core/Conversation/DateeResponseStage.cs
+++ b/src/Pinder.Core/Conversation/DateeResponseStage.cs
@@ -61,7 +61,6 @@ namespace Pinder.Core.Conversation
             string dateeArchetypeDirective = datee.ActiveArchetype?.Directive;
 
             var dateeContext = new DateeContext(
-                playerAvatarPrompt: player.AssembledSystemPrompt,
                 dateePrompt: datee.AssembledSystemPrompt,
                 conversationHistory: TurnOrchestratorHelpers.BuildHistoryForLlmContext(state),
                 dateeLastMessage: GameSessionHelpers.GetLastDateeMessage(state.History, datee.DisplayName),
@@ -77,7 +76,11 @@ namespace Pinder.Core.Conversation
                 currentTurn: state.TurnNumber,
                 shadowThresholds: dateeShadowThresholds,
                 deliveryTier: rollStage.RollResult.Tier,
-                activeArchetypeDirective: dateeArchetypeDirective);
+                activeArchetypeDirective: dateeArchetypeDirective,
+                // #1123 strict bleed isolation: the datee session sees ONLY the
+                // avatar's public dating-app card, never the avatar's full
+                // private system prompt.
+                playerAvatarCard: GameSessionHelpers.BuildPublicProfileCard(player));
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DateeResponseStarted));
 

--- a/src/Pinder.Core/Conversation/DeliveryContext.cs
+++ b/src/Pinder.Core/Conversation/DeliveryContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Pinder.Core.Characters;
 using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
@@ -10,11 +11,19 @@ namespace Pinder.Core.Conversation
     /// </summary>
     public sealed class DeliveryContext
     {
-        /// <summary>Assembled system prompt for the player avatar (the in-game character the human portrays).</summary>
+        /// <summary>Assembled system prompt for the player avatar (the in-game character the human portrays) — this session's own character.</summary>
         public string PlayerAvatarPrompt { get; }
 
-        /// <summary>Assembled system prompt for the datee character.</summary>
-        public string DateePrompt { get; }
+        /// <summary>
+        /// Issue #1123 — strict bleed isolation. The avatar (delivery) session
+        /// carries ONLY the datee's PUBLIC dating-app card (name + public
+        /// profile fields), never the datee's full assembled system prompt
+        /// (private stake, stat block, archetype directives, voice spec). The
+        /// datee otherwise appears only as sent messages in the labelled
+        /// transcript. Never null; <see cref="PublicProfileCard.Empty"/> when no
+        /// card is supplied.
+        /// </summary>
+        public PublicProfileCard DateeCard { get; }
 
         /// <summary>Conversation history as (sender, text) pairs in order.</summary>
         public IReadOnlyList<(string Sender, string Text)> ConversationHistory { get; }
@@ -71,7 +80,6 @@ namespace Pinder.Core.Conversation
 
         public DeliveryContext(
             string playerAvatarPrompt,
-            string dateePrompt,
             IReadOnlyList<(string Sender, string Text)> conversationHistory,
             string dateeLastMessage,
             DialogueOption chosenOption,
@@ -85,10 +93,11 @@ namespace Pinder.Core.Conversation
             int currentTurn = 0,
             bool isNat20 = false,
             string statFailureInstruction = null,
-            string activeArchetypeDirective = null)
+            string activeArchetypeDirective = null,
+            PublicProfileCard? dateeCard = null)
         {
             PlayerAvatarPrompt = playerAvatarPrompt ?? throw new System.ArgumentNullException(nameof(playerAvatarPrompt));
-            DateePrompt = dateePrompt ?? throw new System.ArgumentNullException(nameof(dateePrompt));
+            DateeCard = dateeCard ?? PublicProfileCard.Empty;
             ConversationHistory = conversationHistory ?? throw new System.ArgumentNullException(nameof(conversationHistory));
             DateeLastMessage = dateeLastMessage ?? throw new System.ArgumentNullException(nameof(dateeLastMessage));
             ChosenOption = chosenOption ?? throw new System.ArgumentNullException(nameof(chosenOption));

--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -120,7 +120,6 @@ namespace Pinder.Core.Conversation
 
             var deliveryContext = new DeliveryContext(
                 playerAvatarPrompt: player.AssembledSystemPrompt,
-                dateePrompt: datee.AssembledSystemPrompt,
                 conversationHistory: TurnOrchestratorHelpers.BuildHistoryForLlmContext(state),
                 dateeLastMessage: GameSessionHelpers.GetLastDateeMessage(state.History, datee.DisplayName),
                 chosenOption: deliveryOption,
@@ -134,10 +133,40 @@ namespace Pinder.Core.Conversation
                 shadowThresholds: state.CurrentShadowThresholds,
                 isNat20: rollResult.IsNatTwenty,
                 statFailureInstruction: statFailureInstruction,
-                activeArchetypeDirective: playerArchetypeDirectiveForDelivery);
+                activeArchetypeDirective: playerArchetypeDirectiveForDelivery,
+                // #1123 strict bleed isolation: the avatar (delivery) session
+                // sees ONLY the datee's public dating-app card, never the
+                // datee's full private system prompt.
+                dateeCard: GameSessionHelpers.BuildPublicProfileCard(datee, state.DateeOutfitDescription));
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
-            string deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext, ct).ConfigureAwait(false);
+            // #1123: the avatar (delivery) session is now stateful like the datee
+            // session — the engine owns AvatarHistory and threads it through the
+            // stateful avatar adapter overload, appending the new entries the
+            // adapter returns. Stateless adapters fall back to the one-shot path.
+            string deliveredMessage;
+            if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter statefulAvatarLlm)
+            {
+                var avatarResult = await statefulAvatarLlm.DeliverMessageAsync(
+                    deliveryContext,
+                    state.AvatarHistory,
+                    ct).ConfigureAwait(false);
+                if (avatarResult == null)
+                    throw new InvalidOperationException("LLM adapter returned null stateful avatar result");
+                deliveredMessage = avatarResult.DeliveredMessage ?? string.Empty;
+                if (avatarResult.NewHistoryEntries != null)
+                {
+                    foreach (var entry in avatarResult.NewHistoryEntries)
+                    {
+                        if (entry != null)
+                            state.AvatarHistory.Add(entry);
+                    }
+                }
+            }
+            else
+            {
+                deliveredMessage = await _llm.DeliverMessageAsync(deliveryContext, ct).ConfigureAwait(false);
+            }
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryCompleted, deliveredMessage));
 
             // #902: Meta-prefix strip immediately after delivery LLM call.

--- a/src/Pinder.Core/Conversation/GameSession.Helpers.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Helpers.cs
@@ -208,7 +208,8 @@ namespace Pinder.Core.Conversation
                 _traps,
                 _turnNumber,
                 _comboTracker.HasTripleBonus,
-                _dateeHistory);
+                _dateeHistory,
+                _avatarHistory);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.Helpers.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Helpers.cs
@@ -85,6 +85,16 @@ namespace Pinder.Core.Conversation
             => _dateeHistory;
 
         /// <summary>
+        /// #1123: avatar-LLM conversation history owned by the engine, the
+        /// symmetric sibling of <see cref="DateeHistory"/>. Each entry's role is
+        /// <c>"user"</c> or <c>"assistant"</c>. Read-only view over the live
+        /// mutable list so callers see updates as turns resolve. Survives
+        /// snapshot/restore via <see cref="ResimulateData.AvatarHistory"/>.
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<ConversationMessage> AvatarHistory
+            => _avatarHistory;
+
+        /// <summary>
         /// Build the conversation history view fed to subsequent LLM calls.
         /// Excludes synthetic scene-setting entries (issue #333) so the
         /// matchup analyser / delivery LLM / datee-response LLM never

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -49,6 +49,13 @@ namespace Pinder.Core.Conversation
         // adapter. Survives snapshot/restore via ResimulateData.DateeHistory.
         private List<ConversationMessage> _dateeHistory { get => _state.DateeHistory; set => _state.DateeHistory = value; }
 
+        // #1123: avatar LLM conversation history lives here, symmetric to
+        // _dateeHistory. The avatar (delivery) session is now stateful — the
+        // engine passes this list in on every avatar call and appends the new
+        // entries returned by the adapter. Survives snapshot/restore via
+        // ResimulateData.AvatarHistory.
+        private List<ConversationMessage> _avatarHistory { get => _state.AvatarHistory; set => _state.AvatarHistory = value; }
+
         // Sprint 8 Wave 0: optional config fields
         private readonly IGameClock? _clock;
         private SessionShadowTracker? _playerShadows { get => _state.PlayerShadows; set => _state.PlayerShadows = value; }

--- a/src/Pinder.Core/Conversation/GameSessionHelpers.cs
+++ b/src/Pinder.Core/Conversation/GameSessionHelpers.cs
@@ -47,6 +47,38 @@ namespace Pinder.Core.Conversation
         }
 
         /// <summary>
+        /// Issue #1123: builds the minimal, public dating-app card for a
+        /// character so the OTHER two-session GM session can reference it
+        /// without ever seeing the character's full private system prompt
+        /// (psychological stake, stat block, archetype directives, voice spec).
+        ///
+        /// <para>
+        /// This is the symmetric, role-neutral card used for strict bleed
+        /// isolation between the avatar session and the datee session. It
+        /// carries the SAME fields a real dating-app profile view would show —
+        /// name, self-reported gender identity, bio, and an outfit/scene
+        /// signal — and nothing else.
+        /// </para>
+        /// </summary>
+        /// <param name="character">The character whose public card to build.</param>
+        /// <param name="outfitDescription">
+        /// Optional LLM-generated outfit / scene description. When non-empty it
+        /// replaces the equipped-items fallback in the rendered card. Pass an
+        /// empty string when no describer was wired or the call failed.
+        /// </param>
+        public static PublicProfileCard BuildPublicProfileCard(
+            CharacterProfile character, string outfitDescription = "")
+        {
+            if (character == null) throw new System.ArgumentNullException(nameof(character));
+            return new PublicProfileCard(
+                displayName:                       character.DisplayName,
+                genderIdentity:                    character.GenderIdentity,
+                bio:                               character.Bio,
+                outfitDescription:                 outfitDescription,
+                equippedItemDisplayNamesFallback:  character.EquippedItemDisplayNames);
+        }
+
+        /// <summary>
         /// Formats a trap definition's penalty for display.
         /// </summary>
         public static string FormatTrapPenalty(TrapDefinition def)
@@ -113,7 +145,8 @@ namespace Pinder.Core.Conversation
             TrapState traps,
             int turnNumber,
             bool tripleBonusActive,
-            System.Collections.Generic.IReadOnlyList<ConversationMessage> dateeHistory = null)
+            System.Collections.Generic.IReadOnlyList<ConversationMessage> dateeHistory = null,
+            System.Collections.Generic.IReadOnlyList<ConversationMessage> avatarHistory = null)
         {
             var trapNames = traps.AllActive
                 .Select(t => t.Definition.Id)
@@ -133,6 +166,11 @@ namespace Pinder.Core.Conversation
                 ? System.Array.Empty<ConversationMessage>()
                 : dateeHistory.ToArray();
 
+            // #1123: same defensive copy for the avatar history.
+            ConversationMessage[] avatarHistorySnapshot = avatarHistory == null
+                ? System.Array.Empty<ConversationMessage>()
+                : avatarHistory.ToArray();
+
             // #905: Derive ghost probability from interest state.
             // When Bored, the ghost-trigger check fires with 25% probability (dice.Roll(4)==1).
             // All other states have 0% probability. Exposed on the snapshot so the frontend
@@ -148,7 +186,8 @@ namespace Pinder.Core.Conversation
                 tripleBonusActive: tripleBonusActive,
                 activeTrapDetails: trapDetails,
                 dateeHistory: historySnapshot,
-                ghostProbabilityPerTurn: ghostProbabilityPerTurn);
+                ghostProbabilityPerTurn: ghostProbabilityPerTurn,
+                avatarHistory: avatarHistorySnapshot);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/GameSessionState.cs
+++ b/src/Pinder.Core/Conversation/GameSessionState.cs
@@ -18,6 +18,11 @@ namespace Pinder.Core.Conversation
         public List<(string Sender, string Text)> History { get; internal set; } = new List<(string Sender, string Text)>();
         public string DateeOutfitDescription { get; internal set; } = string.Empty;
         public List<ConversationMessage> DateeHistory { get; internal set; } = new List<ConversationMessage>();
+        // #1123: avatar-session LLM conversation history, the symmetric sibling
+        // of DateeHistory. The avatar (delivery) session is now stateful and
+        // cached just like the datee session — the engine owns this list and
+        // threads it through the stateful avatar adapter overload on each turn.
+        public List<ConversationMessage> AvatarHistory { get; internal set; } = new List<ConversationMessage>();
         public SessionShadowTracker? PlayerShadows { get; internal set; }
         public SessionShadowTracker? DateeShadows { get; internal set; }
         public ComboTracker ComboTracker { get; internal set; } = new ComboTracker();
@@ -57,6 +62,7 @@ namespace Pinder.Core.Conversation
             clone.History = new List<(string Sender, string Text)>(History);
             clone.DateeOutfitDescription = DateeOutfitDescription;
             clone.DateeHistory = new List<ConversationMessage>(DateeHistory);
+            clone.AvatarHistory = new List<ConversationMessage>(AvatarHistory);
             clone.PlayerShadows = PlayerShadows?.Clone();
             clone.DateeShadows = DateeShadows?.Clone();
             clone.ComboTracker = ComboTracker.Clone();
@@ -102,6 +108,7 @@ namespace Pinder.Core.Conversation
             Traps = src.Traps.Clone();
             History.Clear(); History.AddRange(src.History);
             DateeHistory.Clear(); DateeHistory.AddRange(src.DateeHistory);
+            AvatarHistory.Clear(); AvatarHistory.AddRange(src.AvatarHistory);
             ComboTracker = src.ComboTracker.Clone();
             Topics.Clear(); Topics.AddRange(src.Topics);
             XpLedger = src.XpLedger.Clone();
@@ -181,6 +188,22 @@ namespace Pinder.Core.Conversation
                     try
                     {
                         DateeHistory.Add(new ConversationMessage(role, content ?? string.Empty));
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                }
+            }
+
+            AvatarHistory.Clear();
+            if (data.AvatarHistory != null)
+            {
+                foreach (var (role, content) in data.AvatarHistory)
+                {
+                    if (string.IsNullOrEmpty(role)) continue;
+                    try
+                    {
+                        AvatarHistory.Add(new ConversationMessage(role, content ?? string.Empty));
                     }
                     catch (ArgumentException)
                     {

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -46,6 +46,15 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public IReadOnlyList<ConversationMessage> DateeHistory { get; }
 
+        /// <summary>
+        /// #1123: snapshot of the engine-owned avatar LLM conversation history
+        /// at the time the snapshot was taken — the symmetric sibling of
+        /// <see cref="DateeHistory"/>. Each entry's role is <c>"user"</c> or
+        /// <c>"assistant"</c>. Always non-null — empty list when no avatar calls
+        /// have resolved yet.
+        /// </summary>
+        public IReadOnlyList<ConversationMessage> AvatarHistory { get; }
+
         public GameStateSnapshot(
             int interest,
             InterestState state,
@@ -55,7 +64,8 @@ namespace Pinder.Core.Conversation
             bool tripleBonusActive = false,
             TrapDetail[] activeTrapDetails = null,
             IReadOnlyList<ConversationMessage> dateeHistory = null,
-            double ghostProbabilityPerTurn = 0.0)
+            double ghostProbabilityPerTurn = 0.0,
+            IReadOnlyList<ConversationMessage> avatarHistory = null)
         {
             Interest = interest;
             State = state;
@@ -65,6 +75,7 @@ namespace Pinder.Core.Conversation
             TurnNumber = turnNumber;
             TripleBonusActive = tripleBonusActive;
             DateeHistory = dateeHistory ?? System.Array.Empty<ConversationMessage>();
+            AvatarHistory = avatarHistory ?? System.Array.Empty<ConversationMessage>();
             GhostProbabilityPerTurn = ghostProbabilityPerTurn;
         }
     }

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -43,6 +43,26 @@ namespace Pinder.Core.Conversation
             return Task.FromResult(message);
         }
 
+        /// <inheritdoc />
+        public Task<StatefulAvatarResult> DeliverMessageAsync(
+            DeliveryContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string message = context.Outcome == FailureTier.Success
+                ? context.ChosenOption.IntendedText
+                : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
+            // NullLlmAdapter still records placeholder history entries so engine
+            // round-trips (snapshot/restore) behave the same as a real adapter.
+            var entries = new ConversationMessage[]
+            {
+                ConversationMessage.User(string.Empty),
+                ConversationMessage.Assistant(message ?? string.Empty),
+            };
+            return Task.FromResult(new StatefulAvatarResult(message ?? string.Empty, entries));
+        }
+
         /// <summary>
         /// Returns a minimal placeholder DateeResponse with "..." text and no signals.
         /// </summary>

--- a/src/Pinder.Core/Conversation/ResimulateData.cs
+++ b/src/Pinder.Core/Conversation/ResimulateData.cs
@@ -51,5 +51,23 @@ namespace Pinder.Core.Conversation
         /// with. Empty list = no prior turns.
         /// </summary>
         public List<(string Role, string Content)> DateeHistory { get; set; } = new List<(string, string)>();
+
+        /// <summary>
+        /// Engine-owned avatar LLM conversation history (#1123) — the symmetric
+        /// sibling of <see cref="DateeHistory"/>. Each entry is a (role, content)
+        /// pair where role is <c>"user"</c> or <c>"assistant"</c>. Survives
+        /// snapshot/restore so a replayed session reproduces the same multi-turn
+        /// avatar context the original ran with. Empty list = no prior turns.
+        ///
+        /// <para>
+        /// Deploy-ordering note (#1129): this is a NEW persisted field added with
+        /// NO back-compat, on the same convention #1121 used for the renamed
+        /// persisted keys — the data wipe is owned by #1129. Pre-#1123 snapshots
+        /// deserialise this as an empty list (the replay then starts the avatar
+        /// session statelessly from turn 1, which is the correct degraded
+        /// behaviour for old snapshots).
+        /// </para>
+        /// </summary>
+        public List<(string Role, string Content)> AvatarHistory { get; set; } = new List<(string, string)>();
     }
 }

--- a/src/Pinder.Core/Conversation/StatefulAvatarResult.cs
+++ b/src/Pinder.Core/Conversation/StatefulAvatarResult.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Result of a stateful avatar (delivery) call (#1123). The symmetric
+    /// sibling of <see cref="StatefulDateeResult"/>. Wraps the delivered message
+    /// text plus the conversation entries the adapter wants the engine to append
+    /// to its <c>AvatarHistory</c>.
+    ///
+    /// <para>
+    /// As with the datee session, the adapter is the source of truth for "what
+    /// content went on the wire this turn" (it builds the user prompt from the
+    /// <see cref="DeliveryContext"/> and knows what the assistant returned); the
+    /// engine is the source of truth for "where that history is stored." This
+    /// struct lets the adapter hand the engine exactly the entries it needs to
+    /// append, in order, without leaking adapter-internal prompt shape into the
+    /// engine.
+    /// </para>
+    /// </summary>
+    public sealed class StatefulAvatarResult
+    {
+        /// <summary>The delivered message text (post-degradation).</summary>
+        public string DeliveredMessage { get; }
+
+        /// <summary>
+        /// New entries the engine should append to its avatar history.
+        /// Typically one user-role entry (the prompt this turn) followed by one
+        /// assistant-role entry (the delivered message). May be empty when the
+        /// call short-circuited.
+        /// </summary>
+        public IReadOnlyList<ConversationMessage> NewHistoryEntries { get; }
+
+        public StatefulAvatarResult(
+            string deliveredMessage,
+            IReadOnlyList<ConversationMessage> newHistoryEntries)
+        {
+            DeliveredMessage = deliveredMessage ?? string.Empty;
+            NewHistoryEntries = newHistoryEntries ?? throw new System.ArgumentNullException(nameof(newHistoryEntries));
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
@@ -77,7 +77,8 @@ namespace Pinder.Core.Conversation
                 state.Traps,
                 state.TurnNumber,
                 state.ComboTracker.HasTripleBonus,
-                state.DateeHistory);
+                state.DateeHistory,
+                state.AvatarHistory);
         }
 
         internal static System.Collections.Generic.IReadOnlyList<(string Sender, string Text)> BuildHistoryForLlmContext(GameSessionState state)

--- a/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
@@ -54,6 +54,34 @@ namespace Pinder.Core.Interfaces
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// #1123: Deliver the chosen option as the avatar, given the prior
+        /// avatar conversation history accumulated by the engine. The symmetric
+        /// sibling of <see cref="GetDateeResponseAsync(DateeContext, IReadOnlyList{ConversationMessage}, CancellationToken)"/>:
+        /// the avatar session is now stateful and cached just like the datee
+        /// session. Stateless: implementations MUST NOT retain any avatar-session
+        /// field across calls.
+        /// </summary>
+        /// <param name="context">Delivery context for the current turn (system prompt, chosen option, outcome, etc.).</param>
+        /// <param name="history">
+        /// Prior avatar conversation, in chronological order. Each entry's
+        /// <see cref="ConversationMessage.Role"/> is one of <c>"user"</c> or
+        /// <c>"assistant"</c>. The current-turn user prompt is NOT included —
+        /// the implementation derives it from <paramref name="context"/> and
+        /// appends it after the supplied history.
+        /// </param>
+        /// <param name="cancellationToken">Cooperative cancellation (#794 alignment).</param>
+        /// <returns>
+        /// A <see cref="StatefulAvatarResult"/> bundling the delivered message
+        /// with the new history entries the engine should append to its avatar
+        /// history (typically one user-role entry followed by one
+        /// assistant-role entry).
+        /// </returns>
+        Task<StatefulAvatarResult> DeliverMessageAsync(
+            DeliveryContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Generate a steering question to append to the player's delivered message.
         /// Called after a successful steering roll. The question should reference
         /// specifics from the conversation and nudge toward meeting up.

--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -102,43 +102,95 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <inheritdoc />
         public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
+            // #1123: stateless single-turn fallback. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await DeliverMessageAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
+            return result.DeliveredMessage;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulAvatarResult> DeliverMessageAsync(
+            DeliveryContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var deliveryRules = _options.GameDefinition?.DeliveryRules;
             var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context, deliveryRules: deliveryRules, statDeliveryInstructions: _options.StatDeliveryInstructions);
             var fullPlayerAvatarPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+            // #1123: prompt caching for the avatar session, identical machinery
+            // to the datee session — the system prompt + character spec are
+            // cached as the static prefix and the transcript is the volatile
+            // suffix carried on user blocks via the stateful replay path below.
             var systemBlocks = CacheBlockBuilder.BuildPlayerAvatarOnlySystemBlocks(fullPlayerAvatarPrompt);
 
-            var request = AnthropicRequestBuilders.BuildMessagesRequest(
-                _options.Model, _options.MaxTokens, systemBlocks, userContent,
-                _options.DeliveryTemperature ?? DefaultDeliveryTemperature);
+            MessagesRequest request;
+            if (history.Count == 0)
+            {
+                request = AnthropicRequestBuilders.BuildMessagesRequest(
+                    _options.Model, _options.MaxTokens, systemBlocks, userContent,
+                    _options.DeliveryTemperature ?? DefaultDeliveryTemperature);
+            }
+            else
+            {
+                // Multi-turn: build a fresh ConversationSession per call from the
+                // engine-supplied avatar history. Symmetric to the datee stateful
+                // replay path; the session object is purely a request-builder
+                // helper — no state survives the call.
+                var ephemeral = new ConversationSession();
+                for (int i = 0; i < history.Count; i++)
+                {
+                    var msg = history[i];
+                    if (msg.Role == ConversationMessage.UserRole)
+                        ephemeral.AppendUser(msg.Content);
+                    else
+                        ephemeral.AppendAssistant(msg.Content);
+                }
+                ephemeral.AppendUser(userContent);
+                request = ephemeral.BuildRequest(
+                    _options.Model,
+                    _options.MaxTokens,
+                    _options.DeliveryTemperature ?? DefaultDeliveryTemperature,
+                    systemBlocks);
+            }
             AnthropicRequestBuilders.AttachTool(request, ToolSchemas.Delivery);
 
-            var response = await _client.SendMessagesAsync(request, ct).ConfigureAwait(false);
+            var response = await _client.SendMessagesAsync(request, cancellationToken).ConfigureAwait(false);
             _debugLogger.LogDebug("delivery", context.CurrentTurn, request, response, _options.DebugDirectory);
 
+            string delivered;
             // Try structured tool_use first
             var toolInput = response.GetToolInput();
-            if (toolInput != null)
+            if (toolInput != null && !string.IsNullOrWhiteSpace(toolInput.Value<string>("delivered")))
             {
-                var delivered = toolInput.Value<string>("delivered");
-                if (!string.IsNullOrWhiteSpace(delivered))
-                    return delivered;
+                delivered = toolInput.Value<string>("delivered");
+            }
+            else
+            {
+                var deliveryDraft = response.GetText();
+
+                // Only apply improvement on notable outcomes
+                bool applyImprovement = context.CurrentTurn > 1 && (
+                    context.Outcome == Pinder.Core.Rolls.FailureTier.Success
+                        ? context.BeatDcBy >= 5 || context.IsNat20
+                        : context.Outcome >= Pinder.Core.Rolls.FailureTier.Misfire);
+
+                delivered = applyImprovement
+                    ? await AnthropicResponseImprover.ApplyImprovementAsync(
+                        _client, _options, systemBlocks, userContent, deliveryDraft,
+                        _options.DeliveryTemperature ?? DefaultDeliveryTemperature, cancellationToken).ConfigureAwait(false)
+                    : deliveryDraft;
             }
 
-            var deliveryDraft = response.GetText();
-
-            // Only apply improvement on notable outcomes
-            bool applyImprovement = context.CurrentTurn > 1 && (
-                context.Outcome == Pinder.Core.Rolls.FailureTier.Success
-                    ? context.BeatDcBy >= 5 || context.IsNat20
-                    : context.Outcome >= Pinder.Core.Rolls.FailureTier.Misfire);
-
-            return applyImprovement
-                ? await AnthropicResponseImprover.ApplyImprovementAsync(
-                    _client, _options, systemBlocks, userContent, deliveryDraft,
-                    _options.DeliveryTemperature ?? DefaultDeliveryTemperature, ct).ConfigureAwait(false)
-                : deliveryDraft;
+            delivered ??= string.Empty;
+            var newEntries = new ConversationMessage[]
+            {
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(delivered),
+            };
+            return new StatefulAvatarResult(delivered, newEntries);
         }
 
         /// <inheritdoc />

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -60,16 +60,47 @@ namespace Pinder.LlmAdapters.OpenAi
         /// <inheritdoc />
         public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
+            // #1123: stateless single-turn fallback. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await DeliverMessageAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
+            return result.DeliveredMessage;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulAvatarResult> DeliverMessageAsync(
+            DeliveryContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var deliveryRules = _options.GameDefinition?.DeliveryRules;
             var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(context, deliveryRules: deliveryRules, statDeliveryInstructions: _options.StatDeliveryInstructions);
+            // #1123: shared compile path — system prompt + character spec cached
+            // as the static prefix (via cache_control wrapping), transcript as
+            // the volatile suffix; symmetric to the datee stateful path.
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
 
-            var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDeliveryTemperature);
-            var responseText = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
+            string requestJson;
+            if (history.Count == 0)
+            {
+                requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDeliveryTemperature);
+            }
+            else
+            {
+                requestJson = BuildStatefulRequestJson(systemPrompt, history, userContent, DefaultDeliveryTemperature);
+            }
 
-            return responseText;
+            var responseText = await _client.SendChatCompletionAsync(requestJson, cancellationToken).ConfigureAwait(false);
+            string delivered = responseText ?? string.Empty;
+
+            var newEntries = new ConversationMessage[]
+            {
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(delivered),
+            };
+            return new StatefulAvatarResult(delivered, newEntries);
         }
 
         /// <inheritdoc />

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -74,18 +74,57 @@ namespace Pinder.LlmAdapters
         /// <inheritdoc />
         public async Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
         {
+            // #1123: stateless single-turn fallback path. Stateful callers route
+            // through the IStatefulLlmAdapter overload that takes a history.
+            var result = await DeliverMessageAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
+            return result.DeliveredMessage;
+        }
+
+        /// <inheritdoc />
+        public async Task<StatefulAvatarResult> DeliverMessageAsync(
+            DeliveryContext context,
+            IReadOnlyList<ConversationMessage> history,
+            CancellationToken cancellationToken = default)
+        {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (history == null) throw new ArgumentNullException(nameof(history));
 
             var deliveryRules = _options.GameDefinition?.DeliveryRules;
             var userContent = SessionDocumentBuilder.BuildDeliveryPrompt(
                 context, deliveryRules: deliveryRules, statDeliveryInstructions: _options.StatDeliveryInstructions);
+            // #1123 shared compile path: GM system prompt + character spec, with
+            // the running transcript as the volatile suffix. The injected
+            // character spec (the avatar's PlayerAvatarPrompt) is the only delta
+            // vs the datee session, which injects DateePrompt instead.
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
             double temperature = _options.DeliveryTemperature ?? DefaultDeliveryTemperature;
 
-            var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery, ct: ct)
-                .ConfigureAwait(false);
+            string responseText;
+            if (history.Count == 0)
+            {
+                // No prior turns — single-shot.
+                responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery, ct: cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                // Multi-turn: flatten the supplied avatar history into the user
+                // content (the transport contract is single-turn), mirroring the
+                // datee stateful path exactly.
+                responseText = await SendStatefulAvatarAsync(systemPrompt, userContent, history, temperature, cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
-            return responseText ?? "";
+            string delivered = responseText ?? "";
+
+            // Hand the engine the two new history entries to append: the user
+            // prompt we just sent and the assistant response we got back.
+            var newEntries = new ConversationMessage[]
+            {
+                ConversationMessage.User(userContent),
+                ConversationMessage.Assistant(delivered),
+            };
+            return new StatefulAvatarResult(delivered, newEntries);
         }
 
         /// <inheritdoc />
@@ -415,6 +454,47 @@ namespace Pinder.LlmAdapters
             double temperature,
             CancellationToken ct = default)
         {
+            return SendStatefulAsync(
+                systemPrompt, currentUserContent, priorHistory, temperature,
+                LlmPhase.DateeResponse, ct);
+        }
+
+        /// <summary>
+        /// #1123: Sends a stateful avatar (delivery) request by flattening the
+        /// supplied avatar history into the user message. The exact symmetric
+        /// sibling of <see cref="SendStatefulDateeAsync"/> — the avatar session
+        /// is compiled via the same path; only the injected character spec (and
+        /// the <see cref="LlmPhase"/> tag) differ. Pure function of its inputs —
+        /// no adapter-side state is read or written.
+        /// </summary>
+        private Task<string> SendStatefulAvatarAsync(
+            string systemPrompt,
+            string currentUserContent,
+            IReadOnlyList<ConversationMessage> priorHistory,
+            double temperature,
+            CancellationToken ct = default)
+        {
+            return SendStatefulAsync(
+                systemPrompt, currentUserContent, priorHistory, temperature,
+                LlmPhase.Delivery, ct);
+        }
+
+        /// <summary>
+        /// #1123: the single shared compile path for BOTH the datee and avatar
+        /// sessions. Each session = GM system prompt + character spec (the
+        /// cacheable prefix passed in <paramref name="systemPrompt"/>) + the
+        /// running labelled transcript as the volatile suffix. The ONLY
+        /// difference between the two sessions is the injected character spec;
+        /// the history-flattening, ordering, and cache breakpoints are identical.
+        /// </summary>
+        private Task<string> SendStatefulAsync(
+            string systemPrompt,
+            string currentUserContent,
+            IReadOnlyList<ConversationMessage> priorHistory,
+            double temperature,
+            string phase,
+            CancellationToken ct = default)
+        {
             // Multi-turn: prefix prior exchanges into the user message for context.
             var contextBuilder = new StringBuilder();
             contextBuilder.AppendLine("[PREVIOUS CONVERSATION CONTEXT]");
@@ -434,7 +514,7 @@ namespace Pinder.LlmAdapters
                 contextBuilder.ToString(),
                 temperature,
                 _options.MaxTokens,
-                phase: LlmPhase.DateeResponse,
+                phase: phase,
                 ct: ct);
         }
 

--- a/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+
+namespace Pinder.Core.Tests.Conversation
+{
+    /// <summary>
+    /// Issue #1123 — Symmetric two-session GM acceptance tests.
+    ///
+    /// <para>
+    /// The avatar (delivery) session is now stateful + cached + bleed-isolated,
+    /// structurally identical to the datee session. These tests lock the three
+    /// mandatory acceptance criteria:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>
+    ///     <b>Avatar history accumulation</b>: the engine owns
+    ///     <see cref="GameSession.AvatarHistory"/> and threads the accumulated
+    ///     prior turns into the stateful avatar adapter on each subsequent turn —
+    ///     the mirror of the existing datee-history contract.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Bidirectional bleed isolation</b>: the datee session's context never
+    ///     carries the avatar's full private system prompt, and the avatar
+    ///     session's context never carries the datee's full private system prompt.
+    ///     Each session sees only its OWN private stake plus the opposing
+    ///     character's PUBLIC dating-app card.
+    ///   </description></item>
+    /// </list>
+    /// (The third criterion — caching of the avatar stateful path — lives in
+    /// <c>Pinder.LlmAdapters.Tests/Anthropic/AnthropicTransportCachingTests.cs</c>
+    /// alongside the rest of the cache-block coverage.)
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1123_SymmetricTwoSessionGmTests
+    {
+        // Private stake markers — distinct, unguessable tokens embedded in each
+        // character's full assembled system prompt. Used to prove the OTHER
+        // session never receives the opposing character's private spec.
+        private const string AvatarPrivateStake = "AVATAR_PRIVATE_STAKE_7f3a";
+        private const string DateePrivateStake = "DATEE_PRIVATE_STAKE_9c2b";
+
+        private static CharacterProfile MakeAvatarProfile() =>
+            new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are Avery. {AvatarPrivateStake} You secretly want to impress.",
+                displayName: "Avery",
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1,
+                bio: "Avery's public bio.",
+                genderIdentity: "they/them");
+
+        private static CharacterProfile MakeDateeProfile() =>
+            new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(2),
+                assembledSystemPrompt: $"You are Dakota. {DateePrivateStake} You secretly are unsure.",
+                displayName: "Dakota",
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1,
+                bio: "Dakota's public bio.",
+                genderIdentity: "she/her");
+
+        /// <summary>
+        /// Recording adapter: implements the full stateful surface and captures the
+        /// avatar history it is handed on every <see cref="DeliverMessageAsync(DeliveryContext, IReadOnlyList{ConversationMessage}, CancellationToken)"/>
+        /// call, plus the system prompts/context seen by both the avatar (delivery)
+        /// and datee paths. Contributes one user + one assistant entry per stateful
+        /// call so the engine's owned history grows across turns.
+        /// </summary>
+        private sealed class RecordingStatefulAdapter : IStatefulLlmAdapter
+        {
+            // Avatar (delivery) path observations.
+            public readonly List<IReadOnlyList<ConversationMessage>> AvatarHistoriesSeen = new();
+            public readonly List<string> AvatarPromptsSeen = new();
+            public readonly List<PublicProfileCard> AvatarDateeCardsSeen = new();
+            private int _avatarCallCount;
+
+            // Datee path observations.
+            public readonly List<IReadOnlyList<ConversationMessage>> DateeHistoriesSeen = new();
+            public readonly List<string> DateePromptsSeen = new();
+            public readonly List<PublicProfileCard> DateePlayerAvatarCardsSeen = new();
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+                => Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, "option 1"),
+                    new DialogueOption(StatType.Rizz, "option 2"),
+                    new DialogueOption(StatType.Honesty, "option 3"),
+                    new DialogueOption(StatType.Wit, "option 4"),
+                });
+
+            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
+                => Task.FromResult("delivered");
+
+            public Task<StatefulAvatarResult> DeliverMessageAsync(
+                DeliveryContext context,
+                IReadOnlyList<ConversationMessage> history,
+                CancellationToken ct = default)
+            {
+                // Snapshot the history as the engine handed it to us this turn.
+                AvatarHistoriesSeen.Add(history.ToArray());
+                AvatarPromptsSeen.Add(context.PlayerAvatarPrompt);
+                AvatarDateeCardsSeen.Add(context.DateeCard);
+                int callNo = ++_avatarCallCount;
+                string delivered = context.ChosenOption.IntendedText ?? "delivered";
+                return Task.FromResult(new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User($"avatar-prompt-call-{callNo}"),
+                    ConversationMessage.Assistant(delivered),
+                }));
+            }
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
+                => Task.FromResult(new DateeResponse("response"));
+
+            public Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context,
+                IReadOnlyList<ConversationMessage> history,
+                CancellationToken ct = default)
+            {
+                DateeHistoriesSeen.Add(history.ToArray());
+                DateePromptsSeen.Add(context.DateePrompt);
+                DateePlayerAvatarCardsSeen.Add(context.PlayerAvatarCard);
+                return Task.FromResult(new StatefulDateeResult(
+                    new DateeResponse("response"),
+                    new ConversationMessage[]
+                    {
+                        ConversationMessage.User($"datee-prompt-turn-{context.CurrentTurn}"),
+                        ConversationMessage.Assistant("response"),
+                    }));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+                => Task.FromResult(string.Empty);
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
+        }
+
+        private static GameSession MakeSession(RecordingStatefulAdapter adapter, IDiceRoller dice) =>
+            new GameSession(
+                MakeAvatarProfile(),
+                MakeDateeProfile(),
+                adapter,
+                dice,
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+        // AC-1: Avatar GM response at turn N includes turns 1..N-1 from its
+        // persistent history — the engine accumulates AvatarHistory and threads
+        // it into the stateful avatar adapter, mirroring the datee-history test.
+        [Fact]
+        public async Task AvatarSession_AccumulatesHistory_AndThreadsItIntoSubsequentTurns()
+        {
+            var adapter = new RecordingStatefulAdapter();
+            // ctor d10 + per-turn (d20 main + d100 timing) for 3 turns.
+            var session = MakeSession(adapter, new FixedDice(5, 15, 50, 15, 50, 15, 50));
+
+            // Engine starts with empty avatar history.
+            Assert.Empty(session.AvatarHistory);
+
+            // Turn 1.
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // First avatar call saw an EMPTY history (no prior turns).
+            Assert.Single(adapter.AvatarHistoriesSeen);
+            Assert.Empty(adapter.AvatarHistoriesSeen[0]);
+            // Engine appended the one user + one assistant entry the adapter returned.
+            Assert.Equal(2, session.AvatarHistory.Count);
+            Assert.Equal(ConversationMessage.UserRole, session.AvatarHistory[0].Role);
+            Assert.Equal(ConversationMessage.AssistantRole, session.AvatarHistory[1].Role);
+
+            // Turn 2.
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Second avatar call saw the 2 entries accumulated from turn 1.
+            Assert.Equal(2, adapter.AvatarHistoriesSeen.Count);
+            Assert.Equal(2, adapter.AvatarHistoriesSeen[1].Count);
+            Assert.Equal("avatar-prompt-call-1", adapter.AvatarHistoriesSeen[1][0].Content);
+            Assert.Equal(4, session.AvatarHistory.Count);
+
+            // Turn 3.
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Third avatar call saw all 4 entries from turns 1..2.
+            Assert.Equal(3, adapter.AvatarHistoriesSeen.Count);
+            Assert.Equal(4, adapter.AvatarHistoriesSeen[2].Count);
+            Assert.Equal("avatar-prompt-call-1", adapter.AvatarHistoriesSeen[2][0].Content);
+            Assert.Equal("avatar-prompt-call-2", adapter.AvatarHistoriesSeen[2][2].Content);
+            Assert.Equal(6, session.AvatarHistory.Count); // 3 turns × (user + assistant)
+        }
+
+        // AC-2: Bidirectional bleed isolation. The datee session's context never
+        // carries the avatar's full private system prompt, AND the avatar
+        // session's context never carries the datee's full private system prompt.
+        // Each session sees only its own private stake + the opposing PUBLIC card.
+        [Fact]
+        public async Task BothSessions_AreBleedIsolated_FromEachOthersPrivateStake()
+        {
+            var adapter = new RecordingStatefulAdapter();
+            var session = MakeSession(adapter, new FixedDice(5, 15, 50));
+
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            Assert.NotEmpty(adapter.AvatarPromptsSeen);
+            Assert.NotEmpty(adapter.DateePromptsSeen);
+
+            // --- Avatar (delivery) session ---
+            string avatarPrompt = adapter.AvatarPromptsSeen[0];
+            // Sees its OWN private stake...
+            Assert.Contains(AvatarPrivateStake, avatarPrompt);
+            // ...but NOT the datee's private stake.
+            Assert.DoesNotContain(DateePrivateStake, avatarPrompt);
+            // The datee appears ONLY as its public dating-app card (no full spec).
+            PublicProfileCard dateeCard = adapter.AvatarDateeCardsSeen[0];
+            Assert.Equal("Dakota", dateeCard.DisplayName);
+            Assert.DoesNotContain(DateePrivateStake, dateeCard.Render());
+            Assert.DoesNotContain(DateePrivateStake, dateeCard.Bio);
+
+            // --- Datee session ---
+            string dateePrompt = adapter.DateePromptsSeen[0];
+            // Sees its OWN private stake...
+            Assert.Contains(DateePrivateStake, dateePrompt);
+            // ...but NOT the avatar's private stake.
+            Assert.DoesNotContain(AvatarPrivateStake, dateePrompt);
+            // The avatar appears ONLY as its public dating-app card (no full spec).
+            PublicProfileCard avatarCard = adapter.DateePlayerAvatarCardsSeen[0];
+            Assert.Equal("Avery", avatarCard.DisplayName);
+            Assert.DoesNotContain(AvatarPrivateStake, avatarCard.Render());
+            Assert.DoesNotContain(AvatarPrivateStake, avatarCard.Bio);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -44,6 +44,16 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DateeResponse("", null, null));
 
+            public Task<StatefulAvatarResult> DeliverMessageAsync(
+                DeliveryContext context,
+                IReadOnlyList<ConversationMessage> history,
+                System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new StatefulAvatarResult("", new ConversationMessage[]
+                {
+                    ConversationMessage.User("u"),
+                    ConversationMessage.Assistant("a"),
+                }));
+
             public Task<StatefulDateeResult> GetDateeResponseAsync(
                 DateeContext context,
                 IReadOnlyList<ConversationMessage> history,

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
@@ -181,5 +181,63 @@ namespace Pinder.Core.Tests.Conversation
                 Assert.Equal(historyA[i].Content, sessionB.DateeHistory[i].Content);
             }
         }
+
+        /// <summary>
+        /// #1123 review blocker: the public <see cref="GameSession.CreateSnapshot"/>
+        /// must populate <see cref="GameStateSnapshot.AvatarHistory"/> symmetrically
+        /// with <see cref="GameStateSnapshot.DateeHistory"/>. The instance method
+        /// previously omitted the avatar-history argument, so the returned snapshot's
+        /// AvatarHistory was silently always empty. This drives avatar history onto a
+        /// session via RestoreState, calls the PUBLIC CreateSnapshot(), and asserts the
+        /// snapshot round-trips the avatar history (NOT empty).
+        /// </summary>
+        [Fact]
+        public void CreateSnapshot_PopulatesAvatarHistory_FromRestoredState()
+        {
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+
+            // Engine starts with empty avatar history -> snapshot reflects empty.
+            Assert.Empty(session.CreateSnapshot().AvatarHistory);
+
+            session.RestoreState(new ResimulateData
+            {
+                TargetInterest = session.CreateSnapshot().Interest,
+                TurnNumber = 2,
+                MomentumStreak = 0,
+                ShadowValues = new Dictionary<string, int>(),
+                ActiveTraps = new List<(string, int)>(),
+                ConversationHistory = new List<(string, string)>(),
+                ComboHistory = new List<(string, bool)>(),
+                PendingTripleBonus = false,
+                RizzCumulativeFailureCount = 0,
+                AvatarHistory = new List<(string, string)>
+                {
+                    ("user", "first avatar prompt"),
+                    ("assistant", "first avatar reply"),
+                    ("user", "second avatar prompt"),
+                    ("assistant", "second avatar reply"),
+                },
+            }, new NullTrapRegistry());
+
+            // The live engine view reflects the restored avatar history.
+            Assert.Equal(4, session.AvatarHistory.Count);
+
+            // The PUBLIC CreateSnapshot() must round-trip the avatar history, not drop it.
+            var snap = session.CreateSnapshot();
+            Assert.Equal(4, snap.AvatarHistory.Count);
+            Assert.Equal("user", snap.AvatarHistory[0].Role);
+            Assert.Equal("first avatar prompt", snap.AvatarHistory[0].Content);
+            Assert.Equal("assistant", snap.AvatarHistory[1].Role);
+            Assert.Equal("first avatar reply", snap.AvatarHistory[1].Content);
+            Assert.Equal("user", snap.AvatarHistory[2].Role);
+            Assert.Equal("assistant", snap.AvatarHistory[3].Role);
+            Assert.Equal("second avatar reply", snap.AvatarHistory[3].Content);
+        }
     }
 }

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -47,6 +47,12 @@ namespace Pinder.Core.Tests.Conversation
                 => Task.FromResult(System.Array.Empty<DialogueOption>());
             public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
                 => Task.FromResult(string.Empty);
+            public Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, CancellationToken ct = default)
+                => Task.FromResult(new StatefulAvatarResult(string.Empty, new ConversationMessage[]
+                {
+                    ConversationMessage.User("u"),
+                    ConversationMessage.Assistant("a"),
+                }));
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse(string.Empty));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
@@ -95,7 +101,6 @@ namespace Pinder.Core.Tests.Conversation
 
         private static DateeContext MakeContext(string playerLabel) =>
             new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: System.Array.Empty<(string, string)>(),
                 dateeLastMessage: string.Empty,

--- a/tests/Pinder.Core.Tests/DateeResponseTests.cs
+++ b/tests/Pinder.Core.Tests/DateeResponseTests.cs
@@ -172,7 +172,6 @@ namespace Pinder.Core.Tests
             var option = new DialogueOption(StatType.Charm, "Hi");
             var ctx = new DeliveryContext(
                 playerAvatarPrompt: "p",
-                dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: option,
@@ -194,7 +193,6 @@ namespace Pinder.Core.Tests
             var option = new DialogueOption(StatType.Charm, "Hi");
             var ctx = new DeliveryContext(
                 playerAvatarPrompt: "p",
-                dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: option,
@@ -212,7 +210,6 @@ namespace Pinder.Core.Tests
         public void DateeContext_New_Fields_Default_To_Null()
         {
             var ctx = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
@@ -235,7 +232,6 @@ namespace Pinder.Core.Tests
                 { ShadowStatType.Dread, 6 }
             };
             var ctx = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -263,6 +263,16 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered),
+                });
+            }
+
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
 

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -264,6 +264,16 @@ namespace Pinder.Core.Tests
                 });
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered ?? string.Empty),
+                });
+            }
+
             public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
             {
                 CapturedDeliveryContext = context;

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -263,6 +263,16 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, System.Collections.Generic.IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered),
+                });
+            }
+
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
 

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -345,6 +345,16 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, System.Collections.Generic.IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered),
+                });
+            }
+
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
 

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -75,7 +75,6 @@ namespace Pinder.Core.Tests
         public void AC1_DateeContext_DeliveryTier_SetFromConstructor()
         {
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)> { ("P", "hi") },
                 dateeLastMessage: "hi",
@@ -95,7 +94,6 @@ namespace Pinder.Core.Tests
         public void AC1_DateeContext_DeliveryTier_DefaultsToNone()
         {
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)> { ("P", "hi") },
                 dateeLastMessage: "hi",
@@ -120,7 +118,6 @@ namespace Pinder.Core.Tests
         public void AC1_DateeContext_PreservesAllTierValues(FailureTier tier)
         {
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)> { ("P", "hi") },
                 dateeLastMessage: "hi",
@@ -220,7 +217,6 @@ namespace Pinder.Core.Tests
         {
             // This test verifies the constructor compiles and works without deliveryTier
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
@@ -245,7 +241,6 @@ namespace Pinder.Core.Tests
             };
 
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)> { ("P", "hi") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
+++ b/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
@@ -159,6 +159,16 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, System.Collections.Generic.IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered),
+                });
+            }
+
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
 

--- a/tests/Pinder.Core.Tests/LlmAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/LlmAdapterTests.cs
@@ -81,7 +81,6 @@ namespace Pinder.Core.Tests
             var option = new DialogueOption(StatType.Charm, "Hello there!");
             var ctx = new DeliveryContext(
                 playerAvatarPrompt: "p",
-                dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: option,
@@ -107,7 +106,6 @@ namespace Pinder.Core.Tests
             var option = new DialogueOption(StatType.Wit, "Clever line.");
             var ctx = new DeliveryContext(
                 playerAvatarPrompt: "p",
-                dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: option,
@@ -129,7 +127,6 @@ namespace Pinder.Core.Tests
         public async Task GetDateeResponseAsync_Returns_NonNull()
         {
             var ctx = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",

--- a/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
@@ -384,6 +384,16 @@ namespace Pinder.Core.Tests
                     : $"[{context.Outcome}] {intended}");
             }
 
+            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, CancellationToken ct = default)
+            {
+                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
+                return new StatefulAvatarResult(delivered, new ConversationMessage[]
+                {
+                    ConversationMessage.User(string.Empty),
+                    ConversationMessage.Assistant(delivered),
+                });
+            }
+
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
 

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
@@ -75,7 +75,6 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
 
         private static DeliveryContext MakeDeliveryContext() => new DeliveryContext(
             playerAvatarPrompt: "You are Thundercock",
-            dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",
             chosenOption: new DialogueOption(StatType.Charm, "Nice to meet you"),
@@ -86,7 +85,6 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             dateeName: "Velvet");
 
         private static DateeContext MakeDateeContext() => new DateeContext(
-            playerAvatarPrompt: "You are Thundercock",
             dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
@@ -100,7 +100,6 @@ OPTION_4
 
         private static DeliveryContext MakeDeliveryContext() => new DeliveryContext(
             playerAvatarPrompt: "You are Thundercock",
-            dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",
             chosenOption: new DialogueOption(StatType.Charm, "Nice to meet you"),
@@ -111,7 +110,6 @@ OPTION_4
             dateeName: "Velvet");
 
         private static DateeContext MakeDateeContext() => new DateeContext(
-            playerAvatarPrompt: "You are Thundercock",
             dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",
@@ -260,7 +258,7 @@ OPTION_4
         public void DateeContext_NewFieldsDefaultCorrectly()
         {
             var ctx = new DateeContext(
-                "player", "datee",
+                "datee",
                 new List<(string, string)>(),
                 "last", new string[0], 10, "msg",
                 10, 12, 2.0);
@@ -276,7 +274,7 @@ OPTION_4
         public void DeliveryContext_NewFieldsDefaultCorrectly()
         {
             var ctx = new DeliveryContext(
-                "player", "datee",
+                "player",
                 new List<(string, string)>(),
                 "last",
                 new DialogueOption(StatType.Charm, "text"),

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ContextDto.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ContextDto.cs
@@ -27,7 +27,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void DeliveryContext_defaults_backward_compatible()
         {
             var ctx = new DeliveryContext(
-                "player", "datee",
+                "player",
                 new List<(string, string)>(), "last",
                 new DialogueOption(StatType.Charm, "test"),
                 FailureTier.None, 5,
@@ -42,7 +42,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void DateeContext_defaults_backward_compatible()
         {
             var ctx = new DateeContext(
-                "player", "datee",
+                "datee",
                 new List<(string, string)>(), "last",
                 new string[0], 10, "delivered",
                 10, 12, 2.0);

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
@@ -72,7 +72,6 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
 
         private static DeliveryContext MakeDeliveryContext() => new DeliveryContext(
             playerAvatarPrompt: "You are Thundercock",
-            dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",
             chosenOption: new DialogueOption(StatType.Charm, "Nice to meet you"),
@@ -83,7 +82,6 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             dateeName: "Velvet");
 
         private static DateeContext MakeDateeContext() => new DateeContext(
-            playerAvatarPrompt: "You are Thundercock",
             dateePrompt: "You are Velvet",
             conversationHistory: new List<(string, string)> { ("Velvet", "Hey") },
             dateeLastMessage: "Hey",

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicTransportCachingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicTransportCachingTests.cs
@@ -8,6 +8,73 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
 {
     public class AnthropicTransportCachingTests
     {
+        // ── #1123: avatar stateful path caching ────────────────────────────
+        //
+        // The avatar (delivery) session is now stateful + cached, structurally
+        // identical to the datee session. Per CACHE-PREFIX-STABILITY, the GM
+        // system prompt + avatar character spec must form a STABLE cacheable
+        // prefix (cache_control: ephemeral) while the running transcript is the
+        // volatile suffix carried on the user/assistant messages. These tests
+        // exercise the exact request-building machinery the Anthropic avatar
+        // stateful overload uses (CacheBlockBuilder.BuildPlayerAvatarOnlySystemBlocks
+        // + ConversationSession replay), proving the cached prefix is reused
+        // byte-for-byte on repeated turns.
+
+        [Fact]
+        public void AvatarSystemBlocks_AreCacheable_StaticPrefix()
+        {
+            const string avatarSpec = "You are Avery. §3.1 full avatar spec.";
+            var blocks = CacheBlockBuilder.BuildPlayerAvatarOnlySystemBlocks(avatarSpec);
+
+            Assert.Single(blocks);
+            Assert.Equal("text", blocks[0].Type);
+            Assert.Equal(avatarSpec, blocks[0].Text);
+            Assert.NotNull(blocks[0].CacheControl);
+            Assert.Equal("ephemeral", blocks[0].CacheControl!.Type);
+        }
+
+        [Fact]
+        public void AvatarStatefulPath_ReusesCachedPrefix_AcrossRepeatedTurns()
+        {
+            const string avatarSpec = "You are Avery. §3.1 full avatar spec (cacheable).";
+
+            // Turn 1 (first delivery): no prior history -> system blocks only.
+            var systemBlocksTurn1 = CacheBlockBuilder.BuildPlayerAvatarOnlySystemBlocks(avatarSpec);
+            var requestTurn1 = AnthropicRequestBuilders.BuildMessagesRequest(
+                model: "claude", maxTokens: 1024, systemBlocks: systemBlocksTurn1,
+                userContent: "deliver turn 1", temperature: 0.7);
+
+            // Turn 2 (repeated delivery): prior avatar history replayed via
+            // ConversationSession, SAME cached system prefix re-supplied.
+            var systemBlocksTurn2 = CacheBlockBuilder.BuildPlayerAvatarOnlySystemBlocks(avatarSpec);
+            var session = new ConversationSession();
+            session.AppendUser("deliver turn 1");
+            session.AppendAssistant("delivered 1");
+            session.AppendUser("deliver turn 2");
+            var requestTurn2 = session.BuildRequest("claude", 1024, 0.7, systemBlocksTurn2);
+
+            // The cacheable system prefix is identical (same text, same
+            // ephemeral cache_control) on both turns — the prefix is stable, so
+            // turn 2 reads it from cache rather than re-sending fresh tokens.
+            Assert.Single(requestTurn1.System);
+            Assert.Single(requestTurn2.System);
+            Assert.Equal(requestTurn1.System[0].Text, requestTurn2.System[0].Text);
+            Assert.Equal(avatarSpec, requestTurn2.System[0].Text);
+            Assert.NotNull(requestTurn1.System[0].CacheControl);
+            Assert.NotNull(requestTurn2.System[0].CacheControl);
+            Assert.Equal("ephemeral", requestTurn1.System[0].CacheControl!.Type);
+            Assert.Equal("ephemeral", requestTurn2.System[0].CacheControl!.Type);
+
+            // The transcript (volatile suffix) GROWS turn-over-turn: turn 1 has
+            // one user message; turn 2 replays the full prior exchange + the new
+            // turn's user message.
+            Assert.Single(requestTurn1.Messages);
+            Assert.Equal(3, requestTurn2.Messages.Length);
+            Assert.Equal("user", requestTurn2.Messages[0].Role);
+            Assert.Equal("assistant", requestTurn2.Messages[1].Role);
+            Assert.Equal("user", requestTurn2.Messages[2].Role);
+        }
+
         [Fact]
         public void BuildMessages_SingleTurn_ReturnsPlainStringMessage()
         {

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue241_LegendaryFailVoiceTests.cs
@@ -27,7 +27,6 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: conversationHistory ?? new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue534_DebugFlagTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue534_DebugFlagTests.cs
@@ -98,7 +98,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             var history = new System.Collections.Generic.List<(string, string)>();
             var option = new DialogueOption(StatType.Charm, "Test", 0, null, false);
             return new DeliveryContext(
-                "Player Prompt", "Datee Prompt", history, "Last message", option, Pinder.Core.Rolls.FailureTier.None, 5, new System.Collections.Generic.List<string>());
+                "Player Prompt", history, "Last message", option, Pinder.Core.Rolls.FailureTier.None, 5, new System.Collections.Generic.List<string>());
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
@@ -30,7 +30,6 @@ namespace Pinder.LlmAdapters.Tests
         private static DateeContext MakeDateeContext(string activeArchetypeDirective = null)
         {
             return new DateeContext(
-                playerAvatarPrompt: "You are a test player.",
                 dateePrompt: "You are a test datee.",
                 conversationHistory: Array.Empty<(string, string)>(),
                 dateeLastMessage: "",

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
@@ -82,7 +82,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "velvet system prompt",
-                dateePrompt: "sable system prompt",
                 conversationHistory: new List<(string, string)>
                 {
                     ("Velvet", "hey there"),
@@ -111,7 +110,6 @@ namespace Pinder.LlmAdapters.Tests
             FailureTier deliveryTier = FailureTier.None)
         {
             return new DateeContext(
-                playerAvatarPrompt: "velvet system prompt",
                 dateePrompt: "sable system prompt",
                 conversationHistory: new List<(string, string)>
                 {

--- a/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
@@ -219,7 +219,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Datee", "Hey") },
                 dateeLastMessage: "Hey",
                 chosenOption: option,
@@ -235,7 +234,6 @@ namespace Pinder.LlmAdapters.Tests
             Dictionary<ShadowStatType, int>? shadowThresholds)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Datee", "Hey") },
                 dateeLastMessage: "Hey",

--- a/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue372_ArchetypeDirectiveDeliveryTests.cs
@@ -28,7 +28,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: new List<(string Sender, string Text)>(),
                 dateeLastMessage: "",
                 chosenOption: new DialogueOption(StatType.Charm, "ok cool"),

--- a/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
@@ -18,7 +18,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             if (interestBefore < 0) interestBefore = interestAfter;
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceSpec_Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceSpec_Tests.cs
@@ -21,7 +21,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             if (interestBefore < 0) interestBefore = interestAfter;
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Player", "hey"), ("Datee", "hi") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.LlmAdapters.Tests/Issue491_SuccessDeliveryTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue491_SuccessDeliveryTests.cs
@@ -21,7 +21,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
                 dateeLastMessage: "hi",
                 chosenOption: new DialogueOption(StatType.Charm, "honestly? you're kind of funny"),
@@ -206,7 +205,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             var ctx = new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
                 dateeLastMessage: "hi",
                 chosenOption: new DialogueOption(StatType.Charm, "test message"),

--- a/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationSpecTests.cs
@@ -18,7 +18,6 @@ namespace Pinder.LlmAdapters.Tests
         private static DateeContext MakeContext(FailureTier tier, int interestBefore = 12, int interestAfter = 11)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Player", "hey"), ("Datee", "hi") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
@@ -18,7 +18,6 @@ namespace Pinder.LlmAdapters.Tests
         private static DateeContext MakeContext(FailureTier tier)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Player", "hey"), ("Datee", "hi") },
                 dateeLastMessage: "hi",
@@ -106,7 +105,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             // Backward compatibility: DateeContext without deliveryTier defaults to None
             var context = new DateeContext(
-                playerAvatarPrompt: "p",
                 dateePrompt: "o",
                 conversationHistory: new List<(string, string)> { ("P", "hey") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
@@ -69,7 +69,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player system prompt",
-                dateePrompt: "datee system prompt",
                 conversationHistory: new List<(string, string)>
                 {
                     ("Velvet", "hey there"),
@@ -95,7 +94,6 @@ namespace Pinder.LlmAdapters.Tests
             FailureTier deliveryTier = FailureTier.None)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player system prompt",
                 dateePrompt: "datee system prompt",
                 conversationHistory: new List<(string, string)>
                 {

--- a/tests/Pinder.LlmAdapters.Tests/Issue866_DateeLengthCapTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue866_DateeLengthCapTests.cs
@@ -20,7 +20,6 @@ namespace Pinder.LlmAdapters.Tests
         private static DateeContext MakeDateeContext(string playerDeliveredMessage)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player system prompt",
                 dateePrompt: "datee system prompt",
                 conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
                 dateeLastMessage: "hi",

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
@@ -51,7 +51,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: conversationHistory ?? new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),
@@ -76,7 +75,6 @@ namespace Pinder.LlmAdapters.Tests
             Dictionary<ShadowStatType, int> shadowThresholds = null)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: conversationHistory ?? new List<(string, string)>(),
                 dateeLastMessage: "",

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.Helpers.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.Helpers.cs
@@ -52,7 +52,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: conversationHistory ?? new List<(string, string)>(),
                 dateeLastMessage: "",
                 chosenOption: chosenOption ?? new DialogueOption(StatType.Charm, "default"),
@@ -77,7 +76,6 @@ namespace Pinder.LlmAdapters.Tests
             Dictionary<ShadowStatType, int> shadowThresholds = null)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: conversationHistory ?? new List<(string, string)>(),
                 dateeLastMessage: "",

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -31,7 +31,6 @@ namespace Pinder.LlmAdapters.Tests
         {
             return new DeliveryContext(
                 playerAvatarPrompt: "player prompt",
-                dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Datee", "Hey there") },
                 dateeLastMessage: "Hey there",
                 chosenOption: option,
@@ -47,7 +46,6 @@ namespace Pinder.LlmAdapters.Tests
             Dictionary<ShadowStatType, int> shadowThresholds = null)
         {
             return new DateeContext(
-                playerAvatarPrompt: "player prompt",
                 dateePrompt: "datee prompt",
                 conversationHistory: new List<(string, string)> { ("Datee", "Hey there") },
                 dateeLastMessage: "Hey there",


### PR DESCRIPTION
## Summary

Makes the avatar (delivery) GM session **stateful + cached + bleed-isolated**, structurally identical to the datee session. There is now ONE labeled `AVATAR:`/`DATEE:` transcript; both sessions compile through the same shared path (only the injected character spec differs); each session carries only its own character's private stake as a cacheable prefix and never the other's.

Closes #1123

### Engine
- `GameSessionState.AvatarHistory` (field + `Clone` + `AdoptStateFrom` + `RestoreFromSnapshot`), `GameSession._avatarHistory` + public `AvatarHistory`, `ResimulateData.AvatarHistory`, `GameStateSnapshot.AvatarHistory`, threaded through `CreateSnapshot` and the session-runner snapshot (`SessionSnapshot.AvatarHistory`).
- New `StatefulAvatarResult` + a stateful `DeliverMessageAsync(context, history, ct)` overload on `IStatefulLlmAdapter`, implemented in `PinderLlmAdapter` / `AnthropicLlmAdapter` / `OpenAiLlmAdapter` / `NullLlmAdapter`. `DeliveryStage` threads `state.AvatarHistory` and accumulates the returned entries; stateless adapters fall back to the one-shot path.
- Extracted shared `SendStatefulAsync` in `PinderLlmAdapter` used by both datee + avatar paths. Anthropic avatar path reuses `BuildPlayerAvatarOnlySystemBlocks` + `ConversationSession` replay; OpenAI reuses `cache_control` wrapping.

### Bleed isolation
- New `PublicProfileCard` struct (name + public profile fields only) + `GameSessionHelpers.BuildPublicProfileCard`. The dead full-spec carries `DateeContext.PlayerAvatarPrompt` / `DeliveryContext.DateePrompt` (injected but never read) are replaced with `PlayerAvatarCard` / `DateeCard`; `DateeResponseStage` + `DeliveryStage` re-pointed.

## DoD Evidence

All verification run **locally** (CI = local only per project AGENTS.md). Toolchain: `/usr/bin/dotnet 8.0.128`.

### Build — `dotnet build Pinder.Core.sln`
```
Build succeeded.
    0 Error(s)
```

### Tests — `dotnet test Pinder.Core.sln`
```
Passed!  - Failed: 0, Passed:   54, Skipped:  0, Total:   54 - Pinder.RemoteAssets.Tests.dll
Passed!  - Failed: 0, Passed:  243, Skipped:  0, Total:  243 - Pinder.Rules.Tests.dll
Passed!  - Failed: 0, Passed: 2938, Skipped: 18, Total: 2956 - Pinder.Core.Tests.dll
Passed!  - Failed: 0, Passed: 1196, Skipped:  9, Total: 1205 - Pinder.LlmAdapters.Tests.dll
```
**Totals: 4431 passed / 0 failed / 27 skipped.** Baseline before this ticket was 4427 passed / 0 failed / 27 skipped; the +4 are the new acceptance tests added by this PR (2 in Core, 2 in LlmAdapters). No regressions, no flakes observed.

### Acceptance tests added
`tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs`
- `AvatarSession_AccumulatesHistory_AndThreadsItIntoSubsequentTurns` — drives 3 turns through the engine with a recording stateful adapter; asserts the avatar adapter is handed an empty history on turn 1 and the accumulated prior turns (2, then 4 entries) on turns 2 and 3, and that `GameSession.AvatarHistory` grows to 6 (3 × user+assistant). Mirrors the existing datee-history test.
- `BothSessions_AreBleedIsolated_FromEachOthersPrivateStake` — embeds distinct private-stake markers in each character's full system prompt; asserts the avatar (delivery) session sees its OWN stake but NOT the datee's, the datee session sees its OWN stake but NOT the avatar's, and each opposing character is present only as its public `PublicProfileCard` (no private stake in `.Render()` / `.Bio`). Both directions.

`tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicTransportCachingTests.cs`
- `AvatarSystemBlocks_AreCacheable_StaticPrefix` — the avatar system block is a single `text` block with `cache_control: ephemeral`.
- `AvatarStatefulPath_ReusesCachedPrefix_AcrossRepeatedTurns` — exercises the exact request-building machinery the Anthropic avatar stateful overload uses (`BuildPlayerAvatarOnlySystemBlocks` + `ConversationSession` replay); asserts the cached system prefix is byte-identical (and still `ephemeral`) on turns 1 and 2 while the transcript (volatile suffix) grows from 1 to 3 messages.

## Research Log

- **Continuation context.** This finished a max-iterations WIP. On inspection the worktree already built clean (`src` + all test projects) — a prior continuation had already completed steps 1–2 of the task spec: the new stateful avatar overload was present on all 4 remaining fake adapters (Issue365/399/840/927) following the established delegating pattern, and every `playerAvatarPrompt:` / `dateePrompt:` construction site had been updated. The full suite was already green at the 4427 baseline. The remaining gap was the 3 mandatory acceptance tests, which this PR adds.
- **Shared compile path.** Both sessions route through `PinderLlmAdapter.SendStatefulAsync(systemPrompt, currentUserContent, priorHistory, temperature, phase, ct)`. The only delta between the datee and avatar sessions is the injected character spec (`BuildDatee(DateePrompt)` vs `BuildPlayerAvatar(PlayerAvatarPrompt)`) and the `LlmPhase` tag; history flattening, ordering and cache breakpoints are identical. Confirms the "symmetric" requirement structurally rather than by duplication.
- **Bleed-removal approach + `PublicProfileCard` shape.** `DateeContext.PlayerAvatarPrompt` and `DeliveryContext.DateePrompt` were dead full-spec carries — injected onto the opposing session's context DTO but never read by any prompt builder. They are replaced by `PlayerAvatarCard` / `DateeCard` of type `PublicProfileCard`, which carries ONLY the public dating-app fields: `DisplayName`, `GenderIdentity`, `Bio`, `OutfitDescription`, and an equipped-items fallback — never stake, stats, archetype, or the §3.1 system prompt. `Render()` formats them as a neutral card. Because the removed fields were never read, dropping them preserves behavior.
- **New persisted `AvatarHistory` field + #1129 deploy-ordering note.** `AvatarHistory` is added to `GameSessionState`, `GameStateSnapshot`, `ResimulateData`, and the session-runner `SessionSnapshot`, mirroring `DateeHistory`. This is a NEW persisted field: replays/rehydrations created before this lands will have no `AvatarHistory` (it defaults to an empty list, so the avatar session simply starts cold on a restored session — safe). The schema rename / data-reset coordination belongs to **#1129**; deploy this AFTER or in lockstep with the #1129 data work to avoid a window where persisted snapshots carry datee history but not avatar history.
- **Test assertions.** No existing assertions had to be dropped or rewritten by this PR (the construction-site updates and assertion adjustments for the removed params were already done in the WIP this continued). The avatar-history acceptance test labels its synthetic entries by an internal adapter call counter rather than `DeliveryContext.CurrentTurn`, since the engine's first delivery carries `CurrentTurn == 0`.
- **Follow-ups.** None filed — no file crossed the 600-line hard cap and no refactor debt surfaced.
