### PR TITLE
fix(#1154): collapse character-card structural framing into single config field

### DIFF
--- a/data/prompts/structural.yaml
+++ b/data/prompts/structural.yaml
@@ -1,16 +1,17 @@
 schema_version: 1
 prompts:
-  structural-lead-in:
-    system_prompt: 'RULES'
-  structural-identity:
-    system_prompt: IDENTITY
-  structural-personality:
-    system_prompt: PERSONALITY
-  structural-backstory:
-    system_prompt: BACKSTORY
-  structural-texting-style:
-    system_prompt: TEXTING STYLE
-  structural-active-archetype:
-    system_prompt: ACTIVE ARCHETYPE
-  structural-active-trap-instructions:
-    system_prompt: ACTIVE TRAP INSTRUCTIONS
+  # Issue #1154: the 7 former structural-* header keys (RULES, IDENTITY,
+  # PERSONALITY, BACKSTORY, TEXTING STYLE, ACTIVE ARCHETYPE, ACTIVE TRAP
+  # INSTRUCTIONS) are collapsed into this single constant-framing field.
+  # PromptBuilder.BuildSystemPromptEx splits it back into the 7 labels by
+  # line, in order, and emits them in the exact same byte positions as
+  # before — the compiled character card stays byte-identical.
+  character_card_framing:
+    system_prompt: |-
+      RULES
+      IDENTITY
+      PERSONALITY
+      BACKSTORY
+      TEXTING STYLE
+      ACTIVE ARCHETYPE
+      ACTIVE TRAP INSTRUCTIONS

--- a/src/Pinder.Core/Prompts/PromptBuilder.cs
+++ b/src/Pinder.Core/Prompts/PromptBuilder.cs
@@ -29,12 +29,22 @@ namespace Pinder.Core.Prompts
     public static class PromptBuilder
     {
         /// <summary>
+        /// The single yaml key (since #1154) holding the collapsed
+        /// constant character-card framing. Its value is the 7 section
+        /// labels, one per line, in emission order:
+        /// RULES / IDENTITY / PERSONALITY / BACKSTORY / TEXTING STYLE /
+        /// ACTIVE ARCHETYPE / ACTIVE TRAP INSTRUCTIONS.
+        /// </summary>
+        public const string CharacterCardFramingKey = "character_card_framing";
+
+        /// <summary>
         /// Resolves structural prompt fragments from the yaml catalog.
-        /// Keys are kebab-case (e.g. <c>"structural-lead-in"</c>,
-        /// <c>"structural-identity"</c>). Set at startup (typically by
-        /// <c>PromptWiring.Wire()</c>). After Phase 5 of #871, null
-        /// or missing keys cause <see cref="BuildSystemPrompt"/> to throw
-        /// — there are no embedded const fallbacks.
+        /// Since #1154 the only key consulted is
+        /// <see cref="CharacterCardFramingKey"/> (<c>"character_card_framing"</c>).
+        /// Set at startup (typically by <c>PromptWiring.Wire()</c>). After
+        /// Phase 5 of #871, null or missing keys cause
+        /// <see cref="BuildSystemPrompt"/> to throw — there are no embedded
+        /// const fallbacks.
         /// </summary>
         public static Func<string, string?>? StructuralFragmentLookup { get; set; }
 
@@ -48,11 +58,6 @@ namespace Pinder.Core.Prompts
         /// delegate is not wired or the key is missing — after Phase 5
         /// there are no const fallbacks.
         /// </summary>
-        private static string GetHeader(string key)
-        {
-            return GetHeaderEx(key).Content;
-        }
-
         private static (string Content, string SourceFile) GetHeaderEx(string key)
         {
             var lookup = StructuralFragmentLookup
@@ -78,6 +83,62 @@ namespace Pinder.Core.Prompts
             }
 
             return (value, sourceFile);
+        }
+
+        /// <summary>
+        /// #1154: the 7 constant section labels recovered, in order, from
+        /// the single <see cref="CharacterCardFramingKey"/> field.
+        /// </summary>
+        private readonly struct CardFraming
+        {
+            public readonly string LeadIn;
+            public readonly string Identity;
+            public readonly string Personality;
+            public readonly string Backstory;
+            public readonly string TextingStyle;
+            public readonly string ActiveArchetype;
+            public readonly string ActiveTrapInstructions;
+            public readonly string SourceFile;
+
+            public CardFraming(string[] labels, string sourceFile)
+            {
+                LeadIn                 = labels[0];
+                Identity               = labels[1];
+                Personality            = labels[2];
+                Backstory              = labels[3];
+                TextingStyle           = labels[4];
+                ActiveArchetype        = labels[5];
+                ActiveTrapInstructions = labels[6];
+                SourceFile             = sourceFile;
+            }
+        }
+
+        /// <summary>
+        /// Load the collapsed framing field and split it back into the 7
+        /// section labels (one per line, in emission order). The split is
+        /// byte-preserving: each recovered label is emitted in the exact
+        /// same position as the legacy per-key headers.
+        /// </summary>
+        private static CardFraming GetCardFraming()
+        {
+            var framing = GetHeaderEx(CharacterCardFramingKey);
+            // Split on LF, tolerating CRLF, and drop a single trailing
+            // blank line if the yaml block scalar produced one.
+            var lines = framing.Content.Replace("\r\n", "\n").Split('\n');
+            int count = lines.Length;
+            while (count > 0 && lines[count - 1].Length == 0) count--;
+
+            if (count != 7)
+            {
+                throw new InvalidOperationException(
+                    $"prompt-catalog: '{CharacterCardFramingKey}' must declare exactly " +
+                    $"7 section labels (one per line); found {count}. " +
+                    $"Check data/prompts/structural.yaml.");
+            }
+
+            var labels = new string[7];
+            for (int i = 0; i < 7; i++) labels[i] = lines[i];
+            return new CardFraming(labels, framing.SourceFile);
         }
 
         /// <summary>
@@ -128,40 +189,41 @@ namespace Pinder.Core.Prompts
 
             var sb = new AnnotatedStringBuilder();
 
+            // #1154: the constant section framing now lives in ONE collapsed
+            // field (character_card_framing); split it back into the 7 labels
+            // and emit them in the EXACT same byte positions as before.
+            var framing = GetCardFraming();
+            string srcFile = framing.SourceFile;
+            const string srcKey = CharacterCardFramingKey;
+
             // Header — sourced from structural.yaml, no fallback.
-            var leadIn = GetHeaderEx("structural-lead-in");
-            sb.AppendLine(leadIn.Content.Replace("{name}", displayName), leadIn.SourceFile, "structural-lead-in");
+            sb.AppendLine(framing.LeadIn.Replace("{name}", displayName), srcFile, srcKey);
             sb.AppendLine();
 
             // IDENTITY
-            var identity = GetHeaderEx("structural-identity");
-            sb.AppendLine(identity.Content, identity.SourceFile, "structural-identity");
+            sb.AppendLine(framing.Identity, srcFile, srcKey);
             sb.AppendLine($"- Gender identity: {genderIdentity}");
             sb.AppendLine($"- Bio: {(string.IsNullOrWhiteSpace(bioOneLiner) ? "none" : bioOneLiner)}");
             sb.AppendLine();
 
             // PERSONALITY
-            var personality = GetHeaderEx("structural-personality");
-            sb.AppendLine(personality.Content, personality.SourceFile, "structural-personality");
+            sb.AppendLine(framing.Personality, srcFile, srcKey);
             AppendBulletList(sb, fragments.PersonalityFragments);
             sb.AppendLine();
 
             // BACKSTORY
-            var backstory = GetHeaderEx("structural-backstory");
-            sb.AppendLine(backstory.Content, backstory.SourceFile, "structural-backstory");
+            sb.AppendLine(framing.Backstory, srcFile, srcKey);
             AppendBulletList(sb, fragments.BackstoryFragments);
             sb.AppendLine();
 
             // TEXTING STYLE
-            var textingStyle = GetHeaderEx("structural-texting-style");
-            sb.AppendLine(textingStyle.Content, textingStyle.SourceFile, "structural-texting-style");
+            sb.AppendLine(framing.TextingStyle, srcFile, srcKey);
             AppendBulletList(sb, TextingStyleAggregator.AggregateAsList(
                 fragments.TextingStyleSources, characterIdSeed));
             sb.AppendLine();
 
             // ACTIVE ARCHETYPE
-            var activeArchetype = GetHeaderEx("structural-active-archetype");
-            sb.AppendLine(activeArchetype.Content, activeArchetype.SourceFile, "structural-active-archetype");
+            sb.AppendLine(framing.ActiveArchetype, srcFile, srcKey);
             if (fragments.ActiveArchetype != null)
             {
                 var aa = fragments.ActiveArchetype;
@@ -191,8 +253,7 @@ namespace Pinder.Core.Prompts
                 if (!hasActiveHeader)
                 {
                     sb.AppendLine();
-                    var activeTrapHeader = GetHeaderEx("structural-active-trap-instructions");
-                    sb.AppendLine(activeTrapHeader.Content, activeTrapHeader.SourceFile, "structural-active-trap-instructions");
+                    sb.AppendLine(framing.ActiveTrapInstructions, srcFile, srcKey);
                     hasActiveHeader = true;
                 }
                 sb.AppendLine(trap.Definition.LlmInstruction);

--- a/tests/Pinder.Core.Tests/Fixtures/Issue1154/golden_active.txt
+++ b/tests/Pinder.Core.Tests/Fixtures/Issue1154/golden_active.txt
@@ -1,0 +1,34 @@
+RULES
+
+IDENTITY
+- Gender identity: she/her
+- Bio: just here for the vibes
+
+PERSONALITY
+- warm but guarded
+- dry humour
+- secretly competitive
+
+BACKSTORY
+- grew up by the sea
+- dropped out of art school
+- adopted a three-legged cat
+
+TEXTING STYLE
+- emoji: never uses emoji at all
+
+ACTIVE ARCHETYPE
+- The Peacock (dominant)
+Loud, expensive flex.
+*Sample lines:* "check my watch" · "weekend trip booked"
+
+EFFECTIVE STATS
+- Charm: 3
+- Rizz: 2
+- Honesty: 5
+- Chaos: 1
+- Wit: 4
+- Self-Awareness: 0
+
+ACTIVE TRAP INSTRUCTIONS
+You just said something deeply cringe. Overcompensate awkwardly for the next few messages.

--- a/tests/Pinder.Core.Tests/Fixtures/Issue1154/golden_inactive.txt
+++ b/tests/Pinder.Core.Tests/Fixtures/Issue1154/golden_inactive.txt
@@ -1,0 +1,31 @@
+RULES
+
+IDENTITY
+- Gender identity: she/her
+- Bio: just here for the vibes
+
+PERSONALITY
+- warm but guarded
+- dry humour
+- secretly competitive
+
+BACKSTORY
+- grew up by the sea
+- dropped out of art school
+- adopted a three-legged cat
+
+TEXTING STYLE
+- emoji: never uses emoji at all
+
+ACTIVE ARCHETYPE
+- The Peacock (dominant)
+Loud, expensive flex.
+*Sample lines:* "check my watch" · "weekend trip booked"
+
+EFFECTIVE STATS
+- Charm: 3
+- Rizz: 2
+- Honesty: 5
+- Chaos: 1
+- Wit: 4
+- Self-Awareness: 0

--- a/tests/Pinder.Core.Tests/Issue1154_CharacterCardGoldenTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1154_CharacterCardGoldenTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Prompts;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #1154 — golden byte-identity oracle for the inner character-card
+    /// builder <see cref="PromptBuilder.BuildSystemPromptEx"/>.
+    ///
+    /// The #1154 refactor collapsed the 7 <c>structural-*</c> section-header
+    /// keys in <c>data/prompts/structural.yaml</c> into a single
+    /// <c>character_card_framing</c> field; the builder splits that one field
+    /// back into the 7 labels and emits them in the EXACT same byte positions
+    /// as before. This is a BEHAVIOR-PRESERVING change: the compiled character
+    /// card must stay byte-for-byte identical to what the old per-key builder
+    /// produced.
+    ///
+    /// The golden fixtures were captured from the UNMODIFIED pre-refactor code
+    /// and checked in verbatim. Both the trap-INACTIVE and trap-ACTIVE cases
+    /// are pinned (the trap block is gated on <c>activeTraps.AllActive</c>).
+    ///
+    /// NOTE (orchestrator decision): #1154's other half — reordering sections
+    /// so variable per-character data forms a trailing block — was DEFERRED
+    /// because it is byte-CHANGING and conflicts with this non-negotiable
+    /// byte-identity contract. Only the SSOT collapse landed here.
+    /// </summary>
+    [Trait("Category", "PromptCatalog")]
+    [Collection("StaticWiring")]
+    public class Issue1154_CharacterCardGoldenTests
+    {
+        private static string FixturesDir =>
+            Path.Combine(AppContext.BaseDirectory, "Fixtures", "Issue1154");
+
+        private static string ReadFixture(string name) =>
+            File.ReadAllText(Path.Combine(FixturesDir, name));
+
+        private static readonly Dictionary<StatType, int> BaseStats =
+            new Dictionary<StatType, int>
+            {
+                { StatType.Charm, 3 }, { StatType.Rizz, 2 },
+                { StatType.Honesty, 5 }, { StatType.Chaos, 1 },
+                { StatType.Wit, 4 }, { StatType.SelfAwareness, 0 },
+            };
+
+        private static readonly Dictionary<ShadowStatType, int> Shadow =
+            new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 },
+            };
+
+        private static FragmentCollection BuildDeterministicFragments()
+        {
+            return new FragmentCollection(
+                personalityFragments: new List<string> { "warm but guarded", "dry humour", "secretly competitive" },
+                backstoryFragments:   new List<string> { "grew up by the sea", "dropped out of art school", "adopted a three-legged cat" },
+                textingStyleFragments: new List<string>(),
+                rankedArchetypes:     new List<(string, int)> { ("The Peacock", 4) },
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(BaseStats, Shadow),
+                activeArchetype: new ActiveArchetype(
+                    "The Peacock",
+                    "Loud, expensive flex.\n*Sample lines:* \"check my watch\" \u00b7 \"weekend trip booked\"",
+                    4, 5),
+                textingStyleSources: new List<TextingStyleFragmentSource>
+                {
+                    new TextingStyleFragmentSource(
+                        "item", "hiking-boots",
+                        "SYNTAX:\n- emoji: never uses emoji at all\n- shorthand: \n- grammar: \n- structure: \n- length: \n- tics: \nTONE:",
+                        slotOrParameter: "shoes"),
+                });
+        }
+
+        // ── trap-INACTIVE: no ACTIVE TRAP block ───────────────────────────
+        [Fact]
+        public void BuildSystemPromptEx_TrapInactive_MatchesGoldenByteForByte()
+        {
+            var fragments = BuildDeterministicFragments();
+
+            var result = PromptBuilder.BuildSystemPromptEx(
+                "Velvet", "she/her", "just here for the vibes",
+                fragments, new TrapState(), characterIdSeed: "fixed-seed-1154");
+
+            Assert.Equal(ReadFixture("golden_inactive.txt"), result.Text);
+        }
+
+        // ── trap-ACTIVE: the gated ACTIVE TRAP INSTRUCTIONS block appears ──
+        [Fact]
+        public void BuildSystemPromptEx_TrapActive_MatchesGoldenByteForByte()
+        {
+            var fragments = BuildDeterministicFragments();
+
+            var trapState = new TrapState();
+            trapState.Activate(new TrapDefinition(
+                id: "cringe",
+                stat: StatType.Charm,
+                effect: TrapEffect.StatPenalty,
+                effectValue: 2,
+                durationTurns: 3,
+                llmInstruction: "You just said something deeply cringe. Overcompensate awkwardly for the next few messages.",
+                clearMethod: "land a genuine joke",
+                nat1Bonus: "double cringe",
+                displayName: "Cringe"));
+
+            var result = PromptBuilder.BuildSystemPromptEx(
+                "Velvet", "she/her", "just here for the vibes",
+                fragments, trapState, characterIdSeed: "fixed-seed-1154");
+
+            Assert.Equal(ReadFixture("golden_active.txt"), result.Text);
+        }
+
+        // ── provenance: every framing span is now sourced from the single
+        //    collapsed key (was the 7 structural-* keys) ────────────────────
+        [Fact]
+        public void BuildSystemPromptEx_FramingSpans_AttributeToCollapsedKey()
+        {
+            var fragments = BuildDeterministicFragments();
+
+            var trapState = new TrapState();
+            trapState.Activate(new TrapDefinition(
+                "cringe", StatType.Charm, TrapEffect.StatPenalty, 2, 3,
+                "trap instr", "clear", "nat1", "Cringe"));
+
+            var result = PromptBuilder.BuildSystemPromptEx(
+                "Velvet", "she/her", "bio", fragments, trapState,
+                characterIdSeed: "fixed-seed-1154");
+
+            // No span carries a legacy structural-* key anymore.
+            Assert.DoesNotContain(result.Spans, s => s.Key.StartsWith("structural-", StringComparison.Ordinal));
+            // The framing headers are now attributed to the collapsed key.
+            Assert.Contains(result.Spans, s => s.Key == PromptBuilder.CharacterCardFramingKey);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
@@ -12,18 +12,20 @@ using Xunit;
 namespace Pinder.Core.Tests
 {
     /// <summary>
-    /// Issue #874 Phase 3 + #875 Phase 5: <see cref="PromptBuilder"/>
+    /// Issue #874 Phase 3 + #875 Phase 5 (updated by #1154): <see cref="PromptBuilder"/>
     /// structural strings sourced exclusively from
     /// <c>data/prompts/structural.yaml</c>.
     ///
-    /// What this file pins (updated after Phase 5):
+    /// What this file pins (updated after #1154):
     /// - The loader parses <c>data/prompts/structural.yaml</c> into a
-    ///   <see cref="PromptCatalog"/> with 7 expected entries.
+    ///   <see cref="PromptCatalog"/> with the single collapsed
+    ///   <c>character_card_framing</c> entry (was 7 <c>structural-*</c> keys).
     /// - <see cref="PromptBuilder.StructuralFragmentLookup"/> MUST be wired
     ///   before calling <see cref="PromptBuilder.BuildSystemPrompt"/> —
     ///   a null or missing-key lookup throws <see cref="InvalidOperationException"/>.
     /// - When the lookup is wired, <see cref="PromptBuilder.BuildSystemPrompt"/>
-    ///   emits the yaml-sourced section headers into the assembled prompt.
+    ///   splits the collapsed framing back into the yaml-sourced section
+    ///   headers and emits them into the assembled prompt.
     /// </summary>
     [Trait("Category", "PromptCatalog")]
     [Collection("StaticWiring")]
@@ -69,49 +71,52 @@ namespace Pinder.Core.Tests
         // ----- loader: entry count -------------------------------------------
 
         [Fact]
-        public void StructuralYaml_LoadsAll7Entries()
+        public void StructuralYaml_LoadsCollapsedFramingEntry()
         {
             var catalog = LoadCatalog();
 
-            // The 7 structural entries must be present.
+            // #1154: the 7 structural-* keys collapsed into one field.
             var names = catalog.Names.ToList();
-            Assert.Contains("structural-lead-in", names);
-            Assert.Contains("structural-identity", names);
-            Assert.Contains("structural-personality", names);
-            Assert.Contains("structural-backstory", names);
-            Assert.Contains("structural-texting-style", names);
-            Assert.Contains("structural-active-archetype", names);
-            Assert.Contains("structural-active-trap-instructions", names);
+            Assert.Contains("character_card_framing", names);
+
+            // The old per-section keys are gone.
+            Assert.DoesNotContain("structural-lead-in", names);
+            Assert.DoesNotContain("structural-identity", names);
+            Assert.DoesNotContain("structural-personality", names);
+            Assert.DoesNotContain("structural-backstory", names);
+            Assert.DoesNotContain("structural-texting-style", names);
+            Assert.DoesNotContain("structural-active-archetype", names);
+            Assert.DoesNotContain("structural-active-trap-instructions", names);
         }
 
-        // ----- byte-identity contract: representative entry ------------------
+        // ----- byte-identity contract: collapsed framing carries the 7 labels --
 
         [Fact]
-        public void Yaml_StructuralIdentity_MatchesConst_ByteForByte()
+        public void Yaml_CharacterCardFraming_CarriesSevenLabelsInOrder()
         {
-            // #874 Phase 3 contract: this is a pure relocation. The yaml
-            // must produce the same text the legacy const does. If a
-            // future PR renames the section header, it MUST update both
-            // the yaml AND the const (or, post-Phase 5, just the yaml).
+            // #1154 contract: the collapsed field is the 7 section labels,
+            // one per line, in emission order. Splitting it back must
+            // recover the exact legacy label strings byte-for-byte.
             var catalog = LoadCatalog();
-            var entry = catalog.Get("structural-identity");
+            var entry = catalog.Get("character_card_framing");
 
-            string fromYaml = entry.SystemPrompt!;
-            const string fromConst = "IDENTITY";
+            var labels = entry.SystemPrompt!
+                .Replace("\r\n", "\n")
+                .TrimEnd('\n')
+                .Split('\n');
 
-            Assert.Equal(fromConst, fromYaml);
-        }
-
-        [Fact]
-        public void Yaml_StructuralLeadIn_MatchesConst_ByteForByte()
-        {
-            var catalog = LoadCatalog();
-            var entry = catalog.Get("structural-lead-in");
-
-            string fromYaml = entry.SystemPrompt!;
-            const string fromConst = "RULES";
-
-            Assert.Equal(fromConst, fromYaml);
+            Assert.Equal(
+                new[]
+                {
+                    "RULES",
+                    "IDENTITY",
+                    "PERSONALITY",
+                    "BACKSTORY",
+                    "TEXTING STYLE",
+                    "ACTIVE ARCHETYPE",
+                    "ACTIVE TRAP INSTRUCTIONS",
+                },
+                labels);
         }
 
         // ----- StructuralFragmentLookup: must be wired (Phase 5) ------------

--- a/tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
+++ b/tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Fixtures\Issue1154\*.txt" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Pinder.Core\Pinder.Core.csproj" />
     <ProjectReference Include="..\..\session-runner\session-runner.csproj" />
     <ProjectReference Include="..\..\src\Pinder.LlmAdapters\Pinder.LlmAdapters.csproj" />


### PR DESCRIPTION
Closes #1154 (SSOT collapse portion).

Behavior-preserving: the compiled character card is **byte-identical** pre/post, pinned by a golden test for BOTH the trap-active and trap-inactive cases.

## What changed
- `data/prompts/structural.yaml`: the 7 `structural-*` header keys (`structural-lead-in`, `structural-identity`, `structural-personality`, `structural-backstory`, `structural-texting-style`, `structural-active-archetype`, `structural-active-trap-instructions`) collapsed into ONE field `character_card_framing` — a block scalar carrying the 7 labels, one per line, in emission order.
- `src/Pinder.Core/Prompts/PromptBuilder.cs`: `BuildSystemPromptEx` now loads the single `character_card_framing` field once and **splits it back into the 7 labels by line** (`GetCardFraming()` → `CardFraming` struct), emitting each label in the EXACT same byte position as before (same `{name}` substitution on the lead-in, same blank lines, bullet lists, EFFECTIVE STATS block, and the gated ACTIVE TRAP block). Span provenance for the framing headers now attributes to `character_card_framing` instead of the old per-section keys.
- Tests: new `Issue1154_CharacterCardGoldenTests` (byte-for-byte `Assert.Equal`, no Trim, trap-active + trap-inactive + provenance). `Issue874_PromptBuilderPhase3Tests` updated to assert the single collapsed key (and that the framing round-trips into the 7 exact labels) instead of 7 separate keys.

## Local verification (no GitHub CI on this repo)
- `dotnet build -c Release Pinder.Core.sln` → **0 Error(s)**
- `Pinder.Core.Tests` → Passed: 2950, Failed: 0, Skipped: 18
- `Pinder.LlmAdapters.Tests` → Passed: 1112, Failed: 0, Skipped: 9
- `Pinder.Rules.Tests` → Passed: 241, Failed: 0, Skipped: 0

## Deferred (orchestrator decision)
The issue's other half — the byte-CHANGING cache-reorder that moves variable per-character data into a clearly-delimited **trailing block** after the constant framing — was intentionally **NOT** done here. The character card interleaves constant section headers with their variable data, so moving headers to a front block necessarily changes bytes, which directly conflicts with the **non-negotiable byte-identity requirement** that wins. AC item "variable data forms a trailing block" is therefore intentionally not satisfied; every other AC is. The reorder is deferred to a separate ticket (queued for Daniel).

## Frontend/backend follow-up
The admin **structural prompts** editor (`/api/admin/content/prompts-structural`) now sees 1 key instead of 7 — file a companion pinder-web ticket if needed.
