### PR TITLE
feat(#1174): archetypes_enabled flag (default OFF)

### DIFF
--- a/data/game-definition.yaml
+++ b/data/game-definition.yaml
@@ -6,6 +6,7 @@ name: "Pinder"
 max_turns: 30
 max_dialogue_options: 3
 max_delivery_words: 80
+archetypes_enabled: false  # When false (default), no archetype content is injected into any prompt surface.
 game_master_prompt: |
   ## 1. Role
 

--- a/session-runner/Program.Setup.cs
+++ b/session-runner/Program.Setup.cs
@@ -277,7 +277,8 @@ partial class Program
             shadowDcBias: yamlShadowDcBias,
             horninessDcBias: yamlHorninessDcBias,
             statDeliveryInstructions: statDeliveryInstructions,
-            consequenceCatalog: consequenceCatalog);
+            consequenceCatalog: consequenceCatalog,
+            archetypesEnabled: result.GameDef?.ArchetypesEnabled ?? false);
         int? diceSeed = null;
         { if (ParseArg(args, "--seed") is string s2 && int.TryParse(s2, out int s3)) diceSeed = s3; }
         result.Session = new GameSession(result.Sable, result.Brick, result.Llm, new SystemRandomDiceRoller(diceSeed), result.TrapRegistry, config);

--- a/src/Pinder.Core/Characters/CharacterAssembler.cs
+++ b/src/Pinder.Core/Characters/CharacterAssembler.cs
@@ -34,12 +34,14 @@ namespace Pinder.Core.Characters
         /// Character level used to filter archetypes by their eligible level range.
         /// When 0 (default), no level filtering is applied (backward-compatible).
         /// </param>
+        /// <param name="archetypesEnabled">Whether archetype selection/resolution is enabled.</param>
         public FragmentCollection Assemble(
             IEnumerable<string> equippedItemIds,
             IReadOnlyDictionary<string, string> anatomySelections,
             IReadOnlyDictionary<StatType, int> playerBaseStats,
             IReadOnlyDictionary<ShadowStatType, int> shadowStats,
-            int characterLevel = 0)
+            int characterLevel = 0,
+            bool archetypesEnabled = false)
         {
             // --- 1. Resolve items and anatomy tiers --------------------------------
 
@@ -195,7 +197,7 @@ namespace Pinder.Core.Characters
 
             // --- 7. Resolve active archetype ------------------------------------
 
-            ActiveArchetype activeArchetype = ResolveActiveArchetype(ranked, characterLevel);
+            ActiveArchetype activeArchetype = archetypesEnabled ? ResolveActiveArchetype(ranked, characterLevel) : null;
 
             // --- 8. Return FragmentCollection -------------------------------------
 

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -142,6 +142,7 @@ namespace Pinder.Core.Conversation
         private readonly IConsequenceCatalog? _consequenceCatalog;
         private readonly int _maxDialogueOptions;
         private readonly int _maxDeliveryWords;
+        private readonly bool _archetypesEnabled;
 
         internal GameSessionState State => _state;
 
@@ -234,6 +235,7 @@ namespace Pinder.Core.Conversation
             _consequenceCatalog = config.ConsequenceCatalog;
             _maxDialogueOptions = config.MaxDialogueOptions ?? 3;
             _maxDeliveryWords = config.MaxDeliveryWords ?? 80;
+            _archetypesEnabled = config.ArchetypesEnabled;
             _steeringEngine = new SteeringEngine(steeringRng);
             _horninessEngine = new HorninessEngine(steeringRng, _consequenceCatalog, _horninessDcBias);
             _shadowCheckEngine = new ShadowCheckEngine(steeringRng, _consequenceCatalog, _shadowDcBias);

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -110,6 +110,9 @@ namespace Pinder.Core.Conversation
         /// <summary>Max delivery words configured in GameDefinition. Null means default 80.</summary>
         public int? MaxDeliveryWords { get; }
 
+        /// <summary>Whether archetype content is injected into prompt surfaces.</summary>
+        public bool ArchetypesEnabled { get; }
+
         public GameSessionConfig(
             IGameClock? clock = null,
             SessionShadowTracker? playerShadows = null,
@@ -127,7 +130,8 @@ namespace Pinder.Core.Conversation
             Action<TextLayerNoopEvent>? onTextLayerNoop = null,
             IConsequenceCatalog? consequenceCatalog = null,
             int? maxDialogueOptions = null,
-            int? maxDeliveryWords = null)
+            int? maxDeliveryWords = null,
+            bool archetypesEnabled = false)
         {
             Clock = clock;
             PlayerShadows = playerShadows;
@@ -146,6 +150,7 @@ namespace Pinder.Core.Conversation
             ConsequenceCatalog = consequenceCatalog;
             MaxDialogueOptions = maxDialogueOptions;
             MaxDeliveryWords = maxDeliveryWords;
+            ArchetypesEnabled = archetypesEnabled;
         }
     }
 }

--- a/src/Pinder.Core/Prompts/PromptBuilder.cs
+++ b/src/Pinder.Core/Prompts/PromptBuilder.cs
@@ -166,9 +166,10 @@ namespace Pinder.Core.Prompts
             string? bioOneLiner,
             FragmentCollection fragments,
             TrapState activeTraps,
-            string? characterIdSeed = null)
+            string? characterIdSeed = null,
+            bool archetypesEnabled = false)
         {
-            return BuildSystemPromptEx(displayName, genderIdentity, bioOneLiner, fragments, activeTraps, characterIdSeed).Text;
+            return BuildSystemPromptEx(displayName, genderIdentity, bioOneLiner, fragments, activeTraps, characterIdSeed, archetypesEnabled).Text;
         }
 
         /// <summary>
@@ -180,7 +181,8 @@ namespace Pinder.Core.Prompts
             string? bioOneLiner,
             FragmentCollection fragments,
             TrapState activeTraps,
-            string? characterIdSeed = null)
+            string? characterIdSeed = null,
+            bool archetypesEnabled = false)
         {
             if (displayName  == null) throw new ArgumentNullException(nameof(displayName));
             if (genderIdentity == null) throw new ArgumentNullException(nameof(genderIdentity));
@@ -203,7 +205,10 @@ namespace Pinder.Core.Prompts
             sb.AppendLine(framing.Personality, srcFile, srcKey);
             sb.AppendLine(framing.Backstory, srcFile, srcKey);
             sb.AppendLine(framing.TextingStyle, srcFile, srcKey);
-            sb.AppendLine(framing.ActiveArchetype, srcFile, srcKey);
+            if (archetypesEnabled)
+            {
+                sb.AppendLine(framing.ActiveArchetype, srcFile, srcKey);
+            }
             sb.AppendLine("EFFECTIVE STATS");
             sb.AppendLine(framing.ActiveTrapInstructions, srcFile, srcKey);
 
@@ -230,19 +235,22 @@ namespace Pinder.Core.Prompts
                 fragments.TextingStyleSources, characterIdSeed));
             sb.AppendLine();
 
-            sb.AppendLine(framing.ActiveArchetype, srcFile, srcKey);
-            if (fragments.ActiveArchetype != null)
+            if (archetypesEnabled)
             {
-                var aa = fragments.ActiveArchetype;
-                sb.AppendLine($"- {aa.Name} ({aa.InterferenceLevel})");
-                if (!string.IsNullOrWhiteSpace(aa.Behavior))
-                    sb.AppendLine(aa.Behavior);
+                sb.AppendLine(framing.ActiveArchetype, srcFile, srcKey);
+                if (fragments.ActiveArchetype != null)
+                {
+                    var aa = fragments.ActiveArchetype;
+                    sb.AppendLine($"- {aa.Name} ({aa.InterferenceLevel})");
+                    if (!string.IsNullOrWhiteSpace(aa.Behavior))
+                        sb.AppendLine(aa.Behavior);
+                }
+                else
+                {
+                    sb.AppendLine("(none resolved)");
+                }
+                sb.AppendLine();
             }
-            else
-            {
-                sb.AppendLine("(none resolved)");
-            }
-            sb.AppendLine();
 
             sb.AppendLine("EFFECTIVE STATS");
             sb.AppendLine($"- Charm: {fragments.Stats.GetEffective(StatType.Charm)}");

--- a/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
@@ -83,6 +83,14 @@ namespace Pinder.LlmAdapters
                     throw new InvalidOperationException("game-definition.yaml horniness_dc_bias must be an integer");
             }
 
+            // Parse optional archetypes_enabled
+            bool archetypesEnabled = false;
+            if (parsed.TryGetValue("archetypes_enabled", out var aeObj) && aeObj != null)
+            {
+                if (!bool.TryParse(aeObj.ToString(), out archetypesEnabled))
+                    throw new InvalidOperationException("game-definition.yaml archetypes_enabled must be a boolean");
+            }
+
             return new GameDefinition(
                 name: name,
                 gameMasterPrompt: gameMasterPrompt,
@@ -94,6 +102,7 @@ namespace Pinder.LlmAdapters
                 globalDcBias: globalDcBias,
                 shadowDcBias: shadowDcBias,
                 horninessDcBias: horninessDcBias,
+                archetypesEnabled: archetypesEnabled,
                 maxTurns: parsed.TryGetValue("max_turns", out var mtObj) && int.TryParse(mtObj?.ToString(), out int mt) ? mt : 30,
                 maxDialogueOptions: parsed.TryGetValue("max_dialogue_options", out var mdoObj) && int.TryParse(mdoObj?.ToString(), out int mdo) ? mdo : 3,
                 maxDeliveryWords: parsed.TryGetValue("max_delivery_words", out var mdwObj) && int.TryParse(mdwObj?.ToString(), out int mdw) ? mdw : 80

--- a/src/Pinder.LlmAdapters/GameDefinition.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.cs
@@ -41,6 +41,11 @@ namespace Pinder.LlmAdapters
         /// <summary>DC bias applied to horniness checks. 0 = standard difficulty. Positive = easier.</summary>
         public int HorninessDcBias { get; }
 
+        /// <summary>
+        /// When false (default), no archetype content is injected into any prompt surface.
+        /// </summary>
+        public bool ArchetypesEnabled { get; }
+
         /// <summary>Maximum number of turns per session. Default 30 if not set in YAML.</summary>
         public int MaxTurns { get; }
 
@@ -64,6 +69,7 @@ namespace Pinder.LlmAdapters
             int globalDcBias = 0,
             int shadowDcBias = 0,
             int horninessDcBias = 0,
+            bool archetypesEnabled = false,
             int maxTurns = 30,
             int maxDialogueOptions = 3,
             int maxDeliveryWords = 80)
@@ -78,6 +84,7 @@ namespace Pinder.LlmAdapters
             GlobalDcBias = globalDcBias;
             ShadowDcBias = shadowDcBias;
             HorninessDcBias = horninessDcBias;
+            ArchetypesEnabled = archetypesEnabled;
             MaxTurns = maxTurns > 0 ? maxTurns : 30;
             MaxDialogueOptions = maxDialogueOptions > 0 ? maxDialogueOptions : 3;
             MaxDeliveryWords = maxDeliveryWords > 0 ? maxDeliveryWords : 80;

--- a/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
+++ b/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
@@ -39,6 +39,7 @@ namespace Pinder.Tools.NarrativeHarness
                 globalDcBias: baseDef.GlobalDcBias,
                 shadowDcBias: baseDef.ShadowDcBias,
                 horninessDcBias: baseDef.HorninessDcBias,
+                archetypesEnabled: baseDef.ArchetypesEnabled,
                 maxTurns: baseDef.MaxTurns,
                 maxDialogueOptions: baseDef.MaxDialogueOptions,
                 maxDeliveryWords: baseDef.MaxDeliveryWords);

--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -45,13 +45,14 @@ namespace Pinder.SessionSetup
         public static CharacterProfile Load(
             string jsonPath,
             IItemRepository itemRepo,
-            IAnatomyRepository anatomyRepo)
+            IAnatomyRepository anatomyRepo,
+            bool archetypesEnabled = false)
         {
             if (!File.Exists(jsonPath))
                 throw new FileNotFoundException($"Character definition file not found: {jsonPath}", jsonPath);
 
             string json = File.ReadAllText(jsonPath);
-            return Parse(json, itemRepo, anatomyRepo);
+            return Parse(json, itemRepo, anatomyRepo, archetypesEnabled);
         }
 
         /// <summary>
@@ -136,13 +137,14 @@ namespace Pinder.SessionSetup
         public static CharacterProfile Parse(
             string json,
             IItemRepository itemRepo,
-            IAnatomyRepository anatomyRepo)
+            IAnatomyRepository anatomyRepo,
+            bool archetypesEnabled = false)
         {
             if (itemRepo == null) throw new ArgumentNullException(nameof(itemRepo));
             if (anatomyRepo == null) throw new ArgumentNullException(nameof(anatomyRepo));
 
             CharacterDefinition def = ParseDefinition(json);
-            return Assemble(def, itemRepo, anatomyRepo);
+            return Assemble(def, itemRepo, anatomyRepo, archetypesEnabled);
         }
 
         /// <summary>
@@ -154,7 +156,8 @@ namespace Pinder.SessionSetup
         public static CharacterProfile Assemble(
             CharacterDefinition def,
             IItemRepository itemRepo,
-            IAnatomyRepository anatomyRepo)
+            IAnatomyRepository anatomyRepo,
+            bool archetypesEnabled = false)
         {
             if (def == null) throw new ArgumentNullException(nameof(def));
             if (itemRepo == null) throw new ArgumentNullException(nameof(itemRepo));
@@ -166,7 +169,8 @@ namespace Pinder.SessionSetup
                 def.Anatomy,
                 def.Allocation.Spent,
                 def.Allocation.Shadows,
-                def.Level);
+                def.Level,
+                archetypesEnabled: archetypesEnabled);
 
             // #836 placeholder aggregation: use the character UUID as the
             // stable seed so the system prompt and the runtime
@@ -177,7 +181,8 @@ namespace Pinder.SessionSetup
 
             string systemPrompt = PromptBuilder.BuildSystemPrompt(
                 def.Name, def.GenderIdentity, def.Bio, fragments, new TrapState(),
-                characterIdSeed: textingSeed);
+                characterIdSeed: textingSeed,
+                archetypesEnabled: archetypesEnabled);
 
             // #907: Use AggregateWithAudit so conflict drops are visible at
             // session-creation time. ConflictCatalog is loaded by PromptWiring.Wire();

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -346,7 +346,7 @@ namespace Pinder.Core.Tests
             string path = Path.Combine(RepoRoot, "data", "characters", "gerald.json");
             string json = File.ReadAllText(path);
 
-            var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo);
+            var profile = CharacterDefinitionLoader.Parse(json, itemRepo, anatomyRepo, archetypesEnabled: true);
 
             // Should contain assembled fragments, not be empty
             // Lead-in is now RULES token; character name no longer in character-level prompt (RULES migration).

--- a/tests/Pinder.Core.Tests/CharacterSystemTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterSystemTests.cs
@@ -182,7 +182,8 @@ namespace Pinder.Core.Tests
                 ZeroBaseStats, ZeroShadow);
 
             var prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", "A test bio.", fragments, new TrapState());
+                "TestChar", "she/her", "A test bio.", fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.Contains("PERSONALITY", prompt);
             Assert.Contains("BACKSTORY", prompt);

--- a/tests/Pinder.Core.Tests/Issue1154_CharacterCardGoldenTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1154_CharacterCardGoldenTests.cs
@@ -87,7 +87,8 @@ namespace Pinder.Core.Tests
 
             var result = PromptBuilder.BuildSystemPromptEx(
                 "Velvet", "she/her", "just here for the vibes",
-                fragments, new TrapState(), characterIdSeed: "fixed-seed-1154");
+                fragments, new TrapState(), characterIdSeed: "fixed-seed-1154",
+                archetypesEnabled: true);
 
             Assert.Equal(ReadFixture("golden_inactive.txt"), result.Text);
         }
@@ -112,7 +113,8 @@ namespace Pinder.Core.Tests
 
             var result = PromptBuilder.BuildSystemPromptEx(
                 "Velvet", "she/her", "just here for the vibes",
-                fragments, trapState, characterIdSeed: "fixed-seed-1154");
+                fragments, trapState, characterIdSeed: "fixed-seed-1154",
+                archetypesEnabled: true);
 
             Assert.Equal(ReadFixture("golden_active.txt"), result.Text);
         }

--- a/tests/Pinder.Core.Tests/Issue649_TierBasedArchetypeSelectionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue649_TierBasedArchetypeSelectionTests.cs
@@ -218,7 +218,8 @@ namespace Pinder.Core.Tests
                 new[] { "a", "b" },
                 new Dictionary<string, string>(),
                 ZeroStats, ZeroShadow,
-                characterLevel: 1);
+                characterLevel: 1,
+                archetypesEnabled: true);
 
             Assert.Equal("The Hey Opener", result.ActiveArchetype?.Name);
         }
@@ -237,7 +238,8 @@ namespace Pinder.Core.Tests
                 new[] { "a", "b" },
                 new Dictionary<string, string>(),
                 ZeroStats, ZeroShadow,
-                characterLevel: 5);
+                characterLevel: 5,
+                archetypesEnabled: true);
 
             Assert.Equal("The Sniper", result.ActiveArchetype?.Name);
         }
@@ -255,7 +257,8 @@ namespace Pinder.Core.Tests
                 new[] { "a", "b" },
                 new Dictionary<string, string>(),
                 ZeroStats, ZeroShadow,
-                characterLevel: 5);
+                characterLevel: 5,
+                archetypesEnabled: true);
 
             Assert.NotNull(result.ActiveArchetype);
             Assert.NotEmpty(result.ActiveArchetype!.Behavior);
@@ -276,7 +279,8 @@ namespace Pinder.Core.Tests
                 new[] { "a", "b" },
                 new Dictionary<string, string>(),
                 ZeroStats, ZeroShadow,
-                characterLevel: 1);
+                characterLevel: 1,
+                archetypesEnabled: true);
 
             // Fallback: highest count overall
             Assert.NotNull(result.ActiveArchetype);
@@ -296,7 +300,8 @@ namespace Pinder.Core.Tests
                 new[] { "a" },
                 new Dictionary<string, string>(),
                 ZeroStats, ZeroShadow,
-                characterLevel: 5); // T3 eligible at level 5
+                characterLevel: 5,
+                archetypesEnabled: true); // T3 eligible at level 5
 
             Assert.NotNull(result.ActiveArchetype);
             var directive = result.ActiveArchetype!.Directive;

--- a/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
+++ b/tests/Pinder.Core.Tests/Issue832_ActiveArchetypePromptTests.cs
@@ -45,7 +45,8 @@ namespace Pinder.Core.Tests
                 behavior: "Loud, expensive flex. Sample lines: \"check my watch\" \u00b7 \"weekend trip booked\"",
                 count: 4, totalCount: 5);
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", "bio", fragments, new TrapState());
+                "TestChar", "she/her", "bio", fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.Contains("ACTIVE ARCHETYPE", prompt);
         }
@@ -60,7 +61,8 @@ namespace Pinder.Core.Tests
                 name: "The Peacock", behavior: "behavior", count: 4, totalCount: 5,
                 rankedNonActives: new[] { ("The Wall of Text", 2), ("The Hey Opener", 1) });
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", "bio", fragments, new TrapState());
+                "TestChar", "she/her", "bio", fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.DoesNotContain("ARCHETYPES (tendency order", prompt);
             // The non-active archetypes must NOT appear in the prompt.
@@ -80,7 +82,8 @@ namespace Pinder.Core.Tests
                 count: 4, totalCount: 5);
 
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", "bio", fragments, new TrapState());
+                "TestChar", "she/her", "bio", fragments, new TrapState(),
+                archetypesEnabled: true);
 
             // Name + interference level on a labelled bullet so a parser
             // can split them out cleanly.
@@ -98,7 +101,8 @@ namespace Pinder.Core.Tests
                 name: "The Peacock", behavior: "b", count: 2, totalCount: 4);
 
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", null, fragments, new TrapState());
+                "TestChar", "she/her", null, fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.Contains("- The Peacock (clear)", prompt);
         }
@@ -111,7 +115,8 @@ namespace Pinder.Core.Tests
                 name: "The Peacock", behavior: "b", count: 1, totalCount: 5);
 
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", null, fragments, new TrapState());
+                "TestChar", "she/her", null, fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.Contains("- The Peacock (slight)", prompt);
         }
@@ -132,7 +137,8 @@ namespace Pinder.Core.Tests
                 activeArchetype: null);
 
             string prompt = PromptBuilder.BuildSystemPrompt(
-                "TestChar", "she/her", null, fragments, new TrapState());
+                "TestChar", "she/her", null, fragments, new TrapState(),
+                archetypesEnabled: true);
 
             Assert.Contains("ACTIVE ARCHETYPE", prompt);
             Assert.Contains("(none resolved)", prompt);

--- a/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.AnatomyAndIntegration.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.AnatomyAndIntegration.cs
@@ -103,7 +103,8 @@ namespace Pinder.Core.Tests
 
             var prompt = PromptBuilder.BuildSystemPrompt(
                 "TestChar", "she/her", "bio", fragments, new TrapState(),
-                characterIdSeed: "stable-seed");
+                characterIdSeed: "stable-seed",
+                archetypesEnabled: true);
 
             // Slice out the TEXTING STYLE section.
             string section = ExtractSection(prompt, "TEXTING STYLE", "ACTIVE ARCHETYPE");

--- a/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue874_PromptBuilderPhase3Tests.cs
@@ -150,7 +150,8 @@ namespace Pinder.Core.Tests
             try
             {
                 string prompt = PromptBuilder.BuildSystemPrompt(
-                    "TestChar", "they/them", null, EmptyFragments, new TrapState());
+                    "TestChar", "they/them", null, EmptyFragments, new TrapState(),
+                    archetypesEnabled: true);
 
                 // Headers from yaml must appear.
                 Assert.Contains("IDENTITY", prompt);

--- a/tests/Pinder.LlmAdapters.Tests/Issue1174_ArchetypesEnabledFlagTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1174_ArchetypesEnabledFlagTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Prompts;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1174_ArchetypesEnabledFlagTests
+    {
+        private const string BaseYaml = @"
+name: ""TestGame""
+game_master_prompt: |
+  A test game master prompt.
+  With writing rules text.
+player_avatar_role_description: |
+  Player role.
+datee_role_description: |
+  Datee role.
+global_dc_bias: 0
+horniness_time_modifiers:
+  morning: 3
+  afternoon: 0
+  evening: 2
+  overnight: 5
+";
+
+        [Fact]
+        public void LoadFrom_ArchetypesEnabled_Absent_DefaultsToFalse()
+        {
+            var gd = GameDefinition.LoadFrom(BaseYaml);
+            Assert.False(gd.ArchetypesEnabled);
+        }
+
+        [Fact]
+        public void LoadFrom_ArchetypesEnabled_ExplicitTrue_LoadsCorrectly()
+        {
+            var yaml = BaseYaml + "archetypes_enabled: true\n";
+            var gd = GameDefinition.LoadFrom(yaml);
+            Assert.True(gd.ArchetypesEnabled);
+        }
+
+        [Fact]
+        public void LoadFrom_ArchetypesEnabled_ExplicitFalse_LoadsCorrectly()
+        {
+            var yaml = BaseYaml + "archetypes_enabled: false\n";
+            var gd = GameDefinition.LoadFrom(yaml);
+            Assert.False(gd.ArchetypesEnabled);
+        }
+
+        [Fact]
+        public void BuildSystemPrompt_ArchetypesDisabled_SuppressArchetypeContent()
+        {
+            // Set up a deterministic fragment collection with a resolved active archetype
+            var activeArchetype = new ActiveArchetype(
+                "The Peacock",
+                "Loud, expensive flex.\n*Sample lines:* \"check my watch\" · \"weekend trip booked\"",
+                4, 5);
+
+            var fragments = new FragmentCollection(
+                personalityFragments: new List<string> { "warm but guarded" },
+                backstoryFragments:   new List<string> { "grew up by the sea" },
+                textingStyleFragments: new List<string>(),
+                rankedArchetypes:     new List<(string, int)> { ("The Peacock", 4) },
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(
+                    new Dictionary<StatType, int> { { StatType.Charm, 3 } },
+                    new Dictionary<ShadowStatType, int>()
+                ),
+                activeArchetype: activeArchetype);
+
+            // Build system prompt with archetypesEnabled = false
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "Velvet", "she/her", "just here for the vibes",
+                fragments, new TrapState(), characterIdSeed: "fixed-seed",
+                archetypesEnabled: false);
+
+            // Assert that there is ZERO archetype content
+            Assert.DoesNotContain("The Peacock", prompt);
+            Assert.DoesNotContain("Loud, expensive flex", prompt);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", prompt);
+            Assert.DoesNotContain("(none resolved)", prompt);
+        }
+
+        [Fact]
+        public void BuildSystemPrompt_ArchetypesEnabled_EmitsArchetypeContent()
+        {
+            // Set up a deterministic fragment collection with a resolved active archetype
+            var activeArchetype = new ActiveArchetype(
+                "The Peacock",
+                "Loud, expensive flex.\n*Sample lines:* \"check my watch\" · \"weekend trip booked\"",
+                4, 5);
+
+            var fragments = new FragmentCollection(
+                personalityFragments: new List<string> { "warm but guarded" },
+                backstoryFragments:   new List<string> { "grew up by the sea" },
+                textingStyleFragments: new List<string>(),
+                rankedArchetypes:     new List<(string, int)> { ("The Peacock", 4) },
+                timing: new TimingProfile(5, 1.0f, 0.0f, "neutral"),
+                stats: new StatBlock(
+                    new Dictionary<StatType, int> { { StatType.Charm, 3 } },
+                    new Dictionary<ShadowStatType, int>()
+                ),
+                activeArchetype: activeArchetype);
+
+            // Build system prompt with archetypesEnabled = true
+            string prompt = PromptBuilder.BuildSystemPrompt(
+                "Velvet", "she/her", "just here for the vibes",
+                fragments, new TrapState(), characterIdSeed: "fixed-seed",
+                archetypesEnabled: true);
+
+            // Assert that the archetype directive + char-card block ARE present
+            Assert.Contains("ACTIVE ARCHETYPE", prompt);
+            Assert.Contains("The Peacock (dominant)", prompt);
+            Assert.Contains("Loud, expensive flex", prompt);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1174

This PR integrates the `archetypes_enabled` game-definition flag (default `false`) and adds comprehensive regression tests to secure its behavior.

### Archetype Injection Sites and Gating:
1. **GameDefinition / Parser**: Parses `archetypes_enabled` from YAML, defaulting to `false`.
2. **CharacterAssembler (Resolution Suppression)**: `Assemble` now accepts `bool archetypesEnabled = false`. When `false`, it sets `ActiveArchetype` to `null` directly, suppressing resolution.
3. **PromptBuilder (Char-Card Guard)**: `BuildSystemPrompt` and `BuildSystemPromptEx` now accept `bool archetypesEnabled = false`. The appending of `ACTIVE ARCHETYPE` framing and content (including name, interference level, behavior, and fallback) is gated on `if (archetypesEnabled)`. When disabled, it emits nothing.
4. **4 Directive Sites (No-op on null)**:
   - `TurnOrchestrator.cs` resolves `player.ActiveArchetype?.Directive`.
   - `DateeResponseStage.cs` resolves `datee.ActiveArchetype?.Directive`.
   - `SessionDocumentBuilder.Trace.cs` (2 sites) checks `context.ActiveArchetypeDirective` and only appends it if it's not null/empty.

### Golden Re-baselines:
- Golden tests in `Issue1154_CharacterCardGoldenTests.cs` have been updated to explicitly enable archetypes so they continue to validate the expected behavior-preserving refactoring with archetypes on. No golden files needed re-baselining as this test adjustment fully preserves the regression check.

## Drive-by changes
none

### DoD / Research-Log
- Added `tests/Pinder.LlmAdapters.Tests/Issue1174_ArchetypesEnabledFlagTests.cs` to test parsing defaults and prompt-level suppression / emission.
- Verified that all pre-existing active archetype prompt and assembly tests in `Pinder.Core.Tests.dll` now explicitly set `archetypesEnabled: true` in their context to pass properly.
- All 2,975 tests in `Pinder.Core.Tests.dll` pass with 0 failures.
- No net-new failing tests compared to the 14 pre-existing baseline failures.