### PR TITLE
fix(#1164): enforce drawn-stats contract on dialogue options

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/AnthropicLlmAdapter.cs
@@ -85,7 +85,7 @@ namespace Pinder.LlmAdapters.Anthropic
             var toolInput = response.GetToolInput();
             if (toolInput != null)
             {
-                var parsed = DialogueOptionParsers.ParseDialogueOptionsTool(toolInput);
+                var parsed = DialogueOptionParsers.ParseDialogueOptionsTool(toolInput, context.AvailableStats);
                 if (parsed != null) return parsed;
             }
 
@@ -96,7 +96,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 : await AnthropicResponseImprover.ApplyImprovementAsync(
                     _client, _options, systemBlocks, userContent, optionsDraft,
                     _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature, ct).ConfigureAwait(false);
-            return DialogueOptionParsers.ParseDialogueOptionsText(optionsText);
+            return DialogueOptionParsers.ParseDialogueOptionsText(optionsText, context.AvailableStats);
         }
 
         /// <inheritdoc />
@@ -386,8 +386,8 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Parses structured LLM output into DialogueOption array.
         /// Delegates to DialogueOptionParsers.ParseDialogueOptionsText.
         /// </summary>
-        internal static DialogueOption[] ParseDialogueOptions(string? llmResponse)
-            => DialogueOptionParsers.ParseDialogueOptionsText(llmResponse);
+        internal static DialogueOption[] ParseDialogueOptions(string? llmResponse, StatType[]? availableStats = null)
+            => DialogueOptionParsers.ParseDialogueOptionsText(llmResponse, availableStats);
 
         /// <summary>
         /// Parses structured LLM output with optional [SIGNALS] blocks.

--- a/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
@@ -67,7 +67,7 @@ namespace Pinder.LlmAdapters.Anthropic
         /// Parses structured LLM text output into DialogueOption array.
         /// Never throws — returns 4 options, padding with defaults if needed.
         /// </summary>
-        public static DialogueOption[] ParseDialogueOptionsText(string? llmResponse)
+        public static DialogueOption[] ParseDialogueOptionsText(string? llmResponse, StatType[]? availableStats = null)
         {
             var parsed = new List<DialogueOption>();
 
@@ -157,14 +157,14 @@ namespace Pinder.LlmAdapters.Anthropic
                 }
             }
 
-            return PadDialogueOptionsToFour(parsed);
+            return ReconcileAndPadDialogueOptions(parsed, availableStats);
         }
 
         /// <summary>
         /// Parses dialogue options from a tool_use JSON input.
         /// Returns null if the input is malformed (caller should fall back to text parsing).
         /// </summary>
-        public static DialogueOption[]? ParseDialogueOptionsTool(JObject toolInput)
+        public static DialogueOption[]? ParseDialogueOptionsTool(JObject toolInput, StatType[]? availableStats = null)
         {
             try
             {
@@ -229,7 +229,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 }
 
                 if (parsed.Count == 0) return null;
-                return PadDialogueOptionsToFour(parsed);
+                return ReconcileAndPadDialogueOptions(parsed, availableStats);
             }
             catch
             {
@@ -237,35 +237,91 @@ namespace Pinder.LlmAdapters.Anthropic
             }
         }
 
-        public static DialogueOption[] PadDialogueOptionsToFour(List<DialogueOption> parsed)
+        public static DialogueOption[] ReconcileAndPadDialogueOptions(List<DialogueOption> parsed, StatType[]? availableStats = null)
         {
-            if (parsed.Count >= 4)
-            {
-                return parsed.GetRange(0, 4).ToArray();
-            }
-
+            var result = new List<DialogueOption>();
             var usedStats = new HashSet<StatType>();
-            foreach (var opt in parsed)
+            var remainingAllowed = availableStats != null ? new List<StatType>(availableStats) : new List<StatType>(DefaultPaddingStats);
+
+            var tempOptions = new DialogueOption[parsed.Count];
+            for (int i = 0; i < parsed.Count; i++)
             {
-                usedStats.Add(opt.Stat);
+                var opt = parsed[i];
+                if (remainingAllowed.Contains(opt.Stat))
+                {
+                    tempOptions[i] = opt;
+                    remainingAllowed.Remove(opt.Stat);
+                    usedStats.Add(opt.Stat);
+                }
             }
 
-            var result = new List<DialogueOption>(parsed);
-            foreach (var defaultStat in DefaultPaddingStats)
+            for (int i = 0; i < parsed.Count; i++)
             {
-                if (result.Count >= 4) break;
-                if (usedStats.Contains(defaultStat)) continue;
-                result.Add(new DialogueOption(defaultStat, "...",
-                    callbackTurnNumber: null, comboName: null,
-                    hasTellBonus: false, hasWeaknessWindow: false));
+                if (tempOptions[i] == null)
+                {
+                    var opt = parsed[i];
+                    StatType assignedStat;
+                    if (remainingAllowed.Count > 0)
+                    {
+                        assignedStat = remainingAllowed[0];
+                        remainingAllowed.RemoveAt(0);
+                    }
+                    else
+                    {
+                        assignedStat = StatType.Charm;
+                        foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                        {
+                            if (!usedStats.Contains(s))
+                            {
+                                assignedStat = s;
+                                break;
+                            }
+                        }
+                    }
+                    usedStats.Add(assignedStat);
+                    
+                    tempOptions[i] = new DialogueOption(
+                        assignedStat,
+                        opt.IntendedText,
+                        opt.CallbackTurnNumber,
+                        opt.ComboName,
+                        opt.HasTellBonus,
+                        opt.HasWeaknessWindow
+                    );
+                }
             }
+
+            result.AddRange(tempOptions);
 
             while (result.Count < 4)
             {
-                // If we still need more, just pad with Charm (or any valid stat)
-                result.Add(new DialogueOption(StatType.Charm, "...",
+                StatType padStat;
+                if (remainingAllowed.Count > 0)
+                {
+                    padStat = remainingAllowed[0];
+                    remainingAllowed.RemoveAt(0);
+                }
+                else
+                {
+                    padStat = StatType.Charm;
+                    foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                    {
+                        if (!usedStats.Contains(s))
+                        {
+                            padStat = s;
+                            break;
+                        }
+                    }
+                }
+                usedStats.Add(padStat);
+                result.Add(new DialogueOption(padStat, "...",
                     callbackTurnNumber: null, comboName: null,
                     hasTellBonus: false, hasWeaknessWindow: false));
+            }
+
+            if (result.Count > 4)
+            {
+                return result.GetRange(0, 4).ToArray();
             }
 
             return result.ToArray();

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.Parsing.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.Parsing.cs
@@ -38,7 +38,7 @@ namespace Pinder.LlmAdapters.OpenAi
         /// Parses structured LLM output into DialogueOption array.
         /// Never throws — returns 4 options, padding with defaults if needed.
         /// </summary>
-        internal static DialogueOption[] ParseDialogueOptions(string? llmResponse)
+        internal static DialogueOption[] ParseDialogueOptions(string? llmResponse, StatType[]? availableStats = null)
         {
             var parsed = new List<DialogueOption>();
 
@@ -115,7 +115,7 @@ namespace Pinder.LlmAdapters.OpenAi
                 }
             }
 
-            return PadToFour(parsed);
+            return PadToFour(parsed, availableStats);
         }
 
         /// <summary>
@@ -195,30 +195,90 @@ namespace Pinder.LlmAdapters.OpenAi
             return raw;
         }
 
-        private static DialogueOption[] PadToFour(List<DialogueOption> parsed)
+        private static DialogueOption[] PadToFour(List<DialogueOption> parsed, StatType[]? availableStats = null)
         {
-            if (parsed.Count >= 4)
-                return parsed.GetRange(0, 4).ToArray();
-
             var usedStats = new HashSet<StatType>();
-            foreach (var opt in parsed)
-                usedStats.Add(opt.Stat);
+            var remainingAllowed = availableStats != null ? new List<StatType>(availableStats) : new List<StatType>(DefaultPaddingStats);
 
-            var result = new List<DialogueOption>(parsed);
-            foreach (var defaultStat in DefaultPaddingStats)
+            var tempOptions = new DialogueOption[parsed.Count];
+            for (int i = 0; i < parsed.Count; i++)
             {
-                if (result.Count >= 4) break;
-                if (usedStats.Contains(defaultStat)) continue;
-                result.Add(new DialogueOption(defaultStat, "...",
+                var opt = parsed[i];
+                if (remainingAllowed.Contains(opt.Stat))
+                {
+                    tempOptions[i] = opt;
+                    remainingAllowed.Remove(opt.Stat);
+                    usedStats.Add(opt.Stat);
+                }
+            }
+
+            for (int i = 0; i < parsed.Count; i++)
+            {
+                if (tempOptions[i] == null)
+                {
+                    var opt = parsed[i];
+                    StatType assignedStat;
+                    if (remainingAllowed.Count > 0)
+                    {
+                        assignedStat = remainingAllowed[0];
+                        remainingAllowed.RemoveAt(0);
+                    }
+                    else
+                    {
+                        assignedStat = StatType.Charm;
+                        foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                        {
+                            if (!usedStats.Contains(s))
+                            {
+                                assignedStat = s;
+                                break;
+                            }
+                        }
+                    }
+                    usedStats.Add(assignedStat);
+                    
+                    tempOptions[i] = new DialogueOption(
+                        assignedStat,
+                        opt.IntendedText,
+                        opt.CallbackTurnNumber,
+                        opt.ComboName,
+                        opt.HasTellBonus,
+                        opt.HasWeaknessWindow
+                    );
+                }
+            }
+
+            var result = new List<DialogueOption>(tempOptions);
+
+            while (result.Count < 4)
+            {
+                StatType padStat;
+                if (remainingAllowed.Count > 0)
+                {
+                    padStat = remainingAllowed[0];
+                    remainingAllowed.RemoveAt(0);
+                }
+                else
+                {
+                    padStat = StatType.Charm;
+                    foreach (StatType s in Enum.GetValues(typeof(StatType)))
+                    {
+                        if (!usedStats.Contains(s))
+                        {
+                            padStat = s;
+                            break;
+                        }
+                    }
+                }
+                usedStats.Add(padStat);
+                result.Add(new DialogueOption(padStat, "...",
                     callbackTurnNumber: null, comboName: null,
                     hasTellBonus: false, hasWeaknessWindow: false));
             }
 
-            while (result.Count < 4)
+            if (result.Count > 4)
             {
-                result.Add(new DialogueOption(StatType.Charm, "...",
-                    callbackTurnNumber: null, comboName: null,
-                    hasTellBonus: false, hasWeaknessWindow: false));
+                return result.GetRange(0, 4).ToArray();
             }
 
             return result.ToArray();

--- a/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/OpenAi/OpenAiLlmAdapter.cs
@@ -54,7 +54,7 @@ namespace Pinder.LlmAdapters.OpenAi
             var requestJson = BuildRequestJson(systemPrompt, userContent, DefaultDialogueOptionsTemperature);
             var responseText = await _client.SendChatCompletionAsync(requestJson, ct).ConfigureAwait(false);
 
-            return ParseDialogueOptions(responseText);
+            return ParseDialogueOptions(responseText, context.AvailableStats);
         }
 
         /// <inheritdoc />

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -51,7 +51,7 @@ namespace Pinder.LlmAdapters
             var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions, ct: ct)
                 .ConfigureAwait(false);
 
-            var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText);
+            var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText, context.AvailableStats);
             int maxOptions = _options.GameDefinition?.MaxDialogueOptions ?? 99;
             if (parsedOptions.Length > maxOptions)
             {

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json.Linq;
 using Pinder.Core.Stats;
 using Pinder.LlmAdapters.Anthropic;
+using System.Linq;
 using Xunit;
 
 namespace Pinder.LlmAdapters.Tests.Anthropic
@@ -166,6 +167,47 @@ OPTION_2 [STAT: Wit] ""That's a genuinely funny take, I'll give you that."" [CAL
             Assert.DoesNotContain(result, o => o.IntendedText == "the");
             // The real option is still parsed and surfaced.
             Assert.Contains(result, o => o.IntendedText == "That's a genuinely funny take, I'll give you that.");
+        }
+
+        // --- Issue #1164 regression coverage ---
+
+        [Fact, Trait("Category", "regression-test-required")]
+        public void ParseDialogueOptionsText_DuplicateStats_ReconcilesAgainstAvailableStats()
+        {
+            var input = @"OPTION_1 [STAT: Honesty] ""First honesty"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_2 [STAT: Honesty] ""Second honesty"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_3 [STAT: Charm] ""A charm"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var drawnStats = new[] { StatType.Honesty, StatType.Charm, StatType.Wit, StatType.Chaos };
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, drawnStats);
+
+            Assert.Equal(4, result.Length);
+            var resultStats = result.Select(r => r.Stat).Distinct().ToList();
+            Assert.Equal(4, resultStats.Count);
+            Assert.Contains(StatType.Honesty, resultStats);
+            Assert.Contains(StatType.Charm, resultStats);
+            Assert.Contains(StatType.Wit, resultStats);
+            Assert.Contains(StatType.Chaos, resultStats);
+        }
+
+        [Fact]
+        public void ParseDialogueOptionsTool_DuplicateStats_ReconcilesAgainstAvailableStats()
+        {
+            var json = JObject.Parse(@"{
+                ""options"": [
+                    { ""stat"": ""Honesty"", ""text"": ""First honesty"" },
+                    { ""stat"": ""Honesty"", ""text"": ""Second honesty"" },
+                    { ""stat"": ""Charm"", ""text"": ""A charm"" }
+                ]
+            }");
+
+            var drawnStats = new[] { StatType.Honesty, StatType.Charm, StatType.Wit, StatType.Chaos };
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json, drawnStats);
+
+            Assert.NotNull(result);
+            Assert.Equal(4, result!.Length);
+            var resultStats = result.Select(r => r.Stat).Distinct().ToList();
+            Assert.Equal(4, resultStats.Count);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OpenAi/OpenAiLlmAdapterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
@@ -86,6 +87,27 @@ WEAKNESS: Honesty-2 (gets flustered when people are direct about attraction)";
             Assert.Equal("", result.MessageText);
             Assert.Null(result.DetectedTell);
             Assert.Null(result.WeaknessWindow);
+        }
+
+        // --- Issue #1164 regression coverage ---
+
+        [Fact, Trait("Category", "regression-test-required")]
+        public void ParseDialogueOptions_DuplicateStats_ReconcilesAgainstAvailableStats()
+        {
+            var input = @"OPTION_1 [STAT: Honesty] ""First honesty"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_2 [STAT: Honesty] ""Second honesty"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_3 [STAT: Charm] ""A charm"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var drawnStats = new[] { StatType.Honesty, StatType.Charm, StatType.Wit, StatType.Chaos };
+            var result = OpenAiLlmAdapter.ParseDialogueOptions(input, drawnStats);
+
+            Assert.Equal(4, result.Length);
+            var resultStats = result.Select(r => r.Stat).Distinct().ToList();
+            Assert.Equal(4, resultStats.Count);
+            Assert.Contains(StatType.Honesty, resultStats);
+            Assert.Contains(StatType.Charm, resultStats);
+            Assert.Contains(StatType.Wit, resultStats);
+            Assert.Contains(StatType.Chaos, resultStats);
         }
     }
 }


### PR DESCRIPTION
Closes #1164

## DoD Evidence
Build succeeded.
Tests passed: 1123 in Pinder.LlmAdapters.Tests.dll, 2951 in Pinder.Core.Tests.dll.

Fail-on-revert test output:
```
[xUnit.net 00:00:01.73]     Pinder.LlmAdapters.Tests.Anthropic.DialogueOptionParsersTests.ParseDialogueOptionsText_DuplicateStats_ReconcilesAgainstAvailableStats [FAIL]
  Failed Pinder.LlmAdapters.Tests.Anthropic.DialogueOptionParsersTests.ParseDialogueOptionsText_DuplicateStats_ReconcilesAgainstAvailableStats [217 ms]
  Error Message:
   Assert.Equal() Failure
Expected: 4
Actual:   3
```

## Research Log
- Investigated `TurnOrchestrator` and `DialogueOptionParsers`
- Decided to thread `availableStats` into the parsers to ensure tool JSON and text paths are covered.
- Replaced `PadDialogueOptionsToFour` with `ReconcileAndPadDialogueOptions` to do uniqueness checking on parsed stats and backfill duplicates using unused allowed stats, falling back to defaults if necessary.
- Covered both `ParseDialogueOptionsText` and `ParseDialogueOptionsTool` in new regression tests.