### PR TITLE
#1126: Slim prompt-fragment config to the minimal variable set

### DIFF
--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -88,12 +88,6 @@ prompts:
 
       WORD & PATTERN REPETITION — check all delivered messages above before writing options. Do not repeat: (a) the same filler words or phrases used in the previous 2 messages ('honestly', 'literally', 'actually', 'okay but', etc.), (b) the same emoji used in the previous message, (c) the same structural pattern (e.g. 'wait...???', 'omg...\U0001f62d', 'I literally just realized...') used in the last 2 messages. Each option should feel like a new move, not a variation on the last one.
       - Since Turn 1 has empty conversation history, options generated for Turn 1 must never assume the DATEE has already spoken (never say 'you mentioned', 'since you said', 'interesting that you mention', etc.). You are initiating the contact.
-  engine-delivery-block:
-    system_prompt: |-
-      [ENGINE — DELIVERY]
-      PLAYER AVATAR chose: '{chosen_option}'
-      Dice result: {roll_context}
-      Write the message {player_name} actually sends, given the above.
   engine-datee-block:
     system_prompt: |-
       [ENGINE — DATEE]
@@ -106,83 +100,6 @@ prompts:
       {game_state}
       Generate {options_count} options for what {player_name} might send, given the conversation above.
       Format: {options_format_list}
-  failure-delivery-instruction:
-    system_prompt: |-
-      You are writing as {player_name}. This is THEIR message, in THEIR voice.
-      Do NOT write as the DATEE. The failure corrupts what {player_name} says.
-
-      The PLAYER AVATAR chose option: "{intended_message}"
-      Stat used: {stat}
-      They rolled FAILED — missed DC by {miss_margin}.
-      Failure tier: {tier}
-
-      Failure principle: the character doesn't know it went wrong. They hit send on
-      exactly the message they meant to send. The corruption happened inside — their
-      shadow spoke through the same sentence structure, replacing the intended meaning
-      with the thing they were trying not to say. The result is ONE coherent message
-      that reads as intentional. The reader sees the break. The character never does.
-
-      You are a writer. Your job is to rewrite the intended message so it arrives
-      corrupted from within. The FORM stays. The CONTENT breaks.
-
-      THE ABSOLUTE RULES:
-      1. ONE MESSAGE. Not two messages stitched together. No asterisks, no italics
-         separating an "original" from a "corruption." One thing they sent.
-      2. SAME LENGTH OR SHORTER. Never append. Never add a tail. If the intended
-         message is two sentences, the delivered message is two sentences or one.
-         Count the sentences. If yours is longer, cut until it isn't.
-      3. NO SELF-AWARENESS. The character does not notice. No "wait that came out
-         wrong," no "omg why did I say that," no commenting on their own words.
-         They sent this on purpose. It IS what they meant to say (to them).
-      4. NO META-COMMENTARY. No stage directions, no narration, no breaking the
-         fourth wall. This is a text message on a phone. That's all.
-      5. THE SHADOW REPLACES, NEVER APPENDS. The corruption works by swapping
-         words and phrases inside the original structure. The sentence that was
-         there gets rewritten — it doesn't get a new sentence bolted on after it.
-
-      HOW CORRUPTION WORKS — by tier:
-
-      FUMBLE (miss 1–2): One small thing goes wrong. A single word gets swapped for
-      the wrong one. A hedge appears that undermines the landing. A qualifier kills
-      the punchline. The message is 95% the intended one — but that 5% changes
-      everything. Same sentence count. Same length.
-
-      MISFIRE (miss 3–5): The message starts as intended, then the shadow takes the
-      steering wheel mid-sentence. The first half is recognizable. The second half
-      has been replaced — not appended to, REPLACED — by the shadow's version.
-      The intent is visible but the execution broke. Same sentence count.
-
-      TROPE_TRAP (miss 6–9): The shadow stat fully wrote this message. The original
-      intent is barely visible. A recognizable bad pattern has taken over — but the
-      character delivered it with full conviction. They think this IS the good
-      version. Same length or shorter than intended.
-
-      CATASTROPHE (miss 10+): The thing they would never say. Sent with complete
-      confidence. The shadow stat has fully possessed the message. The character's
-      worst impulse speaks through their exact voice and texting style. Same length
-      or shorter.
-
-      LEGENDARY (Nat 1): The character's deepest wound surfaces, delivered as if
-      completely normal. This is the message that makes the reader wince because
-      the character has no idea what they just revealed. Their specific wound, in
-      their specific voice, sent like a Tuesday afternoon text. Same length or
-      shorter.
-
-      STAT SHADOWS — each stat fails differently:
-      - CHARM → FIXATION: warm noticing curdles into cataloguing, tracking, dossier-building
-      - RIZZ → HORNINESS: flirty subtext becomes explicitly physical too fast
-      - HONESTY → DENIAL: performs vulnerability while protecting the real thing
-      - CHAOS → MADNESS: one association leads to another until the wound surfaces
-      - WIT → OVERTHINKING: explains the joke, qualifies everything, kills the timing
-      - SA → DREAD: sees the failure coming and narrates the countdown while doing it
-
-      STAT AND TIER INSTRUCTION:
-      {tier_instruction}
-
-      {active_trap_llm_instructions}
-
-      Output ONLY the delivered message text. No quotes. No explanation. No framing.
-      The character sent this.
   interest-beat-above15:
     system_prompt: >-
       Generate a brief reaction — one sentence or a small gesture — showing {datee_name} becoming more invested. Subtle. Not a proclamation. A shift in energy.

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -137,7 +137,14 @@ namespace Pinder.LlmAdapters
 
         internal static string EngineOptionsBlock => GetCatalogString("engine-options-block");
 
-        internal static string EngineDeliveryBlock => GetCatalogString("engine-delivery-block");
+        // EngineDeliveryBlock (yaml key "engine-delivery-block") REMOVED, #1126.
+        // It was the [ENGINE — DELIVERY] block consumed only by the creative
+        // delivery-prompt builder (BuildDeliveryPrompt), which #1125/#1138
+        // deleted when delivery collapsed into the deterministic, non-LLM
+        // DeliveryOverlay. No live builder appended it, so the property and its
+        // yaml entry are both gone. (failure-delivery-instruction yaml key was
+        // likewise removed — its C# property FailureDeliveryInstruction was
+        // already deleted in #1138, leaving the yaml entry orphaned.)
 
         internal static string EngineDateeBlock => GetCatalogString("engine-datee-block");
     }

--- a/tests/Pinder.Core.Tests/Issue872_PromptTemplatesPhase2Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue872_PromptTemplatesPhase2Tests.cs
@@ -44,15 +44,17 @@ namespace Pinder.Core.Tests
         // ----- loader: entry count -------------------------------------------
 
         [Fact]
-        public void TemplatesYaml_LoadsAll37Entries()
+        public void TemplatesYaml_LoadsAll35Entries()
         {
             var catalog = PromptCatalog.LoadFromDirectory(PromptsRoot);
 
-            // Verify the templates.yaml entries are present (37 Phase 2
-            // entries + 1 Phase 1 stake entry = at least 38 names).
+            // #1126: two dead creative-delivery templates were removed
+            // (engine-delivery-block, failure-delivery-instruction), dropping
+            // templates.yaml from 37 to 35 Phase 2 entries. With the Phase 1
+            // stake entry that is at least 36 names.
             var names = catalog.Names.ToList();
-            Assert.True(names.Count >= 38,
-                $"expected >=38 prompt names (37 templates + stake), got {names.Count}");
+            Assert.True(names.Count >= 36,
+                $"expected >=36 prompt names (35 templates + stake), got {names.Count}");
 
             // Spot-check a few representative keys.
             Assert.Contains("dialogue-options-instruction", names);

--- a/tests/Pinder.LlmAdapters.Tests/Issue1126_SlimPromptConfigTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1126_SlimPromptConfigTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Pinder.Core.TestCommon;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// #1126 — Slim prompt-fragment config to the minimal variable set.
+    ///
+    /// With one shared GM puppeteer prompt (#1124) and delivery collapsed into
+    /// the deterministic, non-LLM <c>DeliveryOverlay</c> (#1125/#1138), the
+    /// creative-delivery prompt fragments became dead config. This ticket
+    /// removed the two provably-orphaned templates from
+    /// <c>data/prompts/templates.yaml</c> and the matching loader surface:
+    ///   - <c>engine-delivery-block</c>  (was <c>PromptTemplates.EngineDeliveryBlock</c>)
+    ///   - <c>failure-delivery-instruction</c> (its C# property
+    ///     <c>FailureDeliveryInstruction</c> was already deleted in #1138, leaving
+    ///     the yaml entry orphaned).
+    ///
+    /// CONSERVATIVE-REMOVAL: every other prompt-fragment field was KEPT. In
+    /// particular the still-live overlay machinery — <c>DeliveryRules</c>, the
+    /// <c>default-*</c> tier strings, <c>max_delivery_words</c>, and the overlay
+    /// length/tier/threshold instructions — remain, because the deterministic
+    /// DeliveryOverlay (horniness/shadow/trap rewrites) still consumes them.
+    ///
+    /// These tests pin the slimmed surface:
+    ///   (a) a session system prompt assembles with the slimmed field set and
+    ///       contains NO unresolved <c>{placeholder}</c> tokens; and
+    ///   (b) each removed field is genuinely unreferenced — the parser does not
+    ///       throw a missing-required for it, the catalog no longer exposes it,
+    ///       and the builder emits no empty/dead section for it.
+    /// </summary>
+    public class Issue1126_SlimPromptConfigTests
+    {
+        public Issue1126_SlimPromptConfigTests()
+        {
+            // Wire PromptTemplates.Catalog / structural lookups from data/prompts
+            // exactly as the production startup path does.
+            PromptCatalogInitializer.Initialize();
+        }
+
+        private static string FindPromptsRoot()
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null)
+            {
+                string candidate = Path.Combine(dir, "data", "prompts");
+                if (Directory.Exists(candidate)) return Path.GetFullPath(candidate);
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            throw new DirectoryNotFoundException(
+                "Could not locate data/prompts in any ancestor of the test binary.");
+        }
+
+        // ── (a) slimmed prompt assembles with NO unresolved {placeholder} ──────
+
+        [Theory]
+        [InlineData("player")]
+        [InlineData("datee")]
+        public void SessionSystemPrompt_AssemblesWithSlimmedSet_NoUnresolvedPlaceholders(string session)
+        {
+            // Build with the real PinderDefaults game definition (the slimmed
+            // field set) so any removed-field hole would surface as a dead token.
+            var def = GameDefinition.PinderDefaults;
+            string prompt = session == "player"
+                ? SessionSystemPromptBuilder.BuildPlayerAvatar(
+                    "You are Velvet. Lowercase-with-intent. Ironic.", def)
+                : SessionSystemPromptBuilder.BuildDatee(
+                    "You are Sable. Fast-talking. Uses omg and emoji.", def);
+
+            Assert.False(string.IsNullOrWhiteSpace(prompt));
+
+            // No unresolved {placeholder} token may survive in the assembled
+            // system prompt. A {token} is a lowercase/underscore identifier in
+            // braces (the substitution syntax used across templates.yaml). This
+            // would only appear if a removed field left a dangling reference.
+            var unresolved = Regex.Matches(prompt, @"\{[a-z][a-z0-9_]*\}")
+                .Select(m => m.Value)
+                .Distinct()
+                .ToList();
+
+            Assert.True(unresolved.Count == 0,
+                $"Assembled {session} system prompt contains unresolved placeholder token(s): " +
+                string.Join(", ", unresolved));
+        }
+
+        [Fact]
+        public void TemplatesAndStructural_HaveNoDeadPlaceholderTokens_AcrossSuppliedVariables()
+        {
+            // AC grep-clean: every {...} token in templates.yaml / structural.yaml
+            // must resolve to a variable some live builder supplies. The two
+            // removed templates were the only fragments still carrying the dead
+            // creative-delivery tokens ({chosen_option}, {roll_context},
+            // {intended_message}, {miss_margin}, {tier_instruction}, ...). After
+            // their removal those tokens must be gone from the retained catalog.
+            string root = FindPromptsRoot();
+            string templates = File.ReadAllText(Path.Combine(root, "templates.yaml"));
+            string structural = File.ReadAllText(Path.Combine(root, "structural.yaml"));
+
+            string[] deadTokens =
+            {
+                "{chosen_option}",
+                "{roll_context}",
+                "{intended_message}",
+                "{miss_margin}",
+                "{tier_instruction}",
+                "{active_trap_llm_instructions}",
+            };
+
+            foreach (var tok in deadTokens)
+            {
+                Assert.DoesNotContain(tok, templates);
+                Assert.DoesNotContain(tok, structural);
+            }
+        }
+
+        // ── (b) each removed field is genuinely unreferenced ──────────────────
+
+        [Fact]
+        public void RemovedTemplateKeys_AreGoneFromCatalog()
+        {
+            var catalog = PromptCatalog.LoadFromDirectory(FindPromptsRoot());
+            var names = catalog.Names.ToList();
+
+            Assert.DoesNotContain("engine-delivery-block", names);
+            Assert.DoesNotContain("failure-delivery-instruction", names);
+
+            // TryGet returns null (not throw) for a genuinely absent key.
+            Assert.Null(catalog.TryGet("engine-delivery-block"));
+            Assert.Null(catalog.TryGet("failure-delivery-instruction"));
+        }
+
+        [Fact]
+        public void Parser_DoesNotThrowMissingRequired_ForRemovedTemplates()
+        {
+            // The removed templates were NEVER game-definition.yaml required keys,
+            // so loading the real game definition must still succeed end-to-end.
+            // (A missing-required regression would throw here.)
+            var def = GameDefinition.PinderDefaults;
+            Assert.NotNull(def);
+
+            // And the slimmed catalog loads cleanly with no exception.
+            var catalog = PromptCatalog.LoadFromDirectory(FindPromptsRoot());
+            Assert.NotNull(catalog);
+        }
+
+        [Fact]
+        public void RemovedEngineDeliveryBlock_PropertyIsGone_FromPromptTemplates()
+        {
+            // The C# accessor must be removed together with the yaml key, so no
+            // builder can append the dead block. Reflection guard pins removal.
+            var prop = typeof(PromptTemplates).GetProperty(
+                "EngineDeliveryBlock",
+                System.Reflection.BindingFlags.Static
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Public);
+            Assert.Null(prop);
+
+            // FailureDeliveryInstruction was already removed in #1138; pin it too.
+            var failureProp = typeof(PromptTemplates).GetProperty(
+                "FailureDeliveryInstruction",
+                System.Reflection.BindingFlags.Static
+                | System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Public);
+            Assert.Null(failureProp);
+        }
+
+        [Fact]
+        public void StillLiveOverlayFields_AreRetained()
+        {
+            // CONSERVATIVE-REMOVAL guard: the deterministic DeliveryOverlay still
+            // consumes these, so they must NOT have been swept up with the dead
+            // creative-delivery templates.
+            var def = GameDefinition.PinderDefaults;
+            Assert.NotNull(def.DeliveryRules);
+            Assert.True(def.MaxDeliveryWords > 0);
+
+            // The delivery-tier instruction strings (default-*) stay in the catalog.
+            var catalog = PromptCatalog.LoadFromDirectory(FindPromptsRoot());
+            var names = catalog.Names.ToList();
+            Assert.Contains("default-clean", names);
+            Assert.Contains("default-strong", names);
+            Assert.Contains("default-critical", names);
+            Assert.Contains("default-exceptional", names);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1126

Part of the Pinder two-session Game-Master refactor. With one shared GM puppeteer prompt (#1124) and delivery collapsed into the deterministic, non-LLM `DeliveryOverlay` (#1125/#1138), the creative-delivery prompt fragments became dead config. This PR removes the two **provably-orphaned** fragments and keeps everything else (CONSERVATIVE removal).

## Before / after — config-field audit + rationale

| Field (yaml key / C# accessor) | Decision | Rationale |
|---|---|---|
| `engine-delivery-block` / `PromptTemplates.EngineDeliveryBlock` | **REMOVED** | `[ENGINE — DELIVERY]` block. Grep-clean: zero live consumers. Only ever appended by the creative delivery-prompt builder `BuildDeliveryPrompt`, deleted in #1125/#1138. Carried dead tokens `{chosen_option}`, `{roll_context}`. |
| `failure-delivery-instruction` (yaml) | **REMOVED** | Its C# property `FailureDeliveryInstruction` was already deleted in #1138; the yaml entry was an orphan with no accessor and no consumer. Carried dead tokens `{intended_message}`, `{miss_margin}`, `{tier_instruction}`, `{active_trap_llm_instructions}`. |
| `DeliveryRules` / `default-clean/strong/critical/exceptional/test/medium-rule/register-instruction` | **KEPT** | ORCHESTRATOR-VERIFIED still-live: consumed by the deterministic `DeliveryOverlay` tier rewrites. Borderline (creative-delivery LLM call is gone) but the overlay still reads them — not removed. |
| `max_delivery_words` / `MaxDeliveryWords` | **KEPT** | Live word-cap in `GameSession` / DeliveryOverlay. |
| `DeliveryTemperature` | **KEPT** | Live overlay temperature in all three adapter overlay appliers. |
| `DramaticCraft` | **KEPT** | Live: appended to the shared GM base (`== DRAMATIC CRAFT ==`). |
| `DateeFriction`, `DateeCuriosity`, `ConversationArcProgression`, `PlayerProbing` | **KEPT (variable)** | Live: each appended to the shared GM base under its own header in `SessionSystemPromptBuilder`. |
| `ImprovementPrompt` | **KEPT** | Live: read by `AnthropicResponseImprover`. |
| `SteeringPrompt` | **KEPT** | Live: read by all three adapters' steering-question path. |
| `MaxDialogueOptions`, `MaxTurns`, `GlobalDcBias`, role/vision/world/narrative/horniness fields | **KEPT** | Live engine knobs / required GM-base inputs. |

Net: 2 dead creative-delivery fragments removed; all still-variable knobs retained. Borderline `DeliveryRules`/overlay fields kept per orchestrator verification.

## Grep-clean assertion
Every `{...}` token remaining in `templates.yaml`/`structural.yaml` resolves to a variable a live builder supplies. The dead creative-delivery tokens (`{chosen_option}`, `{roll_context}`, `{intended_message}`, `{miss_margin}`, `{tier_instruction}`, `{active_trap_llm_instructions}`) are fully gone — pinned by a regression test.

## Cross-repo follow-up
Admin prompt-editor (`PromptTracerPanel`/`SOURCE_FILE_TO_TAB`) lives in pinder-web — NOT edited here. Paired follow-up: **decay256/pinder-web#882**.

## DoD Evidence

**Build (CI=LOCAL-ONLY):** `dotnet build Pinder.Core.sln`
```
192 Warning(s)
0 Error(s)
Time Elapsed 00:00:19.72
```

**Tests:** `dotnet test` (LlmAdapters + Core prompt-builder)
```
# Pinder.LlmAdapters.Tests
Passed!  - Failed:     0, Passed:  1104, Skipped:     9, Total:  1113 - Pinder.LlmAdapters.Tests.dll (net8.0)
# Pinder.LlmAdapters.Tests --filter Issue1126 (the 2 new regression tests, 7 cases)
Passed!  - Failed:     0, Passed:     7, Skipped:     0, Total:     7
# Pinder.Core.Tests (full suite, incl. updated Issue872 count assertion)
Passed!  - Failed:     0, Passed:  2935, Skipped:    18, Total:  2953 - Pinder.Core.Tests.dll (net8.0)
```

**Regression tests added** (`tests/Pinder.LlmAdapters.Tests/Issue1126_SlimPromptConfigTests.cs`):
- `SessionSystemPrompt_AssemblesWithSlimmedSet_NoUnresolvedPlaceholders` (player + datee) — assembles with the slimmed set, contains NO unresolved `{placeholder}`.
- `TemplatesAndStructural_HaveNoDeadPlaceholderTokens_AcrossSuppliedVariables` — the removed creative-delivery tokens are gone from the retained catalog.
- `RemovedTemplateKeys_AreGoneFromCatalog` / `Parser_DoesNotThrowMissingRequired_ForRemovedTemplates` — removed keys genuinely unreferenced; parser does not throw missing-required.
- `RemovedEngineDeliveryBlock_PropertyIsGone_FromPromptTemplates` — accessor removed (reflection guard).
- `StillLiveOverlayFields_AreRetained` — `DeliveryRules` / `default-*` / `max_delivery_words` kept (CONSERVATIVE-removal guard).

**Commit:** `eade419 #1126: slim prompt config — remove dead creative-delivery fragments`

**Docs:** before/after table above; not required at this maturity beyond the table.

**Deviations from contract:** none. Admin-UI scoped out to pinder-web#882 per ticket. Pre-existing template-internal example tokens `{reduction}` (weakness-descriptor example) and `{token}` (comment) are out of scope and untouched.