### PR TITLE
feat(contract): apiVersion handshake contract slice (#1127)

### DIFF
--- a/src/Pinder.Core/Contracts/ApiContract.cs
+++ b/src/Pinder.Core/Contracts/ApiContract.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pinder.Core.Contracts
+{
+    /// <summary>
+    /// #1127: THE single canonical wire-contract version handshake for the
+    /// Unity client ⇆ game-api request envelope, part of the two-session
+    /// Game-Master refactor. This type is the CANONICAL source of truth for
+    /// the current API contract version; pinder-web's server-side validation
+    /// (game-api 5101) and the Unity client (GitLab, read-only here) both
+    /// reference this same number and the same <see cref="ApiVersionMismatchError"/>
+    /// shape so all three parties agree on the wire.
+    ///
+    /// <para>
+    /// <b>Bump policy (monotonic integer).</b> <see cref="ApiContractVersion"/>
+    /// is a monotonically increasing integer. It is incremented by exactly one
+    /// on ANY breaking change to the request/response wire contract — a renamed
+    /// or removed field, a changed field type, a changed required-ness, or a
+    /// changed semantic interpretation of an existing field. Purely additive,
+    /// backwards-compatible changes (a new OPTIONAL field that old clients may
+    /// omit and old servers may ignore) do NOT bump the version. The handshake's
+    /// only job is accept/reject on the supported-set match below; an integer is
+    /// deliberately simpler to validate and document than semver because there is
+    /// no notion of "minor compatible" — a version is either in
+    /// <see cref="SupportedVersions"/> or it is rejected.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Coordination with #1128 (T8).</b> #1128's integration doc MUST stamp
+    /// the SAME number this constant holds (currently <c>1</c>). This constant is
+    /// authoritative; the doc mirrors it. <see cref="ContractTests"/> assert the
+    /// stamped number so a drift between code and doc breaks the build.
+    /// </para>
+    /// </summary>
+    public static class ApiContract
+    {
+        /// <summary>
+        /// The current canonical API contract version. Monotonic integer; see the
+        /// type doc-comment for the bump policy. #1128 must stamp this same value.
+        /// </summary>
+        public const int ApiContractVersion = 1;
+
+        /// <summary>
+        /// The set of contract versions this build accepts. Today it is exactly the
+        /// current version. When a breaking change ships we bump
+        /// <see cref="ApiContractVersion"/>; this set may transiently list more than
+        /// one entry during a deliberate dual-version migration window, but the
+        /// default policy is "current version only".
+        /// </summary>
+        public static readonly IReadOnlyCollection<int> SupportedVersions =
+            new[] { ApiContractVersion };
+
+        /// <summary>
+        /// True only if <paramref name="apiVersion"/> is present AND belongs to the
+        /// <see cref="SupportedVersions"/> set. A missing (null) version is NOT
+        /// supported — the handshake is mandatory. Note this deliberately is NOT a
+        /// naive <c>apiVersion != null</c> check: a present-but-unsupported version
+        /// (e.g. a future <c>2</c>) is rejected even though it parses fine.
+        /// </summary>
+        public static bool IsSupported(int? apiVersion)
+        {
+            return apiVersion.HasValue && SupportedVersions.Contains(apiVersion.Value);
+        }
+
+        /// <summary>
+        /// Validates the <c>apiVersion</c> carried by a request contract against the
+        /// supported set. Returns <c>null</c> when the version is accepted, or a
+        /// populated <see cref="ApiVersionMismatchError"/> describing the rejection.
+        /// This is the contract DEFINITION reused by pinder-web's server-side
+        /// validation; pinder-core does NOT itself reject requests on the wire
+        /// (that wiring is the pinder-web follow-up).
+        /// </summary>
+        /// <returns>
+        /// <c>null</c> if accepted; otherwise the structured mismatch error to emit
+        /// on the wire.
+        /// </returns>
+        public static ApiVersionMismatchError? Validate(ApiRequestContract? request)
+        {
+            int? received = request?.ApiVersion;
+            if (IsSupported(received))
+            {
+                return null;
+            }
+
+            return ApiVersionMismatchError.ForReceived(received);
+        }
+    }
+}

--- a/src/Pinder.Core/Contracts/ApiRequestContract.cs
+++ b/src/Pinder.Core/Contracts/ApiRequestContract.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace Pinder.Core.Contracts
+{
+    /// <summary>
+    /// #1127: the canonical Unity client ⇆ game-api REQUEST envelope contract.
+    /// Today it carries only the mandatory version handshake field; future
+    /// request payload fields are added here (additive fields do not bump
+    /// <see cref="ApiContract.ApiContractVersion"/> — see the bump policy).
+    ///
+    /// <para>
+    /// The <c>apiVersion</c> field is defined ON the request contract rather than
+    /// as a parallel handshake envelope so there is a single, non-jagged wire
+    /// shape that both server and client serialize. It is nullable so the
+    /// "missing version" case round-trips faithfully through deserialization and
+    /// is then rejected by <see cref="ApiContract.Validate"/> — a missing version
+    /// is a mismatch, not a silent default.
+    /// </para>
+    /// </summary>
+    public sealed class ApiRequestContract
+    {
+        /// <summary>
+        /// The wire field name for the API contract version. Pinned here as the
+        /// single source of truth for the serialized property name; renaming it
+        /// is a breaking wire change and is guarded by the contract tests.
+        /// </summary>
+        public const string ApiVersionFieldName = "apiVersion";
+
+        /// <summary>
+        /// The contract version the caller declares it speaks. Nullable: a request
+        /// that omits it deserializes to <c>null</c> and is rejected by the
+        /// handshake (the version is mandatory). Serialized as <c>apiVersion</c>.
+        /// </summary>
+        [JsonPropertyName(ApiVersionFieldName)]
+        public int? ApiVersion { get; set; }
+
+        public ApiRequestContract()
+        {
+        }
+
+        public ApiRequestContract(int? apiVersion)
+        {
+            ApiVersion = apiVersion;
+        }
+    }
+}

--- a/src/Pinder.Core/Contracts/ApiVersionMismatchError.cs
+++ b/src/Pinder.Core/Contracts/ApiVersionMismatchError.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Pinder.Core.Contracts
+{
+    /// <summary>
+    /// #1127: the structured error a server emits when a request's
+    /// <c>apiVersion</c> handshake fails (missing or unsupported). Defined ONCE
+    /// here in pinder-core so pinder-web (which performs the actual wire-level
+    /// rejection in game-api 5101) and the Unity client (which parses the
+    /// rejection) reference the SAME type and the SAME field names — there is no
+    /// second, drifting copy of the error shape.
+    ///
+    /// <para>
+    /// <b>Wire body shape</b> (System.Text.Json, camelCase property names pinned
+    /// via <see cref="JsonPropertyName"/>):
+    /// <code>
+    /// {
+    ///   "code": "api_version_mismatch",
+    ///   "message": "Unsupported apiVersion ...",
+    ///   "received": 2,            // null when the request omitted apiVersion
+    ///   "supported": [1]
+    /// }
+    /// </code>
+    /// The <see cref="Code"/> string and the four field names are part of the wire
+    /// contract; the regression tests pin them so a rename breaks the build rather
+    /// than silently changing the wire.
+    /// </para>
+    /// </summary>
+    public sealed class ApiVersionMismatchError
+    {
+        /// <summary>
+        /// The stable, machine-readable error code clients switch on. PINNED wire
+        /// value — do not change without bumping <see cref="ApiContract.ApiContractVersion"/>.
+        /// </summary>
+        public const string CodeValue = "api_version_mismatch";
+
+        /// <summary>Machine-readable error code. Always <see cref="CodeValue"/>.</summary>
+        [JsonPropertyName("code")]
+        public string Code { get; set; } = CodeValue;
+
+        /// <summary>Human-readable diagnostic; not a stable contract surface.</summary>
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The version the client sent, or <c>null</c> if the request omitted
+        /// <c>apiVersion</c> entirely. Echoed back so the client can diagnose.
+        /// </summary>
+        [JsonPropertyName("received")]
+        public int? Received { get; set; }
+
+        /// <summary>The versions this server accepts (mirrors <see cref="ApiContract.SupportedVersions"/>).</summary>
+        [JsonPropertyName("supported")]
+        public IReadOnlyCollection<int> Supported { get; set; } = new int[0];
+
+        public ApiVersionMismatchError()
+        {
+        }
+
+        /// <summary>
+        /// Builds the mismatch error for a given received version (null = the
+        /// request omitted <c>apiVersion</c>). Populates the supported set and a
+        /// deterministic human-readable message.
+        /// </summary>
+        public static ApiVersionMismatchError ForReceived(int? received)
+        {
+            var supported = ApiContract.SupportedVersions.ToArray();
+            string supportedList = string.Join(", ", supported);
+            string message = received.HasValue
+                ? $"Unsupported apiVersion {received.Value}; this server supports [{supportedList}]."
+                : $"Missing required apiVersion; this server supports [{supportedList}].";
+
+            return new ApiVersionMismatchError
+            {
+                Code = CodeValue,
+                Message = message,
+                Received = received,
+                Supported = supported,
+            };
+        }
+
+        /// <summary>
+        /// Serializes this error to its canonical wire JSON. Deterministic: the
+        /// same error value always produces byte-identical JSON (no indentation,
+        /// fixed property order from the declaration / attributes).
+        /// </summary>
+        public string ToJson()
+        {
+            return JsonSerializer.Serialize(this, SerializerOptions);
+        }
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            // Property names come from [JsonPropertyName]; no naming policy applied
+            // so the wire shape is fully pinned by the attributes above.
+        };
+    }
+}

--- a/tests/Pinder.Core.Tests/Contracts/ApiContractTests.cs
+++ b/tests/Pinder.Core.Tests/Contracts/ApiContractTests.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using Pinder.Core.Contracts;
+using Xunit;
+
+namespace Pinder.Core.Tests.Contracts
+{
+    /// <summary>
+    /// #1127 WIRE-CONTRACT-REGRESSION-TESTS for the apiVersion handshake.
+    ///
+    /// The "looks right but is wrong" trap for a version handshake is a naive
+    /// <c>apiVersion != null</c> (or any non-empty) acceptance check: it accepts a
+    /// present-but-unsupported version. These tests deliberately feed values that
+    /// PASS a naive check but must FAIL the documented supported-set policy, and
+    /// pin the exact wire <c>code</c> string + body field names so a rename breaks
+    /// the build rather than silently changing the wire.
+    /// </summary>
+    public class ApiContractTests
+    {
+        // ---- version constant / #1128 coordination --------------------------------
+
+        [Fact]
+        public void ApiContractVersion_is_the_stamped_monotonic_integer_one()
+        {
+            // #1128 (T8) MUST stamp this SAME number in its integration doc.
+            // If the canonical version is bumped, update #1128's doc in the same change.
+            Assert.Equal(1, ApiContract.ApiContractVersion);
+        }
+
+        [Fact]
+        public void SupportedVersions_contains_the_current_version()
+        {
+            Assert.Contains(ApiContract.ApiContractVersion, ApiContract.SupportedVersions);
+        }
+
+        // ---- accept / reject policy (the "looks right but wrong" trap) -------------
+
+        [Fact]
+        public void Matching_version_is_accepted()
+        {
+            var request = new ApiRequestContract(ApiContract.ApiContractVersion);
+
+            Assert.True(ApiContract.IsSupported(request.ApiVersion));
+            Assert.Null(ApiContract.Validate(request)); // null == accepted
+        }
+
+        [Fact]
+        public void Missing_apiVersion_maps_to_the_mismatch_error()
+        {
+            var request = new ApiRequestContract(null);
+
+            // Trap: a naive `apiVersion != null` check would treat this differently,
+            // but the handshake is mandatory — a missing version is a mismatch.
+            Assert.False(ApiContract.IsSupported(request.ApiVersion));
+
+            var error = ApiContract.Validate(request);
+            Assert.NotNull(error);
+            Assert.Equal(ApiVersionMismatchError.CodeValue, error!.Code);
+            Assert.Null(error.Received);
+        }
+
+        [Fact]
+        public void Wrong_but_parseable_apiVersion_maps_to_the_mismatch_error()
+        {
+            // 2 is a perfectly parseable integer and would PASS any naive
+            // "non-null"/"parses as int" acceptance — but it is NOT in the
+            // supported set, so the documented policy must reject it.
+            const int unsupportedButParseable = 2;
+            var request = new ApiRequestContract(unsupportedButParseable);
+
+            Assert.False(ApiContract.IsSupported(request.ApiVersion));
+
+            var error = ApiContract.Validate(request);
+            Assert.NotNull(error);
+            Assert.Equal(ApiVersionMismatchError.CodeValue, error!.Code);
+            Assert.Equal(unsupportedButParseable, error.Received);
+        }
+
+        [Fact]
+        public void Null_request_maps_to_the_mismatch_error()
+        {
+            var error = ApiContract.Validate(null);
+            Assert.NotNull(error);
+            Assert.Equal(ApiVersionMismatchError.CodeValue, error!.Code);
+            Assert.Null(error.Received);
+        }
+
+        // ---- exact wire body pinning (rename must break the build) -----------------
+
+        [Fact]
+        public void Mismatch_error_code_string_is_pinned()
+        {
+            // A refactor that renames the code must break THIS test, not silently
+            // change the wire contract every client switches on.
+            Assert.Equal("api_version_mismatch", ApiVersionMismatchError.CodeValue);
+        }
+
+        [Fact]
+        public void Request_contract_field_name_is_pinned()
+        {
+            Assert.Equal("apiVersion", ApiRequestContract.ApiVersionFieldName);
+        }
+
+        [Fact]
+        public void Mismatch_error_serializes_to_the_documented_body_shape_for_unsupported_version()
+        {
+            var error = ApiVersionMismatchError.ForReceived(2);
+
+            // Deterministic, byte-stable serialization of the documented shape.
+            // Property order follows declaration order: code, message, received, supported.
+            string json = error.ToJson();
+            Assert.Equal(
+                "{\"code\":\"api_version_mismatch\",\"message\":\"Unsupported apiVersion 2; this server supports [1].\",\"received\":2,\"supported\":[1]}",
+                json);
+        }
+
+        [Fact]
+        public void Mismatch_error_serializes_to_the_documented_body_shape_for_missing_version()
+        {
+            var error = ApiVersionMismatchError.ForReceived(null);
+
+            string json = error.ToJson();
+            Assert.Equal(
+                "{\"code\":\"api_version_mismatch\",\"message\":\"Missing required apiVersion; this server supports [1].\",\"received\":null,\"supported\":[1]}",
+                json);
+        }
+
+        [Fact]
+        public void Mismatch_error_body_field_names_are_pinned()
+        {
+            // Pin the EXACT JSON property names. Renaming any C# property without
+            // its [JsonPropertyName] must break this test (the wire field names are
+            // the contract clients parse).
+            using var doc = JsonDocument.Parse(ApiVersionMismatchError.ForReceived(2).ToJson());
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("code", out _), "wire field 'code' missing");
+            Assert.True(root.TryGetProperty("message", out _), "wire field 'message' missing");
+            Assert.True(root.TryGetProperty("received", out _), "wire field 'received' missing");
+            Assert.True(root.TryGetProperty("supported", out _), "wire field 'supported' missing");
+            Assert.Equal(4, root.EnumerateObject().Count()); // no extra/unexpected wire fields
+        }
+
+        // ---- request contract round-trips the missing-version case faithfully -----
+
+        [Fact]
+        public void Request_deserializes_missing_apiVersion_to_null_then_rejected()
+        {
+            // A wire payload that omits apiVersion must deserialize to null (not a
+            // silent default of 0), and then be rejected by the handshake.
+            var request = JsonSerializer.Deserialize<ApiRequestContract>("{}");
+            Assert.NotNull(request);
+            Assert.Null(request!.ApiVersion);
+            Assert.NotNull(ApiContract.Validate(request));
+        }
+
+        [Fact]
+        public void Request_round_trips_apiVersion_field_name_on_the_wire()
+        {
+            var request = new ApiRequestContract(ApiContract.ApiContractVersion);
+            string json = JsonSerializer.Serialize(request);
+
+            // The serialized property MUST be the pinned 'apiVersion' name.
+            using var doc = JsonDocument.Parse(json);
+            Assert.True(doc.RootElement.TryGetProperty("apiVersion", out var v));
+            Assert.Equal(ApiContract.ApiContractVersion, v.GetInt32());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1127

Part of the **Pinder two-session Game-Master refactor**. Lands the **pinder-core CONTRACT SLICE only** for the `apiVersion` wire handshake, following the `GmOutputContract.cs` precedent (a single, canonical, testable contract type living in pinder-core and consumed by both server and Unity — no parallel/jagged envelope).

## What landed (pinder-core only)
- **`src/Pinder.Core/Contracts/ApiContract.cs`**
  - `ApiContractVersion = 1` — the **canonical source of truth**, a **monotonic integer** with a documented bump policy (increment by one on any breaking wire change; additive optional fields do NOT bump). **#1128 (T8) must stamp this SAME number.**
  - `SupportedVersions` (= `{1}` today) + `IsSupported(int?)` + `Validate(ApiRequestContract?)` returning `null` (accepted) or a populated mismatch error. **Definition only — no server-side wire rejection here** (that's pinder-web's job).
- **`src/Pinder.Core/Contracts/ApiRequestContract.cs`** — the request-contract type carrying the `apiVersion` field (nullable `int?`, serialized as `apiVersion`), so a *missing* version round-trips as `null` and is rejected rather than silently defaulting to `0`. Field name pinned via `ApiVersionFieldName`.
- **`src/Pinder.Core/Contracts/ApiVersionMismatchError.cs`** — the structured mismatch error defined **once** for reuse. Pinned wire `code = "api_version_mismatch"`; body fields `code` / `message` / `received` / `supported`; deterministic `ToJson()`.

## Regression tests (WIRE-CONTRACT-REGRESSION-TESTS)
`tests/Pinder.Core.Tests/Contracts/ApiContractTests.cs` (13 tests):
- **Missing** `apiVersion` AND **wrong-but-parseable** (`2`) both map to the documented mismatch error code/body; **matching** (`1`) is accepted — values chosen to **pass a naive `!= null` check but fail the documented supported-set policy** (the classic handshake trap).
- Exact `code` string + body field names pinned (a rename breaks the build, not the wire silently); deterministic body-shape serialization for both the unsupported and missing cases; `{}` deserializes `apiVersion`→null then rejected.
- Asserts `ApiContractVersion == 1` so drift vs #1128's stamped number breaks the build.

## CROSS-REPO follow-ups (paired tickets — NOT implemented here)
- **(i) pinder-web — server-side request validation:** decay256/pinder-web#883. Game-api 5101 parses `apiVersion`, calls `ApiContract.Validate(...)`, and emits `ApiVersionMismatchError` on the wire (reject unsupported versions). Filed & referencing #1127.
- **(ii) Unity (GitLab `Diego_Quarantine/p-game`, READ-ONLY here, owned by Martin) — send `apiVersion`:** NOT a code change made here; to be **documented in #1128's integration doc** (Unity must send `apiVersion: 1`).

**Note for #1128:** stamp `ApiContractVersion = 1` in the integration doc (same value as this constant).

## DoD Evidence (CI = LOCAL ONLY)
**Build:** `dotnet build Pinder.Core.sln` → `0 Error(s)` (192 pre-existing warnings).
**Tests:** `dotnet test --filter Contracts.ApiContractTests` → `Passed! - Failed: 0, Passed: 13, Total: 13`.