### PR TITLE
feat(#1124): shared GM puppeteer system prompt + parseable output contract

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -99,8 +99,9 @@ fallback is still present (Phase 1-4).
 - `prompt_builder_section_labels` —
   `PromptBuilder.BuildSystemPrompt` headers + glyphs — **status:
   const** (Phase 3).
-- `session_system_prompt` — `SessionSystemPromptBuilder.Build` /
-  `BuildPlayer` / `BuildDatee` — **status: const** (Phase 3).
+- `session_system_prompt` — `SessionSystemPromptBuilder.BuildPlayerAvatar` /
+  `BuildDatee` — shared GM puppeteer template + injected character spec
+  (#1124) — **status: const** (Phase 3).
 - `archetype_catalog` — `ArchetypeCatalog._behaviors` (12 archetypes)
   — **status: const** (Phase 4).
 - `player_response_delay` —

--- a/src/Pinder.LlmAdapters/Anthropic/DateeResponseParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DateeResponseParsers.cs
@@ -1,6 +1,5 @@
 using Newtonsoft.Json.Linq;
 using System;
-using System.Text.RegularExpressions;
 using Pinder.Core.Conversation;
 using Pinder.Core.Stats;
 
@@ -13,13 +12,10 @@ namespace Pinder.LlmAdapters.Anthropic
     /// </summary>
     internal static class DateeResponseParsers
     {
-        private static readonly Regex TellSignalRegex = new Regex(
-            @"TELL:\s*(\w+)\s*\(([^)]+)\)",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-        private static readonly Regex WeaknessSignalRegex = new Regex(
-            @"WEAKNESS:\s*(\w+)\s*-(\d+)\s*\(([^)]+)\)",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // #1124: the [SIGNALS] block (TELL/WEAKNESS) is parsed via the single
+        // canonical GmOutputContract — the ONE output-format contract shared by
+        // both GM sessions — rather than a duplicate regex here. The datee path
+        // keeps its own message-cleaning (eval headers, quotes, persona tags).
 
         /// <summary>
         /// Defensively removes the persona "self-tag" tics ("/end", "/rant") that the
@@ -123,47 +119,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 // Strip persona self-tag tics ("/end", "/rant") that must never persist to chat history.
                 messageText = StripPersonaSelfTags(messageText);
 
-                // Parse optional [SIGNALS] block
-                var signalsIndex = response.IndexOf("[SIGNALS]", StringComparison.OrdinalIgnoreCase);
-                if (signalsIndex >= 0)
-                {
-                    var signalsBlock = response.Substring(signalsIndex);
-
-                    var tellMatch = TellSignalRegex.Match(signalsBlock);
-                    if (tellMatch.Success)
-                    {
-                        var statStr = StatNameNormalizer.NormalizeStatName(tellMatch.Groups[1].Value.Trim());
-                        try
-                        {
-                            var stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
-                            var description = tellMatch.Groups[2].Value.Trim();
-                            tell = new Tell(stat, description);
-                        }
-                        catch (ArgumentException)
-                        {
-                            // Invalid stat — tell stays null
-                        }
-                    }
-
-                    var weaknessMatch = WeaknessSignalRegex.Match(signalsBlock);
-                    if (weaknessMatch.Success)
-                    {
-                        var statStr = StatNameNormalizer.NormalizeStatName(weaknessMatch.Groups[1].Value.Trim());
-                        try
-                        {
-                            var stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
-                            var reduction = int.Parse(weaknessMatch.Groups[2].Value.Trim());
-                            if (reduction > 0)
-                            {
-                                weakness = new WeaknessWindow(stat, reduction);
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            // Invalid stat or reduction — weakness stays null
-                        }
-                    }
-                }
+                // #1124: parse the optional [SIGNALS] block via the single
+                // canonical contract shared by both GM sessions.
+                var signals = GmOutputContract.Parse(response);
+                tell = signals.Tell;
+                weakness = signals.Weakness;
             }
             catch
             {

--- a/src/Pinder.LlmAdapters/GmOutputContract.cs
+++ b/src/Pinder.LlmAdapters/GmOutputContract.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters.Anthropic;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// #1124: THE single canonical text output-format contract the Game Master
+    /// must emit, reused by BOTH sessions (player-avatar delivery and datee
+    /// response). pinder-core parses this format deterministically.
+    ///
+    /// Canonical shape:
+    ///
+    ///   &lt;message text — one or more lines&gt;
+    ///   [SIGNALS]
+    ///   TELL: &lt;Stat&gt; (&lt;description&gt;)
+    ///   WEAKNESS: &lt;Stat&gt; -&lt;n&gt; (&lt;description&gt;)
+    ///
+    /// Rules:
+    ///   • The message text is everything before the optional <c>[SIGNALS]</c>
+    ///     marker. It is always present (may be empty on malformed input).
+    ///   • The <c>[SIGNALS]</c> block is OPTIONAL. When present it may carry a
+    ///     <c>TELL:</c> line and/or a <c>WEAKNESS:</c> line, in any order.
+    ///   • A <c>TELL:</c> names the revealed stat and a parenthetical description.
+    ///   • A <c>WEAKNESS:</c> names the defending stat, a <c>-n</c> DC reduction,
+    ///     and a parenthetical description.
+    ///
+    /// <see cref="Emit"/> renders a <see cref="GmTurnOutput"/> to this format and
+    /// <see cref="Parse"/> reads it back. The pair round-trips:
+    /// <c>Parse(Emit(x)).Equals(x)</c> for any well-formed value. Parsing
+    /// degrades gracefully — malformed or partial input never throws; unknown
+    /// stats / missing fields collapse to a message-only result.
+    /// </summary>
+    public static class GmOutputContract
+    {
+        /// <summary>Marker that opens the optional structured signals block.</summary>
+        public const string SignalsMarker = "[SIGNALS]";
+
+        private static readonly Regex TellSignalRegex = new Regex(
+            @"TELL:\s*(\w+)\s*\(([^)]+)\)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex WeaknessSignalRegex = new Regex(
+            @"WEAKNESS:\s*(\w+)\s*-(\d+)\s*\(([^)]+)\)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Renders a GM turn output to the canonical text format. The result is
+        /// parseable back into an equal value by <see cref="Parse"/>.
+        /// </summary>
+        public static string Emit(GmTurnOutput output)
+        {
+            if (output == null) throw new ArgumentNullException(nameof(output));
+
+            var sb = new StringBuilder();
+            sb.Append(output.Message ?? string.Empty);
+
+            var tell = output.Tell;
+            var weakness = output.Weakness;
+            if (tell != null || weakness != null)
+            {
+                sb.Append('\n').Append(SignalsMarker);
+                if (tell != null)
+                {
+                    sb.Append('\n')
+                      .Append("TELL: ")
+                      .Append(StatName(tell.Stat))
+                      .Append(" (")
+                      .Append(tell.Description)
+                      .Append(')');
+                }
+                if (weakness != null)
+                {
+                    sb.Append('\n')
+                      .Append("WEAKNESS: ")
+                      .Append(StatName(weakness.DefendingStat))
+                      .Append(" -")
+                      .Append(weakness.DcReduction.ToString())
+                      .Append(" (")
+                      .Append(output.WeaknessDescription ?? string.Empty)
+                      .Append(')');
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Parses canonical GM output text into a <see cref="GmTurnOutput"/>.
+        /// Never throws — malformed input degrades to a message-only result with
+        /// null signals. The message is everything before <c>[SIGNALS]</c>.
+        /// </summary>
+        public static GmTurnOutput Parse(string? raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+                return new GmTurnOutput(string.Empty);
+
+            string message;
+            Tell? tell = null;
+            WeaknessWindow? weakness = null;
+            string? weaknessDescription = null;
+
+            try
+            {
+                int signalsIdx = raw!.IndexOf(SignalsMarker, StringComparison.OrdinalIgnoreCase);
+                message = signalsIdx >= 0 ? raw.Substring(0, signalsIdx) : raw;
+                message = message.TrimEnd('\n', '\r', ' ', '\t');
+
+                if (signalsIdx >= 0)
+                {
+                    string block = raw.Substring(signalsIdx);
+
+                    var tellMatch = TellSignalRegex.Match(block);
+                    if (tellMatch.Success)
+                    {
+                        if (TryParseStat(tellMatch.Groups[1].Value, out var stat))
+                        {
+                            tell = new Tell(stat, tellMatch.Groups[2].Value.Trim());
+                        }
+                    }
+
+                    var weakMatch = WeaknessSignalRegex.Match(block);
+                    if (weakMatch.Success)
+                    {
+                        if (TryParseStat(weakMatch.Groups[1].Value, out var stat) &&
+                            int.TryParse(weakMatch.Groups[2].Value.Trim(), out int reduction) &&
+                            reduction > 0)
+                        {
+                            weakness = new WeaknessWindow(stat, reduction);
+                            weaknessDescription = weakMatch.Groups[3].Value.Trim();
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Defensive: any unexpected failure collapses to message-only.
+                return new GmTurnOutput(raw!.Trim());
+            }
+
+            return new GmTurnOutput(message, tell, weakness, weaknessDescription);
+        }
+
+        private static bool TryParseStat(string raw, out StatType stat)
+        {
+            var normalized = StatNameNormalizer.NormalizeStatName(raw.Trim());
+            try
+            {
+                stat = (StatType)Enum.Parse(typeof(StatType), normalized, true);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                stat = default;
+                return false;
+            }
+        }
+
+        private static string StatName(StatType stat)
+        {
+            // Canonical wire spelling: enum name, with SelfAwareness expanded to
+            // the SELF_AWARENESS token the model emits and the normalizer accepts.
+            return stat == StatType.SelfAwareness ? "SELF_AWARENESS" : stat.ToString();
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/GmTurnOutput.cs
+++ b/src/Pinder.LlmAdapters/GmTurnOutput.cs
@@ -1,0 +1,84 @@
+using System;
+using Pinder.Core.Conversation;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// #1124: the parsed/structured form of one Game Master turn, as defined by
+    /// the canonical <see cref="GmOutputContract"/>. Carries the message text
+    /// plus the optional gameplay signals (a tell and/or a weakness window).
+    ///
+    /// Value-equatable so tests can assert the round-trip
+    /// <c>GmOutputContract.Parse(GmOutputContract.Emit(x)).Equals(x)</c>.
+    /// </summary>
+    public sealed class GmTurnOutput : IEquatable<GmTurnOutput>
+    {
+        /// <summary>The character's message text (signals stripped).</summary>
+        public string Message { get; }
+
+        /// <summary>A tell revealed this turn, or null.</summary>
+        public Tell? Tell { get; }
+
+        /// <summary>A weakness window opened this turn, or null.</summary>
+        public WeaknessWindow? Weakness { get; }
+
+        /// <summary>
+        /// The parenthetical description that accompanied the weakness on the
+        /// wire. Held here because <see cref="WeaknessWindow"/> itself does not
+        /// carry a description; preserved so the contract round-trips exactly.
+        /// </summary>
+        public string? WeaknessDescription { get; }
+
+        public GmTurnOutput(
+            string message,
+            Tell? tell = null,
+            WeaknessWindow? weakness = null,
+            string? weaknessDescription = null)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Tell = tell;
+            Weakness = weakness;
+            WeaknessDescription = weaknessDescription;
+        }
+
+        public bool Equals(GmTurnOutput? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            if (!string.Equals(Message, other.Message, StringComparison.Ordinal)) return false;
+            if (!TellEquals(Tell, other.Tell)) return false;
+            if (!WeaknessEquals(Weakness, other.Weakness)) return false;
+            if (!string.Equals(WeaknessDescription, other.WeaknessDescription, StringComparison.Ordinal)) return false;
+            return true;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as GmTurnOutput);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = Message?.GetHashCode() ?? 0;
+                hash = (hash * 397) ^ (Tell != null ? ((int)Tell.Stat * 17) ^ (Tell.Description?.GetHashCode() ?? 0) : 0);
+                hash = (hash * 397) ^ (Weakness != null ? ((int)Weakness.DefendingStat * 17) ^ Weakness.DcReduction : 0);
+                hash = (hash * 397) ^ (WeaknessDescription?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+
+        private static bool TellEquals(Tell? a, Tell? b)
+        {
+            if (a is null && b is null) return true;
+            if (a is null || b is null) return false;
+            return a.Stat == b.Stat && string.Equals(a.Description, b.Description, StringComparison.Ordinal);
+        }
+
+        private static bool WeaknessEquals(WeaknessWindow? a, WeaknessWindow? b)
+        {
+            if (a is null && b is null) return true;
+            if (a is null || b is null) return false;
+            return a.DefendingStat == b.DefendingStat && a.DcReduction == b.DcReduction;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
@@ -4,70 +4,47 @@ using Pinder.Core.Text;
 namespace Pinder.LlmAdapters
 {
     /// <summary>
-    /// Assembles a session-level system prompt from character profiles and game definition.
-    /// Section ordering places the STATIC, session-invariant material (game vision, world
-    /// rules, narrative doctrine, dramatic craft, structural sections) FIRST, and the
-    /// CHARACTER-SPECIFIC / VARIABLE material (the assembled player/datee profiles) LAST.
-    /// Keeping the variable character block at the tail maximizes the stable, cacheable
-    /// prompt prefix across sessions and keeps role-specific content closest to the turn.
+    /// Assembles a session-level system prompt for the Game Master puppeteer.
+    ///
+    /// #1124: BOTH sessions (player-avatar and datee) share ONE canonical GM
+    /// system-prompt template. The GM is a puppeteer that portrays exactly ONE
+    /// character; the per-session character spec (role description + the
+    /// assembled character profile) is injected as the FINAL block under
+    /// "== CHARACTER YOU CONTROL ==". The static GM base — puppeteer framing,
+    /// game vision, world rules, narrative doctrine, dramatic craft, and the
+    /// shared conversation-dynamic sections — is byte-for-byte identical across
+    /// both sessions, so the ONLY difference between the two built prompts is
+    /// the injected character-spec block.
+    ///
+    /// Section ordering places the STATIC, session-invariant material FIRST and
+    /// the VARIABLE character-spec block LAST. This keeps the stable cacheable
+    /// prefix (GM base + game definition) ahead of the per-character delta and
+    /// the volatile running transcript, so #1123's prompt caching still pays off.
     /// </summary>
     public static class SessionSystemPromptBuilder
     {
         /// <summary>
-        /// Build the full session system prompt.
+        /// Shared GM puppeteer framing. Static and identical for both sessions:
+        /// the GM is told it portrays exactly the one character defined at the
+        /// end of the prompt and knows/controls no other character.
         /// </summary>
-        /// <param name="playerAvatarPrompt">
-        /// Player's assembled character system prompt (from CharacterProfile.AssembledSystemPrompt).
-        /// </param>
-        /// <param name="dateePrompt">
-        /// Datee's assembled character system prompt (from CharacterProfile.AssembledSystemPrompt).
-        /// </param>
-        /// <param name="gameDef">
-        /// Game definition containing vision, world rules, meta contract.
-        /// When null, GameDefinition.PinderDefaults is used.
-        /// </param>
-        /// <returns>A single string containing the full session system prompt.</returns>
-        public static string Build(
-            string playerAvatarPrompt,
-            string dateePrompt,
-            GameDefinition? gameDef = null)
-        {
-            if (playerAvatarPrompt == null)
-                throw new ArgumentNullException(nameof(playerAvatarPrompt));
-            if (dateePrompt == null)
-                throw new ArgumentNullException(nameof(dateePrompt));
-
-            var def = gameDef ?? GameDefinition.PinderDefaults;
-
-            return string.Concat(
-                // --- STATIC, session-invariant sections first (cacheable prefix) ---
-                "== GAME VISION ==\n\n",
-                def.Vision.TrimEnd(),
-                "\n\n== WORLD RULES ==\n\n",
-                def.WorldDescription.TrimEnd(),
-                "\n\n== NARRATIVE DOCTRINE ==\n\n",
-                def.NarrativeDoctrine.TrimEnd(),
-                "\n\n== DRAMATIC CRAFT ==\n\n",
-                def.DramaticCraft != null ? def.DramaticCraft.BuildSection().TrimEnd() : "",
-                // Build() is the legacy joint prompt for callers that want both
-                // roles in one system block. Per #867 LESSONS_LEARNED, this method
-                // retains all sections (only BuildPlayerAvatar is trimmed).
-                string.IsNullOrWhiteSpace(def.DateeFriction) ? "" : "\n\n== DATEE RESISTANCE ==\n\n" + def.DateeFriction.TrimEnd(),
-                string.IsNullOrWhiteSpace(def.DateeCuriosity) ? "" : "\n\n== DATEE CURIOSITY ==\n\n" + def.DateeCuriosity.TrimEnd(),
-                string.IsNullOrWhiteSpace(def.ConversationArcProgression) ? "" : "\n\n== CONVERSATION ARC ==\n\n" + def.ConversationArcProgression.TrimEnd(),
-                string.IsNullOrWhiteSpace(def.PlayerProbing) ? "" : "\n\n== PLAYER PROBING ==\n\n" + def.PlayerProbing.TrimEnd(),
-                // --- CHARACTER-SPECIFIC / VARIABLE sections LAST ---
-                "\n\n== PLAYER CHARACTER ==\n\n",
-                playerAvatarPrompt.TrimEnd(),
-                "\n\n== DATEE CHARACTER ==\n\n",
-                dateePrompt.TrimEnd(),
-                "\n");
-        }
+        internal const string GmRoleFraming =
+            "You are the Game Master for this session, acting as a puppeteer who portrays " +
+            "EXACTLY ONE character: the character defined in the CHARACTER block at the very " +
+            "end of this prompt. You do not know, voice, or control any other character — " +
+            "you only ever speak and act as your assigned character. Everything below this line is " +
+            "shared world and craft guidance that applies to whichever single character you have " +
+            "been assigned. Stay fully in that character's voice for every turn.";
 
         /// <summary>
-        /// Build a system prompt containing only the player avatar's character profile and game definition.
-        /// (The "player avatar" is the in-game character the human portrays — distinct from the human user.)
-        /// Used to prevent voice bleed when generating dialogue options or delivering messages.
+        /// Header that marks the start of the per-session character-spec block.
+        /// Everything BEFORE this marker is the shared, identical GM base.
+        /// </summary>
+        public const string CharacterSpecHeader = "== CHARACTER YOU CONTROL ==";
+
+        /// <summary>
+        /// Build the GM system prompt for the player-avatar session.
+        /// The injected character spec is the player avatar's role + assembled profile.
         /// </summary>
         public static string BuildPlayerAvatar(string playerAvatarPrompt, GameDefinition? gameDef = null)
         {
@@ -82,48 +59,16 @@ namespace Pinder.LlmAdapters
             var def = gameDef ?? GameDefinition.PinderDefaults;
 
             var sb = new AnnotatedStringBuilder();
-
-            // --- STATIC, session-invariant sections first (cacheable prefix) ---
-            sb.Append("== GAME VISION ==\n\n");
-            sb.AppendLine(def.Vision.TrimEnd(), "game-definition.yaml", "vision");
-            sb.Append("\n== WORLD RULES ==\n\n");
-            sb.AppendLine(def.WorldDescription.TrimEnd(), "game-definition.yaml", "world_description");
-
-            sb.Append("\n== NARRATIVE DOCTRINE ==\n\n");
-            sb.AppendLine(def.NarrativeDoctrine.TrimEnd(), "game-definition.yaml", "narrative_doctrine");
-
-            if (def.DramaticCraft != null)
-            {
-                sb.Append("\n== DRAMATIC CRAFT ==\n\n");
-                sb.AppendLine(def.DramaticCraft.BuildSection().TrimEnd(), "game-definition.yaml", "dramatic_craft");
-            }
-
-            if (!string.IsNullOrWhiteSpace(def.ConversationArcProgression))
-            {
-                sb.Append("\n== CONVERSATION ARC ==\n\n");
-                sb.AppendLine(def.ConversationArcProgression.TrimEnd(), "game-definition.yaml", "conversation_arc_progression");
-            }
-
-            if (!string.IsNullOrWhiteSpace(def.PlayerProbing))
-            {
-                sb.Append("\n== PLAYER PROBING ==\n\n");
-                sb.AppendLine(def.PlayerProbing.TrimEnd(), "game-definition.yaml", "player_probing");
-            }
-
-            // --- CHARACTER-SPECIFIC / VARIABLE section LAST ---
-            sb.Append("\n== PLAYER CHARACTER ==\n\n");
-            sb.AppendLine(def.PlayerRoleDescription.TrimEnd(), "game-definition.yaml", "player_role_description");
-            sb.Append("\n");
-            sb.AppendLine(playerAvatarPrompt.TrimEnd(), "character-profile", "player-profile");
-
-            sb.Append("\n");
+            AppendGmBase(sb, def);
+            AppendCharacterSpec(sb, def.PlayerRoleDescription, "player_role_description",
+                playerAvatarPrompt, "player-profile");
 
             return new PromptTraceResult(sb.ToString(), sb.Spans);
         }
 
         /// <summary>
-        /// Build a system prompt containing only the datee's character profile and game definition.
-        /// Used to prevent voice bleed when generating datee responses.
+        /// Build the GM system prompt for the datee session.
+        /// The injected character spec is the datee's role + assembled profile.
         /// </summary>
         public static string BuildDatee(string dateePrompt, GameDefinition? gameDef = null)
         {
@@ -138,10 +83,29 @@ namespace Pinder.LlmAdapters
             var def = gameDef ?? GameDefinition.PinderDefaults;
 
             var sb = new AnnotatedStringBuilder();
+            AppendGmBase(sb, def);
+            AppendCharacterSpec(sb, def.DateeRoleDescription, "datee_role_description",
+                dateePrompt, "datee-profile");
 
-            // --- STATIC, session-invariant sections first (cacheable prefix) ---
-            sb.Append("== GAME VISION ==\n\n");
+            return new PromptTraceResult(sb.ToString(), sb.Spans);
+        }
+
+        /// <summary>
+        /// Appends the shared, session-invariant GM base. This block is produced
+        /// identically for BOTH sessions — the cacheable static prefix. Optional
+        /// sections are gated on non-empty content so an empty game definition
+        /// still yields an identical base across both sessions.
+        /// </summary>
+        private static void AppendGmBase(AnnotatedStringBuilder sb, GameDefinition def)
+        {
+            // --- Puppeteer framing (static; shared across both sessions) ---
+            sb.Append("== GAME MASTER ==\n\n");
+            sb.AppendLine(GmRoleFraming, "session-system-prompt-builder", "gm-role-framing");
+
+            // --- STATIC, session-invariant game definition sections ---
+            sb.Append("\n== GAME VISION ==\n\n");
             sb.AppendLine(def.Vision.TrimEnd(), "game-definition.yaml", "vision");
+
             sb.Append("\n== WORLD RULES ==\n\n");
             sb.AppendLine(def.WorldDescription.TrimEnd(), "game-definition.yaml", "world_description");
 
@@ -154,6 +118,9 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine(def.DramaticCraft.BuildSection().TrimEnd(), "game-definition.yaml", "dramatic_craft");
             }
 
+            // Shared conversation-dynamic sections. Under the single-puppeteer
+            // model the GM needs the full dynamic regardless of which character
+            // it portrays, so these live in the shared base (not split per role).
             if (!string.IsNullOrWhiteSpace(def.DateeFriction))
             {
                 sb.Append("\n== DATEE RESISTANCE ==\n\n");
@@ -172,15 +139,30 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine(def.ConversationArcProgression.TrimEnd(), "game-definition.yaml", "conversation_arc_progression");
             }
 
-            // --- CHARACTER-SPECIFIC / VARIABLE section LAST ---
-            sb.Append("\n== DATEE CHARACTER ==\n\n");
-            sb.AppendLine(def.DateeRoleDescription.TrimEnd(), "game-definition.yaml", "datee_role_description");
-            sb.Append("\n");
-            sb.AppendLine(dateePrompt.TrimEnd(), "character-profile", "datee-profile");
+            if (!string.IsNullOrWhiteSpace(def.PlayerProbing))
+            {
+                sb.Append("\n== PLAYER PROBING ==\n\n");
+                sb.AppendLine(def.PlayerProbing.TrimEnd(), "game-definition.yaml", "player_probing");
+            }
+        }
 
+        /// <summary>
+        /// Appends the per-session character-spec block — the ONLY difference
+        /// between the two built prompts. Placed LAST to keep the shared base as
+        /// the stable cacheable prefix.
+        /// </summary>
+        private static void AppendCharacterSpec(
+            AnnotatedStringBuilder sb,
+            string roleDescription,
+            string roleKey,
+            string characterPrompt,
+            string profileKey)
+        {
+            sb.Append("\n" + CharacterSpecHeader + "\n\n");
+            sb.AppendLine(roleDescription.TrimEnd(), "game-definition.yaml", roleKey);
             sb.Append("\n");
-
-            return new PromptTraceResult(sb.ToString(), sb.Spans);
+            sb.AppendLine(characterPrompt.TrimEnd(), "character-profile", profileKey);
+            sb.Append("\n");
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/GmOutputContractTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/GmOutputContractTests.cs
@@ -1,0 +1,191 @@
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #1124: the ONE canonical Game Master output-format contract. Verifies
+    /// the emit/parse pair round-trips and that malformed input degrades
+    /// gracefully (never throws; collapses to a message-only result).
+    /// </summary>
+    public class GmOutputContractTests
+    {
+        // ── Round-trip: parse(emit(x)) == x ──────────────────────────────────
+
+        [Fact]
+        public void RoundTrip_MessageOnly()
+        {
+            var x = new GmTurnOutput("hey, what's up?");
+            var emitted = GmOutputContract.Emit(x);
+            var parsed = GmOutputContract.Parse(emitted);
+            Assert.Equal(x, parsed);
+        }
+
+        [Fact]
+        public void RoundTrip_MessageWithTell()
+        {
+            var x = new GmTurnOutput(
+                "Nice try, but you'll have to do better than that.",
+                tell: new Tell(StatType.Charm, "she twirls her hair when nervous"));
+
+            var emitted = GmOutputContract.Emit(x);
+            var parsed = GmOutputContract.Parse(emitted);
+            Assert.Equal(x, parsed);
+        }
+
+        [Fact]
+        public void RoundTrip_MessageWithWeakness()
+        {
+            var x = new GmTurnOutput(
+                "ok that actually got me",
+                weakness: new WeaknessWindow(StatType.Wit, 2),
+                weaknessDescription: "distracted by the joke");
+
+            var emitted = GmOutputContract.Emit(x);
+            var parsed = GmOutputContract.Parse(emitted);
+            Assert.Equal(x, parsed);
+        }
+
+        [Fact]
+        public void RoundTrip_MessageWithBothSignals()
+        {
+            var x = new GmTurnOutput(
+                "you think you're clever?",
+                tell: new Tell(StatType.Honesty, "avoiding eye contact"),
+                weakness: new WeaknessWindow(StatType.Chaos, 3),
+                weaknessDescription: "thrown off balance");
+
+            var emitted = GmOutputContract.Emit(x);
+            var parsed = GmOutputContract.Parse(emitted);
+            Assert.Equal(x, parsed);
+        }
+
+        [Fact]
+        public void RoundTrip_SelfAwareness_NormalizesAndSurvives()
+        {
+            var x = new GmTurnOutput(
+                "I know exactly what I'm doing.",
+                tell: new Tell(StatType.SelfAwareness, "knows her flaws"));
+
+            var emitted = GmOutputContract.Emit(x);
+            // Canonical wire spelling is the SELF_AWARENESS token.
+            Assert.Contains("SELF_AWARENESS", emitted);
+            var parsed = GmOutputContract.Parse(emitted);
+            Assert.Equal(x, parsed);
+        }
+
+        [Fact]
+        public void RoundTrip_MultiLineMessage()
+        {
+            var x = new GmTurnOutput("first line\nsecond line\nthird line");
+            var parsed = GmOutputContract.Parse(GmOutputContract.Emit(x));
+            Assert.Equal(x, parsed);
+        }
+
+        // ── Emit shape ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Emit_NoSignals_OmitsSignalsBlock()
+        {
+            var emitted = GmOutputContract.Emit(new GmTurnOutput("just a message"));
+            Assert.DoesNotContain(GmOutputContract.SignalsMarker, emitted);
+            Assert.Equal("just a message", emitted);
+        }
+
+        [Fact]
+        public void Emit_WithSignals_IncludesSignalsMarker()
+        {
+            var emitted = GmOutputContract.Emit(new GmTurnOutput(
+                "msg", tell: new Tell(StatType.Rizz, "leaning in")));
+            Assert.Contains(GmOutputContract.SignalsMarker, emitted);
+            Assert.Contains("TELL: Rizz (leaning in)", emitted);
+        }
+
+        // ── Parse from raw model text (canonical hand-authored format) ────────
+
+        [Fact]
+        public void Parse_CanonicalText_ExtractsMessageAndSignals()
+        {
+            var raw = "Nice try, but you'll have to do better than that.\n" +
+                      "[SIGNALS]\n" +
+                      "TELL: Charm (she twirls her hair when nervous)\n" +
+                      "WEAKNESS: Wit -2 (distracted by the joke)";
+
+            var parsed = GmOutputContract.Parse(raw);
+            Assert.Equal("Nice try, but you'll have to do better than that.", parsed.Message);
+            Assert.NotNull(parsed.Tell);
+            Assert.Equal(StatType.Charm, parsed.Tell!.Stat);
+            Assert.Equal("she twirls her hair when nervous", parsed.Tell.Description);
+            Assert.NotNull(parsed.Weakness);
+            Assert.Equal(StatType.Wit, parsed.Weakness!.DefendingStat);
+            Assert.Equal(2, parsed.Weakness.DcReduction);
+        }
+
+        // ── Graceful degradation (malformed input never throws) ───────────────
+
+        [Fact]
+        public void Parse_Null_ReturnsEmptyMessage()
+        {
+            var parsed = GmOutputContract.Parse(null);
+            Assert.Equal(string.Empty, parsed.Message);
+            Assert.Null(parsed.Tell);
+            Assert.Null(parsed.Weakness);
+        }
+
+        [Fact]
+        public void Parse_Empty_ReturnsEmptyMessage()
+        {
+            var parsed = GmOutputContract.Parse("");
+            Assert.Equal(string.Empty, parsed.Message);
+            Assert.Null(parsed.Tell);
+            Assert.Null(parsed.Weakness);
+        }
+
+        [Fact]
+        public void Parse_SignalsMarkerButGarbageBody_DegradesToMessageOnly()
+        {
+            var raw = "here's my reply\n[SIGNALS]\nTELL: this is not valid at all";
+            var parsed = GmOutputContract.Parse(raw);
+            // Message is preserved; unparseable signals collapse to null.
+            Assert.Equal("here's my reply", parsed.Message);
+            Assert.Null(parsed.Tell);
+            Assert.Null(parsed.Weakness);
+        }
+
+        [Fact]
+        public void Parse_UnknownStat_DropsSignalKeepsMessage()
+        {
+            var raw = "reply text\n[SIGNALS]\nTELL: Telepathy (not a real stat)";
+            var parsed = GmOutputContract.Parse(raw);
+            Assert.Equal("reply text", parsed.Message);
+            Assert.Null(parsed.Tell);
+        }
+
+        [Fact]
+        public void Parse_ZeroWeaknessReduction_DropsWeakness()
+        {
+            var raw = "reply\n[SIGNALS]\nWEAKNESS: Wit -0 (no real opening)";
+            var parsed = GmOutputContract.Parse(raw);
+            Assert.Null(parsed.Weakness);
+        }
+
+        [Fact]
+        public void Parse_PlainTextNoSignals_ReturnsWholeMessage()
+        {
+            var parsed = GmOutputContract.Parse("just a normal line with no signals");
+            Assert.Equal("just a normal line with no signals", parsed.Message);
+            Assert.Null(parsed.Tell);
+            Assert.Null(parsed.Weakness);
+        }
+
+        // ── Emit guards ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void Emit_NullOutput_Throws()
+        {
+            Assert.Throws<System.ArgumentNullException>(() => GmOutputContract.Emit(null!));
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue543_SessionSystemPromptSpecTests.Builder.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue543_SessionSystemPromptSpecTests.Builder.cs
@@ -94,39 +94,37 @@ namespace Pinder.LlmAdapters.Tests
 
         #endregion
 
-        #region AC4: SessionSystemPromptBuilder.Build — 5 sections in order
+        #region AC4: Shared GM template — sections in order (#1124)
 
-        // What: AC4 — Build produces 5 section headers
-        // Mutation: would catch if any section header was missing
+        // What: AC4 — the shared GM base produces its core section headers.
+        // Mutation: would catch if any section header was missing.
         [Fact]
-        public void Build_ContainsAllFiveSectionHeaders()
+        public void Build_ContainsSharedSectionHeaders()
         {
-            var result = SessionSystemPromptBuilder.Build("player text", "datee text");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player text");
+            Assert.Contains("== GAME MASTER ==", result);
             Assert.Contains("== GAME VISION ==", result);
             Assert.Contains("== WORLD RULES ==", result);
-            Assert.Contains("== PLAYER CHARACTER ==", result);
-            Assert.Contains("== DATEE CHARACTER ==", result);
             Assert.Contains("== NARRATIVE DOCTRINE ==", result);
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, result);
         }
 
-        // What: AC4 — Sections are in correct order: Vision < World < Player < Datee < Meta
-        // Mutation: would catch if section order was swapped (e.g. player before world)
+        // What: AC4 — static GM base first, character-spec block last.
+        // Mutation: would catch if section order was swapped.
         [Fact]
         public void Build_SectionsInCorrectOrder()
         {
-            var result = SessionSystemPromptBuilder.Build("player text", "datee text");
-            var visionIdx = result.IndexOf("== GAME VISION ==");
-            var worldIdx = result.IndexOf("== WORLD RULES ==");
-            var playerIdx = result.IndexOf("== PLAYER CHARACTER ==");
-            var dateeIdx = result.IndexOf("== DATEE CHARACTER ==");
-            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player text");
+            var gmIdx = result.IndexOf("== GAME MASTER ==", StringComparison.Ordinal);
+            var visionIdx = result.IndexOf("== GAME VISION ==", StringComparison.Ordinal);
+            var worldIdx = result.IndexOf("== WORLD RULES ==", StringComparison.Ordinal);
+            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==", StringComparison.Ordinal);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
 
-            // Variable character sections come LAST: static game/doctrine material first,
-            // then PLAYER CHARACTER and DATEE CHARACTER at the tail.
+            Assert.True(gmIdx < visionIdx, "GAME MASTER must precede GAME VISION");
             Assert.True(visionIdx < worldIdx, "GAME VISION must precede WORLD RULES");
             Assert.True(worldIdx < metaIdx, "WORLD RULES must precede NARRATIVE DOCTRINE");
-            Assert.True(metaIdx < playerIdx, "NARRATIVE DOCTRINE must precede PLAYER CHARACTER");
-            Assert.True(playerIdx < dateeIdx, "PLAYER CHARACTER must precede DATEE CHARACTER");
+            Assert.True(metaIdx < specIdx, "NARRATIVE DOCTRINE must precede the character-spec block");
         }
 
         // What: AC4 — GAME VISION section sourced from gameDef.Vision
@@ -136,10 +134,10 @@ namespace Pinder.LlmAdapters.Tests
         {
             var custom = new GameDefinition(
                 "G", "UNIQUE_VISION_XYZ", "W", "P", "O", "ND");
-            var result = SessionSystemPromptBuilder.Build("player", "datee", custom);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player", custom);
 
-            var visionIdx = result.IndexOf("== GAME VISION ==");
-            var worldIdx = result.IndexOf("== WORLD RULES ==");
+            var visionIdx = result.IndexOf("== GAME VISION ==", StringComparison.Ordinal);
+            var worldIdx = result.IndexOf("== WORLD RULES ==", StringComparison.Ordinal);
             var visionSection = result.Substring(visionIdx, worldIdx - visionIdx);
             Assert.Contains("UNIQUE_VISION_XYZ", visionSection);
         }
@@ -151,40 +149,38 @@ namespace Pinder.LlmAdapters.Tests
         {
             var custom = new GameDefinition(
                 "G", "V", "UNIQUE_WORLD_ABC", "P", "O", "ND");
-            var result = SessionSystemPromptBuilder.Build("player", "datee", custom);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player", custom);
 
-            var worldIdx = result.IndexOf("== WORLD RULES ==");
-            var playerIdx = result.IndexOf("== PLAYER CHARACTER ==");
-            var worldSection = result.Substring(worldIdx, playerIdx - worldIdx);
+            var worldIdx = result.IndexOf("== WORLD RULES ==", StringComparison.Ordinal);
+            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==", StringComparison.Ordinal);
+            var worldSection = result.Substring(worldIdx, metaIdx - worldIdx);
             Assert.Contains("UNIQUE_WORLD_ABC", worldSection);
         }
 
-        // What: AC4 — PLAYER CHARACTER section contains playerAvatarPrompt verbatim
+        // What: AC4 — character-spec block contains the player avatar prompt verbatim
         // Mutation: would catch if playerAvatarPrompt was modified, trimmed, or summarized
         [Fact]
-        public void Build_PlayerSectionContainsPlayerPromptVerbatim()
+        public void Build_CharacterSpecContainsPlayerPromptVerbatim()
         {
             var playerText = "You are Velvet. Lowercase-with-intent. Ironic. Level 7 Veteran.";
-            var result = SessionSystemPromptBuilder.Build(playerText, "opp");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(playerText);
 
-            var playerIdx = result.IndexOf("== PLAYER CHARACTER ==");
-            var dateeIdx = result.IndexOf("== DATEE CHARACTER ==");
-            var playerSection = result.Substring(playerIdx, dateeIdx - playerIdx);
-            Assert.Contains(playerText, playerSection);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
+            var specSection = result.Substring(specIdx);
+            Assert.Contains(playerText, specSection);
         }
 
-        // What: AC4 — DATEE CHARACTER section contains dateePrompt verbatim
-        // Mutation: would catch if dateePrompt was modified or placed in player section
+        // What: AC4 — datee session character-spec block contains the datee prompt verbatim
+        // Mutation: would catch if dateePrompt was modified or placed elsewhere
         [Fact]
-        public void Build_DateeSectionContainsDateePromptVerbatim()
+        public void Build_CharacterSpecContainsDateePromptVerbatim()
         {
             var dateeText = "You are Sable. Fast-talking. Uses omg and emoji. Level 5.";
-            var result = SessionSystemPromptBuilder.Build("player", dateeText);
+            var result = SessionSystemPromptBuilder.BuildDatee(dateeText);
 
-            // DATEE CHARACTER is now the final section; it runs to the end of the prompt.
-            var dateeIdx = result.IndexOf("== DATEE CHARACTER ==");
-            var dateeSection = result.Substring(dateeIdx);
-            Assert.Contains(dateeText, dateeSection);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
+            var specSection = result.Substring(specIdx);
+            Assert.Contains(dateeText, specSection);
         }
 
         // What: AC4 — NARRATIVE DOCTRINE section contains the merged doctrine body
@@ -196,8 +192,8 @@ namespace Pinder.LlmAdapters.Tests
                 "G", "V", "W", "P", "O",
                 "UNIQUE_META_CONTRACT_123 UNIQUE_WRITING_RULES_456");
 
-            var result = SessionSystemPromptBuilder.Build("p", "o", custom);
-            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("p", custom);
+            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==", StringComparison.Ordinal);
             var afterMeta = result.Substring(metaIdx);
             Assert.Contains("UNIQUE_META_CONTRACT_123", afterMeta);
             Assert.Contains("UNIQUE_WRITING_RULES_456", afterMeta);
@@ -205,23 +201,20 @@ namespace Pinder.LlmAdapters.Tests
 
         #endregion
 
-        #region AC5: Unit test — prompt contains both character names, game vision, world rules
+        #region AC5: Unit test — prompt contains character name, game vision, world rules
 
-        // What: AC5 — full integration: Build with known inputs contains all expected content
-        // Mutation: would catch if any of the 5 content sources was dropped
+        // What: AC5 — full integration: a built prompt contains the expected content sources
+        // Mutation: would catch if any of the content sources was dropped
         [Fact]
         public void Build_WithKnownInputs_ContainsAllContent()
         {
             var playerAvatarPrompt = "You are Velvet. Lowercase-with-intent. Ironic. Level 7 Veteran.";
-            var dateePrompt = "You are Sable. Fast-talking. Uses omg and emoji. Level 5 Journeyman.";
             var gameDef = GameDefinition.PinderDefaults;
 
-            var result = SessionSystemPromptBuilder.Build(playerAvatarPrompt, dateePrompt, gameDef);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(playerAvatarPrompt, gameDef);
 
-            // Player prompt appears verbatim
+            // Character prompt appears verbatim
             Assert.Contains(playerAvatarPrompt, result);
-            // Datee prompt appears verbatim
-            Assert.Contains(dateePrompt, result);
             // Game vision content present
             Assert.Contains("comedy dating RPG", result);
             // World description content present
@@ -230,6 +223,8 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains(gameDef.WorldDescription.Trim(), result);
             // Meta contract content present
             Assert.Contains("break character", result);
+            // GM puppeteer framing present
+            Assert.Contains("== GAME MASTER ==", result);
         }
 
         #endregion
@@ -241,8 +236,7 @@ namespace Pinder.LlmAdapters.Tests
         [Fact]
         public void Build_NullGameDef_UsesPinderDefaults()
         {
-            var result = SessionSystemPromptBuilder.Build("player", "datee", null);
-            // Should use PinderDefaults, which contains "Pinder" and "comedy dating RPG"
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player", null);
             Assert.Contains("comedy dating RPG", result);
             Assert.Contains("== GAME VISION ==", result);
         }
@@ -252,27 +246,27 @@ namespace Pinder.LlmAdapters.Tests
         [Fact]
         public void Build_OmittedGameDef_UsesPinderDefaults()
         {
-            var result = SessionSystemPromptBuilder.Build("player", "datee");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player");
             Assert.Contains("comedy dating RPG", result);
         }
 
-        // What: Edge case — null playerAvatarPrompt throws ArgumentNullException
+        // What: Edge case — null player prompt throws ArgumentNullException
         // Mutation: would catch if null check on playerAvatarPrompt was removed
         [Fact]
         public void Build_NullPlayerPrompt_ThrowsArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() =>
-                SessionSystemPromptBuilder.Build(null!, "datee"));
+                SessionSystemPromptBuilder.BuildPlayerAvatar(null!));
             Assert.Equal("playerAvatarPrompt", ex.ParamName);
         }
 
-        // What: Edge case — null dateePrompt throws ArgumentNullException
+        // What: Edge case — null datee prompt throws ArgumentNullException
         // Mutation: would catch if null check on dateePrompt was removed
         [Fact]
         public void Build_NullDateePrompt_ThrowsArgumentNullException()
         {
             var ex = Assert.Throws<ArgumentNullException>(() =>
-                SessionSystemPromptBuilder.Build("player", null!));
+                SessionSystemPromptBuilder.BuildDatee(null!));
             Assert.Equal("dateePrompt", ex.ParamName);
         }
 
@@ -281,12 +275,12 @@ namespace Pinder.LlmAdapters.Tests
         [Fact]
         public void Build_EmptyPrompts_ProducesAllSections()
         {
-            var result = SessionSystemPromptBuilder.Build("", "");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("");
+            Assert.Contains("== GAME MASTER ==", result);
             Assert.Contains("== GAME VISION ==", result);
             Assert.Contains("== WORLD RULES ==", result);
-            Assert.Contains("== PLAYER CHARACTER ==", result);
-            Assert.Contains("== DATEE CHARACTER ==", result);
             Assert.Contains("== NARRATIVE DOCTRINE ==", result);
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, result);
         }
 
         // What: Edge case — empty GameDefinition fields produce sections with empty bodies
@@ -295,11 +289,10 @@ namespace Pinder.LlmAdapters.Tests
         public void Build_EmptyGameDefFields_ProducesAllSections()
         {
             var emptyDef = new GameDefinition("", "", "", "", "", "");
-            var result = SessionSystemPromptBuilder.Build("player", "datee", emptyDef);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player", emptyDef);
             Assert.Contains("== GAME VISION ==", result);
             Assert.Contains("== NARRATIVE DOCTRINE ==", result);
             Assert.Contains("player", result);
-            Assert.Contains("datee", result);
         }
 
         #endregion
@@ -312,10 +305,8 @@ namespace Pinder.LlmAdapters.Tests
         public void Build_LargePrompts_NotTruncated()
         {
             var largePlayer = new string('A', 10000);
-            var largeDatee = new string('B', 10000);
-            var result = SessionSystemPromptBuilder.Build(largePlayer, largeDatee);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(largePlayer);
             Assert.Contains(largePlayer, result);
-            Assert.Contains(largeDatee, result);
         }
 
         #endregion
@@ -356,39 +347,39 @@ horniness_time_modifiers:
 
         #endregion
 
-        #region Cross-cutting: Build does not mix player/datee sections
+        #region Cross-cutting: shared base identical except character spec (#1124)
 
-        // What: Player prompt must not appear in datee section and vice versa
-        // Mutation: would catch if playerAvatarPrompt and dateePrompt params were swapped
+        // What: the two sessions share ONE template; only the spec block differs.
+        // Mutation: would catch if the shared base diverged between sessions or
+        // if player/datee prompts leaked across sessions.
         [Fact]
-        public void Build_PlayerAndDateePromptsInCorrectSections()
+        public void Build_SharedBaseIdentical_OnlyCharacterSpecDiffers()
         {
             var playerAvatarPrompt = "PLAYER_UNIQUE_MARKER_111";
             var dateePrompt = "DATEE_UNIQUE_MARKER_222";
-            var result = SessionSystemPromptBuilder.Build(playerAvatarPrompt, dateePrompt);
+            var def = GameDefinition.PinderDefaults;
 
-            var playerIdx = result.IndexOf("== PLAYER CHARACTER ==");
-            var dateeIdx = result.IndexOf("== DATEE CHARACTER ==");
+            var playerResult = SessionSystemPromptBuilder.BuildPlayerAvatar(playerAvatarPrompt, def);
+            var dateeResult = SessionSystemPromptBuilder.BuildDatee(dateePrompt, def);
 
-            // PLAYER CHARACTER and DATEE CHARACTER are the final two sections.
-            var playerSection = result.Substring(playerIdx, dateeIdx - playerIdx);
-            var dateeSection = result.Substring(dateeIdx);
+            var header = SessionSystemPromptBuilder.CharacterSpecHeader;
+            var playerBase = playerResult.Substring(0, playerResult.IndexOf(header, StringComparison.Ordinal));
+            var dateeBase = dateeResult.Substring(0, dateeResult.IndexOf(header, StringComparison.Ordinal));
 
-            // Player marker in player section, not in datee section
-            Assert.Contains("PLAYER_UNIQUE_MARKER_111", playerSection);
-            Assert.DoesNotContain("PLAYER_UNIQUE_MARKER_111", dateeSection);
+            Assert.Equal(dateeBase, playerBase);
 
-            // Datee marker in datee section, not in player section
-            Assert.Contains("DATEE_UNIQUE_MARKER_222", dateeSection);
-            Assert.DoesNotContain("DATEE_UNIQUE_MARKER_222", playerSection);
+            Assert.Contains("PLAYER_UNIQUE_MARKER_111", playerResult);
+            Assert.DoesNotContain("DATEE_UNIQUE_MARKER_222", playerResult);
+            Assert.Contains("DATEE_UNIQUE_MARKER_222", dateeResult);
+            Assert.DoesNotContain("PLAYER_UNIQUE_MARKER_111", dateeResult);
         }
 
         #endregion
 
-        #region Custom GameDefinition flows through Build
+        #region Custom GameDefinition flows through builders
 
         // What: Custom GameDefinition values appear instead of PinderDefaults
-        // Mutation: would catch if Build always used PinderDefaults regardless of gameDef param
+        // Mutation: would catch if builder always used PinderDefaults regardless of gameDef param
         [Fact]
         public void Build_CustomGameDef_OverridesPinderDefaults()
         {
@@ -400,7 +391,7 @@ horniness_time_modifiers:
                 "CUSTOM_DATEE_ROLE",
                 "CUSTOM_META_CONTRACT CUSTOM_WRITING_RULES");
 
-            var result = SessionSystemPromptBuilder.Build("p", "o", custom);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("p", custom);
 
             Assert.Contains("CUSTOM_VISION_TEXT", result);
             Assert.Contains("CUSTOM_WORLD_TEXT", result);

--- a/tests/Pinder.LlmAdapters.Tests/Issue855_TwoCharacterHarnessTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue855_TwoCharacterHarnessTests.cs
@@ -66,10 +66,10 @@ namespace Pinder.LlmAdapters.Tests
 
             Assert.Equal("hey, I noticed you too.", line);
             // The system prompt is the REAL production datee prompt for the
-            // pursuer character — proven by the DATEE CHARACTER section and
-            // the pursuer's own assembled profile text appearing in it.
+            // pursuer character — proven by the shared GM character-spec block
+            // and the pursuer's own assembled profile text appearing in it.
             Assert.NotNull(transport.LastSystem);
-            Assert.Contains("== DATEE CHARACTER ==", transport.LastSystem!);
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, transport.LastSystem!);
             Assert.Contains(PursuerAssembledPrompt, transport.LastSystem!);
             // It is NOT the generic-persona prompt.
             Assert.DoesNotContain("witty, curious person texting", transport.LastSystem!);

--- a/tests/Pinder.LlmAdapters.Tests/Issue867_DeliveryTokenAuditSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue867_DeliveryTokenAuditSpecTests.cs
@@ -4,11 +4,13 @@ using Xunit;
 namespace Pinder.LlmAdapters.Tests
 {
     /// <summary>
-    /// Spec-driven tests for Issue #867: audit + cut datee-behavior sections from BuildPlayerAvatar.
-    /// Verifies DateeFriction and DateeCuriosity are stripped from player-side
-    /// system prompts while preserved in datee-side prompts.
-    /// ConversationArcProgression is shared conversation structure — kept in both.
-    /// PlayerProbing is player-specific — kept in BuildPlayerAvatar.
+    /// #1124 supersedes #867: the two sessions now share ONE canonical GM
+    /// puppeteer template, so the shared GM base (including the conversation-
+    /// dynamic sections) is identical for both BuildPlayerAvatar and BuildDatee.
+    /// The only per-session difference is the injected character-spec block.
+    ///
+    /// These tests pin the new shared-base contract and keep the original
+    /// token-ceiling sanity check.
     /// </summary>
     public class Issue867_DeliveryTokenAuditSpecTests
     {
@@ -29,170 +31,96 @@ namespace Pinder.LlmAdapters.Tests
                 playerProbing: "player probing content");
         }
 
-        #region BuildPlayerAvatar: datee sections removed
+        #region Shared GM base is identical for both sessions (#1124)
 
         [Fact]
-        public void BuildPlayer_ExcludesDateeFriction()
+        public void SharedBase_IdenticalForBothSessions()
         {
             var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
-            Assert.DoesNotContain("DATEE RESISTANCE", result);
-            Assert.DoesNotContain("datee friction content", result);
+            var player = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
+            var datee = SessionSystemPromptBuilder.BuildDatee("datee prompt", def);
+
+            var header = SessionSystemPromptBuilder.CharacterSpecHeader;
+            var playerBase = player.Substring(0, player.IndexOf(header, StringComparison.Ordinal));
+            var dateeBase = datee.Substring(0, datee.IndexOf(header, StringComparison.Ordinal));
+
+            Assert.Equal(dateeBase, playerBase);
         }
 
         [Fact]
-        public void BuildPlayer_ExcludesDateeCuriosity()
+        public void SharedBase_IncludesConversationDynamicSections()
         {
+            // Under the single-puppeteer model the GM needs the full conversation
+            // dynamic regardless of which character it portrays, so these live in
+            // the shared base and appear in BOTH sessions.
             var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
-            Assert.DoesNotContain("DATEE CURIOSITY", result);
-            Assert.DoesNotContain("datee curiosity content", result);
+            foreach (var result in new[]
+            {
+                SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def),
+                SessionSystemPromptBuilder.BuildDatee("datee prompt", def),
+            })
+            {
+                Assert.Contains("DATEE RESISTANCE", result);
+                Assert.Contains("datee friction content", result);
+                Assert.Contains("DATEE CURIOSITY", result);
+                Assert.Contains("datee curiosity content", result);
+                Assert.Contains("CONVERSATION ARC", result);
+                Assert.Contains("conversation arc content", result);
+                Assert.Contains("PLAYER PROBING", result);
+                Assert.Contains("player probing content", result);
+            }
         }
 
         [Fact]
-        public void BuildPlayer_IncludesConversationArcProgression()
+        public void SharedBase_IncludesNarrativeDoctrineSubSections()
         {
-            // ConversationArc is shared conversation-structure guidance relevant
-            // to both sides; kept in BuildPlayerAvatar per #867 LESSONS_LEARNED rule.
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
-            Assert.Contains("CONVERSATION ARC", result);
-            Assert.Contains("conversation arc content", result);
-        }
-
-        [Fact]
-        public void BuildPlayer_StillIncludesPlayerProbing()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
-            Assert.Contains("PLAYER PROBING", result);
-            Assert.Contains("player probing content", result);
-        }
-
-        [Fact]
-        public void BuildPlayer_StillIncludesTextingPsychology()
-        {
-            // texting psychology is now a sub-section folded into the merged
-            // narrative_doctrine body; it must still surface in BuildPlayerAvatar output.
+            // texting psychology + revelation-over-statement are folded into the
+            // merged narrative_doctrine body; they must surface in both sessions.
             var def = FullFixture();
             var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
             Assert.Contains("TEXTING PSYCHOLOGY", result);
             Assert.Contains("texting psych content", result);
-        }
-
-        [Fact]
-        public void BuildPlayer_StillIncludesRevelationOverStatement()
-        {
-            // revelation-over-statement is now a sub-section folded into the merged
-            // narrative_doctrine body; it must still surface in BuildPlayerAvatar output.
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
             Assert.Contains("REVELATION OVER STATEMENT", result);
             Assert.Contains("revelation content", result);
         }
 
         #endregion
 
-        #region BuildDatee: datee sections preserved
+        #region Character spec only contains its own profile
 
         [Fact]
-        public void BuildDatee_IncludesDateeFriction()
+        public void PlayerSession_SpecContainsPlayerRoleAndProfile()
         {
             var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildDatee("datee prompt", def);
-            Assert.Contains("DATEE RESISTANCE", result);
-            Assert.Contains("datee friction content", result);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("PLAYER_PROFILE_MARKER", def);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
+            var spec = result.Substring(specIdx);
+            Assert.Contains("Player role description here.", spec);
+            Assert.Contains("PLAYER_PROFILE_MARKER", spec);
         }
 
         [Fact]
-        public void BuildDatee_IncludesDateeCuriosity()
+        public void DateeSession_SpecContainsDateeRoleAndProfile()
         {
             var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildDatee("datee prompt", def);
-            Assert.Contains("DATEE CURIOSITY", result);
-            Assert.Contains("datee curiosity content", result);
-        }
-
-        [Fact]
-        public void BuildDatee_IncludesConversationArcProgression()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildDatee("datee prompt", def);
-            Assert.Contains("CONVERSATION ARC", result);
-            Assert.Contains("conversation arc content", result);
-        }
-
-        [Fact]
-        public void BuildDatee_ExcludesPlayerProbing()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.BuildDatee("datee prompt", def);
-            Assert.DoesNotContain("PLAYER PROBING", result);
-            Assert.DoesNotContain("player probing content", result);
+            var result = SessionSystemPromptBuilder.BuildDatee("DATEE_PROFILE_MARKER", def);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
+            var spec = result.Substring(specIdx);
+            Assert.Contains("Datee role description here.", spec);
+            Assert.Contains("DATEE_PROFILE_MARKER", spec);
         }
 
         #endregion
 
-        #region Build (legacy shared prompt) — datee sections also removed
-
-        // Build() is the legacy joint method that retains ALL sections per
-        // LESSONS_LEARNED PROMPT-BLOAT-FROM-CROSS-ROLE-SECTIONS. Only BuildPlayerAvatar
-        // is trimmed (saves ~1,000 tokens per delivery call). Build() callers are
-        // test-only paths that want the full prompt for parity checks.
-        [Fact]
-        public void Build_IncludesDateeFriction()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.Build("p", "o", def);
-            Assert.Contains("DATEE RESISTANCE", result);
-            Assert.Contains("datee friction content", result);
-        }
+        #region Token savings / bounding-box sanity
 
         [Fact]
-        public void Build_IncludesDateeCuriosity()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.Build("p", "o", def);
-            Assert.Contains("DATEE CURIOSITY", result);
-            Assert.Contains("datee curiosity content", result);
-        }
-
-        [Fact]
-        public void Build_IncludesConversationArcProgression()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.Build("p", "o", def);
-            Assert.Contains("CONVERSATION ARC", result);
-            Assert.Contains("conversation arc content", result);
-        }
-
-        [Fact]
-        public void Build_StillIncludesPlayerProbing()
-        {
-            var def = FullFixture();
-            var result = SessionSystemPromptBuilder.Build("p", "o", def);
-            Assert.Contains("PLAYER PROBING", result);
-            Assert.Contains("player probing content", result);
-        }
-
-        #endregion
-
-        #region Token savings estimate
-
-        [Fact]
-        public void BuildPlayer_WithFullGameDefinition_IsSmallerThanBefore()
+        public void BuildPlayer_WithFullGameDefinition_StaysUnderCeiling()
         {
             var def = FullFixture();
             var result = SessionSystemPromptBuilder.BuildPlayerAvatar("player prompt", def);
-            // With the three datee sections removed, BuildPlayerAvatar should be
-            // measurably smaller. This is a coarse sanity check.
-            // The three removed sections + headers total ~1,400 tokens (~5,600 chars).
-            // Even with a minimal GameDefinition, we'd expect at least 5K chars.
             Assert.True(result.Length > 0);
-            // It must not exceed an arbitrary safe ceiling (full game-definition.yaml
-            // is the largest admissible input; we set the ceiling at 20,000 chars as
-            // a bounding-box sanity check that no accidental bloater section gets
-            // added back).
+            // Bounding-box sanity check: no accidental bloater section creeps in.
             Assert.True(result.Length < 20_000,
                 $"BuildPlayerAvatar output length {result.Length} exceeds safety ceiling of 20,000 chars.");
         }

--- a/tests/Pinder.LlmAdapters.Tests/SessionSystemPromptBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionSystemPromptBuilderTests.cs
@@ -3,87 +3,156 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    /// <summary>
+    /// #1124: BOTH sessions share ONE canonical GM puppeteer system-prompt
+    /// template; only the injected character-spec block differs. The legacy
+    /// combined Build(player, datee) path has been removed.
+    /// </summary>
     public class SessionSystemPromptBuilderTests
     {
         private const string PlayerAvatarPrompt = "You are Velvet. Lowercase-with-intent. Ironic. Level 7 Veteran.";
         private const string DateePrompt = "You are Sable. Fast-talking. Uses omg and emoji. Level 5 Journeyman.";
 
         [Fact]
-        public void Build_ContainsBothCharacterPrompts()
+        public void BuildPlayerAvatar_ContainsCharacterPrompt()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
             Assert.Contains(PlayerAvatarPrompt, result);
+        }
+
+        [Fact]
+        public void BuildDatee_ContainsCharacterPrompt()
+        {
+            var result = SessionSystemPromptBuilder.BuildDatee(DateePrompt);
             Assert.Contains(DateePrompt, result);
         }
 
         [Fact]
         public void Build_ContainsGameVision()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
             Assert.Contains("comedy dating RPG", result);
         }
 
         [Fact]
         public void Build_ContainsWorldDescription()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildDatee(DateePrompt);
             Assert.Contains("dating server", result);
         }
 
         [Fact]
         public void Build_ContainsMetaContract()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
             Assert.Contains("break character", result);
         }
 
         [Fact]
         public void Build_ContainsWritingRules()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildDatee(DateePrompt);
             Assert.Contains("texting register", result);
         }
 
         [Fact]
         public void Build_ContainsNarrativeDoctrineHeader()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
             Assert.Contains("== NARRATIVE DOCTRINE ==", result);
         }
 
         [Fact]
-        public void Build_HasFiveSections()
+        public void Build_ContainsGmPuppeteerFraming()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
+            // #1124: both sessions carry the shared GM puppeteer framing.
+            var playerResult = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
+            var dateeResult = SessionSystemPromptBuilder.BuildDatee(DateePrompt);
+            Assert.Contains("== GAME MASTER ==", playerResult);
+            Assert.Contains("== GAME MASTER ==", dateeResult);
+            Assert.Contains("EXACTLY ONE character", playerResult);
+            Assert.Contains("EXACTLY ONE character", dateeResult);
+        }
+
+        [Fact]
+        public void Build_HasSharedSections()
+        {
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
+            Assert.Contains("== GAME MASTER ==", result);
             Assert.Contains("== GAME VISION ==", result);
             Assert.Contains("== WORLD RULES ==", result);
-            Assert.Contains("== PLAYER CHARACTER ==", result);
-            Assert.Contains("== DATEE CHARACTER ==", result);
             Assert.Contains("== NARRATIVE DOCTRINE ==", result);
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, result);
         }
 
         [Fact]
-        public void Build_SectionsInCorrectOrder()
+        public void Build_CharacterSpecComesLast()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt);
-            var visionIdx = result.IndexOf("== GAME VISION ==");
-            var worldIdx = result.IndexOf("== WORLD RULES ==");
-            var playerIdx = result.IndexOf("== PLAYER CHARACTER ==");
-            var dateeIdx = result.IndexOf("== DATEE CHARACTER ==");
-            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==");
+            // Static GM base first; the variable character-spec block at the tail,
+            // so the cacheable prefix stays stable (#1123 caching).
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt);
+            var gmIdx = result.IndexOf("== GAME MASTER ==", StringComparison.Ordinal);
+            var visionIdx = result.IndexOf("== GAME VISION ==", StringComparison.Ordinal);
+            var doctrineIdx = result.IndexOf("== NARRATIVE DOCTRINE ==", StringComparison.Ordinal);
+            var specIdx = result.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
 
-            // Variable character sections come LAST: static game/doctrine material first,
-            // then PLAYER CHARACTER and DATEE CHARACTER at the tail.
-            Assert.True(visionIdx < worldIdx, "GAME VISION should come before WORLD RULES");
-            Assert.True(worldIdx < metaIdx, "WORLD RULES should come before NARRATIVE DOCTRINE");
-            Assert.True(metaIdx < playerIdx, "NARRATIVE DOCTRINE should come before PLAYER CHARACTER");
-            Assert.True(playerIdx < dateeIdx, "PLAYER CHARACTER should come before DATEE CHARACTER");
+            Assert.True(gmIdx < visionIdx, "GAME MASTER framing should come first");
+            Assert.True(visionIdx < doctrineIdx, "GAME VISION should precede NARRATIVE DOCTRINE");
+            Assert.True(doctrineIdx < specIdx, "Static base should precede the character-spec block");
+            // The character spec is the final block — its prompt text appears after it.
+            Assert.Contains(PlayerAvatarPrompt, result.Substring(specIdx));
+        }
+
+        // ── #1124 KEY ACCEPTANCE: identical-template-except-spec ──────────────
+
+        [Fact]
+        public void BothSessions_ShareIdenticalBase_OnlyCharacterSpecDiffers()
+        {
+            // The single shared GM template means the two built prompts must be
+            // byte-for-byte identical UP TO the character-spec header. Everything
+            // before "== CHARACTER YOU CONTROL ==" is the shared cacheable base.
+            var def = GameDefinition.PinderDefaults;
+            var playerResult = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt, def);
+            var dateeResult = SessionSystemPromptBuilder.BuildDatee(DateePrompt, def);
+
+            var header = SessionSystemPromptBuilder.CharacterSpecHeader;
+            var playerSpecIdx = playerResult.IndexOf(header, StringComparison.Ordinal);
+            var dateeSpecIdx = dateeResult.IndexOf(header, StringComparison.Ordinal);
+
+            Assert.True(playerSpecIdx > 0, "player prompt must contain the character-spec header");
+            Assert.True(dateeSpecIdx > 0, "datee prompt must contain the character-spec header");
+
+            var playerBase = playerResult.Substring(0, playerSpecIdx);
+            var dateeBase = dateeResult.Substring(0, dateeSpecIdx);
+
+            // The shared GM base is identical across both sessions.
+            Assert.Equal(dateeBase, playerBase);
+
+            // And the ONLY difference is the injected character spec.
+            Assert.Contains(PlayerAvatarPrompt, playerResult.Substring(playerSpecIdx));
+            Assert.Contains(DateePrompt, dateeResult.Substring(dateeSpecIdx));
+            Assert.DoesNotContain(DateePrompt, playerResult);
+            Assert.DoesNotContain(PlayerAvatarPrompt, dateeResult);
+        }
+
+        [Fact]
+        public void LegacyBuild_IsRemoved()
+        {
+            // #1124: the legacy combined Build(player, datee) path is deleted.
+            // Reflection guard so the symbol's removal is asserted in tests.
+            var method = typeof(SessionSystemPromptBuilder).GetMethod(
+                "Build",
+                new[] { typeof(string), typeof(string), typeof(GameDefinition) });
+            Assert.Null(method);
+
+            var anyBuild = typeof(SessionSystemPromptBuilder).GetMethod("Build");
+            Assert.Null(anyBuild);
         }
 
         [Fact]
         public void Build_NullGameDef_UsesPinderDefaults()
         {
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt, null);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt, null);
             Assert.Contains("Pinder", result);
             Assert.Contains("comedy dating RPG", result);
         }
@@ -99,7 +168,7 @@ namespace Pinder.LlmAdapters.Tests
                 "Custom datee role",
                 "Custom meta contract Custom writing rules");
 
-            var result = SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, DateePrompt, custom);
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar(PlayerAvatarPrompt, custom);
             Assert.Contains("Custom vision text", result);
             Assert.Contains("Custom world desc", result);
             Assert.Contains("Custom meta contract", result);
@@ -107,25 +176,26 @@ namespace Pinder.LlmAdapters.Tests
         }
 
         [Fact]
-        public void Build_NullPlayerPrompt_ThrowsArgumentNullException()
+        public void BuildPlayerAvatar_NullPrompt_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionSystemPromptBuilder.Build(null!, DateePrompt));
+                SessionSystemPromptBuilder.BuildPlayerAvatar(null!));
         }
 
         [Fact]
-        public void Build_NullDateePrompt_ThrowsArgumentNullException()
+        public void BuildDatee_NullPrompt_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                SessionSystemPromptBuilder.Build(PlayerAvatarPrompt, null!));
+                SessionSystemPromptBuilder.BuildDatee(null!));
         }
 
         [Fact]
         public void Build_EmptyPrompts_ProducesValidOutput()
         {
-            var result = SessionSystemPromptBuilder.Build("", "");
-            Assert.Contains("== PLAYER CHARACTER ==", result);
-            Assert.Contains("== DATEE CHARACTER ==", result);
+            var playerResult = SessionSystemPromptBuilder.BuildPlayerAvatar("");
+            var dateeResult = SessionSystemPromptBuilder.BuildDatee("");
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, playerResult);
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, dateeResult);
         }
 
         [Fact]
@@ -135,55 +205,11 @@ namespace Pinder.LlmAdapters.Tests
                 "G", "V", "W", "P", "O",
                 "MetaSection WritingSection");
 
-            var result = SessionSystemPromptBuilder.Build("p", "o", custom);
-            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==");
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatar("p", custom);
+            var metaIdx = result.IndexOf("== NARRATIVE DOCTRINE ==", StringComparison.Ordinal);
             var afterMeta = result.Substring(metaIdx);
             Assert.Contains("MetaSection", afterMeta);
             Assert.Contains("WritingSection", afterMeta);
-        }
-
-        // Regression: #867 — datee-only sections must NOT leak into BuildPlayerAvatar.
-        [Fact]
-        public void BuildPlayer_ExcludesDateeOnlySections()
-        {
-            var gd = new GameDefinition(
-                "T", "V", "W", "P", "O", "ND",
-                dateeFriction: "datee resists the player",
-                dateeCuriosity: "datee probes player's bio",
-                conversationArcProgression: "both sides move the convo forward",
-                playerProbing: "player follows up on datee's reveals");
-
-            var playerResult = SessionSystemPromptBuilder.BuildPlayerAvatar("p", gd);
-            var dateeResult = SessionSystemPromptBuilder.BuildDatee("o", gd);
-
-            // BuildPlayerAvatar must NOT contain datee-only sections (DateeFriction,
-            // DateeCuriosity). ConversationArcProgression is SHARED structure —
-            // both sides participate in arc progression — kept in BuildPlayerAvatar.
-            // PlayerProbing is player-specific guidance — kept in BuildPlayerAvatar.
-            // See #867 LESSONS_LEARNED PROMPT-BLOAT-FROM-CROSS-ROLE-SECTIONS.
-            Assert.DoesNotContain("DATEE RESISTANCE", playerResult);
-            Assert.DoesNotContain("DATEE CURIOSITY", playerResult);
-            Assert.DoesNotContain("datee resists", playerResult);
-            Assert.DoesNotContain("datee probes", playerResult);
-
-            // BuildDatee MUST contain all datee-side sections.
-            Assert.Contains("DATEE RESISTANCE", dateeResult);
-            Assert.Contains("DATEE CURIOSITY", dateeResult);
-            Assert.Contains("CONVERSATION ARC", dateeResult);
-            Assert.Contains("datee resists", dateeResult);
-            Assert.Contains("datee probes", dateeResult);
-            Assert.Contains("both sides move", dateeResult);
-
-            // BuildPlayerAvatar keeps shared structure + player-side sections.
-            Assert.Contains("CONVERSATION ARC", playerResult);
-            Assert.Contains("both sides move", playerResult);
-            Assert.Contains("PLAYER PROBING", playerResult);
-            Assert.Contains("player follows", playerResult);
-
-            // Token ceiling: BuildPlayerAvatar must be shorter than BuildDatee
-            // (it excludes the two datee-only sections).
-            Assert.True(playerResult.Length < dateeResult.Length,
-                $"BuildPlayerAvatar ({playerResult.Length} chars) should be shorter than BuildDatee ({dateeResult.Length} chars)");
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements #1124 — the shared Game-Master puppeteer system prompt + a single canonical parseable output contract — on top of #1123 (merged, `fce3805`).

### Scope item 1 — single shared GM system prompt
- `SessionSystemPromptBuilder.BuildPlayerAvatar` / `BuildDatee` now assemble ONE shared GM puppeteer base template. The GM is told it portrays **EXACTLY ONE** character; the per-session character spec (role description + assembled profile) is injected **LAST** under `== CHARACTER YOU CONTROL ==`.
- The static GM base — puppeteer framing, game vision, world rules, narrative doctrine, dramatic craft, and the shared conversation-dynamic sections — is **byte-for-byte identical** across both sessions. The ONLY difference between the two built prompts is the injected character-spec block.
- **DELETED** the legacy combined `Build(player, datee)` path and all its callers (test-only — production already used `BuildPlayerAvatar`/`BuildDatee`).
- **Static-prefix-first ordering preserved**: GM base + game definition (cacheable) ahead of the variable character spec ahead of the volatile transcript, so #1123's prompt caching still pays off.

### Scope item 2 — output-format contract
- New `GmOutputContract` (`Emit`/`Parse`) + `GmTurnOutput` value type: **THE** single canonical GM output format, reused by both sessions:
  ```
  <message text>
  [SIGNALS]
  TELL: <Stat> (<description>)
  WEAKNESS: <Stat> -<n> (<description>)
  ```
  Message text is everything before the optional `[SIGNALS]` block. `Parse(Emit(x)) == x` for well-formed values; malformed/partial input **degrades gracefully** (never throws — collapses to a message-only result; unknown stats / bad fields drop the signal, keep the message).
- Wired the datee `[SIGNALS]` parsing through `GmOutputContract` (DRY — one canonical signal parser instead of a duplicate regex).

## DoD Evidence

**Build** — `dotnet build Pinder.Core.sln`:
```
Build succeeded.   (0 errors)
```

**Test** — `dotnet test Pinder.Core.sln`:
```
Pinder.RemoteAssets.Tests   Passed:   54,  Failed: 0, Skipped:  0
Pinder.Rules.Tests          Passed:  243,  Failed: 0, Skipped:  0
Pinder.Core.Tests           Passed: 2939,  Failed: 0, Skipped: 18
Pinder.LlmAdapters.Tests    Passed: 1206,  Failed: 0, Skipped:  9
TOTAL                       Passed: 4442,  Failed: 0, Skipped: 27
```
Baseline was 4432/0/27; +10 passing (new GM-contract round-trip/degradation tests + the shared-template acceptance tests).

**Rerun analysis:** one prior run showed a single failure in `Issue840_SingleLoaderPipelineTests.AssembleMicrobenchmark_P50_UnderOneMillisecond` (p50 = 1.018 ms vs a 1.0 ms gate). This is a **pre-existing CPU-timing microbenchmark flake** in `Pinder.Core.Tests` — a boundary perf assertion unrelated to this ticket (this PR touches **no** `Pinder.Core` source). It passed on the clean rerun (full suite 0 failed above). Not a regression.

## Acceptance tests added
- **Identical-template-except-spec**: `BothSessions_ShareIdenticalBase_OnlyCharacterSpecDiffers` and `Build_SharedBaseIdentical_OnlyCharacterSpecDiffers` assert the two built prompts are equal up to `== CHARACTER YOU CONTROL ==` and that neither character's profile leaks into the other session.
- **Build(both) removed**: `LegacyBuild_IsRemoved` reflection guard asserts the `Build` symbol is gone.
- **Parser round-trip + graceful degradation**: `GmOutputContractTests` — round-trip for message-only / tell / weakness / both / SelfAwareness / multiline, plus null/empty/garbage-body/unknown-stat/zero-reduction degradation cases.

## Research Log

- **Recon.** Both GM sessions already shared the stateful compile path `PinderLlmAdapter.SendStatefulAsync` (#1123); the only delta was the injected character spec. `SessionSystemPromptBuilder` had three paths: `Build(player, datee)` (legacy combined, test-only callers), `BuildPlayerAvatar`, `BuildDatee`. Existing GM output parsing lived in `DateeResponseParsers` (`[SIGNALS]` TELL/WEAKNESS regex) and `DialogueOptionParsers` (`OPTION_N` blocks).
- **Shared GM consolidation.** Refactored the builder into a shared `AppendGmBase(...)` (puppeteer framing → vision → world → doctrine → dramatic craft → conversation-dynamic sections) plus a single `AppendCharacterSpec(...)` tail. Both session builders call the same base; only the role key + profile differ. Under the single-puppeteer model the conversation-dynamic sections (datee resistance/curiosity, conversation arc, player probing) now live in the **shared** base rather than being split per role — the GM needs the full dynamic regardless of which character it portrays — which is what makes the two bases byte-identical.
- **`Build(both)` removal.** Deleted the method and rewrote its only callers (three test files) onto the new contract. No production code referenced it.
- **Output contract shape.** Kept the contract minimal and aligned with the format the model already emits (`[SIGNALS]` + `TELL:`/`WEAKNESS:`), so this is the canonical spec rather than a new wire format. `GmOutputContract.Emit/Parse` round-trips; `GmTurnOutput` is value-equatable for the round-trip assertion. Datee `[SIGNALS]` parsing now delegates to `GmOutputContract` (single source of truth for signal parsing); the datee path keeps its own message-cleaning (eval headers, surrounding quotes, persona `/end`/`/rant` tags). Dialogue-option (`OPTION_N`) parsing was left as-is — it's a distinct multi-option format and collapsing delivery into options is #1125 (out of scope).
- **Cache-prefix stability.** Header marker reworded out of the GM framing string so `== CHARACTER YOU CONTROL ==` occurs exactly once and the static base remains the stable cacheable prefix.
- **Docs.** Updated `docs/prompts.md` (`session_system_prompt` entry) which referenced the removed `Build`. Comprehensive docs sweep remains #1130.
- **Persistence.** No persisted fields added — nothing for #1129 to carry forward.
- **Follow-ups filed:** none required.

Closes #1124
