### PR TITLE
Consolidate dialogue-option count, unify labels to NUMBERED, and dedupe metadata-tag contract

### DIFF
--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -80,7 +80,7 @@ prompts:
       Before writing each option, verify: does this sound exactly like
       the texting style above? If not, rewrite it.
 
-      PSYCHOLOGICAL STAKE — mandatory: if a PSYCHOLOGICAL STAKE section is present in the character profile above, OPTION_C MUST quote or paraphrase one of the numbered stake lines verbatim or near-verbatim. If none of the stake lines fit this turn's emotional moment naturally, that is a signal the conversation needs to pivot — OPTION_C should bridge toward a stake-relevant topic. Options that only respond to the surface topic without touching the emotional through-line are incomplete.
+      PSYCHOLOGICAL STAKE — mandatory: if a PSYCHOLOGICAL STAKE section is present in the character profile above, the final OPTION (OPTION_3) MUST quote or paraphrase one of the numbered stake lines verbatim or near-verbatim. If none of the stake lines fit this turn's emotional moment naturally, that is a signal the conversation needs to pivot — the final OPTION (OPTION_3) should bridge toward a stake-relevant topic. Options that only respond to the surface topic without touching the emotional through-line are incomplete.
 
       BIOGRAPHICAL SPECIFICITY — critical: when the DATEE has revealed a concrete biographical detail (a job they left, a place they went, a relationship, a specific event or year), at least one option should follow up on that specific detail — not the emotional theme, the actual fact. 'You mentioned leaving database engineering — what were you doing the following week?' is stronger than 'you seem like someone who takes big risks.' The conversation only advances when both parties are actually curious about each other's lives.
 

--- a/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
@@ -65,11 +65,12 @@ namespace Pinder.LlmAdapters.Anthropic
 
         /// <summary>
         /// Parses structured LLM text output into DialogueOption array.
-        /// Never throws — returns 4 options, padding with defaults if needed.
+        /// Never throws — returns options padded with defaults if needed.
         /// </summary>
         public static DialogueOption[] ParseDialogueOptionsText(string? llmResponse, StatType[]? availableStats = null)
         {
             var parsed = new List<DialogueOption>();
+            int count = availableStats != null ? availableStats.Length : DefaultPaddingStats.Length;
 
             if (!string.IsNullOrWhiteSpace(llmResponse))
             {
@@ -81,7 +82,7 @@ namespace Pinder.LlmAdapters.Anthropic
                     foreach (var section in sections)
                     {
                         if (string.IsNullOrWhiteSpace(section)) continue;
-                        if (parsed.Count >= 4) break;
+                        if (parsed.Count >= count) break;
 
                         var statMatch = StatRegex.Match(section);
                         if (!statMatch.Success) continue;
@@ -172,10 +173,11 @@ namespace Pinder.LlmAdapters.Anthropic
                 if (optionsArray == null || optionsArray.Count == 0)
                     return null;
 
+                int count = availableStats != null ? availableStats.Length : DefaultPaddingStats.Length;
                 var parsed = new List<DialogueOption>();
                 foreach (var item in optionsArray)
                 {
-                    if (parsed.Count >= 4) break;
+                    if (parsed.Count >= count) break;
 
                     var statStr = StatNameNormalizer.NormalizeStatName(item.Value<string>("stat") ?? "");
                     StatType stat;
@@ -239,6 +241,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
         public static DialogueOption[] ReconcileAndPadDialogueOptions(List<DialogueOption> parsed, StatType[]? availableStats = null)
         {
+            int count = availableStats != null ? availableStats.Length : DefaultPaddingStats.Length;
             var result = new List<DialogueOption>();
             var usedStats = new HashSet<StatType>();
             var remainingAllowed = availableStats != null ? new List<StatType>(availableStats) : new List<StatType>(DefaultPaddingStats);
@@ -293,7 +296,7 @@ namespace Pinder.LlmAdapters.Anthropic
 
             result.AddRange(tempOptions);
 
-            while (result.Count < 4)
+            while (result.Count < count)
             {
                 StatType padStat;
                 if (remainingAllowed.Count > 0)
@@ -319,9 +322,9 @@ namespace Pinder.LlmAdapters.Anthropic
                     hasTellBonus: false, hasWeaknessWindow: false));
             }
 
-            if (result.Count > 4)
+            if (result.Count > count)
             {
-                return result.GetRange(0, 4).ToArray();
+                return result.GetRange(0, count).ToArray();
             }
 
             return result.ToArray();

--- a/src/Pinder.LlmAdapters/Anthropic/ToolSchemas.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/ToolSchemas.cs
@@ -11,55 +11,60 @@ namespace Pinder.LlmAdapters.Anthropic
     internal static class ToolSchemas
     {
         /// <summary>
-        /// Tool for GetDialogueOptionsAsync — returns 4 structured dialogue options.
+        /// Tool for GetDialogueOptionsAsync — returns structured dialogue options.
         /// Schema: {options: [{stat, text, callback, combo, tell_bonus, weakness_window}]}
         /// </summary>
-        public static readonly ToolDefinition DialogueOptions = new ToolDefinition
+        public static ToolDefinition GetDialogueOptions(int count)
         {
-            Name = "submit_dialogue_options",
-            Description = "Submit the generated dialogue options for the player.",
-            InputSchema = JObject.Parse(@"{
-                ""type"": ""object"",
-                ""properties"": {
-                    ""options"": {
-                        ""type"": ""array"",
-                        ""items"": {
-                            ""type"": ""object"",
-                            ""properties"": {
-                                ""stat"": {
-                                    ""type"": ""string"",
-                                    ""description"": ""The stat used for this option. Must be one of: Charm, Rizz, Honesty, Chaos, Wit, SelfAwareness""
-                                },
-                                ""text"": {
-                                    ""type"": ""string"",
-                                    ""description"": ""The dialogue text for this option.""
-                                },
-                                ""callback"": {
-                                    ""type"": [""string"", ""null""],
-                                    ""description"": ""Callback turn reference (e.g. '3' or 'turn_3') or null if none.""
-                                },
-                                ""combo"": {
-                                    ""type"": [""string"", ""null""],
-                                    ""description"": ""Combo name being completed, or null if none.""
-                                },
-                                ""tell_bonus"": {
-                                    ""type"": ""boolean"",
-                                    ""description"": ""Whether this option has a tell bonus.""
-                                },
-                                ""weakness_window"": {
-                                    ""type"": ""boolean"",
-                                    ""description"": ""Whether a weakness window is active for this option.""
-                                }
-                            },
-                            ""required"": [""stat"", ""text"", ""tell_bonus"", ""weakness_window""]
-                        },
-                        ""minItems"": 4,
-                        ""maxItems"": 4
-                    }
-                },
-                ""required"": [""options""]
-            }")
-        };
+            return new ToolDefinition
+            {
+                Name = "submit_dialogue_options",
+                Description = "Submit the generated dialogue options for the player.",
+                InputSchema = JObject.Parse($@"{{
+                    ""type"": ""object"",
+                    ""properties"": {{
+                        ""options"": {{
+                            ""type"": ""array"",
+                            ""items"": {{
+                                ""type"": ""object"",
+                                ""properties"": {{
+                                    ""stat"": {{
+                                        ""type"": ""string"",
+                                        ""description"": ""The stat used for this option. Must be one of: Charm, Rizz, Honesty, Chaos, Wit, SelfAwareness""
+                                    }},
+                                    ""text"": {{
+                                        ""type"": ""string"",
+                                        ""description"": ""The dialogue text for this option.""
+                                    }},
+                                    ""callback"": {{
+                                        ""type"": [""string"", ""null""],
+                                        ""description"": ""Callback turn reference (e.g. '3' or 'turn_3') or null if none.""
+                                    }},
+                                    ""combo"": {{
+                                        ""type"": [""string"", ""null""],
+                                        ""description"": ""Combo name being completed, or null if none.""
+                                    }},
+                                    ""tell_bonus"": {{
+                                        ""type"": ""boolean"",
+                                        ""description"": ""Whether this option has a tell bonus.""
+                                    }},
+                                    ""weakness_window"": {{
+                                        ""type"": ""boolean"",
+                                        ""description"": ""Whether a weakness window is active for this option.""
+                                    }}
+                                }},
+                                ""required"": [""stat"", ""text"", ""tell_bonus"", ""weakness_window""]
+                            }},
+                            ""minItems"": {count},
+                            ""maxItems"": {count}
+                        }}
+                    }},
+                    ""required"": [""options""]
+                }}")
+            };
+        }
+
+        public static readonly ToolDefinition DialogueOptions = GetDialogueOptions(4);
 
         // #1125 — the "submit_delivery" tool schema was removed along with the
         // collapsed delivery LLM call (DeliverMessageAsync is gone from the

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -144,7 +144,7 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine($"STAKE COVERAGE — {referencedCount} line(s) referenced this session, {untouchedIndices.Count} untouched.");
                 if (untouchedIndices.Count > 0)
                 {
-                    sb.AppendLine("Untouched stake lines (OPTION_C must reference one):");
+                    sb.AppendLine("Untouched stake lines (the final OPTION must reference one):");
                     foreach (int idx in untouchedIndices)
                     {
                         string preview = context.StakeLines[idx];
@@ -154,7 +154,7 @@ namespace Pinder.LlmAdapters
                 }
                 else
                 {
-                    sb.AppendLine("All stake lines referenced — OPTION_C may continue the most recent stake thread.");
+                    sb.AppendLine("All stake lines referenced — the final OPTION may continue the most recent stake thread.");
                 }
                 sb.AppendLine();
             }
@@ -165,7 +165,7 @@ namespace Pinder.LlmAdapters
 
             string optionsCountStr = optionCount.ToString();
             string optionsListStr = string.Join(", ", Enumerable.Range(1, optionCount).Select(i => $"OPTION_{i}"));
-            string optionsFormatListStr = string.Join(" ", Enumerable.Range(0, optionCount).Select(i => $"OPTION_{(char)('A' + i)}: [message]"));
+            string optionsFormatListStr = string.Join(" ", Enumerable.Range(0, optionCount).Select(i => $"OPTION_{i + 1}: [message]"));
 
             // [ENGINE — Turn N] injection block
             string engineBlock = PromptTemplates.EngineOptionsBlock

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/DialogueOptionParsersTests.cs
@@ -11,7 +11,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         [Fact]
         public void ParseDialogueOptionsText_NullInput_ReturnsPaddedDefaults()
         {
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(null);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(null, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
             // Defaults should use Charm, Honesty, Wit, Chaos
             Assert.Equal(StatType.Charm, result[0].Stat);
@@ -23,7 +23,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         [Fact]
         public void ParseDialogueOptionsText_EmptyInput_ReturnsPaddedDefaults()
         {
-            var result = DialogueOptionParsers.ParseDialogueOptionsText("");
+            var result = DialogueOptionParsers.ParseDialogueOptionsText("", new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
         }
 
@@ -34,7 +34,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
 OPTION_2 [STAT: Wit] ""Did it hurt when you fell from heaven?"" [CALLBACK: 3] [COMBO: SmoothTalker] [TELL_BONUS: yes]
 OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO: none] [TELL_BONUS: no]";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
 
             Assert.Equal(StatType.Charm, result[0].Stat);
@@ -57,7 +57,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
         {
             var input = @"OPTION_1 [STAT: Charm] ""Hello!"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
             Assert.Equal(StatType.Charm, result[0].Stat);
             Assert.Equal("Hello!", result[0].IntendedText);
@@ -78,7 +78,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
                 ]
             }");
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json);
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.NotNull(result);
             Assert.Equal(4, result!.Length);
 
@@ -97,7 +97,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
         public void ParseDialogueOptionsTool_EmptyOptions_ReturnsNull()
         {
             var json = JObject.Parse(@"{ ""options"": [] }");
-            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json);
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Null(result);
         }
 
@@ -105,7 +105,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
         public void ParseDialogueOptionsTool_MalformedInput_ReturnsNull()
         {
             var json = JObject.Parse(@"{ ""garbage"": true }");
-            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json);
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Null(result);
         }
 
@@ -113,7 +113,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
         public void ParseDialogueOptionsText_SelfAwareness_NormalizesCorrectly()
         {
             var input = @"OPTION_1 [STAT: SELF_AWARENESS] ""I know myself."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.SelfAwareness, StatType.Charm, StatType.Honesty, StatType.Wit });
             Assert.Equal(StatType.SelfAwareness, result[0].Stat);
         }
 
@@ -127,7 +127,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
             // inner double-quote (observed fragments like "see you said it's").
             var input = @"OPTION_1 [STAT: Wit] ""Interesting that you said ""it's a lot"" earlier — care to unpack that?"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Wit, StatType.Charm, StatType.Honesty, StatType.Wit });
 
             Assert.Equal(StatType.Wit, result[0].Stat);
             Assert.Equal(
@@ -142,7 +142,7 @@ OPTION_3 [STAT: Honesty] ""I just wanted to say hi."" [CALLBACK: turn_5] [COMBO:
 OPTION_2 [STAT: Honesty] ""You literally said ""I never text first"" two minutes ago."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 OPTION_3 [STAT: Wit] ""Bold of you to assume I read."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
 
             Assert.Equal(4, result.Length);
             Assert.Equal("Hey there, looking good!", result[0].IntendedText);
@@ -160,7 +160,7 @@ OPTION_3 [STAT: Wit] ""Bold of you to assume I read."" [CALLBACK: none] [COMBO: 
             var input = @"OPTION_1 [STAT: Charm] ""the"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 OPTION_2 [STAT: Wit] ""That's a genuinely funny take, I'll give you that."" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Wit, StatType.Honesty, StatType.Chaos });
 
             Assert.Equal(4, result.Length);
             // The degenerate "the" fragment must not appear as any option's text.

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue1170_ConsolidatedCountAndMetadataParityTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue1170_ConsolidatedCountAndMetadataParityTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters.Anthropic;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.Anthropic
+{
+    public sealed class Issue1170_ConsolidatedCountAndMetadataParityTests
+    {
+        // ═══════════════════════════════════════════════════════════════
+        // 1. Configurable Option Count / Distinct Stats / Non-leakage
+        // ═══════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void ParseDialogueOptionsText_WithDrawnStatCountN_ReturnsExactlyNOptions(int n)
+        {
+            // Create N distinct drawn stats
+            var allStats = new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos, StatType.Rizz, StatType.SelfAwareness };
+            var drawnStats = allStats.Take(n).ToArray();
+
+            // Feed an LLM response containing fewer, equal, and more option headers than N to test padding/cap
+            var llmResponse = string.Join("\n", Enumerable.Range(1, n + 2).Select(i => 
+                $"OPTION_{i} [STAT: {drawnStats[i % n]}] \"Text option {i}\" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]"));
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(llmResponse, drawnStats);
+
+            // Exactly N options returned
+            Assert.Equal(n, result.Length);
+
+            // Distinct stats contract
+            var resultStats = result.Select(r => r.Stat).ToList();
+            Assert.Equal(n, resultStats.Distinct().Count());
+
+            // All stats within the drawn set
+            foreach (var stat in resultStats)
+            {
+                Assert.Contains(stat, drawnStats);
+            }
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void ParseDialogueOptionsTool_WithDrawnStatCountN_ReturnsExactlyNOptions(int n)
+        {
+            var allStats = new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos, StatType.Rizz, StatType.SelfAwareness };
+            var drawnStats = allStats.Take(n).ToArray();
+
+            var optionsArray = new JArray();
+            for (int i = 0; i < n + 2; i++)
+            {
+                optionsArray.Add(new JObject
+                {
+                    ["stat"] = drawnStats[i % n].ToString(),
+                    ["text"] = $"Tool text option {i}",
+                    ["callback"] = "none",
+                    ["combo"] = "none",
+                    ["tell_bonus"] = false,
+                    ["weakness_window"] = false
+                });
+            }
+            var toolInput = new JObject { ["options"] = optionsArray };
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(toolInput, drawnStats);
+
+            Assert.NotNull(result);
+            Assert.Equal(n, result!.Length);
+
+            var resultStats = result.Select(r => r.Stat).ToList();
+            Assert.Equal(n, resultStats.Distinct().Count());
+
+            foreach (var stat in resultStats)
+            {
+                Assert.Contains(stat, drawnStats);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // 2. Text-fallback parse of NUMBERED OPTION_1..N block
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void TextFallbackParse_OfNumberedOptionsBlock_YieldsNRealOptions()
+        {
+            var drawnStats = new[] { StatType.Charm, StatType.Honesty, StatType.Wit };
+            var n = drawnStats.Length;
+
+            var input = @"OPTION_1 [STAT: Charm] ""Charming message"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_2 [STAT: Honesty] ""Honest message"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
+OPTION_3 [STAT: Wit] ""Witty message"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
+
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, drawnStats);
+
+            Assert.Equal(n, result.Length);
+            Assert.Equal("Charming message", result[0].IntendedText);
+            Assert.Equal("Honest message", result[1].IntendedText);
+            Assert.Equal("Witty message", result[2].IntendedText);
+            
+            // Prove no padded fallbacks were used
+            foreach (var opt in result)
+            {
+                Assert.NotEqual("...", opt.IntendedText);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // 3. Tool-schema builder parametrizes minItems/maxItems
+        // ═══════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void ToolSchema_GetDialogueOptions_ParametrizesItemsExactly(int n)
+        {
+            var schema = ToolSchemas.GetDialogueOptions(n);
+            Assert.Equal(n, schema.InputSchema["properties"]!["options"]!["minItems"]!.Value<int>());
+            Assert.Equal(n, schema.InputSchema["properties"]!["options"]!["maxItems"]!.Value<int>());
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // 4. Metadata field-parity test
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void MetadataTags_And_ToolSchemaFields_AreIdentical()
+        {
+            // Get regex tags via reflection from DialogueOptionParsers
+            var parserType = typeof(DialogueOptionParsers);
+            var regexFields = parserType.GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                .Where(f => f.FieldType == typeof(Regex) && f.Name.EndsWith("Regex"))
+                .ToList();
+
+            var textTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var field in regexFields)
+            {
+                var regex = (Regex)field.GetValue(null)!;
+                var pattern = regex.ToString();
+                var match = Regex.Match(pattern, @"\\\[([A-Z_]+):");
+                if (match.Success)
+                {
+                    textTags.Add(match.Groups[1].Value);
+                }
+            }
+
+            Assert.Contains("STAT", textTags);
+            Assert.Contains("CALLBACK", textTags);
+            Assert.Contains("COMBO", textTags);
+            Assert.Contains("TELL_BONUS", textTags);
+            Assert.Equal(4, textTags.Count);
+
+            // Get schema fields from ToolSchemas
+            var toolSchema = ToolSchemas.GetDialogueOptions(4);
+            var optionsProps = toolSchema.InputSchema["properties"]?["options"]?["items"]?["properties"] as JObject;
+            Assert.NotNull(optionsProps);
+
+            var schemaFields = optionsProps.Properties()
+                .Select(p => p.Name)
+                .Where(name => name != "text" && name != "weakness_window")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            Assert.Contains("stat", schemaFields);
+            Assert.Contains("callback", schemaFields);
+            Assert.Contains("combo", schemaFields);
+            Assert.Contains("tell_bonus", schemaFields);
+            Assert.Equal(4, schemaFields.Count);
+
+            Assert.True(textTags.SetEquals(schemaFields), "Metadata fields must be 100% synchronized between regex parser and tool schema.");
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        // 5. Revert-proof guard
+        // ═══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void RevertProofGuard_AssertsNoHardcodedFourInOptionPipeline()
+        {
+            // Find DialogueOptionParsers.cs relative to test directory
+            var currentDir = Directory.GetCurrentDirectory();
+            var searchPaths = new[]
+            {
+                Path.Combine(currentDir, "../../../src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs"),
+                Path.Combine(currentDir, "../../../../../src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs"),
+                Path.Combine(currentDir, "src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs"),
+                Path.Combine(currentDir, "../src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs"),
+                "/root/projects/pinder-core/.worktrees/1170/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs"
+            };
+
+            string? sourcePath = null;
+            foreach (var path in searchPaths)
+            {
+                if (File.Exists(path))
+                {
+                    sourcePath = path;
+                    break;
+                }
+            }
+
+            Assert.NotNull(sourcePath);
+            var sourceContent = File.ReadAllText(sourcePath!);
+
+            // Normalize whitespace and remove comments so we only check code
+            var cleanedContent = Regex.Replace(sourceContent, @"//.*|/\*.*?\*/", "", RegexOptions.Singleline);
+
+            // Assert that there are NO hardcoded literals for DialogueOption cap/pad limit of 4
+            Assert.DoesNotContain("parsed.Count >= 4", cleanedContent);
+            Assert.DoesNotContain("result.Count < 4", cleanedContent);
+            Assert.DoesNotContain("result.Count > 4", cleanedContent);
+            Assert.DoesNotContain("GetRange(0, 4)", cleanedContent);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue240_DialogueOptionsFormatTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Anthropic/Issue240_DialogueOptionsFormatTests.cs
@@ -78,7 +78,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_WellFormed_4_options_returns_exactly_4()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.Equal(4, result.Length);
         }
 
@@ -87,7 +87,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_WellFormed_4_options_all_have_non_placeholder_IntendedText()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             foreach (var opt in result)
             {
                 Assert.NotEqual("...", opt.IntendedText);
@@ -100,7 +100,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_Stats_match_STAT_tags_in_input()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.Equal(StatType.Charm, result[0].Stat);
             Assert.Equal(StatType.Honesty, result[1].Stat);
             Assert.Equal(StatType.Chaos, result[2].Stat);
@@ -112,7 +112,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_Callback_turn_number_parsed_when_present()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.Equal(2, result[1].CallbackTurnNumber);
         }
 
@@ -121,7 +121,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_ComboName_parsed_when_present()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.Equal("The Reveal", result[1].ComboName);
         }
 
@@ -130,7 +130,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_HasTellBonus_parsed_when_yes()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.True(result[1].HasTellBonus);
         }
 
@@ -139,7 +139,7 @@ namespace Pinder.LlmAdapters.Tests.Anthropic
         public void AC2_None_metadata_parsed_as_null()
         {
             var input = BuildWellFormed4Options();
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Chaos, StatType.Wit });
             Assert.Null(result[0].CallbackTurnNumber);
             Assert.Null(result[0].ComboName);
             Assert.False(result[0].HasTellBonus);
@@ -161,7 +161,7 @@ OPTION_2
 [STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""Is your bio a riddle? Because I'm intrigued.""";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Wit, StatType.Honesty, StatType.Chaos });
             Assert.Equal(4, result.Length);
             // First two should be parsed, last two padded
             Assert.NotEqual("...", result[0].IntendedText);
@@ -192,7 +192,7 @@ OPTION_4
 [STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""I'm genuinely curious about you""";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Rizz, StatType.Wit, StatType.Honesty });
             Assert.Equal(4, result.Length);
             foreach (var opt in result)
             {
@@ -224,7 +224,7 @@ OPTION_5
 [STAT: CHAOS] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""Option five should be ignored""";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Rizz, StatType.Wit, StatType.Honesty });
             Assert.Equal(4, result.Length);
         }
 
@@ -232,7 +232,7 @@ OPTION_5
         [Fact]
         public void EdgeCase_Null_response_returns_4_defaults_without_throwing()
         {
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(null);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(null, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
             foreach (var opt in result)
             {
@@ -244,7 +244,7 @@ OPTION_5
         [Fact]
         public void EdgeCase_Whitespace_only_response_returns_4_defaults()
         {
-            var result = DialogueOptionParsers.ParseDialogueOptionsText("   \n\t  ");
+            var result = DialogueOptionParsers.ParseDialogueOptionsText("   \n\t  ", new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
             foreach (var opt in result)
             {
@@ -272,7 +272,7 @@ OPTION_4
 [STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""Valid too""";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Wit, StatType.Honesty, StatType.Chaos });
             Assert.Equal(4, result.Length);
             // The invalid-stat option should be skipped; 3 parsed + 1 padded
         }
@@ -288,7 +288,7 @@ OPTION_4
 3. **Wit** - ""so your bio says..."" Clever approach...
 4. **Chaos** - ""what if penguins..."" Wild card...";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             Assert.Equal(4, result.Length);
             foreach (var opt in result)
             {
@@ -325,7 +325,7 @@ OPTION_4
 [STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]
 ""Honest line""";
 
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(input);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(input, new[] { StatType.Rizz, StatType.SelfAwareness, StatType.Charm, StatType.Honesty });
             Assert.Equal(4, result.Length);
             Assert.Equal(StatType.Rizz, result[0].Stat);
             Assert.Equal(StatType.SelfAwareness, result[1].Stat);

--- a/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/EngineInjectionBlockTests.cs
@@ -50,7 +50,7 @@ namespace Pinder.LlmAdapters.Tests
         public void OptionsPrompt_ContainsFormatInstruction()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(MakeDialogueContext());
-            Assert.Contains("Format: OPTION_A: [message] OPTION_B: [message] OPTION_C: [message]", result);
+            Assert.Contains("Format: OPTION_1: [message] OPTION_2: [message] OPTION_3: [message]", result);
         }
 
         [Theory]

--- a/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue544_EngineInjectionSpecTests.cs
@@ -127,14 +127,14 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Contains("Interest: 22/25", result);
         }
 
-        // Mutation: would catch if OPTION_A/B/C/D format instruction was missing
+        // Mutation: would catch if OPTION_1/2/3 format instruction was missing
         [Fact]
         public void AC1_OptionsInjection_HasOptionFormatInstruction()
         {
             var result = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
                 MakeDialogueContext());
-            Assert.Contains("OPTION_A", result);
-            Assert.Contains("OPTION_B", result);
+            Assert.Contains("OPTION_1", result);
+            Assert.Contains("OPTION_2", result);
         }
 
         // Mutation: would catch if horniness was not included when >= 6

--- a/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
@@ -58,8 +58,8 @@ namespace Pinder.LlmAdapters.Tests
             var context = MakeContextWithStake();
             var prompt = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
 
-            // The templates.yaml dialogue-options-instruction now mandates OPTION_C.
-            Assert.Contains("OPTION_C MUST", prompt);
+            // The templates.yaml dialogue-options-instruction now mandates OPTION_3.
+            Assert.Contains("the final OPTION (OPTION_3) MUST", prompt);
         }
 
         // ── test 2: stake-coverage block injected when StakeLines set ────

--- a/tests/Pinder.LlmAdapters.Tests/MetaPrefixTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/MetaPrefixTests.cs
@@ -18,7 +18,7 @@ namespace Pinder.LlmAdapters.Tests
         {
             // We test via the Anthropic parser which is the primary implementation
             var rawInput = $@"OPTION_1 [STAT: Charm] ""{input}"" [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]";
-            var result = DialogueOptionParsers.ParseDialogueOptionsText(rawInput);
+            var result = DialogueOptionParsers.ParseDialogueOptionsText(rawInput, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             
             Assert.Equal(expected, result[0].IntendedText);
         }
@@ -31,7 +31,7 @@ namespace Pinder.LlmAdapters.Tests
                     { ""stat"": ""Charm"", ""text"": ""CONTEXT: tool message"", ""callback"": ""none"", ""combo"": ""none"", ""tell_bonus"": false, ""weakness_window"": false }
                 ]
             }");
-            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json);
+            var result = DialogueOptionParsers.ParseDialogueOptionsTool(json, new[] { StatType.Charm, StatType.Honesty, StatType.Wit, StatType.Chaos });
             
             Assert.Equal("tool message", result![0].IntendedText);
         }


### PR DESCRIPTION
Closes #1170

### Summary of Changes

#### 1. Configurable Option Count
Removed all hardcoded `4` counts in the dialogue option parsing and reconciliation pipeline, replacing them with a configurable count derived from the drawn stats array (`availableStats.Length`) when available, falling back to `DefaultPaddingStats.Length` (6) when null.
- Modified files:
  - `src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs`:
    - `ParseDialogueOptionsText`: Threaded `count` derived from `availableStats.Length` or `DefaultPaddingStats.Length`. Replaced cap `parsed.Count >= 4` with `parsed.Count >= count`.
    - `ParseDialogueOptionsTool`: Threaded `count` and replaced loop break `parsed.Count >= 4` with `parsed.Count >= count`.
    - `ReconcileAndPadDialogueOptions`: Replaced padding loop limit `result.Count < 4` with `result.Count < count`, and fallback truncation `result.Count > 4` / `result.GetRange(0, 4)` with `result.Count > count` / `result.GetRange(0, count)`.
  - `src/Pinder.LlmAdapters/Anthropic/ToolSchemas.cs`:
    - Refactored the `DialogueOptions` schema definition into a builder method `GetDialogueOptions(int count)` which dynamically builds `minItems` and `maxItems` to equal `count`, preserving the legacy field `DialogueOptions` as `GetDialogueOptions(4)`.
- Added a revert-proof guard test checking `DialogueOptionParsers.cs` source code for any regression-introducing literal `4` limits.

#### 2. Label Convention Unification (NUMBERED OPTION_1..N)
- Modified `src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs` at `optionsFormatListStr` to emit `OPTION_{i+1}: [message]` instead of lettered `OPTION_A...`.
- Re-anchored the psychological stake instructions in `data/prompts/templates.yaml` off of the old fixed letter `OPTION_C` to "the final OPTION (OPTION_3)".
- Re-baselined prompt content assertions in test suites targeting the old formatting, adapting them to the new unified NUMBERED label convention.

#### 3. Single Metadata-Tag Contract / Field Parity
- Chose the cleaner test-driven synchronization verification approach: added a robust reflection-based unit test (`MetadataTags_And_ToolSchemaFields_AreIdentical`) which verifies that the regex tags extracted dynamically from the `DialogueOptionParsers` class match field-for-field (case-insensitively) with the properties defined in the dynamically generated `ToolSchemas.DialogueOptions` schema, ensuring they can never silently drift.

## DoD / Research Log

- **Build Gate:** Successfully executed `dotnet build Pinder.Core.sln -c Debug --nologo` yielding 0 errors.
- **Test Gate:** Successfully ran `dotnet test Pinder.Core.sln -c Debug --no-build --nologo`. Exactly 0 net-new failures were introduced. All newly introduced unit tests in `Issue1170_ConsolidatedCountAndMetadataParityTests` passed successfully.
- **Revert-Proof Guard:** Confirmed that the `RevertProofGuard_AssertsNoHardcodedFourInOptionPipeline` test correctly validates that no literal 4 limits exist in `DialogueOptionParsers.cs`.

## Drive-by changes
none
