### PR TITLE
fix(#1137): migrate Pinder.Core.Tests off removed delivery surface (mechanical)

### DIFF
--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -48,8 +48,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -37,10 +37,6 @@ namespace Pinder.Core.Tests
             });
         }
 
-        public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-        {
-            return Task.FromResult(context.ChosenOption.IntendedText);
-        }
 
         public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
         {

--- a/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
@@ -66,10 +66,11 @@ namespace Pinder.Core.Tests.Conversation
 
         /// <summary>
         /// Recording adapter: implements the full stateful surface and captures the
-        /// avatar history it is handed on every <see cref="DeliverMessageAsync(DeliveryContext, IReadOnlyList{ConversationMessage}, CancellationToken)"/>
-        /// call, plus the system prompts/context seen by both the avatar (delivery)
-        /// and datee paths. Contributes one user + one assistant entry per stateful
-        /// call so the engine's owned history grows across turns.
+        /// system prompts/context seen by the datee path. The avatar (delivery)
+        /// path no longer exists (#1125 collapsed the delivery LLM call), so the
+        /// avatar observation lists stay empty — the AC-1 test below asserts that.
+        /// Contributes one user + one assistant entry per stateful datee call so
+        /// the engine's owned history grows across turns.
         /// </summary>
         private sealed class RecordingStatefulAdapter : IStatefulLlmAdapter
         {
@@ -93,10 +94,7 @@ namespace Pinder.Core.Tests.Conversation
                     new DialogueOption(StatType.Wit, "option 4"),
                 });
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
-                => Task.FromResult("delivered");
-
-            // #1125: the stateful avatar (delivery) call no longer exists on the
+            // #1125: the avatar (delivery) LLM call no longer exists on the
             // interface and the engine never invokes it. Kept as a guard: if the
             // engine ever routed through an avatar call again, _avatarCallCount
             // would be observed non-zero by the AC-1 test below.

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -19,7 +19,6 @@ namespace Pinder.Core.Tests.Conversation
         private sealed class NullLlm : ILlmAdapter
         {
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DateeResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -26,7 +26,6 @@ namespace Pinder.Core.Tests.Conversation
         private sealed class DummyLlmAdapter : ILlmAdapter
         {
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DateeResponse("", null, null));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
@@ -41,18 +40,7 @@ namespace Pinder.Core.Tests.Conversation
             public IReadOnlyList<ConversationMessage>? LastHistorySeen { get; private set; }
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DialogueOption[0]);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("");
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult(new DateeResponse("", null, null));
-
-            public Task<StatefulAvatarResult> DeliverMessageAsync(
-                DeliveryContext context,
-                IReadOnlyList<ConversationMessage> history,
-                System.Threading.CancellationToken ct = default)
-                => Task.FromResult(new StatefulAvatarResult("", new ConversationMessage[]
-                {
-                    ConversationMessage.User("u"),
-                    ConversationMessage.Assistant("a"),
-                }));
 
             public Task<StatefulDateeResult> GetDateeResponseAsync(
                 DateeContext context,

--- a/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
@@ -181,11 +181,6 @@ namespace Pinder.Core.Tests.Conversation
                 return Task.FromResult(options);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
-            {
-                ct.ThrowIfCancellationRequested();
-                return Task.FromResult(context.ChosenOption.IntendedText);
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -45,14 +45,6 @@ namespace Pinder.Core.Tests.Conversation
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
                 => Task.FromResult(System.Array.Empty<DialogueOption>());
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
-                => Task.FromResult(string.Empty);
-            public Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, CancellationToken ct = default)
-                => Task.FromResult(new StatefulAvatarResult(string.Empty, new ConversationMessage[]
-                {
-                    ConversationMessage.User("u"),
-                    ConversationMessage.Assistant("a"),
-                }));
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse(string.Empty));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Conversation/Issue957_WaitTransactionalTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue957_WaitTransactionalTests.cs
@@ -342,8 +342,6 @@ namespace Pinder.Core.Tests.Conversation
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(Array.Empty<DialogueOption>());
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult("delivered message");
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("datee reply"));

--- a/tests/Pinder.Core.Tests/Conversation/LlmDispatcherTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/LlmDispatcherTests.cs
@@ -22,7 +22,6 @@ namespace Pinder.Core.Tests.Conversation
             public string ShadowResponse { get; set; } = "Shadow Response";
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default) => throw new NotImplementedException();
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default) => throw new NotImplementedException();
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default) => throw new NotImplementedException();
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default) => throw new NotImplementedException();
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -221,10 +221,6 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                return Task.FromResult("delivered");
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/DateeResponseTests.cs
+++ b/tests/Pinder.Core.Tests/DateeResponseTests.cs
@@ -166,45 +166,15 @@ namespace Pinder.Core.Tests
             Assert.Single(ctx.ActiveTrapInstructions!);
         }
 
-        [Fact]
-        public void DeliveryContext_New_Fields_Default_To_Null()
-        {
-            var option = new DialogueOption(StatType.Charm, "Hi");
-            var ctx = new DeliveryContext(
-                playerAvatarPrompt: "p",
-                conversationHistory: new List<(string, string)>(),
-                dateeLastMessage: "",
-                chosenOption: option,
-                outcome: Rolls.FailureTier.Success,
-                beatDcBy: 3,
-                activeTraps: new List<string>());
-
-            Assert.Null(ctx.ShadowThresholds);
-            Assert.Null(ctx.ActiveTrapInstructions);
-        }
-
-        [Fact]
-        public void DeliveryContext_Accepts_New_Optional_Fields()
-        {
-            var shadows = new Dictionary<ShadowStatType, int>
-            {
-                { ShadowStatType.Madness, 4 }
-            };
-            var option = new DialogueOption(StatType.Charm, "Hi");
-            var ctx = new DeliveryContext(
-                playerAvatarPrompt: "p",
-                conversationHistory: new List<(string, string)>(),
-                dateeLastMessage: "",
-                chosenOption: option,
-                outcome: Rolls.FailureTier.Success,
-                beatDcBy: 3,
-                activeTraps: new List<string>(),
-                shadowThresholds: shadows,
-                activeTrapInstructions: new[] { "Be creepy" });
-
-            Assert.NotNull(ctx.ShadowThresholds);
-            Assert.NotNull(ctx.ActiveTrapInstructions);
-        }
+        // #1125/#1137: the two DeliveryContext field-default tests
+        // (DeliveryContext_New_Fields_Default_To_Null /
+        // DeliveryContext_Accepts_New_Optional_Fields) were DELETED. They only
+        // exercised the constructor of the removed `DeliveryContext` type (the
+        // delivery LLM call was collapsed into the deterministic, non-LLM
+        // DeliveryOverlay commit step). There is no overlay/commit equivalent to
+        // re-point them at — DeliveryContext carried no behaviour, just the
+        // payload for the deleted call — so they have no successor assertion.
+        // The surviving DateeContext field-default coverage remains below.
 
         [Fact]
         public void DateeContext_New_Fields_Default_To_Null()

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -207,8 +207,6 @@ namespace Pinder.Core.Tests
                 _call++;
                 return Task.FromResult(_optionSets[idx]);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/GameSessionTrapTaintTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionTrapTaintTests.cs
@@ -165,8 +165,8 @@ namespace Pinder.Core.Tests
             // Choose option 2 (Wit) — triggers TropeTrap tier, activates wit_trap
             await session.ResolveTurnAsync(2);
 
-            // #1125: no DeliveryContext is built anymore.
-            Assert.Empty(capturingLlm.DeliveryContexts);
+            // #1125: no delivery LLM call / DeliveryContext exists anymore — the
+            // commit step is the deterministic, non-LLM DeliveryOverlay.
 
             // Check datee context had trap instructions (trap was activated during
             // RollEngine.Resolve; AdvanceTurn runs AFTER the datee call (#692), so
@@ -199,7 +199,6 @@ namespace Pinder.Core.Tests
             await session.ResolveTurnAsync(0);
 
             // #1125: no DeliveryContext is built; assert on the surviving datee context.
-            Assert.Empty(capturingLlm.DeliveryContexts);
             var oppCtx = capturingLlm.DateeContexts[0];
             Assert.Null(oppCtx.ActiveTrapInstructions);
         }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -275,8 +275,6 @@ namespace Pinder.Core.Tests
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => throw new InvalidOperationException("LLM should not be called for Wait");
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => throw new InvalidOperationException("LLM should not be called for Wait");

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -154,8 +154,6 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -236,8 +236,6 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -141,13 +141,6 @@ namespace Pinder.Core.Tests.Integration
                 return Task.FromResult(_optionSets.Dequeue());
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                string message = context.Outcome == FailureTier.Success
-                    ? context.ChosenOption.IntendedText
-                    : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
-                return Task.FromResult(message);
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -255,23 +255,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                string intended = context.ChosenOption.IntendedText;
-                return Task.FromResult(context.Outcome == FailureTier.Success
-                    ? intended
-                    : $"[{context.Outcome}] {intended}");
-            }
-
-            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
-            {
-                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
-                return new StatefulAvatarResult(delivered, new ConversationMessage[]
-                {
-                    ConversationMessage.User(string.Empty),
-                    ConversationMessage.Assistant(delivered),
-                });
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
@@ -60,15 +60,23 @@ namespace Pinder.Core.Tests
 
         /// <summary>
         /// LLM adapter that emits a single FULL-text option (so we control the
-        /// picked line) and HARD-FAILS if any creative delivery call is made.
-        /// Overlays (trap/shadow/horniness) and steering are no-ops here so the
-        /// only transform that can touch the committed line is the deterministic
-        /// <see cref="DeliveryOverlay"/>.
+        /// picked line). Overlays (trap/shadow/horniness) and steering are no-ops
+        /// here so the only transform that can touch the committed line is the
+        /// deterministic <see cref="DeliveryOverlay"/>.
+        ///
+        /// <para>
+        /// #1125/#1137: the old delivery LLM surface (a <c>DeliverMessageAsync</c>
+        /// overload) was removed from the adapter contract entirely, so there is
+        /// no longer a method this adapter could implement to "forbid" — the
+        /// guarantee that no creative delivery call fires is now a COMPILE-TIME
+        /// property of <see cref="ILlmAdapter"/>/<see cref="IStatefulLlmAdapter"/>,
+        /// not a runtime throw. The remaining regression coverage asserts that no
+        /// <c>"delivery"</c> prompt-trace is compiled during a full turn.
+        /// </para>
         /// </summary>
         private sealed class DeliveryForbiddenAdapter : ILlmAdapter, IStatefulLlmAdapter
         {
             private readonly string _optionText;
-            public bool DeliverMessageCalled { get; private set; }
 
             public DeliveryForbiddenAdapter(string optionText)
             {
@@ -77,23 +85,6 @@ namespace Pinder.Core.Tests
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
                 => Task.FromResult(new[] { new DialogueOption(StatType.Charm, _optionText) });
-
-            // The collapsed delivery surface — must NEVER be invoked by the engine
-            // post-#1125. Both the stateless and stateful overloads fail loudly.
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
-            {
-                DeliverMessageCalled = true;
-                throw new InvalidOperationException(
-                    "#1125 regression: the engine invoked the delivery LLM call, which must be collapsed.");
-            }
-
-            public Task<StatefulAvatarResult> DeliverMessageAsync(
-                DeliveryContext context, IReadOnlyList<ConversationMessage> history, CancellationToken cancellationToken = default)
-            {
-                DeliverMessageCalled = true;
-                throw new InvalidOperationException(
-                    "#1125 regression: the engine invoked the stateful delivery LLM call, which must be collapsed.");
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("ok, go on..."));
@@ -221,8 +212,9 @@ namespace Pinder.Core.Tests
 
         // ── Regression 3: no delivery LLM call / prompt-trace fires ──────────
 
-        // A full turn must not invoke DeliverMessageAsync, and the prompt-trace
-        // set must not include a "delivery" creative compilation.
+        // A full turn must not compile a "delivery" creative prompt-trace. (The
+        // delivery LLM call itself no longer exists on the adapter contract, so
+        // "no delivery call fires" is enforced at compile time — #1137.)
         [Fact]
         public async Task FullTurn_FiresNoDeliveryLlmCall_NorDeliveryPromptTrace()
         {
@@ -233,12 +225,10 @@ namespace Pinder.Core.Tests
             var session = NewSession(llm, dice);
 
             await session.StartTurnAsync();
-            // Would throw from DeliveryForbiddenAdapter.DeliverMessageAsync if the
-            // engine still routed through the delivery LLM surface.
             await session.ResolveTurnAsync(0);
 
-            Assert.False(llm.DeliverMessageCalled,
-                "The engine must not invoke the delivery LLM call after #1125.");
+            // No "delivery" creative prompt is compiled — the delivery LLM call
+            // was collapsed into the deterministic DeliveryOverlay commit step.
             Assert.Null(InMemoryPromptTraceService.Instance.GetLastTrace("delivery"));
         }
     }

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -31,9 +31,8 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             await session.ResolveTurnAsync(0);
 
-            // #1125: no DeliveryContext is built anymore; the wiring lives on the
-            // surviving DateeContext.
-            Assert.Null(llm.CapturedDeliveryContext);
+            // #1125: no delivery LLM call / DeliveryContext exists anymore; the
+            // name/turn wiring lives on the surviving DateeContext.
             Assert.NotNull(llm.CapturedDateeContext);
             Assert.Equal("Sable", llm.CapturedDateeContext!.PlayerName);
             Assert.Equal("Brick", llm.CapturedDateeContext.DateeName);
@@ -91,11 +90,10 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// LLM adapter that captures the DeliveryContext and DateeContext for assertion.
+        /// LLM adapter that captures the DateeContext for assertion.
         /// </summary>
         private sealed class CapturingLlm : ILlmAdapter
         {
-            public DeliveryContext? CapturedDeliveryContext { get; private set; }
             public DateeContext? CapturedDateeContext { get; private set; }
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
@@ -107,12 +105,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Honesty, "Real talk"),
                     new DialogueOption(StatType.Wit, "Clever")
                 });
-            }
-
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                CapturedDeliveryContext = context;
-                return Task.FromResult(context.ChosenOption.IntendedText);
             }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -272,8 +272,6 @@ namespace Pinder.Core.Tests
             public CustomOptionsLlmAdapter(DialogueOption[] options) => _options = options;
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
@@ -296,8 +294,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
+++ b/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
@@ -177,8 +177,6 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("Reply"));

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -145,7 +145,6 @@ namespace Pinder.Core.Tests
 
         private sealed class CapturingLlm : ILlmAdapter
         {
-            public DeliveryContext? CapturedDeliveryContext { get; private set; }
             public DateeContext? CapturedDateeContext { get; private set; }
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
@@ -156,12 +155,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Honesty, "Real talk"),
                     new DialogueOption(StatType.Wit, "Clever")
                 });
-
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                CapturedDeliveryContext = context;
-                return Task.FromResult(context.ChosenOption.IntendedText);
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -255,23 +255,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                string intended = context.ChosenOption.IntendedText;
-                return Task.FromResult(context.Outcome == FailureTier.Success
-                    ? intended
-                    : $"[{context.Outcome}] {intended}");
-            }
-
-            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, System.Collections.Generic.IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
-            {
-                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
-                return new StatefulAvatarResult(delivered, new ConversationMessage[]
-                {
-                    ConversationMessage.User(string.Empty),
-                    ConversationMessage.Assistant(delivered),
-                });
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -337,23 +337,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                string intended = context.ChosenOption.IntendedText;
-                return Task.FromResult(context.Outcome == FailureTier.Success
-                    ? intended
-                    : $"[{context.Outcome}] {intended}");
-            }
-
-            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, System.Collections.Generic.IReadOnlyList<ConversationMessage> history, System.Threading.CancellationToken ct = default)
-            {
-                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
-                return new StatefulAvatarResult(delivered, new ConversationMessage[]
-                {
-                    ConversationMessage.User(string.Empty),
-                    ConversationMessage.Assistant(delivered),
-                });
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -50,8 +50,6 @@ namespace Pinder.Core.Tests
                 });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -427,8 +427,6 @@ namespace Pinder.Core.Tests
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
@@ -376,23 +376,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(LastOptions);
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, CancellationToken ct = default)
-            {
-                string intended = context.ChosenOption.IntendedText;
-                return Task.FromResult(context.Outcome == FailureTier.Success
-                    ? intended
-                    : $"[{context.Outcome}] {intended}");
-            }
-
-            public async Task<StatefulAvatarResult> DeliverMessageAsync(DeliveryContext context, IReadOnlyList<ConversationMessage> history, CancellationToken ct = default)
-            {
-                string delivered = await DeliverMessageAsync(context, ct).ConfigureAwait(false);
-                return new StatefulAvatarResult(delivered, new ConversationMessage[]
-                {
-                    ConversationMessage.User(string.Empty),
-                    ConversationMessage.Assistant(delivered),
-                });
-            }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -161,8 +161,6 @@ namespace Pinder.Core.Tests
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.Helpers.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.Helpers.cs
@@ -129,8 +129,6 @@ namespace Pinder.Core.Tests
                 };
                 return Task.FromResult(options);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("...",
                     detectedTell: new Tell(_tellStat, $"Tell on {_tellStat}")));
@@ -154,8 +152,6 @@ namespace Pinder.Core.Tests
                 _call++;
                 return Task.FromResult(_optionSets[idx]);
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.Helpers.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.Helpers.cs
@@ -118,8 +118,6 @@ namespace Pinder.Core.Tests
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
@@ -144,8 +142,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -285,8 +285,6 @@ namespace Pinder.Core.Tests
 
             public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_options);
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
@@ -310,8 +308,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.Wit, "Clever")
                 });
             }
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(new DateeResponse("..."));
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -319,8 +319,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -196,8 +196,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/TrapDuration1RegressionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapDuration1RegressionTests.cs
@@ -78,8 +78,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             await session.ResolveTurnAsync(0); // option 0 = Charm
 
-            // #1125: no DeliveryContext is built anymore.
-            Assert.Empty(capturingLlm.DeliveryContexts);
+            // #1125: no delivery LLM call / DeliveryContext exists anymore — the
+            // commit step is the deterministic, non-LLM DeliveryOverlay. Nothing
+            // to assert here (no captured delivery contexts to inspect).
 
             // Datee context must see the trap
             var oppCtx = capturingLlm.DateeContexts[0];

--- a/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
+++ b/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
@@ -51,7 +51,6 @@ namespace Pinder.Core.Tests
         private sealed class W2aTrapLlmAdapter : ILlmAdapter
         {
             public List<DialogueContext> DialogueContexts { get; } = new();
-            public List<DeliveryContext> DeliveryContexts { get; } = new();
             public List<DateeContext> DateeContexts { get; } = new();
             public int TrapOverlayCalls { get; private set; }
 
@@ -66,17 +65,6 @@ namespace Pinder.Core.Tests
                     new DialogueOption(StatType.SelfAwareness, "SA option"),
                 };
                 return Task.FromResult(options);
-            }
-
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-            {
-                DeliveryContexts.Add(context);
-                // Tag the message with the tier so it is observably different
-                // from the IntendedText (so a TextDiff is emitted on failure).
-                string text = context.Outcome == FailureTier.Success
-                    ? context.ChosenOption.IntendedText
-                    : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
-                return Task.FromResult(text);
             }
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -20,7 +20,6 @@ namespace Pinder.Core.Tests
     public sealed class CapturingLlmAdapter : ILlmAdapter
     {
         public List<DialogueContext> DialogueContexts { get; } = new List<DialogueContext>();
-        public List<DeliveryContext> DeliveryContexts { get; } = new List<DeliveryContext>();
         public List<DateeContext> DateeContexts { get; } = new List<DateeContext>();
 
         public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
@@ -34,15 +33,6 @@ namespace Pinder.Core.Tests
                 new DialogueOption(StatType.Chaos, "I once ate a whole pizza in a bouncy castle.")
             };
             return Task.FromResult(options);
-        }
-
-        public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-        {
-            DeliveryContexts.Add(context);
-            string message = context.Outcome == FailureTier.Success
-                ? context.ChosenOption.IntendedText
-                : $"[{context.Outcome}] {context.ChosenOption.IntendedText}";
-            return Task.FromResult(message);
         }
 
         public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -411,8 +411,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -428,8 +428,6 @@ namespace Pinder.Core.Tests
                 return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Default") });
             }
 
-            public Task<string> DeliverMessageAsync(DeliveryContext context, System.Threading.CancellationToken ct = default)
-                => Task.FromResult(context.ChosenOption.IntendedText);
 
             public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
             {


### PR DESCRIPTION
## #1137 — [#1125 b] Migrate Pinder.Core.Tests off the removed delivery surface (mechanical)

Closes #1137

Mechanical, test-only migration of `tests/Pinder.Core.Tests` off the
delivery creative surface that #1125 collapsed, so that **#1138 can delete
the production `DeliveryContext` / `DeliverMessageAsync` / `StatefulAvatarResult`
types** without breaking this project.

### What changed (no production-code edits; `tests/Pinder.LlmAdapters.Tests` untouched)
- Removed every vestigial `DeliverMessageAsync` overload (stateless `Task<string>`
  and stateful `Task<StatefulAvatarResult>`) from test-local stub adapters.
  These were no longer part of `ILlmAdapter` / `IStatefulLlmAdapter` after #1125
  — the engine never calls them; they were dead methods that only kept the
  removed types alive in this project.
- Removed `DeliveryContext` / `StatefulAvatarResult` constructions and the
  `CapturedDeliveryContext` / `DeliveryContexts` capture members from stubs.
- Re-pointed or dropped the now-vacuous assertions on those captures
  (`Assert.Null(...CapturedDeliveryContext)` / `Assert.Empty(...DeliveryContexts)`)
  to a structural-guarantee comment; the surviving `DateeContext` wiring
  assertions are retained unchanged.
- `Issue1125_CollapseDeliveryTests`: the "no delivery LLM call fires" guard is
  now a **compile-time** property (there is no delivery method to implement), so
  the runtime-throw `DeliveryForbiddenAdapter` overloads + `DeliverMessageCalled`
  flag were removed. The meaningful regression check — no `"delivery"`
  prompt-trace compiles during a full turn — is kept.
- `DateeResponseTests`: **deleted** the two `DeliveryContext` field-default tests
  (`DeliveryContext_New_Fields_Default_To_Null`,
  `DeliveryContext_Accepts_New_Optional_Fields`). They exercised only the
  constructor of the removed type and have no overlay/commit successor
  (`DeliveryContext` carried no behaviour). Reason documented inline.

### Grep-clean
No **live-code** references to `DeliverMessageAsync` / `DeliveryContext` /
`StatefulAvatarResult` remain under `tests/Pinder.Core.Tests`. Remaining matches
are intentionally-documented residue only: `#1125`/`#1137` explanatory comments
and two historical test class/file names
(`Issue241_GameSessionDeliveryContextTests`,
`Issue308_DeliveryDateeShadowThresholdsTests`) — renaming those is unnecessary
churn and not required by the AC.

## DoD Evidence (CI = LOCAL ONLY)

**Build** — `dotnet build Pinder.Core.sln`:
```
    213 Warning(s)
    0 Error(s)
BUILD_EXIT=0
```

**Tests** — `dotnet test Pinder.Core.sln --filter "FullyQualifiedName~Pinder.Core.Tests"`:
```
Passed!  - Failed:     0, Passed:  2935, Skipped:    18, Total:  2953, Duration: 8 s - Pinder.Core.Tests.dll (net8.0)
TEST_EXIT=0
```
(2935 vs the pre-migration 2937 — exactly the 2 deleted `DeliveryContext`
field-default tests.)

**Scope**: 39 files changed, all under `tests/Pinder.Core.Tests/`. No
production-code edits. `tests/Pinder.LlmAdapters.Tests` untouched. `agent.log`
not committed.

**Deviations**: none.
