### PR TITLE
fix(#859): harden HarnessCharacterLoader.Load against path-traversal slugs (item 2)

### DIFF
--- a/src/Pinder.NarrativeHarness/HarnessCharacterLoader.cs
+++ b/src/Pinder.NarrativeHarness/HarnessCharacterLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Pinder.Core.Characters;
 using Pinder.Core.Data;
 using Pinder.Core.Interfaces;
@@ -37,8 +38,31 @@ namespace Pinder.Tools.NarrativeHarness
     /// </summary>
     public static class HarnessCharacterLoader
     {
+        // Defense-in-depth allowlist for admin-supplied character slugs
+        // (--character / --pursuer-character). Accept only a leading
+        // alphanumeric followed by alphanumerics/hyphen/underscore. This
+        // rejects path separators ('/', '\'), parent-dir traversal (".."),
+        // bare dots, leading separators/dots, drive roots, and whitespace,
+        // BEFORE any path is constructed from the slug.
+        private static readonly Regex SafeSlugPattern =
+            new Regex("^[A-Za-z0-9][A-Za-z0-9_-]*$", RegexOptions.Compiled);
+
+        private static void ValidateSlug(string slug)
+        {
+            if (string.IsNullOrWhiteSpace(slug) || !SafeSlugPattern.IsMatch(slug))
+                throw new ArgumentException(
+                    $"Invalid character slug: '{slug}'. Slugs must match ^[A-Za-z0-9][A-Za-z0-9_-]*$ "
+                    + "(no path separators, no '..', no absolute paths, no whitespace).",
+                    nameof(slug));
+        }
+
         public static LoadedCharacter Load(string slug)
         {
+            // Guard first: reject structurally-unsafe slugs before constructing
+            // any filesystem path. Valid-but-missing slugs still fall through to
+            // the FileNotFoundException path below.
+            ValidateSlug(slug);
+
             string baseDir = AppContext.BaseDirectory;
 
             // Production prompt assembly requires the unified PromptCatalog to be

--- a/tests/Pinder.LlmAdapters.Tests/Issue859_HarnessSlugHardeningTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue859_HarnessSlugHardeningTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Pinder.Tools.NarrativeHarness;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Item 2 of decay256/pinder-web#859: HarnessCharacterLoader.Load must reject
+    /// structurally-unsafe / malicious character slugs with ArgumentException
+    /// BEFORE constructing any filesystem path.
+    ///
+    /// Reverse-verification note: these tests are guard-dependent. If the
+    /// ValidateSlug guard is deleted from HarnessCharacterLoader.Load, these
+    /// cases would no longer throw ArgumentException — instead they would throw
+    /// FileNotFoundException (or attempt actual path traversal), so the asserts
+    /// below would FAIL. That is the point: the tests prove the guard is present
+    /// and effective.
+    /// </summary>
+    public class Issue859_HarnessSlugHardeningTests
+    {
+        [Theory]
+        [InlineData("../../etc/passwd")] // classic traversal
+        [InlineData("..")]               // bare parent-dir
+        [InlineData("foo/bar")]          // forward-slash separator
+        [InlineData("foo\\bar")]         // backslash separator
+        [InlineData("/abs/path")]        // leading separator / absolute
+        [InlineData("")]                 // empty
+        [InlineData("  ")]               // whitespace-only
+        [InlineData("a/../b")]           // embedded traversal
+        public void Load_RejectsMaliciousOrInvalidSlugs_WithArgumentException(string slug)
+        {
+            Assert.Throws<ArgumentException>(() => HarnessCharacterLoader.Load(slug));
+        }
+
+        [Fact]
+        public void Load_RejectsNullSlug_WithArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => HarnessCharacterLoader.Load(null!));
+        }
+
+        /// <summary>
+        /// Positive control: a structurally-valid slug that simply doesn't exist
+        /// on disk must NOT be rejected by the guard. It passes ValidateSlug and
+        /// fails later with FileNotFoundException — proving the allowlist guard
+        /// does not over-reject valid-shaped slugs.
+        /// </summary>
+        [Fact]
+        public void Load_ValidShapedButMissingSlug_ThrowsFileNotFound_NotArgumentException()
+        {
+            var ex = Record.Exception(
+                () => HarnessCharacterLoader.Load("definitely-not-a-real-character"));
+            Assert.NotNull(ex);
+            Assert.IsNotType<ArgumentException>(ex);
+            Assert.IsType<System.IO.FileNotFoundException>(ex);
+        }
+    }
+}


### PR DESCRIPTION
Item 2 of decay256/pinder-web#859. Adds an allowlist slug guard to HarnessCharacterLoader.Load (rejects '/', '\\', '..', absolute paths, empty/whitespace via ArgumentException) plus Issue859_HarnessSlugHardeningTests. Admin-gated surface, defense-in-depth. Local build + LlmAdapters.Tests green. NO GitHub CI (verified locally per AGENTS.md).