### PR TITLE
Fix flaky test Issue833_BulletListPromptSectionsTests by using StaticWiring collection

### DIFF
--- a/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
+++ b/tests/Pinder.Core.Tests/ActiveArchetypeTests.cs
@@ -8,6 +8,7 @@ namespace Pinder.Core.Tests
     /// Tests for ActiveArchetype resolution in CharacterAssembler (#649).
     /// </summary>
     [Trait("Category", "Core")]
+    [Collection("StaticWiring")]
     public class ActiveArchetypeTests
     {
         [Fact]

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public class CharacterDefinitionLoaderTests
     {
         // Locate data files relative to repo root

--- a/tests/Pinder.Core.Tests/CharacterSystemTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterSystemTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public class CharacterSystemTests
     {
         // -----------------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue415_CharacterDefinitionLoaderSpecTests.cs
@@ -18,6 +18,7 @@ namespace Pinder.Core.Tests
     /// Tests verify behavior from docs/specs/issue-415-spec.md only.
     /// </summary>
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public partial class Issue415_CharacterDefinitionLoaderSpecTests
     {
         #region Helpers

--- a/tests/Pinder.Core.Tests/Issue527_SessionRunnerBioFormatTests.cs
+++ b/tests/Pinder.Core.Tests/Issue527_SessionRunnerBioFormatTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     [Trait("Category", "SessionRunner")]
-    [Collection("SessionRunnerReflection")]
+    [Collection("StaticWiring")]
     public sealed class Issue527_SessionRunnerBioFormatTests
     {
         [Fact]

--- a/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
+++ b/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
@@ -16,6 +16,7 @@ namespace Pinder.Core.Tests
     /// (a numbered list of every archetype name with vote counts).
     /// </summary>
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public class Issue832_ActiveArchetypePromptTests
     {
         private static readonly Dictionary<StatType, int> ZeroBaseStats =

--- a/tests/Pinder.Core.Tests/Issue833_BulletListPromptSectionsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue833_BulletListPromptSectionsTests.cs
@@ -24,6 +24,7 @@ namespace Pinder.Core.Tests
     /// updated to use #836-conformant SYNTAX/TONE-formatted fragments.
     /// </summary>
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public class Issue833_BulletListPromptSectionsTests
     {
         private static readonly Dictionary<StatType, int> ZeroBaseStats =

--- a/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.cs
@@ -30,6 +30,7 @@ namespace Pinder.Core.Tests
     /// design rationale.
     /// </summary>
     [Trait("Category", "Characters")]
+    [Collection("StaticWiring")]
     public partial class Issue836_TextingStyleAggregationRuleTests
     {
         // ----- repo helpers ---------------------------------------------------

--- a/tests/Pinder.Core.Tests/Issue873_ArchetypeCatalogPhase4Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue873_ArchetypeCatalogPhase4Tests.cs
@@ -21,7 +21,7 @@ namespace Pinder.Core.Tests
     ///   the resolver nor the in-memory dictionary can satisfy a lookup.
     /// </summary>
     [Trait("Category", "PromptCatalog")]
-    [Collection("SessionRunnerReflection")]
+    [Collection("StaticWiring")]
     public class Issue873_ArchetypeCatalogPhase4Tests
     {
         // ----- repo helpers ---------------------------------------------------

--- a/tests/Pinder.Core.Tests/Prompts/TextingStyleAggregatorIntegrationTests.cs
+++ b/tests/Pinder.Core.Tests/Prompts/TextingStyleAggregatorIntegrationTests.cs
@@ -30,6 +30,7 @@ namespace Pinder.Core.Tests.Prompts
     /// <see cref="TextingStyleAggregator.AggregateWithAudit"/> and logs drops.
     /// </summary>
     [Trait("Category", "Prompts")]
+    [Collection("StaticWiring")]
     public class TextingStyleAggregatorIntegrationTests
     {
         // ------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause
The test `Issue833_BulletListPromptSectionsTests.BackstorySection_EmitsBulletList` was intermittently failing with the error `PromptTemplates.Catalog is not wired / Call PromptWiring.Wire()`. The root cause was a race condition in xUnit: `Issue833` runs in parallel with other test classes (since it has no explicit collection), including tests like `Issue874` that temporarily null out the shared global wiring delegates such as `PromptBuilder.StructuralFragmentLookup`. When `Issue833` reads the wiring at the exact moment another test mutates it, it crashes.

## Fix
Put `Issue833_BulletListPromptSectionsTests` (and other test classes that mutate or explicitly rely on the global prompt wiring such as `Issue832_ActiveArchetypePromptTests`, `CharacterSystemTests`, `ActiveArchetypeTests`, `Issue873_ArchetypeCatalogPhase4Tests`, `CharacterDefinitionLoaderTests`, `TextingStyleAggregatorIntegrationTests`, `Issue527_SessionRunnerBioFormatTests`, `Issue836_TextingStyleAggregationRuleTests`, and `Issue415_CharacterDefinitionLoaderSpecTests`) into the `[Collection("StaticWiring")]`. This ensures xUnit serializes execution of any test that either reads without rewiring or temporarily re-wires the global catalog, preventing the state-corruption race condition completely while strictly limiting changes to the test project.

## Flake-gone evidence
10/10 full-project runs green, 3/3 isolated.

Closes #1141