### PR TITLE
fix(#1155): cold-opener guard off-by-one

### DIFF
--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -106,10 +106,12 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine();
             }
 
-            // Turn 1 cold-opener guard
-            if (context.CurrentTurn == 1)
+            // Cold-opener guard: fires only on the genuine first turn (nobody has spoken yet).
+            // Keyed on empty history rather than a turn integer so it is robust to the
+            // 0-based, end-of-turn-incremented counter (issue #1155).
+            if (context.ConversationHistory.Count == 0)
             {
-                sb.AppendLine("COLD OPENER RULE: This is Turn 1. You have never spoken to this person before.");
+                sb.AppendLine("COLD OPENER RULE: This is the very first message. You have never spoken to this person before.");
                 sb.AppendLine("Since you are initiating the contact and sending the very first message, you MUST NOT say \"interesting that you mention\", \"since you said\", \"you mentioned\", or use any other phrasing that assumes the datee has already spoken or sent a message in this conversation. The datee has sent ZERO messages.");
                 sb.AppendLine("Your only knowledge of them is their dating profile: bio text AND visible appearance (items listed after 'Wearing:' in the profile above).");
                 sb.AppendLine("Do NOT reference anything you would only know from inside knowledge of the character — only what is visible on their public profile.");

--- a/tests/Pinder.LlmAdapters.Tests/Issue1155_ColdOpenerGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1155_ColdOpenerGuardTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    // Regression for issue #1155 (cold-opener off-by-one).
+    //
+    // The cold-opener guard used to gate on `context.CurrentTurn == 1`, but the
+    // turn counter is 0-based and incremented at the END of ResolveTurnAsync.
+    // So the guard NEVER fired on the genuine first turn (CurrentTurn == 0, empty
+    // history) and WRONGLY fired on the second turn (CurrentTurn == 1, which already
+    // has a player+datee exchange). The guard is now re-anchored to an empty
+    // ConversationHistory.
+    //
+    // These tests deliberately set CurrentTurn to values that PROVE the fix keys on
+    // history rather than the integer:
+    //   (a) empty history + CurrentTurn == 0 -> cold opener PRESENT
+    //   (b) 1-exchange history + CurrentTurn == 1 -> cold opener ABSENT
+    // Under the OLD code, (a) would fail (absent at turn 0) and (b) would fail
+    // (present at turn 1), so this test would have caught the original bug.
+    public class Issue1155_ColdOpenerGuardTests
+    {
+        private const string ColdOpenerMarker = "COLD OPENER RULE";
+
+        private static DialogueContext MakeContext(
+            IReadOnlyList<(string Sender, string Text)> history,
+            int currentTurn)
+        {
+            return new DialogueContext(
+                playerAvatarPrompt: "player prompt",
+                dateePrompt: "datee prompt",
+                conversationHistory: history,
+                dateeLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerName: "P",
+                dateeName: "O",
+                currentTurn: currentTurn);
+        }
+
+        [Fact]
+        public void ColdOpener_Present_WhenHistoryEmpty_EvenAtTurnZero()
+        {
+            // Genuine first turn: nobody has spoken; counter is still 0.
+            var context = MakeContext(
+                new List<(string, string)>(),
+                currentTurn: 0);
+
+            Assert.Empty(context.ConversationHistory);
+
+            string prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
+
+            Assert.Contains(ColdOpenerMarker, prompt);
+        }
+
+        [Fact]
+        public void ColdOpener_Absent_WhenHistoryHasOneExchange_EvenAtTurnOne()
+        {
+            // Second turn: a player message + a datee reply already exist; the
+            // (previously buggy) counter reads 1 here.
+            var history = new List<(string, string)>
+            {
+                ("P", "hey, nice profile"),
+                ("O", "ha, thanks — you too"),
+            };
+            var context = MakeContext(history, currentTurn: 1);
+
+            Assert.NotEmpty(context.ConversationHistory);
+
+            string prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
+
+            Assert.DoesNotContain(ColdOpenerMarker, prompt);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1155. Re-anchors the cold-opener guard from CurrentTurn==1 to ConversationHistory.Count==0 (the counter is 0-based, end-of-turn incremented). Regression test: cold-opener present on empty history, absent on 1-exchange history. Local: build -c Release clean; LlmAdapters + Core tests green.