### PR TITLE
feat(#1168): per-session DC-bias for shadow + horniness via shared ApplyDcBias helper (flip to positive=easier)

### DIFF
--- a/data/game-definition.yaml
+++ b/data/game-definition.yaml
@@ -278,7 +278,9 @@ improvement_prompt: |
 
   CRITICAL OUTPUT RULE: output ONLY the final content. No evaluation, no numbered lists, no
   "here's what I changed." Just the content itself — a single message or set of options.
-global_dc_bias: 0  # Raises DC for all rolls. 0 = standard difficulty. Positive = harder.
+global_dc_bias: 0  # Adjusts DC for all main rolls. 0 = standard. Positive = easier (lowers DC).
+shadow_dc_bias: 0  # Adjusts DC for the shadow check. 0 = standard. Positive = easier (lowers DC).
+horniness_dc_bias: 0  # Adjusts DC for the horniness check. 0 = standard. Positive = easier (lowers DC).
 
 horniness_time_modifiers:
   morning: 2      # 09:00-11:59

--- a/session-runner/Program.Setup.cs
+++ b/session-runner/Program.Setup.cs
@@ -263,12 +263,21 @@ partial class Program
         }
 
         int yamlDcBias = result.GameDef?.GlobalDcBias ?? 0;
+        int yamlShadowDcBias = result.GameDef?.ShadowDcBias ?? 0;
+        int yamlHorninessDcBias = result.GameDef?.HorninessDcBias ?? 0;
         int totalDcBias = difficultyBias + yamlDcBias;
         Pinder.LlmAdapters.ConsequenceCatalog? consequenceCatalog = null;
         if (result.SnapshotI18nCatalog != null)
             consequenceCatalog = new Pinder.LlmAdapters.ConsequenceCatalog(result.SnapshotI18nCatalog);
 
-        var config = new GameSessionConfig(clock: clock, playerShadows: result.SableShadows, globalDcBias: totalDcBias, statDeliveryInstructions: statDeliveryInstructions, consequenceCatalog: consequenceCatalog);
+        var config = new GameSessionConfig(
+            clock: clock,
+            playerShadows: result.SableShadows,
+            globalDcBias: totalDcBias,
+            shadowDcBias: yamlShadowDcBias,
+            horninessDcBias: yamlHorninessDcBias,
+            statDeliveryInstructions: statDeliveryInstructions,
+            consequenceCatalog: consequenceCatalog);
         int? diceSeed = null;
         { if (ParseArg(args, "--seed") is string s2 && int.TryParse(s2, out int s3)) diceSeed = s3; }
         result.Session = new GameSession(result.Sable, result.Brick, result.Llm, new SystemRandomDiceRoller(diceSeed), result.TrapRegistry, config);

--- a/src/Pinder.Core/Conversation/GameSession.Clone.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Clone.cs
@@ -79,6 +79,8 @@ namespace Pinder.Core.Conversation
             _clock           = src._clock;
             _rules           = src._rules;
             _globalDcBias    = src._globalDcBias;
+            _shadowDcBias    = src._shadowDcBias;
+            _horninessDcBias = src._horninessDcBias;
             _statDeliveryInstructions = src._statDeliveryInstructions;
             _onTextLayerNoop = src._onTextLayerNoop;
             _consequenceCatalog = src._consequenceCatalog;
@@ -98,8 +100,8 @@ namespace Pinder.Core.Conversation
             // in the public ctor; preserve that shape on the clone.
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
-            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog);
-            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog);
+            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog, _horninessDcBias);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog, _shadowDcBias);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             _turnOrchestrator = BuildTurnOrchestrator();
@@ -226,8 +228,8 @@ namespace Pinder.Core.Conversation
             // RNGs (deep-clone to avoid sharing internal state with src).
             var clonedSteeringRng = RandomCloner.Clone(src._steeringEngine.SteeringRngForCloneOnly);
             _steeringEngine  = new SteeringEngine(clonedSteeringRng);
-            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog);
-            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog);
+            _horninessEngine = new HorninessEngine(clonedSteeringRng, _consequenceCatalog, _horninessDcBias);
+            _shadowCheckEngine = new ShadowCheckEngine(clonedSteeringRng, _consequenceCatalog, _shadowDcBias);
             _statDrawRng     = src._statDrawRng != null ? RandomCloner.Clone(src._statDrawRng) : null;
 
             _turnOrchestrator = BuildTurnOrchestrator();

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -82,6 +82,8 @@ namespace Pinder.Core.Conversation
         // Rule resolver for data-driven game constants (#463)
         private readonly IRuleResolver? _rules;
         private readonly int _globalDcBias;
+        private readonly int _shadowDcBias;
+        private readonly int _horninessDcBias;
 
         // Weakness window from datee's last response (#49)
         private WeaknessWindow? _activeWeakness { get => _state.ActiveWeakness; set => _state.ActiveWeakness = value; }
@@ -172,6 +174,8 @@ namespace Pinder.Core.Conversation
             _dateeShadows = config.DateeShadows;
             _rules = config.Rules;
             _globalDcBias = config.GlobalDcBias;
+            _shadowDcBias = config.ShadowDcBias;
+            _horninessDcBias = config.HorninessDcBias;
             var steeringRng = config.SteeringRng ?? new Random();
             _statDrawRng = config.StatDrawRng;
             _statDeliveryInstructions = config.StatDeliveryInstructions;
@@ -231,8 +235,8 @@ namespace Pinder.Core.Conversation
             _maxDialogueOptions = config.MaxDialogueOptions ?? 3;
             _maxDeliveryWords = config.MaxDeliveryWords ?? 80;
             _steeringEngine = new SteeringEngine(steeringRng);
-            _horninessEngine = new HorninessEngine(steeringRng, _consequenceCatalog);
-            _shadowCheckEngine = new ShadowCheckEngine(steeringRng, _consequenceCatalog);
+            _horninessEngine = new HorninessEngine(steeringRng, _consequenceCatalog, _horninessDcBias);
+            _shadowCheckEngine = new ShadowCheckEngine(steeringRng, _consequenceCatalog, _shadowDcBias);
 
             _turnOrchestrator = BuildTurnOrchestrator();
 

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -34,10 +34,22 @@ namespace Pinder.Core.Conversation
         public IRuleResolver? Rules { get; }
 
         /// <summary>
-        /// Global DC adjustment applied to every roll. Positive = harder (DC raised),
-        /// negative = easier (DC lowered). Does not affect Nat 1 / Nat 20 detection.
+        /// Global DC adjustment applied to every main option roll. Positive = easier (DC lowered),
+        /// negative = harder (DC raised). Does not affect Nat 1 / Nat 20 detection.
         /// </summary>
         public int GlobalDcBias { get; }
+
+        /// <summary>
+        /// Shadow DC adjustment applied to shadow checks. Positive = easier (DC lowered),
+        /// negative = harder (DC raised). Fully independent of global DC bias.
+        /// </summary>
+        public int ShadowDcBias { get; }
+
+        /// <summary>
+        /// Horniness DC adjustment applied to horniness checks. Positive = easier (DC lowered),
+        /// negative = harder (DC raised). Fully independent of global DC bias.
+        /// </summary>
+        public int HorninessDcBias { get; }
 
         /// <summary>
         /// Optional RNG for the steering roll. When null, a new System.Random is used.
@@ -106,6 +118,8 @@ namespace Pinder.Core.Conversation
             string? previousOpener = null,
             IRuleResolver? rules = null,
             int globalDcBias = 0,
+            int shadowDcBias = 0,
+            int horninessDcBias = 0,
             Random? steeringRng = null,
             object? statDeliveryInstructions = null,
             IDiceRoller? diceRoller = null,
@@ -122,6 +136,8 @@ namespace Pinder.Core.Conversation
             PreviousOpener = previousOpener;
             Rules = rules;
             GlobalDcBias = globalDcBias;
+            ShadowDcBias = shadowDcBias;
+            HorninessDcBias = horninessDcBias;
             SteeringRng = steeringRng;
             StatDeliveryInstructions = statDeliveryInstructions;
             DiceRoller = diceRoller;

--- a/src/Pinder.Core/Conversation/HorninessEngine.cs
+++ b/src/Pinder.Core/Conversation/HorninessEngine.cs
@@ -16,11 +16,13 @@ namespace Pinder.Core.Conversation
     {
         private readonly Random _rng;
         private readonly IConsequenceCatalog? _consequenceCatalog;
+        private readonly int _horninessDcBias;
 
-        public HorninessEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null)
+        public HorninessEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null, int horninessDcBias = 0)
         {
             _rng = rng ?? throw new ArgumentNullException(nameof(rng));
             _consequenceCatalog = consequenceCatalog;
+            _horninessDcBias = horninessDcBias;
         }
 
         /// <summary>
@@ -63,7 +65,7 @@ namespace Pinder.Core.Conversation
             if (sessionHorniness <= 0 || playerShadows == null)
                 return (HorninessCheckResult.NotPerformed, null);
 
-            int horninessDC = 20 - sessionHorniness;
+            int horninessDC = RollEngine.ApplyDcBias(20 - sessionHorniness, _horninessDcBias);
             // #901: route through single entry point — dice consumption is identical (one Roll(20))
             var check = RollEngine.ResolveCheck(
                 RollCheckKind.Horniness,

--- a/src/Pinder.Core/Conversation/RollResolutionStage.cs
+++ b/src/Pinder.Core/Conversation/RollResolutionStage.cs
@@ -113,7 +113,14 @@ namespace Pinder.Core.Conversation
                 dcAdjustment = state.ActiveWeakness.DcReduction;
             }
             if (_globalDcBias != 0)
-                dcAdjustment -= _globalDcBias;
+            {
+                // Positive bias lowers the effective DC (easier).
+                // Under ApplyDcBias semantics: ApplyDcBias(baseDc, bias) => baseDc - bias.
+                // In RollEngine.Resolve, the final DC is computed as defender.GetDefenceDC(stat) - dcAdjustment.
+                // Therefore, adding _globalDcBias to dcAdjustment is mathematically identical to routing through the shared helper:
+                // defenceDC - (dcAdjustment_without_bias + globalDcBias) == ApplyDcBias(defenceDC - dcAdjustment_without_bias, globalDcBias).
+                dcAdjustment += _globalDcBias;
+            }
 
             // Clear weakness window — consumed this turn regardless of match (#49)
             state.ActiveWeakness = null;

--- a/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
+++ b/src/Pinder.Core/Conversation/ShadowCheckEngine.cs
@@ -15,11 +15,13 @@ namespace Pinder.Core.Conversation
     {
         private readonly Random _rng;
         private readonly IConsequenceCatalog? _consequenceCatalog;
+        private readonly int _shadowDcBias;
 
-        public ShadowCheckEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null)
+        public ShadowCheckEngine(Random rng, IConsequenceCatalog? consequenceCatalog = null, int shadowDcBias = 0)
         {
             _rng = rng ?? throw new ArgumentNullException(nameof(rng));
             _consequenceCatalog = consequenceCatalog;
+            _shadowDcBias = shadowDcBias;
         }
 
         /// <summary>
@@ -34,7 +36,7 @@ namespace Pinder.Core.Conversation
             if (shadowValue <= 0)
                 return ShadowCheckResult.NotPerformed;
 
-            int shadowDC = 20 - shadowValue;
+            int shadowDC = RollEngine.ApplyDcBias(20 - shadowValue, _shadowDcBias);
 
             // #901: route through single entry point.
             // Dice consumption: one Roll(20) — identical to old _steeringEngine.RollD20().

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -15,6 +15,12 @@ namespace Pinder.Core.Rolls
     public static class RollEngine
     {
         /// <summary>
+        /// Applies a difficulty DC bias to a base DC.
+        /// Positive bias lowers the effective DC, making the check easier.
+        /// </summary>
+        public static int ApplyDcBias(int baseDc, int bias) => baseDc - bias;
+
+        /// <summary>
         /// Single entry point for all d20 checks.
         /// Rolls a d20 (with optional advantage/disadvantage), sums the modifier bag,
         /// computes total vs DC, and returns a canonical <see cref="RollCheckResult"/>.

--- a/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
@@ -67,6 +67,22 @@ namespace Pinder.LlmAdapters
             if (!int.TryParse(gdcbObj.ToString(), out int globalDcBias))
                 throw new InvalidOperationException("game-definition.yaml global_dc_bias must be an integer");
 
+            // Parse optional shadow_dc_bias
+            int shadowDcBias = 0;
+            if (parsed.TryGetValue("shadow_dc_bias", out var sObj) && sObj != null)
+            {
+                if (!int.TryParse(sObj.ToString(), out shadowDcBias))
+                    throw new InvalidOperationException("game-definition.yaml shadow_dc_bias must be an integer");
+            }
+
+            // Parse optional horniness_dc_bias
+            int horninessDcBias = 0;
+            if (parsed.TryGetValue("horniness_dc_bias", out var hObj) && hObj != null)
+            {
+                if (!int.TryParse(hObj.ToString(), out horninessDcBias))
+                    throw new InvalidOperationException("game-definition.yaml horniness_dc_bias must be an integer");
+            }
+
             return new GameDefinition(
                 name: name,
                 gameMasterPrompt: gameMasterPrompt,
@@ -76,6 +92,8 @@ namespace Pinder.LlmAdapters
                 steeringPrompt: GetOptional("steering_prompt"),
                 horninessTimeModifiers: horninessTimeModifiers,
                 globalDcBias: globalDcBias,
+                shadowDcBias: shadowDcBias,
+                horninessDcBias: horninessDcBias,
                 maxTurns: parsed.TryGetValue("max_turns", out var mtObj) && int.TryParse(mtObj?.ToString(), out int mt) ? mt : 30,
                 maxDialogueOptions: parsed.TryGetValue("max_dialogue_options", out var mdoObj) && int.TryParse(mdoObj?.ToString(), out int mdo) ? mdo : 3,
                 maxDeliveryWords: parsed.TryGetValue("max_delivery_words", out var mdwObj) && int.TryParse(mdwObj?.ToString(), out int mdw) ? mdw : 80

--- a/src/Pinder.LlmAdapters/GameDefinition.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.cs
@@ -32,8 +32,14 @@ namespace Pinder.LlmAdapters
         /// <summary>Steering question prompt template. Placeholders: {player_name}, {datee_name}, {delivered_message}.</summary>
         public string SteeringPrompt { get; }
 
-        /// <summary>Global DC bias applied to all rolls. 0 = standard difficulty. Positive = harder.</summary>
+        /// <summary>Global DC bias applied to all rolls. 0 = standard difficulty. Positive = easier.</summary>
         public int GlobalDcBias { get; }
+
+        /// <summary>DC bias applied to shadow checks. 0 = standard difficulty. Positive = easier.</summary>
+        public int ShadowDcBias { get; }
+
+        /// <summary>DC bias applied to horniness checks. 0 = standard difficulty. Positive = easier.</summary>
+        public int HorninessDcBias { get; }
 
         /// <summary>Maximum number of turns per session. Default 30 if not set in YAML.</summary>
         public int MaxTurns { get; }
@@ -56,6 +62,8 @@ namespace Pinder.LlmAdapters
             string steeringPrompt = null,
             HorninessTimeModifiers horninessTimeModifiers = null,
             int globalDcBias = 0,
+            int shadowDcBias = 0,
+            int horninessDcBias = 0,
             int maxTurns = 30,
             int maxDialogueOptions = 3,
             int maxDeliveryWords = 80)
@@ -68,6 +76,8 @@ namespace Pinder.LlmAdapters
             SteeringPrompt = steeringPrompt ?? "";
             HorninessTimeModifiers = horninessTimeModifiers;
             GlobalDcBias = globalDcBias;
+            ShadowDcBias = shadowDcBias;
+            HorninessDcBias = horninessDcBias;
             MaxTurns = maxTurns > 0 ? maxTurns : 30;
             MaxDialogueOptions = maxDialogueOptions > 0 ? maxDialogueOptions : 3;
             MaxDeliveryWords = maxDeliveryWords > 0 ? maxDeliveryWords : 80;

--- a/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
+++ b/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
@@ -37,6 +37,8 @@ namespace Pinder.Tools.NarrativeHarness
                 steeringPrompt: baseDef.SteeringPrompt,
                 horninessTimeModifiers: baseDef.HorninessTimeModifiers,
                 globalDcBias: baseDef.GlobalDcBias,
+                shadowDcBias: baseDef.ShadowDcBias,
+                horninessDcBias: baseDef.HorninessDcBias,
                 maxTurns: baseDef.MaxTurns,
                 maxDialogueOptions: baseDef.MaxDialogueOptions,
                 maxDeliveryWords: baseDef.MaxDeliveryWords);

--- a/tests/Pinder.Core.Tests/Issue1168_DcBiasTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1168_DcBiasTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.TestCommon;
+using Pinder.Core.Traps;
+using Pinder.Core.I18n;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1168_DcBiasTests
+    {
+        private static CharacterProfile MakeProfile(string name, int statVal = 2, int shadowVal = 0)
+        {
+            var stats = TestHelpers.MakeStatBlock(statVal, shadowVal);
+            var timing = new TimingProfile(5, 1.0f, 0.0f, "neutral");
+            return new CharacterProfile(stats, "system prompt", name, timing, 1);
+        }
+
+        private class DummyLlm : ILlmAdapter
+        {
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(new[] {
+                    new DialogueOption(StatType.Charm, "Option 1"),
+                    new DialogueOption(StatType.Rizz, "Option 2")
+                });
+            }
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(new DateeResponse("Response text", null, null));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult<string?>("Beat");
+            }
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+        }
+
+        // 1. RollEngine.ApplyDcBias
+        [Fact]
+        public void ApplyDcBias_Zero_IsNoOp()
+        {
+            Assert.Equal(18, RollEngine.ApplyDcBias(18, 0));
+        }
+
+        [Fact]
+        public void ApplyDcBias_Positive_LowersDc_Easier()
+        {
+            // Positive bias lowers effective DC (making check easier)
+            Assert.Equal(15, RollEngine.ApplyDcBias(18, 3));
+        }
+
+        [Fact]
+        public void ApplyDcBias_Negative_RaisesDc_Harder()
+        {
+            Assert.Equal(21, RollEngine.ApplyDcBias(18, -3));
+        }
+
+        // 2. Cross-independence: setting shadow_dc_bias does not shift main or horniness checks.
+        [Fact]
+        public void AllThreeBiases_AreFullyIndependent()
+        {
+            var rng = new Random(42);
+            var consequenceCatalog = null as IConsequenceCatalog;
+
+            // Instantiate engines with distinct biases
+            var shadowEngine = new ShadowCheckEngine(rng, consequenceCatalog, shadowDcBias: 4);
+            var horninessEngine = new HorninessEngine(rng, consequenceCatalog, horninessDcBias: 7);
+            
+            // Check Shadow DC: shadow base DC is 20 - value. At shadowValue = 8, base DC is 12. Bias +4 -> DC = 8.
+            var shadowResult = shadowEngine.Check(ShadowStatType.Madness, 8);
+            Assert.Equal(8, shadowResult.DC);
+
+            // Check Horniness DC: base DC is 20 - value. At value = 12, base DC is 8. Bias +7 -> DC = 1.
+            var playerShadows = new SessionShadowTracker(TestHelpers.MakeStatBlock());
+            var (horninessResult, _) = horninessEngine.PeekAsync(12, playerShadows, null);
+            Assert.Equal(1, horninessResult.DC);
+
+            // Check Main Roll (RollResolutionStage / GameSession with globalDcBias)
+            // If globalDcBias is 3, base DC for a defender with stat 2 is 16 + 2 = 18. Bias +3 -> effective DC = 15.
+            var player = MakeProfile("Player", 2, 0);
+            var datee = MakeProfile("Datee", 2, 0);
+            var dice = new FixedDice(
+                5,    // Horniness session roll
+                10,   // turn 1 roll
+                50    // d100 ghost
+            );
+
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                globalDcBias: 3,
+                shadowDcBias: 0,     // Ensure shadow/horniness biases don't bleed into main roll
+                horninessDcBias: 0
+            );
+
+            var session = new GameSession(player, datee, new DummyLlm(), dice, new NullTrapRegistry(), config);
+            
+            // Resolve Turn and inspect resulting Roll
+            var turnStart = session.StartTurnAsync().GetAwaiter().GetResult();
+            var turnResult = session.ResolveTurnAsync(0).GetAwaiter().GetResult();
+
+            // Effective DC should be: 18 - dcAdjustment = 18 - 3 = 15.
+            Assert.Equal(15, turnResult.Roll.DC);
+        }
+
+        // 3. Symmetric Sign Behavior: positive bias -> lower effective DC -> higher success rate.
+        [Fact]
+        public void PositiveBias_MakesAllThreeChecksEasier()
+        {
+            var rng = new Random(42);
+            var playerShadows = new SessionShadowTracker(TestHelpers.MakeStatBlock());
+
+            // SHADOW: base DC = 20 - 5 = 15. Positive bias = 5 -> DC = 10 (easier).
+            var shadowEngineWithBias = new ShadowCheckEngine(rng, shadowDcBias: 5);
+            var shadowResultWithBias = shadowEngineWithBias.Check(ShadowStatType.Madness, 5);
+            Assert.Equal(10, shadowResultWithBias.DC);
+
+            // HORNINESS: base DC = 20 - 5 = 15. Positive bias = 5 -> DC = 10 (easier).
+            var horninessEngineWithBias = new HorninessEngine(rng, horninessDcBias: 5);
+            var (horninessResultWithBias, _) = horninessEngineWithBias.PeekAsync(5, playerShadows, null);
+            Assert.Equal(10, horninessResultWithBias.DC);
+
+            // MAIN ROLL: base DC = 18. Positive globalDcBias = 5 -> DC = 13 (easier).
+            var player = MakeProfile("Player", 2, 0);
+            var datee = MakeProfile("Datee", 2, 0);
+            var dice = new FixedDice(5, 10, 50);
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), globalDcBias: 5);
+            var session = new GameSession(player, datee, new DummyLlm(), dice, new NullTrapRegistry(), config);
+            session.StartTurnAsync().GetAwaiter().GetResult();
+            var turnResult = session.ResolveTurnAsync(0).GetAwaiter().GetResult();
+            Assert.Equal(13, turnResult.Roll.DC);
+        }
+
+        // 4. global_dc_bias flip refactor:
+        // - At value 0: behaviour byte-identical to pre-refactor (base DC with SA=2 is 18).
+        // - At positive value: is now easier.
+        [Fact]
+        public void GlobalDcBias_Zero_IsByteIdentical_PositiveIsEasier()
+        {
+            var player = MakeProfile("Player", 2, 0);
+            var datee = MakeProfile("Datee", 2, 0);
+
+            // Zero Bias
+            {
+                var dice = new FixedDice(5, 10, 50);
+                var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), globalDcBias: 0);
+                var session = new GameSession(player, datee, new DummyLlm(), dice, new NullTrapRegistry(), config);
+                session.StartTurnAsync().GetAwaiter().GetResult();
+                var turnResult = session.ResolveTurnAsync(0).GetAwaiter().GetResult();
+                
+                // DC with SA=2 is 16 + 2 = 18.
+                Assert.Equal(18, turnResult.Roll.DC);
+            }
+
+            // Positive Bias makes it EASIER (lowers effective DC).
+            {
+                var dice = new FixedDice(5, 10, 50);
+                var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), globalDcBias: 3);
+                var session = new GameSession(player, datee, new DummyLlm(), dice, new NullTrapRegistry(), config);
+                session.StartTurnAsync().GetAwaiter().GetResult();
+                var turnResult = session.ResolveTurnAsync(0).GetAwaiter().GetResult();
+                
+                // DC with globalDcBias=3 should be 18 - 3 = 15.
+                Assert.Equal(15, turnResult.Roll.DC);
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue722_GlobalDcBiasTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue722_GlobalDcBiasTests.cs
@@ -38,12 +38,46 @@ horniness_time_modifiers:
         }
 
         [Fact]
-        public void LoadFrom_GlobalDcBias_PositiveValues_MakeGameHarder()
+        public void LoadFrom_GlobalDcBias_PositiveValues_LowerDc()
         {
             var yaml = BaseYaml + "global_dc_bias: 3\n";
             var gd = GameDefinition.LoadFrom(yaml);
             Assert.Equal(3, gd.GlobalDcBias);
-            Assert.True(gd.GlobalDcBias > 0, "Positive global_dc_bias should make the game harder");
+            Assert.True(gd.GlobalDcBias > 0, "Positive global_dc_bias should make the game easier (lowers DC)");
+        }
+
+        [Fact]
+        public void LoadFrom_ShadowAndHorninessDcBias_LoadsCorrectly()
+        {
+            var yaml = BaseYaml + "global_dc_bias: 0\nshadow_dc_bias: 4\nhorniness_dc_bias: -2\n";
+            var gd = GameDefinition.LoadFrom(yaml);
+            Assert.Equal(4, gd.ShadowDcBias);
+            Assert.Equal(-2, gd.HorninessDcBias);
+        }
+
+        [Fact]
+        public void LoadFrom_ShadowAndHorninessDcBias_Absent_DefaultsToZero()
+        {
+            var yaml = BaseYaml + "global_dc_bias: 0\n";
+            var gd = GameDefinition.LoadFrom(yaml);
+            Assert.Equal(0, gd.ShadowDcBias);
+            Assert.Equal(0, gd.HorninessDcBias);
+        }
+
+        [Fact]
+        public void LoadFrom_ShadowDcBias_NonInteger_ThrowsInvalidOperationException()
+        {
+            var yaml = BaseYaml + "global_dc_bias: 0\nshadow_dc_bias: abc\n";
+            var ex = Assert.Throws<InvalidOperationException>(() => GameDefinition.LoadFrom(yaml));
+            Assert.Contains("shadow_dc_bias must be an integer", ex.Message);
+        }
+
+        [Fact]
+        public void LoadFrom_HorninessDcBias_NonInteger_ThrowsInvalidOperationException()
+        {
+            var yaml = BaseYaml + "global_dc_bias: 0\nhorniness_dc_bias: xyz\n";
+            var ex = Assert.Throws<InvalidOperationException>(() => GameDefinition.LoadFrom(yaml));
+            Assert.Contains("horniness_dc_bias must be an integer", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #1168

## What
Adds per-session DC-bias for the **shadow** and **horniness** d20 checks, symmetric to the existing `global_dc_bias` on the main roll, routing all three checks through ONE shared helper `RollEngine.ApplyDcBias(baseDc, bias) => baseDc - bias`.

Three independent axes:
- main roll — existing `global_dc_bias`
- shadow roll — new `shadow_dc_bias`
- horniness roll — new `horniness_dc_bias`

## Convention flip (decision #2)
`ApplyDcBias` defines **positive bias = EASIER** (lowers effective DC), uniformly across all three checks. This FLIPS the prior main-roll convention (positive `global_dc_bias` was *harder*). Shipped value is `0`, so zero live behavioural effect at the default. YAML comment (`data/game-definition.yaml`) and the `GlobalDcBias` XML-doc updated from "Positive = harder" to "Positive = easier".

## Config + wiring
- `shadow_dc_bias` / `horniness_dc_bias` added to `game-definition.yaml` (default 0).
- Parsed in `GameDefinition.Parser.cs` as **optional with explicit default 0** (throws on non-integer; no silent fallback — honours #1165).
- Properties on `GameDefinition` + `GameSessionConfig`; fields on `GameSession`; copied in `GameSession.Clone`; threaded into `ShadowCheckEngine`/`HorninessEngine` ctors; preserved in `GameDefinitionArcInjector.WithArc`; wired in `session-runner/Program.Setup.cs`.
- shadow/horniness biases are INDEPENDENT of `global_dc_bias`.

## DoD / Research-Log
Verified locally (no GitHub CI on this repo):
- `dotnet build -c Release` → 0 errors.
- `dotnet test tests/Pinder.LlmAdapters.Tests -c Release` → all green (incl. parse/validation round-trip for both new keys).
- `dotnet test tests/Pinder.Core.Tests -c Release` → all green (incl. new `Issue1168_DcBiasTests.cs`).

Invariants proven by tests:
- Each bias independently shifts ONLY its own check's effective DC (cross-independence).
- Positive bias → lower effective DC → easier, for all three (explicit sign assertions pin "positive = easier" so a future regression fails loudly).
- `global_dc_bias` at 0 is byte-identical to pre-refactor; at a positive value it is now EASIER (the flip).
- Bias 0 (default) is a no-op on all three.

## Drive-by changes
- Renamed `Issue722_GlobalDcBiasTests.LoadFrom_GlobalDcBias_PositiveValues_MakeGameHarder` → `...PositiveValues_LowerDc` to reflect the flipped convention (assertion kept green; property value unchanged).
- `session-runner/Program.Setup.cs` threaded to read the two new YAML keys (config wiring, not in the original engine-only intent).
