### PR TITLE
#1129: data reset + persistence schema rename (engine-side: LlmPhase.Delivery retired + regression guards)

### DIFF
--- a/src/Pinder.Core/Interfaces/LlmPhase.cs
+++ b/src/Pinder.Core/Interfaces/LlmPhase.cs
@@ -17,7 +17,18 @@ namespace Pinder.Core.Interfaces
         /// <summary>Player dialogue-options generation.</summary>
         public const string DialogueOptions = "dialogue_options";
 
-        /// <summary>Player message delivery (final transformation of the chosen option).</summary>
+        /// <summary>
+        /// RETIRED — no longer emitted (#1125/#1129). The standalone "delivery"
+        /// creative LLM call was collapsed into the deterministic
+        /// <see cref="Pinder.Core.Conversation.DeliveryOverlay"/> commit step:
+        /// the avatar GM now returns full, sendable candidate lines, so there is
+        /// no second "delivery" LLM call to label. This constant is RETAINED (not
+        /// renamed/removed) only so historical audit/cost rows that reference the
+        /// <c>"delivery"</c> phase string still render with a typed label —
+        /// mirroring the #827 MatchupAnalysis/MatchupSummary precedent below.
+        /// Phase strings are a public decorator contract; do not re-purpose this
+        /// value for a new LLM phase.
+        /// </summary>
         public const string Delivery = "delivery";
 
         /// <summary>Steering question for the player.</summary>

--- a/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.Core.Text;
+using Pinder.Core.TestCommon;
+using Pinder.LlmAdapters;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #1129 (data reset + persistence schema rename to new terminology).
+    ///
+    /// Two regression guards locking the engine-owned persisted/trace surface to
+    /// the post-#1121/#1122 terminology (OPPONENT→DATEE, PLAYER→PLAYER AVATAR)
+    /// and the post-#1125 slimmed phase set:
+    ///
+    ///   (a) ROUND-TRIP: driving every live prompt-compilation emitter records
+    ///       its trace under the NEW <c>prompt_type</c> key names
+    ///       (<c>datee</c>, <c>datee-system</c>, <c>dialogue-options</c>,
+    ///       <c>dialogue-options-system</c>) and the recorded text round-trips
+    ///       back out of the trace registry unchanged.
+    ///
+    ///   (b) GREP-GUARD: the live trace key set contains NONE of the retired
+    ///       old-terminology keys (<c>opponent</c>, <c>opponent-system</c>) and
+    ///       no <c>delivery</c> creative-phase trace (collapsed by #1125). This
+    ///       is the in-test equivalent of the PR-body grep-clean assertion.
+    ///
+    /// Engine-side only. The live Postgres column/jsonb rename + data wipe is the
+    /// cross-repo pinder-web follow-up filed against #1129; this repo owns the
+    /// serialization/trace-key/fixture surface and asserts it here.
+    /// </summary>
+    public sealed class Issue1129_SchemaRenameGuardTests
+    {
+        // The complete set of live prompt_type trace keys the engine compiles
+        // per turn after #1121 (OPPONENT→DATEE) and #1125 (delivery creative
+        // call removed). Kept here as the single canonical expectation so the
+        // guard fails loudly if a future change reintroduces old terminology.
+        private static readonly string[] ExpectedLivePromptTypes =
+        {
+            "dialogue-options",
+            "dialogue-options-system",
+            "datee",
+            "datee-system",
+        };
+
+        // Old-terminology keys that MUST NOT be compiled by any live emitter.
+        private static readonly string[] RetiredPromptTypes =
+        {
+            "opponent",
+            "opponent-system",
+            // #1125: the creative "delivery" LLM call (and its trace) is gone.
+            "delivery",
+        };
+
+        private static DialogueContext MakeDialogueContext() => new DialogueContext(
+            playerAvatarPrompt: "You are reuben.",
+            dateePrompt: "You are talking to velvet.",
+            conversationHistory: new List<(string Sender, string Text)> { ("Velvet", "Hello") },
+            dateeLastMessage: "Hello",
+            activeTraps: new List<string>(),
+            currentInterest: 10,
+            currentTurn: 3);
+
+        private static DateeContext MakeDateeContext() => new DateeContext(
+            dateePrompt: "You are velvet.",
+            conversationHistory: new List<(string Sender, string Text)> { ("Reuben", "Hi") },
+            dateeLastMessage: "Hi",
+            activeTraps: new List<string>(),
+            currentInterest: 10,
+            playerDeliveredMessage: "Hey there",
+            interestBefore: 10,
+            interestAfter: 12,
+            responseDelayMinutes: 0.0,
+            playerName: "Reuben",
+            dateeName: "Velvet",
+            currentTurn: 3);
+
+        /// <summary>
+        /// (a) Round-trip: every live emitter records under a NEW-terminology
+        /// prompt_type key, and the recorded trace text equals what the builder
+        /// returned (registry round-trips it unchanged).
+        /// </summary>
+        [Fact]
+        public void LiveEmitters_RecordTracesUnderNewKeyNames_AndRoundTrip()
+        {
+            PromptCatalogInitializer.Initialize();
+            InMemoryPromptTraceService.Instance.Clear();
+
+            // Drive all four live prompt compilations a fresh session fires.
+            var dialogue = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            var datee = SessionDocumentBuilder.BuildDateePrompt(MakeDateeContext());
+            var dialogueSystem = SessionSystemPromptBuilder.BuildPlayerAvatar("You are reuben.");
+            var dateeSystem = SessionSystemPromptBuilder.BuildDatee("You are velvet.");
+
+            // Each new-terminology key is present and round-trips the exact text.
+            void AssertRoundTrip(string promptType, string expectedText)
+            {
+                var trace = InMemoryPromptTraceService.Instance.GetLastTrace(promptType);
+                Assert.True(trace != null, $"Expected a recorded trace for new prompt_type '{promptType}'.");
+                Assert.Equal(expectedText, trace!.Text);
+            }
+
+            AssertRoundTrip("dialogue-options", dialogue);
+            AssertRoundTrip("datee", datee);
+            AssertRoundTrip("dialogue-options-system", dialogueSystem);
+            AssertRoundTrip("datee-system", dateeSystem);
+
+            // The recorded key set is exactly the expected new-terminology set.
+            var recordedKeys = InMemoryPromptTraceService.Instance.GetAllTraces().Keys
+                .Select(k => k.ToLowerInvariant())
+                .ToHashSet();
+            foreach (var key in ExpectedLivePromptTypes)
+            {
+                Assert.Contains(key, recordedKeys);
+            }
+        }
+
+        /// <summary>
+        /// (b) Grep-guard: after driving every live emitter, NONE of the retired
+        /// old-terminology prompt_type keys (opponent*, delivery) were recorded.
+        /// In-test equivalent of the PR-body "no stale OPPONENT prompt_type"
+        /// grep-clean assertion.
+        /// </summary>
+        [Fact]
+        public void LiveEmitters_RecordNoRetiredOldTerminologyKeys()
+        {
+            PromptCatalogInitializer.Initialize();
+            InMemoryPromptTraceService.Instance.Clear();
+
+            SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
+            SessionDocumentBuilder.BuildDateePrompt(MakeDateeContext());
+            SessionSystemPromptBuilder.BuildPlayerAvatar("You are reuben.");
+            SessionSystemPromptBuilder.BuildDatee("You are velvet.");
+
+            foreach (var retired in RetiredPromptTypes)
+            {
+                Assert.True(
+                    InMemoryPromptTraceService.Instance.GetLastTrace(retired) == null,
+                    $"Retired old-terminology prompt_type '{retired}' must NOT be compiled by any live emitter.");
+            }
+
+            // And no recorded key contains the old "opponent" substring at all.
+            var recordedKeys = InMemoryPromptTraceService.Instance.GetAllTraces().Keys.ToList();
+            Assert.DoesNotContain(recordedKeys, k => k.ToLowerInvariant().Contains("opponent"));
+        }
+    }
+}


### PR DESCRIPTION
## #1129 — Data reset + persistence schema rename to new terminology (engine-side)

Closes #1129

Part of the Pinder two-session Game-Master refactor. **pinder-core (engine) scope only.** The live Postgres data-wipe + jsonb/column rename is the cross-repo follow-up: **decay256/pinder-web#881**.

### Orchestrator-verified starting state (the rename was MOSTLY already done)
T1/#1121 (OPPONENT→DATEE), T2/#1122 (PLAYER→PLAYER AVATAR), and #1125 (delivery creative LLM call removed) had already landed on `main`. Verified before touching anything:
- Live trace `prompt_type` keys are already `dialogue-options`, `dialogue-options-system`, `datee`, `datee-system` — **zero `opponent`/`opponent-system` keys in `src/`** and no live `delivery` `RecordTrace`.
- **Zero `opponent` (old term) references** anywhere in `src/`.
- **No `turn0-*` / `multi-turn-*` JSON fixtures** exist and no `*.json` test fixture contains "opponent". Nothing to rename in fixtures.
- The human-player surface (`PlayerAgent`, `ScoringPlayerAgent`, `PlayerResponseDelay`, `LlmPlayerAgent`) was intentionally **left untouched** — per AGENTS.md the human stays "player"; AVATAR/#1122 applies to the in-game character only.

So the implementation scope was small: the one remaining old-terminology persisted constant + regression tests + the cross-repo follow-up.

### Changes
1. **`LlmPhase.Delivery` — marked RETIRED-but-retained (not renamed/removed).** Its `<summary>` now documents that the `"delivery"` creative LLM call was collapsed into the deterministic `DeliveryOverlay` commit step (#1125) and the constant is retained only to label historical audit/cost rows — mirroring the **#827 MatchupAnalysis/MatchupSummary precedent** in the same file. Phase strings are a public decorator contract; renaming/removing is out of scope and breaking.
2. **Regression tests** (`tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs`):
   - **(a) Round-trip:** driving every live prompt-compilation emitter (`BuildDialogueOptionsPrompt`, `BuildDateePrompt`, `BuildPlayerAvatar`, `BuildDatee`) records its trace under the **new-terminology** `prompt_type` keys (`datee`, `datee-system`, `dialogue-options`, `dialogue-options-system`) and the recorded text round-trips back out of the trace registry unchanged.
   - **(b) Grep-guard:** asserts NONE of the retired old-terminology keys (`opponent`, `opponent-system`) and no `delivery` creative trace is compiled by any live emitter, and no recorded key contains the `opponent` substring. In-test equivalent of the PR-body grep-clean assertion.
   - The existing `Issue788_SnapshotRoundTripTests` already covers the `DateeHistory`/`AvatarHistory` snapshot/restore round-trip with the new key names (extended-not-duplicated rationale: those tests already lock the serialization round-trip, so this PR adds the trace-key/round-trip + grep-guard layer the ticket calls for).

### Grep-clean assertion (no stale OPPONENT/old-PLAYER prompt_type or fixture name)
```
$ grep -rni 'opponent' src --include=*.cs | wc -l
0
$ grep -rniE 'RecordTrace\("[a-z-]+"' src --include=*.cs
src/Pinder.LlmAdapters/SessionDocumentBuilder.cs: RecordTrace("dialogue-options", result)
src/Pinder.LlmAdapters/SessionDocumentBuilder.cs: RecordTrace("datee", result)
src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs: RecordTrace("dialogue-options-system", result)
src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs: RecordTrace("datee-system", result)
$ find . -name '*.json' | grep -iE 'turn0|multi-turn|opponent'   # → (none)
$ grep -rli 'opponent' --include='*.json' .                       # → (none)
```

### Repo-owned-data-preserved checklist (confirmed UNTOUCHED by this diff)
This PR's diff touches exactly 2 files (`LlmPhase.cs` + the new test). Every repo-owned data/config asset is preserved:
- [x] `data/game-definition.yaml` — game definition
- [x] `data/delivery-instructions.yaml`
- [x] `data/prompts/{archetypes,background,narrative,stake,structural,templates}.yaml` — prompt templates
- [x] `data/persona/texting-style-conflicts.yaml`
- [x] `data/characters/{brick,gerald,reuben,sable,velvet,zyx}.json` + `character-schema.json` — test characters
- [x] `data/traps/{traps,trap-schema}.json` — traps
- [x] `data/items/starter-items.json`
- [x] `data/timing/response-profiles.json`
- [x] `data/anatomy/`, `data/i18n/` — untouched
- [x] No `agents-extra/pinder/data/` legacy mirror reintroduced as a load source (per `LEGACY-DATA-FALLBACK-PATH-IS-A-TRAP`).

`git show --stat HEAD` → `2 files changed, 162 insertions(+), 1 deletion(-)`.

### Cross-repo follow-up (filed)
**decay256/pinder-web#881** — live `pinder_staging` Postgres data-wipe (clean reset, no backfill) + jsonb `prompt_type`/column rename on `game_sessions`/`turn_records` to the new terminology, submodule bump to the merged #1129 commit, clean-boot verification. Live DB migration is NOT done from pinder-core.

### DoD Evidence

**Build** (`dotnet build Pinder.Core.sln`):
```
    31 Warning(s)
    0 Error(s)
```

**Tests** (CI=LOCAL-ONLY; fixtures-touching projects):
```
# New regression tests (targeted):
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2 - Pinder.LlmAdapters.Tests.dll
# Full Pinder.LlmAdapters.Tests (trace/serialization surface):
Passed!  - Failed: 0, Passed: 1097, Skipped: 9, Total: 1106 - Pinder.LlmAdapters.Tests.dll
# Snapshot round-trip + delivery-collapse surface (Pinder.Core.Tests):
Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9 - Pinder.Core.Tests.dll
```

**Deviations / notes:**
- **`prompt_type` final set** (refiner-flagged): confirmed against the merged tree — `delivery` is removed (#1125) and `opponent*`→`datee*` is done (#1121). No conflict with #1125's phase set; the live set is exactly `{dialogue-options, dialogue-options-system, datee, datee-system}`.
- `LlmPhase.Delivery` retained (not renamed/removed) per the #827 precedent and the public-contract rule. This is the deliberate decision, not a missed rename.
- Cross-repo DB migration is filed as pinder-web#881, not executed here.
