### PR TITLE
Fix #1147: Isolate InMemoryPromptTraceService test classes

### DIFF
--- a/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
@@ -10,6 +10,7 @@ namespace Pinder.LlmAdapters.Tests
     /// <summary>
     /// Tests that active archetype directives are injected into LLM prompts (#649).
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class ArchetypeInjectionTests
     {
         private static DialogueContext MakeDialogueContext(string activeArchetypeDirective = null)

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
@@ -11,6 +11,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Tests for [ENGINE] injection block format in SessionDocumentBuilder.
     /// Verifies AC from Issue #544: options, delivery, and datee injection formats.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public partial class EngineInjectionBlockTests
     {
         // ═══════════════════════════════════════════════════════════════

--- a/tests/Pinder.LlmAdapters.Tests/Issue1066_PromptTraceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1066_PromptTraceTests.cs
@@ -10,6 +10,7 @@ using Pinder.Core.TestCommon;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public sealed class Issue1066_PromptTraceTests
     {
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Issue1126_SlimPromptConfigTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1126_SlimPromptConfigTests.cs
@@ -34,6 +34,7 @@ namespace Pinder.LlmAdapters.Tests
     ///       throw a missing-required for it, the catalog no longer exposes it,
     ///       and the builder emits no empty/dead section for it.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue1126_SlimPromptConfigTests
     {
         public Issue1126_SlimPromptConfigTests()

--- a/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
@@ -32,6 +32,7 @@ namespace Pinder.LlmAdapters.Tests
     /// cross-repo pinder-web follow-up filed against #1129; this repo owns the
     /// serialization/trace-key/fixture surface and asserts it here.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public sealed class Issue1129_SchemaRenameGuardTests
     {
         // The complete set of live prompt_type trace keys the engine compiles

--- a/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
@@ -14,6 +14,7 @@ namespace Pinder.LlmAdapters.Tests
     /// These tests verify the builder side with raw values as input.
     /// Maturity: Prototype (happy-path per AC).
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue307_ShadowTaintFiringTests
     {
         // ============== AC: Madness=8 → SHADOW STATE section present ==============

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
@@ -13,6 +13,7 @@ namespace Pinder.LlmAdapters.Tests
     /// constraint before option generation.
     /// Tests are derived from docs/specs/issue-489-spec.md acceptance criteria and edge cases.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue489_VoiceDistinctnessSpecTests
     {
         // ── Test-only helpers ──

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
@@ -12,6 +12,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Tests for Issue #489: voice distinctness — explicit texting style constraint
     /// before option generation.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue489_VoiceDistinctnessTests
     {
         // ── Helpers ──

--- a/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceDescriptorTests.cs
@@ -12,6 +12,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Verifies that BuildDateePrompt includes the fundamental resistance rule
     /// and interest-appropriate resistance descriptors.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue490_ResistanceDescriptorTests
     {
         private static DateeContext MakeDateeContext(int interestAfter, int interestBefore = -1)

--- a/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceSpec_Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue490_ResistanceSpec_Tests.cs
@@ -12,6 +12,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Tests verify behavior described in docs/specs/issue-490-spec.md.
     /// Each test has a mutation comment explaining what code change would cause failure.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue490_ResistanceSpec_Tests
     {
         /// <summary>

--- a/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationSpecTests.cs
@@ -13,6 +13,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Supplements the existing Issue493_FailureDegradationTests with edge cases
     /// and additional acceptance criteria coverage.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue493_FailureDegradationSpecTests
     {
         private static DateeContext MakeContext(FailureTier tier, int interestBefore = 12, int interestAfter = 11)

--- a/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
@@ -13,6 +13,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Verifies that BuildDateePrompt injects per-tier failure context when DeliveryTier != None,
     /// and omits it on success.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue493_FailureDegradationTests
     {
         private static DateeContext MakeContext(FailureTier tier)

--- a/tests/Pinder.LlmAdapters.Tests/Issue543_SessionSystemPromptSpecTests.Builder.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue543_SessionSystemPromptSpecTests.Builder.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public partial class Issue543_SessionSystemPromptSpecTests
     {
         #region AC3: GameDefinition.PinderDefaults hardcoded fallback

--- a/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
@@ -18,6 +18,7 @@ namespace Pinder.LlmAdapters.Tests
     ///   AC6: Unit tests verify injection format correctness
     ///   AC7: Build clean
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public partial class Issue544_EngineInjectionSpecTests
     {
         // ── Test Helpers ──

--- a/tests/Pinder.LlmAdapters.Tests/Issue647_ActiveTellOptionsTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue647_ActiveTellOptionsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public class Issue647_ActiveTellOptionsTests
     {
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Issue866_DateeLengthCapTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue866_DateeLengthCapTests.cs
@@ -13,6 +13,7 @@ namespace Pinder.LlmAdapters.Tests
     /// the formula's boundary cases. One formula test verifies ComputeResponseCeiling at
     /// the boundary values and the regression scenario from session 707fca72.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue866_DateeLengthCapTests
     {
         // ── Helpers ──

--- a/tests/Pinder.LlmAdapters.Tests/Issue867_DeliveryTokenAuditSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue867_DeliveryTokenAuditSpecTests.cs
@@ -12,6 +12,7 @@ namespace Pinder.LlmAdapters.Tests
     /// These tests pin the new shared-base contract and keep the original
     /// token-ceiling sanity check.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue867_DeliveryTokenAuditSpecTests
     {
         private static GameDefinition FullFixture()

--- a/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
@@ -14,6 +14,7 @@ namespace Pinder.LlmAdapters.Tests
     /// #950: psychological stake must surface in option-generator prompt.
     /// Tests guard the PROMPT PATH — not live LLM output (stochastic).
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class Issue950_StakeSurfacingTests
     {
         // ── helpers ──────────────────────────────────────────────────────

--- a/tests/Pinder.LlmAdapters.Tests/PromptTraceSingletonCollection.cs
+++ b/tests/Pinder.LlmAdapters.Tests/PromptTraceSingletonCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [CollectionDefinition("PromptTraceSingleton", DisableParallelization = true)]
+    public sealed class PromptTraceSingletonCollection
+    {
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public class SessionDocumentBuilderPromptTests
     {
         private static DialogueContext MakeDialogueContext(

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
@@ -14,6 +14,7 @@ namespace Pinder.LlmAdapters.Tests
     /// Spec-based tests for SessionDocumentBuilder, PromptTemplates, and CacheBlockBuilder.
     /// Tests derived from docs/specs/issue-207-spec.md.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public partial class SessionDocumentBuilderSpecTests
     {
         // ── Helpers ──

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public partial class SessionDocumentBuilderTests
     {
         // Catalog wiring lives in LlmAdaptersTestWiring.ModuleInitializer

--- a/tests/Pinder.LlmAdapters.Tests/SessionSystemPromptBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionSystemPromptBuilderTests.cs
@@ -8,6 +8,7 @@ namespace Pinder.LlmAdapters.Tests
     /// template; only the injected character-spec block differs. The legacy
     /// combined Build(player, datee) path has been removed.
     /// </summary>
+    [Collection("PromptTraceSingleton")]
     public class SessionSystemPromptBuilderTests
     {
         private const string PlayerAvatarPrompt = "You are Velvet. Lowercase-with-intent. Ironic. Level 7 Veteran.";

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Pinder.LlmAdapters.Tests
 {
+    [Collection("PromptTraceSingleton")]
     public class ShadowTaintTests
     {
         private static DialogueContext MakeDialogueContext(


### PR DESCRIPTION
The flaky test `Issue1129_SchemaRenameGuardTests.LiveEmitters_RecordTracesUnderNewKeyNames_AndRoundTrip` (and others) fails intermittently because multiple test classes are running in parallel and mutating the process-wide singleton `InMemoryPromptTraceService.Instance`. In xUnit, classes without a `[Collection]` attribute get their own implicit collections and run in parallel, which interleaves the `Clear()` and trace recordings between tests.

To fix this test-isolation issue without changing production code, a new xUnit `CollectionDefinition` named `"PromptTraceSingleton"` with `DisableParallelization = true` was added. This attribute has been applied to all test classes in `Pinder.LlmAdapters.Tests` that reference `InMemoryPromptTraceService` or its recording emitters (`SessionDocumentBuilder.Build...`, `SessionSystemPromptBuilder.Build...`). This forces these tests to run serially, preventing the race condition.

## Flake-gone evidence
20/20 full-project parallel runs green, isolated filter green.

Closes #1147
