### PR TITLE
refactor(#1165): purge bug-masking fallbacks; fail loud on contract violation

### DIFF
--- a/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
@@ -43,21 +43,6 @@ namespace Pinder.LlmAdapters
                 return value.ToString()!;
             }
 
-            string GetRequiredWithFallback(string newKey, string oldKey)
-            {
-                if (parsed.TryGetValue(newKey, out var val))
-                {
-                    if (val == null) throw new FormatException($"Key \"{newKey}\" has a null value.");
-                    return val.ToString()!;
-                }
-                if (parsed.TryGetValue(oldKey, out val))
-                {
-                    if (val == null) throw new FormatException($"Key \"{oldKey}\" has a null value.");
-                    return val.ToString()!;
-                }
-                throw new FormatException($"Missing required key: \"{newKey}\"");
-            }
-
             // Parse optional prose fields
             string GetOptional(string key)
             {
@@ -73,7 +58,7 @@ namespace Pinder.LlmAdapters
             // Validate core required keys first (throws FormatException)
             var name = GetRequired("name");
             var gameMasterPrompt = GetRequired("game_master_prompt");
-            var playerAvatarRoleDescription = GetRequiredWithFallback("player_avatar_role_description", "player_role_description");
+            var playerAvatarRoleDescription = GetRequired("player_avatar_role_description");
             var dateeRoleDescription = GetRequired("datee_role_description");
 
             // Parse required global_dc_bias

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
@@ -163,10 +163,5 @@ namespace Pinder.LlmAdapters
                 default: return string.Empty;
             }
         }
-
-        private static string FallbackName(string name, string fallback)
-        {
-            return string.IsNullOrEmpty(name) ? fallback : name;
-        }
     }
 }

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -22,9 +22,11 @@ namespace Pinder.LlmAdapters
         public static PromptTraceResult BuildDialogueOptionsPromptEx(DialogueContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (string.IsNullOrEmpty(context.PlayerName)) throw new ArgumentException("PlayerName cannot be null or empty.");
+            if (string.IsNullOrEmpty(context.DateeName)) throw new ArgumentException("DateeName cannot be null or empty.");
 
-            var playerName = FallbackName(context.PlayerName, "Player");
-            var dateeName = FallbackName(context.DateeName, "Datee");
+            var playerName = context.PlayerName;
+            var dateeName = context.DateeName;
 
             var sb = new AnnotatedStringBuilder();
 
@@ -171,28 +173,22 @@ namespace Pinder.LlmAdapters
                 .Replace("{player_name}", playerName)
                 .Replace("{game_state}", gameState.ToString().TrimEnd())
                 .Replace("{options_count}", optionsCountStr)
-                .Replace("{options_format_list}", optionsFormatListStr)
-                // Fallback for non-updated/legacy template yaml
-                .Replace("Generate 4 options", $"Generate {optionCount} options")
-                .Replace("OPTION_A: [message] OPTION_B: [message] etc.", optionsFormatListStr);
+                .Replace("{options_format_list}", optionsFormatListStr);
             sb.Append(engineBlock, GetTemplateSource("engine-options-block"), "engine-options-block");
 
             sb.AppendLine();
             sb.AppendLine();
 
             // Output format instructions
-            string availableStatsStr = context.AvailableStats != null && context.AvailableStats.Length > 0
-                ? string.Join(", ", Array.ConvertAll(context.AvailableStats, s => s.ToString().ToUpperInvariant()))
-                : "CHARM, RIZZ, HONESTY, CHAOS, WIT, SELF_AWARENESS";
+            if (context.AvailableStats == null || context.AvailableStats.Length == 0)
+                throw new InvalidOperationException("AvailableStats cannot be null or empty.");
+            string availableStatsStr = string.Join(", ", Array.ConvertAll(context.AvailableStats, s => s.ToString().ToUpperInvariant()));
+
             string dialogueOptionsInstruction = PromptTemplates.DialogueOptionsInstruction
                 .Replace("{player_name}", playerName)
                 .Replace("{available_stats}", availableStatsStr)
                 .Replace("{options_count}", optionsCountStr)
-                .Replace("{options_list}", optionsListStr)
-                // Fallback for non-updated/legacy template yaml
-                .Replace("Generate exactly 4 dialogue options", $"Generate exactly {optionCount} dialogue options")
-                .Replace("only OPTION_1, OPTION_2, OPTION_3, OPTION_4", "only " + optionsListStr)
-                .Replace("OPTION_4", $"OPTION_{optionCount}");
+                .Replace("{options_list}", optionsListStr);
             sb.Append(dialogueOptionsInstruction, GetTemplateSource("dialogue-options-instruction"), "dialogue-options-instruction");
 
             return new PromptTraceResult(sb.ToString(), sb.Spans);
@@ -212,9 +208,11 @@ namespace Pinder.LlmAdapters
         public static PromptTraceResult BuildDateePromptEx(DateeContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
+            if (string.IsNullOrEmpty(context.PlayerName)) throw new ArgumentException("PlayerName cannot be null or empty.");
+            if (string.IsNullOrEmpty(context.DateeName)) throw new ArgumentException("DateeName cannot be null or empty.");
 
-            var playerName = FallbackName(context.PlayerName, "Player");
-            var dateeName = FallbackName(context.DateeName, "Datee");
+            var playerName = context.PlayerName;
+            var dateeName = context.DateeName;
 
             var sb = new AnnotatedStringBuilder();
 

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterIssue208Tests.cs
@@ -71,7 +71,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             currentInterest: 10,
             playerName: "Thundercock",
             dateeName: "Velvet",
-            currentTurn: 1);
+            currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty, Pinder.Core.Stats.StatType.Chaos, Pinder.Core.Stats.StatType.Wit, Pinder.Core.Stats.StatType.SelfAwareness });
 
         // #1138: MakeDeliveryContext()/DeliveryContext removed — delivery prompt
         // surface was collapsed into the deterministic DeliveryOverlay (#1125).

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterSpecTests.cs
@@ -96,7 +96,7 @@ OPTION_4
             currentInterest: 10,
             playerName: "Thundercock",
             dateeName: "Velvet",
-            currentTurn: 1);
+            currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
         // #1138: MakeDeliveryContext()/DeliveryContext removed — delivery prompt
         // surface was collapsed into the deterministic DeliveryOverlay (#1125).
@@ -238,7 +238,7 @@ OPTION_4
             var ctx = new DialogueContext(
                 "player", "datee",
                 new List<(string, string)>(),
-                "last", new string[0], 10);
+                "last", new string[0], 10, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
             Assert.Equal("", ctx.PlayerName);
             Assert.Equal("", ctx.DateeName);

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ContextDto.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.ContextDto.cs
@@ -16,7 +16,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             var ctx = new DialogueContext(
                 "player", "datee",
                 new List<(string, string)>(), "last",
-                new string[0], 10);
+                new string[0], 10, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
             Assert.Equal("", ctx.PlayerName);
             Assert.Equal("", ctx.DateeName);
@@ -51,7 +51,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
                 new string[0], 10,
                 playerName: "Thundercock",
                 dateeName: "Velvet",
-                currentTurn: 3);
+                currentTurn: 3, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
             Assert.Equal("Thundercock", ctx.PlayerName);
             Assert.Equal("Velvet", ctx.DateeName);

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/AnthropicLlmAdapterTests.cs
@@ -68,7 +68,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             currentInterest: 10,
             playerName: "Thundercock",
             dateeName: "Velvet",
-            currentTurn: 1);
+            currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
         // #1138: MakeDeliveryContext()/DeliveryContext removed — the creative
         // delivery LLM call was collapsed into the deterministic DeliveryOverlay

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue534_DebugFlagTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue534_DebugFlagTests.cs
@@ -90,7 +90,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
             var history = new System.Collections.Generic.List<(string, string)>();
             return new DialogueContext(
                 "Player Prompt", "Datee Prompt", history, "Last message",
-                new System.Collections.Generic.List<string>(), 10);
+                new System.Collections.Generic.List<string>(), 10, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
         }
 
         // #1125: the delivery LLM surface was removed; the "second call" in the
@@ -107,7 +107,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
                 playerDeliveredMessage: "hello",
                 interestBefore: 10,
                 interestAfter: 11,
-                responseDelayMinutes: 1.0);
+                responseDelayMinutes: 1.0, playerName: "P", dateeName: "O");
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ArchetypeInjectionTests.cs
@@ -25,7 +25,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerName: "TestPlayer",
                 dateeName: "TestDatee",
                 currentTurn: 1,
-                activeArchetypeDirective: activeArchetypeDirective);
+                activeArchetypeDirective: activeArchetypeDirective, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         private static DateeContext MakeDateeContext(string activeArchetypeDirective = null)

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.Helpers.cs
@@ -68,7 +68,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerName: playerName,
                 dateeName: dateeName,
                 currentTurn: currentTurn,
-                playerTextingStyle: playerTextingStyle);
+                playerTextingStyle: playerTextingStyle, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // #1138: MakeDeliveryContext() removed — the delivery prompt builder it

--- a/tests/Pinder.LlmAdapters.Tests/GameDefinitionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/GameDefinitionTests.cs
@@ -156,10 +156,10 @@ another: also ignored
         }
 
         [Fact]
-        public void LoadFrom_LegacyPlayerRoleKey_BackwardCompatibility_Regression1133()
+        public void LoadFrom_MissingNewKeyPlayerAvatarRoleDescription_ThrowsFormatException_Regression1165()
         {
-            // 1. Only old key
-            var yamlOld = @"
+            // 1. Old key alone should throw (fallback removed)
+            var yamlOldOnly = @"
 name: Test
 game_master_prompt: gm
 player_role_description: old_role
@@ -171,56 +171,24 @@ horniness_time_modifiers:
   evening: 2
   overnight: 5
 ";
-            var gdOld = GameDefinition.LoadFrom(yamlOld);
-            Assert.Equal("old_role", gdOld.PlayerAvatarRoleDescription);
-
-            // 2. Only new key
-            var yamlNew = @"
-name: Test
-game_master_prompt: gm
-player_avatar_role_description: new_role
-datee_role_description: o
-global_dc_bias: 0
-horniness_time_modifiers:
-  morning: 3
-  afternoon: 0
-  evening: 2
-  overnight: 5
-";
-            var gdNew = GameDefinition.LoadFrom(yamlNew);
-            Assert.Equal("new_role", gdNew.PlayerAvatarRoleDescription);
-
-            // 3. Both keys present - prefers new
-            var yamlBoth = @"
-name: Test
-game_master_prompt: gm
-player_role_description: old_role
-player_avatar_role_description: new_role
-datee_role_description: o
-global_dc_bias: 0
-horniness_time_modifiers:
-  morning: 3
-  afternoon: 0
-  evening: 2
-  overnight: 5
-";
-            var gdBoth = GameDefinition.LoadFrom(yamlBoth);
-            Assert.Equal("new_role", gdBoth.PlayerAvatarRoleDescription);
-
-            // 4. Missing player role key throws naming the new key
-            var yamlMissing = @"
-name: Test
-game_master_prompt: gm
-datee_role_description: o
-global_dc_bias: 0
-horniness_time_modifiers:
-  morning: 3
-  afternoon: 0
-  evening: 2
-  overnight: 5
-";
-            var ex = Assert.Throws<FormatException>(() => GameDefinition.LoadFrom(yamlMissing));
+            var ex = Assert.Throws<FormatException>(() => GameDefinition.LoadFrom(yamlOldOnly));
             Assert.Contains("player_avatar_role_description", ex.Message);
+
+            // 2. New key alone parses
+            var yamlNewOnly = @"
+name: Test
+game_master_prompt: gm
+player_avatar_role_description: new_role
+datee_role_description: o
+global_dc_bias: 0
+horniness_time_modifiers:
+  morning: 3
+  afternoon: 0
+  evening: 2
+  overnight: 5
+";
+            var gdNew = GameDefinition.LoadFrom(yamlNewOnly);
+            Assert.Equal("new_role", gdNew.PlayerAvatarRoleDescription);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue1066_PromptTraceTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1066_PromptTraceTests.cs
@@ -68,7 +68,7 @@ namespace Pinder.LlmAdapters.Tests
                 activeTraps: new List<string>(),
                 currentInterest: 10,
                 currentTurn: 3
-            );
+            , availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
             InMemoryPromptTraceService.Instance.Clear();
             var prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);

--- a/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1129_SchemaRenameGuardTests.cs
@@ -63,7 +63,7 @@ namespace Pinder.LlmAdapters.Tests
             dateeLastMessage: "Hello",
             activeTraps: new List<string>(),
             currentInterest: 10,
-            currentTurn: 3);
+            currentTurn: 3, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
         private static DateeContext MakeDateeContext() => new DateeContext(
             dateePrompt: "You are velvet.",

--- a/tests/Pinder.LlmAdapters.Tests/Issue1155_ColdOpenerGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1155_ColdOpenerGuardTests.cs
@@ -38,7 +38,7 @@ namespace Pinder.LlmAdapters.Tests
                 currentInterest: 10,
                 playerName: "P",
                 dateeName: "O",
-                currentTurn: currentTurn);
+                currentTurn: currentTurn, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Issue1156_OptionsRoleLabelTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1156_OptionsRoleLabelTests.cs
@@ -46,7 +46,7 @@ namespace Pinder.LlmAdapters.Tests
                 currentInterest: 10,
                 playerName: playerName,
                 dateeName: dateeName,
-                currentTurn: 1);
+                currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue307_ShadowTaintFiringTests.cs
@@ -194,7 +194,7 @@ namespace Pinder.LlmAdapters.Tests
                 shadowThresholds: shadowThresholds,
                 playerName: "Player",
                 dateeName: "Datee",
-                currentTurn: 1);
+                currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // #1138: MakeDeliveryContext() removed — BuildDeliveryPrompt no longer

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessSpecTests.cs
@@ -62,7 +62,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerName: playerName,
                 dateeName: dateeName,
                 currentTurn: currentTurn,
-                playerTextingStyle: playerTextingStyle);
+                playerTextingStyle: playerTextingStyle, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // ══════════════════════════════════════════════════════════════
@@ -128,7 +128,7 @@ namespace Pinder.LlmAdapters.Tests
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 activeTraps: Array.Empty<string>(),
-                currentInterest: 10);
+                currentInterest: 10, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
             Assert.Equal(string.Empty, ctx.PlayerTextingStyle);
             Assert.NotNull(ctx.PlayerTextingStyle);
@@ -235,7 +235,7 @@ namespace Pinder.LlmAdapters.Tests
                 currentInterest: 10,
                 playerName: "Velvet",
                 dateeName: "Sable",
-                currentTurn: 1);
+                currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
             string result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
 

--- a/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue489_VoiceDistinctnessTests.cs
@@ -32,7 +32,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerName: "Velvet",
                 dateeName: "Sable",
                 currentTurn: currentTurn,
-                playerTextingStyle: playerTextingStyle);
+                playerTextingStyle: playerTextingStyle, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // ── CharacterProfile.TextingStyleFragment ──
@@ -83,7 +83,7 @@ namespace Pinder.LlmAdapters.Tests
                 conversationHistory: new List<(string, string)>(),
                 dateeLastMessage: "",
                 activeTraps: Array.Empty<string>(),
-                currentInterest: 10);
+                currentInterest: 10, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
             Assert.Equal(string.Empty, ctx.PlayerTextingStyle);
         }
@@ -136,7 +136,7 @@ namespace Pinder.LlmAdapters.Tests
                 currentInterest: 10,
                 playerName: "V",
                 dateeName: "S",
-                currentTurn: 1);
+                currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
             string result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
 
             Assert.DoesNotContain("YOUR TEXTING STYLE", result);

--- a/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue493_FailureDegradationTests.cs
@@ -114,7 +114,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerDeliveredMessage: "hello",
                 interestBefore: 10,
                 interestAfter: 10,
-                responseDelayMinutes: 1.0);
+                responseDelayMinutes: 1.0, playerName: "P", dateeName: "O");
 
             Assert.Equal(FailureTier.None, context.DeliveryTier);
         }

--- a/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
@@ -57,7 +57,7 @@ namespace Pinder.LlmAdapters.Tests
                 playerName: playerName,
                 dateeName: dateeName,
                 currentTurn: currentTurn,
-                playerTextingStyle: playerTextingStyle);
+                playerTextingStyle: playerTextingStyle, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // #1138: MakeDeliveryContext() removed — the delivery prompt builder it

--- a/tests/Pinder.LlmAdapters.Tests/Issue647_ActiveTellOptionsTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue647_ActiveTellOptionsTests.cs
@@ -22,7 +22,7 @@ namespace Pinder.LlmAdapters.Tests
                 activeTraps: new List<string>(),
                 currentInterest: 10,
                 activeTell: activeTell
-            );
+            , availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
             // Act
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
@@ -45,7 +45,7 @@ namespace Pinder.LlmAdapters.Tests
                 activeTraps: new List<string>(),
                 currentInterest: 10,
                 activeTell: null
-            );
+            , availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  }, playerName: "P", dateeName: "O");
 
             // Act
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);

--- a/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
@@ -46,7 +46,7 @@ namespace Pinder.LlmAdapters.Tests
                 dateeName: "O",
                 currentTurn: turn,
                 stakeLines: stakeLines ?? MakeStakeLines(),
-                stakeLinesReferenced: stakeLinesReferenced);
+                stakeLinesReferenced: stakeLinesReferenced, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // ── test 1: OPTION_C mandate appears in prompt (from templates.yaml) ──

--- a/tests/Pinder.LlmAdapters.Tests/Regression1165Tests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Regression1165Tests.cs
@@ -1,0 +1,65 @@
+using System;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class Regression1165Tests
+    {
+        [Fact]
+        public void EmptyPlayerNameDateeName_ThrowsArgumentException_Regression1165()
+        {
+            var contextNoPlayer = new DialogueContext(
+                "p", "d", new System.Collections.Generic.List<(string, string)>(), "last", new string[0], 10,
+                playerName: "", dateeName: "O", currentTurn: 1, availableStats: new[] { StatType.Charm });
+            
+            var ex1 = Assert.Throws<ArgumentException>(() => SessionDocumentBuilder.BuildDialogueOptionsPromptEx(contextNoPlayer));
+            Assert.Contains("PlayerName cannot be null or empty", ex1.Message);
+
+            var contextNoDatee = new DialogueContext(
+                "p", "d", new System.Collections.Generic.List<(string, string)>(), "last", new string[0], 10,
+                playerName: "P", dateeName: "", currentTurn: 1, availableStats: new[] { StatType.Charm });
+            
+            var ex2 = Assert.Throws<ArgumentException>(() => SessionDocumentBuilder.BuildDialogueOptionsPromptEx(contextNoDatee));
+            Assert.Contains("DateeName cannot be null or empty", ex2.Message);
+        }
+
+        [Fact]
+        public void EmptyAvailableStats_ThrowsInvalidOperationException_Regression1165()
+        {
+            var contextNoStats = new DialogueContext(
+                "p", "d", new System.Collections.Generic.List<(string, string)>(), "last", new string[0], 10,
+                playerName: "P", dateeName: "O", currentTurn: 1, availableStats: new StatType[0]);
+
+            var ex1 = Assert.Throws<InvalidOperationException>(() => SessionDocumentBuilder.BuildDialogueOptionsPromptEx(contextNoStats));
+            Assert.Contains("AvailableStats cannot be null or empty", ex1.Message);
+
+            var contextNullStats = new DialogueContext(
+                "p", "d", new System.Collections.Generic.List<(string, string)>(), "last", new string[0], 10,
+                playerName: "P", dateeName: "O", currentTurn: 1, availableStats: null);
+
+            var ex2 = Assert.Throws<InvalidOperationException>(() => SessionDocumentBuilder.BuildDialogueOptionsPromptEx(contextNullStats));
+            Assert.Contains("AvailableStats cannot be null or empty", ex2.Message);
+        }
+    }
+}
+
+    public class LegacyTemplateReplaceRemovalTests
+    {
+        [Fact]
+        public void DialogueOptionsInstruction_ReplacesOptionsCount_WithoutLegacyFallback_Regression1165()
+        {
+            var context = new DialogueContext(
+                "p", "d", new System.Collections.Generic.List<(string, string)>(), "last", new string[0], 10,
+                playerName: "P", dateeName: "O", currentTurn: 1, availableStats: new[] { StatType.Charm, StatType.Rizz });
+
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPromptEx(context);
+            // It should say "Generate exactly 2 dialogue options" because optionCount=2
+            Assert.Contains("Generate exactly 2 dialogue options", result.Text);
+            // It should not contain "Generate exactly 4 dialogue options" from legacy
+            Assert.DoesNotContain("Generate exactly 4 dialogue options", result.Text);
+            Assert.DoesNotContain("Generate exactly 6 dialogue options", result.Text);
+        }
+    }

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderPromptTests.cs
@@ -38,7 +38,7 @@ namespace Pinder.LlmAdapters.Tests
                 activeTrapInstructions: activeTrapInstructions,
                 playerName: playerName,
                 dateeName: dateeName,
-                currentTurn: currentTurn);
+                currentTurn: currentTurn, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         private static string BuildMinimal(

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderSpecTests.cs
@@ -37,7 +37,7 @@ namespace Pinder.LlmAdapters.Tests
                 currentInterest: currentInterest,
                 playerName: playerName,
                 dateeName: dateeName,
-                currentTurn: currentTurn);
+                currentTurn: currentTurn, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // #1138: MakeDeliveryContext() removed — the delivery prompt builder it

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.Helpers.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.Helpers.cs
@@ -21,7 +21,8 @@ namespace Pinder.LlmAdapters.Tests
             List<CallbackOpportunity> callbackOpportunities = null,
             string[] activeTrapInstructions = null,
             int horninessLevel = 0,
-            bool requiresRizzOption = false)
+            bool requiresRizzOption = false,
+            StatType[] availableStats = null)
         {
             return new DialogueContext(
                 playerAvatarPrompt: "player prompt",
@@ -37,7 +38,8 @@ namespace Pinder.LlmAdapters.Tests
                 activeTrapInstructions: activeTrapInstructions,
                 playerName: playerName,
                 dateeName: dateeName,
-                currentTurn: currentTurn);
+                currentTurn: currentTurn,
+                availableStats: availableStats ?? new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
         }
 
         // #1138: MakeDeliveryContext() removed — the delivery prompt builder it

--- a/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/SessionDocumentBuilderTests.cs
@@ -39,7 +39,7 @@ namespace Pinder.LlmAdapters.Tests
                 activeTraps: Array.Empty<string>(),
                 currentInterest: 10,
                 playerName: "P",
-                dateeName: "O");
+                dateeName: "O", availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
 
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(ctx);
 

--- a/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/ShadowTaintTests.cs
@@ -23,7 +23,7 @@ namespace Pinder.LlmAdapters.Tests
                 shadowThresholds: shadowThresholds,
                 playerName: "Player",
                 dateeName: "Datee",
-                currentTurn: 1);
+                currentTurn: 1, availableStats: new[] { Pinder.Core.Stats.StatType.Charm, Pinder.Core.Stats.StatType.Rizz, Pinder.Core.Stats.StatType.Honesty,  });
         }
 
         // #1138: MakeDeliveryContext() removed — BuildDeliveryPrompt no longer


### PR DESCRIPTION
<body>
Closes #1165
Closes #1161

## DoD Evidence
- Build: `Build succeeded. 32 Warning(s), 0 Error(s)`
- Tests Core: `Passed! - Failed: 0, Passed: 2951, Skipped: 18, Total: 2969`
- Tests Adapters: `Passed! - Failed: 0, Passed: 1124, Skipped: 9, Total: 1133`
- Fail-on-revert evidence:
  - Empty Name Fallback: `System.ArgumentException : PlayerName cannot be null or empty.`
  - Empty AvailableStats Fallback: `System.InvalidOperationException : AvailableStats cannot be null or empty.`
  - Missing new YAML key: `System.FormatException : Missing required key: "player_avatar_role_description"`
- YAML sweep result: Only `data/game-definition.yaml` has the new key `player_avatar_role_description`. NO shipped YAMLs use the old key `player_role_description` anymore. No keys needed to be renamed.

## Research Log
- **Item 1 (FallbackName):** Deleted `FallbackName` completely. Passed `PlayerName` and `DateeName` directly in `BuildDialogueOptionsPromptEx` and `BuildDateePromptEx`, and added `ArgumentException` guards so missing names throw loudly.
- **Item 2 (GetRequiredWithFallback):** Deleted `GetRequiredWithFallback` and replaced it with `GetRequired("player_avatar_role_description")`. The old key `player_role_description` is no longer accepted, strictly enforcing the new key.
- **Item 3 (Legacy-template .Replace):** Removed the fallback string replacements `.Replace("Generate 4 options", ...)` and `.Replace("OPTION_4", ...)` since the SSOT template now explicitly uses `{options_count}`. Added `LegacyTemplateReplaceRemovalTests` to prove `{options_count}` binds correctly.
- **Item 4 (AvailableStats empty-default):** Replaced the fallback literal `"CHARM, RIZZ, HONESTY, CHAOS, WIT, SELF_AWARENESS"` with an `InvalidOperationException` if `AvailableStats` is null or empty. (Note: Many tests were lazily instantiating `DialogueContext` without stats and failing because of this strictness; updated test builders and instantiations to provide default mock stats).
- **YAML Sweep Findings:** Ran `grep -rl 'player_role_description' --include='*.yml' --include='*.yaml' .` which returned zero results. Ran `grep -rl 'player_avatar_role_description'` which returned `data/game-definition.yaml`. No yaml files were using the old key, so no updates were needed.
</body>
