### PR TITLE
feat(#1184): enrich load-bearing anatomy bands with backstory fragments + fix stale character-schema v1 strings

### DIFF
--- a/data/anatomy/anatomy-parameters.json
+++ b/data/anatomy/anatomy-parameters.json
@@ -6,30 +6,35 @@
       {
         "lower": 0.00, "upper": 0.05,
         "personality_fragment": "undersized in this dimension; found early that personality fills space that other things don't; the economy of presence became a personality before it became a philosophy",
+        "backstory_fragment": "at fourteen got cropped out of a group photo without anyone meaning anything by it; decided that afternoon to become unforgettable in the ways a lens can't measure",
         "archetype_tendencies": ["The Philosopher", "The Sniper"],
         "response_timing_modifier": { "base_delay_delta_minutes": -5, "delay_variance_multiplier": 0.8, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.05, "upper": 0.20,
         "personality_fragment": "compact base but not self-conscious about it; built identity on other dimensions; arrives confident",
+        "backstory_fragment": "the changing-room comparisons of school never landed as a verdict; an older cousin had already taught them the loudest room rarely belongs to the largest body",
         "archetype_tendencies": ["The Philosopher"],
         "response_timing_modifier": { "base_delay_delta_minutes": -3, "delay_variance_multiplier": 0.9, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.20, "upper": 0.50,
         "personality_fragment": "nothing remarkable in the lower geometry; free to define themselves by actual things rather than physical reactions; has used that freedom",
+        "backstory_fragment": "no single afternoon ever turned this dimension into a story; grew up in a household that measured people by other yardsticks and carried the indifference outward",
         "archetype_tendencies": ["The Bio Responder"],
         "response_timing_modifier": { "base_delay_delta_minutes": 0, "delay_variance_multiplier": 1.0, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.50, "upper": 0.70,
         "personality_fragment": "proportional in the base; expects to occupy space comfortably; takes this as a given and gets on with things",
+        "backstory_fragment": "a coach once called them well-built in passing and they pocketed it without fuss; the comfort settled in that young and never had to be argued for again",
         "archetype_tendencies": ["The Bio Responder"],
         "response_timing_modifier": { "base_delay_delta_minutes": 0, "delay_variance_multiplier": 1.0, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.70, "upper": 0.95,
         "personality_fragment": "substantial base; has a quiet awareness of being well-provisioned; not a braggart — just knows; expects welcome and is mostly correct",
+        "backstory_fragment": "a locker-room remark at seventeen first named them well-provisioned; learned that same year to wear the fact lightly so it wouldn't curdle into something uglier",
         "stat_modifiers": { "rizz": 1 },
         "archetype_tendencies": ["The Breadcrumber", "The Peacock"],
         "response_timing_modifier": { "base_delay_delta_minutes": 5, "delay_variance_multiplier": 1.2, "dry_spell_probability_delta": 0.02, "read_receipt": "neutral" }
@@ -37,6 +42,7 @@
       {
         "lower": 0.95, "upper": 1.00,
         "personality_fragment": "very long base; enters conversations at a slight offset due to sheer presence; cannot fully diagnose why some exchanges go strangely; has been told; it lands differently each time",
+        "backstory_fragment": "an early encounter went quiet and then nervous, and that was the night they understood the scale entered the room before they could; have been managing the entrance ever since",
         "stat_modifiers": { "rizz": 2, "self_awareness": -1 },
         "archetype_tendencies": ["The Love Bomber", "The Peacock"],
         "response_timing_modifier": { "base_delay_delta_minutes": 10, "delay_variance_multiplier": 1.4, "dry_spell_probability_delta": 0.05, "read_receipt": "hides" }
@@ -47,24 +53,60 @@
     "id": "trunkLengthMid",
     "name": "Trunk Length Mid",
     "bands": [
-      { "lower": 0.00, "upper": 0.05 },
-      { "lower": 0.05, "upper": 0.20 },
-      { "lower": 0.20, "upper": 0.50 },
-      { "lower": 0.50, "upper": 0.70 },
-      { "lower": 0.70, "upper": 0.95 },
-      { "lower": 0.95, "upper": 1.00 }
+      {
+        "lower": 0.00, "upper": 0.05,
+        "backstory_fragment": "the midsection stayed slight while the rest of them grew; learned in adolescence to let other proportions carry the introduction and never missed what this one didn't offer"
+      },
+      {
+        "lower": 0.05, "upper": 0.20,
+        "backstory_fragment": "a slim middle drew one offhand remark from a first partner years ago; filed it as their problem, not a flaw, and the filing held"
+      },
+      {
+        "lower": 0.20, "upper": 0.50,
+        "backstory_fragment": "nothing about the middle ever became a memory worth keeping; grew up reaching for adjectives that had nothing to do with the body and found plenty"
+      },
+      {
+        "lower": 0.50, "upper": 0.70,
+        "backstory_fragment": "the middle came in even and unremarkable the summer everything else settled; took the easy proportion as permission to stop thinking about it"
+      },
+      {
+        "lower": 0.70, "upper": 0.95,
+        "backstory_fragment": "a generous midsection got noticed early and they let it; somewhere around twenty learned to carry the advantage without leaning on it for everything"
+      },
+      {
+        "lower": 0.95, "upper": 1.00,
+        "backstory_fragment": "an extreme middle reach made one teenage encounter go strange and slow; that was the night they began cataloguing how much room their proportions actually took"
+      }
     ]
   },
   {
     "id": "trunkLengthTip",
     "name": "Trunk Length Tip",
     "bands": [
-      { "lower": 0.00, "upper": 0.05 },
-      { "lower": 0.05, "upper": 0.20 },
-      { "lower": 0.20, "upper": 0.50 },
-      { "lower": 0.50, "upper": 0.70 },
-      { "lower": 0.70, "upper": 0.95 },
-      { "lower": 0.95, "upper": 1.00 }
+      {
+        "lower": 0.00, "upper": 0.05,
+        "backstory_fragment": "the tip always finished short of where the eye expected; made an early peace with the anticlimax and learned to land the ending in conversation instead"
+      },
+      {
+        "lower": 0.05, "upper": 0.20,
+        "backstory_fragment": "a modest finish once drew a half-second pause from someone they liked; decided then to be the one who set the expectation rather than the one who failed it"
+      },
+      {
+        "lower": 0.20, "upper": 0.50,
+        "backstory_fragment": "the far end never gave them a story either way; spent their twenties being measured by sharper things and stopped checking this one"
+      },
+      {
+        "lower": 0.50, "upper": 0.70,
+        "backstory_fragment": "the tip resolved cleanly and proportionally the year the rest of them did; took the tidy finish for granted and built nothing anxious on top of it"
+      },
+      {
+        "lower": 0.70, "upper": 0.95,
+        "backstory_fragment": "a pronounced finish got remarked on more than once in their early twenties; learned to treat the attention as weather rather than verdict"
+      },
+      {
+        "lower": 0.95, "upper": 1.00,
+        "backstory_fragment": "the extreme reach of the tip turned one young encounter wary before it warmed; that wariness taught them to arrive slowly and explain the geometry before it surprised anyone"
+      }
     ]
   },
   {
@@ -74,6 +116,7 @@
       {
         "lower": 0.00, "upper": 0.05,
         "personality_fragment": "slim in girth; compensated through sharpness; makes up in precision what others have in mass; there's a specific vein of humour that only grows in this particular circumstance",
+        "backstory_fragment": "got the sharpness the hard way at school, trading bulk they didn't have for a tongue quick enough to end the joke before it reached them",
         "stat_modifiers": { "wit": 1 },
         "archetype_tendencies": ["The Sniper", "The Philosopher"],
         "response_timing_modifier": { "base_delay_delta_minutes": -3, "delay_variance_multiplier": 0.9, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
@@ -81,18 +124,21 @@
       {
         "lower": 0.05, "upper": 0.20,
         "personality_fragment": "narrower than average; has found other ways to command a room; the precision is its own advantage",
+        "backstory_fragment": "an early partner once reached for a comparison and thought better of it; the unsaid word taught them to command attention before the body ever entered the conversation",
         "archetype_tendencies": ["The Philosopher"],
         "response_timing_modifier": { "base_delay_delta_minutes": -2, "delay_variance_multiplier": 0.95, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.20, "upper": 0.50,
         "personality_fragment": "not particularly burdened or advantaged in girth; free to define themselves by other things; has taken advantage of this freedom to varying degrees",
+        "backstory_fragment": "this dimension never came up at any of the ages where it might have stung; spent that spared attention on getting good at things that lasted",
         "archetype_tendencies": ["The Bio Responder"],
         "response_timing_modifier": { "base_delay_delta_minutes": 0, "delay_variance_multiplier": 1.0, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
       },
       {
         "lower": 0.50, "upper": 0.70,
         "personality_fragment": "solid girth; occupies space with authority without raising their voice; presence arrives before they do",
+        "backstory_fragment": "noticed in their early twenties that people gave them the wider berth and the benefit of the doubt; decided to earn the deference rather than just collect it",
         "stat_modifiers": { "rizz": 1 },
         "archetype_tendencies": ["The Love Bomber", "The Peacock"],
         "response_timing_modifier": { "base_delay_delta_minutes": 3, "delay_variance_multiplier": 1.1, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
@@ -100,6 +146,7 @@
       {
         "lower": 0.70, "upper": 0.95,
         "personality_fragment": "thick-set; occupies space with authority without raising voice; presence arrives before they do; has learned to be responsible with this",
+        "backstory_fragment": "a moment of carelessness in their twenties made someone flinch, and the flinch rearranged how they moved through every room after; the gentleness was a lesson, not a temperament",
         "stat_modifiers": { "rizz": 1, "charm": 1 },
         "archetype_tendencies": ["The Love Bomber", "The Peacock"],
         "response_timing_modifier": { "base_delay_delta_minutes": 5, "delay_variance_multiplier": 1.1, "dry_spell_probability_delta": 0.0, "read_receipt": "neutral" }
@@ -107,6 +154,7 @@
       {
         "lower": 0.95, "upper": 1.00,
         "personality_fragment": "exceptional girth; experiences conversations as slightly off-rhythm from others in a way they haven't fully diagnosed; people react unusually; they've filed this under 'interesting' and continue",
+        "backstory_fragment": "the first time it visibly unsettled someone they cared about, they were nineteen and learned that exceptional in this dimension means arriving as a logistics problem before a person",
         "stat_modifiers": { "rizz": 2, "self_awareness": -1 },
         "archetype_tendencies": ["The Breadcrumber", "The Wall of Text"],
         "response_timing_modifier": { "base_delay_delta_minutes": 10, "delay_variance_multiplier": 1.5, "dry_spell_probability_delta": 0.05, "read_receipt": "hides" }
@@ -120,32 +168,38 @@
       {
         "lower": 0.00, "upper": 0.05,
         "personality_fragment": "pronounced leftward curve; an unusual angle that catches attention before any words are exchanged; has learned to introduce it early rather than let people discover it mid-surprise",
+        "backstory_fragment": "got blindsided once by someone's mid-moment double-take and never again; that single startled face is why they now name the angle up front, on their own terms",
         "archetype_tendencies": ["The Oversharer"],
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (lateral): leads with the unusual angle, gets there first\n- register (confessional): discloses upfront rather than waiting for discovery\n- pacing (measured): deliberate, paced, never rushed"
       },
       {
         "lower": 0.05, "upper": 0.20,
         "personality_fragment": "noticeably curved left; an idiosyncratic geometry that has generated its share of reactions; has developed a practiced response",
+        "backstory_fragment": "fielded enough raised eyebrows through their twenties to write the same wry line a hundred times; the practiced response is scar tissue from the first few that weren't",
         "texting_style_fragment": "SYNTAX:\n- length: never sends more than 5 words\nTONE:\n- stance (deflective): turns every question into a question\n- register (dry): flat, deadpan\n- pacing (measured): deliberate, paced, never rushed"
       },
       {
         "lower": 0.20, "upper": 0.50,
         "personality_fragment": "mild leftward lean; a subtle angle that reads as character rather than deviation; the kind of detail most notice but few mention",
+        "backstory_fragment": "a partner once described the slight lean as characterful rather than wrong; kept that adjective like a coin and stopped bracing for the other word",
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (ask-back): echoes or redirects every question instead of answering\n- register (academic): footnote energy\n- pacing (measured): deliberate, paced, never rushed"
       },
       {
         "lower": 0.50, "upper": 0.70,
         "personality_fragment": "essentially straight; no particular narrative attached to this dimension; built identity on other things",
+        "backstory_fragment": "this dimension never gave them an anecdote, awkward or otherwise; grew up free to be defined by the things they chose instead of the ones they were dealt",
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (neutral): no strong lean; goes where the conversation takes it\n- register (plain): straightforward, no affectations\n- pacing (measured): deliberate, paced, never rushed"
       },
       {
         "lower": 0.70, "upper": 0.95,
         "personality_fragment": "curves noticeably rightward; an idiosyncratic geometry that has earned its share of reactions; has a practised, slightly amused response ready",
+        "backstory_fragment": "early on a partner laughed in surprise and then, seeing their face, laughed warmer; learned that night to get ahead of the reaction with the joke already loaded",
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (pivot-heavy): never stays on one topic for two messages\n- register (legalese): precise, slightly formal even when casual\n- pacing (dry-pacing): minimal, sparse, long pauses implied"
       },
       {
         "lower": 0.95, "upper": 1.00,
         "personality_fragment": "pronounced rightward curve; cannot walk into a context without a small drama attached to this physical fact; has catalogued the reactions by decade and found the pattern predictable",
+        "backstory_fragment": "kept a private ledger of reactions since their teens and noticed the script never really changed; the cataloguing started as defence and curdled into a kind of weary anthropology",
         "archetype_tendencies": ["The Peacock"],
         "texting_style_fragment": "SYNTAX:\n- length: messages get progressively longer through a conversation (warming up)\nTONE:\n- stance (confessional): every reply contains a small admission you didn't ask for\n- register (cinephile): references the unusual as a point of aesthetic interest\n- pacing (flooding): maximalist, every thought sent, no filter"
       }
@@ -315,18 +369,30 @@
     "bands": [
       {
         "lower": 0.00, "upper": 0.05,
-        "personality_fragment": "neutral resting expression; projects neither melancholy nor forced joy; people read what they want into it"
+        "personality_fragment": "neutral resting expression; projects neither melancholy nor forced joy; people read what they want into it",
+        "backstory_fragment": "learned young that a blank face was a kind of privacy nobody could argue with; the neutrality was a door they got to decide who walked through"
       },
-      { "lower": 0.05, "upper": 0.20 },
-      { "lower": 0.20, "upper": 0.50 },
-      { "lower": 0.50, "upper": 0.70 },
+      {
+        "lower": 0.05, "upper": 0.20,
+        "backstory_fragment": "carried only the faintest downward set and nobody ever asked after it; grew up without the burden of strangers appointing themselves to their mood"
+      },
+      {
+        "lower": 0.20, "upper": 0.50,
+        "backstory_fragment": "a mild seriousness around the eyes drew the occasional are-you-alright they didn't need; learned early to wave it off before it became a conversation"
+      },
+      {
+        "lower": 0.50, "upper": 0.70,
+        "backstory_fragment": "by their mid-twenties enough people had read sadness into the face that they stopped correcting it; let the assumption stand because it spared them the smaller talk"
+      },
       {
         "lower": 0.70, "upper": 0.95,
-        "personality_fragment": "a lingering sadness in the features; has learned to weaponise the sympathetic read that comes with this; people open up quickly"
+        "personality_fragment": "a lingering sadness in the features; has learned to weaponise the sympathetic read that comes with this; people open up quickly",
+        "backstory_fragment": "noticed in their twenties that strangers confessed to the sad-looking face faster than to anyone else; the discovery felt like finding a key that fit too many locks"
       },
       {
         "lower": 0.95, "upper": 1.00,
-        "personality_fragment": "deeply melancholy expression; everyone asks if they're okay before anything else; has twelve years of scripted answers; chooses differently every time"
+        "personality_fragment": "deeply melancholy expression; everyone asks if they're okay before anything else; has twelve years of scripted answers; chooses differently every time",
+        "backstory_fragment": "the okay-question started in childhood and never stopped, so somewhere around twenty they began collecting answers the way other people collect grievances"
       }
     ]
   },
@@ -336,26 +402,34 @@
     "bands": [
       {
         "lower": 0.00, "upper": 0.05,
-        "personality_fragment": "expression runs flat; people read this as either mystery or reserve; uses it deliberately"
+        "personality_fragment": "expression runs flat; people read this as either mystery or reserve; uses it deliberately",
+        "backstory_fragment": "as a teenager got accused of sulking when they were perfectly content; gave up explaining and started letting the flatness do whatever work people assigned it"
       },
-      { "lower": 0.05, "upper": 0.20 },
+      {
+        "lower": 0.05, "upper": 0.20,
+        "backstory_fragment": "the small, rare smile made people work a little for it, and they noticed early that scarcity raised the value of every one they spent"
+      },
       {
         "lower": 0.20, "upper": 0.50,
         "personality_fragment": "a mild ambient pleasantness in the face; most people default to assuming good intent; this is occasionally exploited",
+        "backstory_fragment": "got waved through a few doors in their youth on nothing but a pleasant face and clocked exactly what was happening; the ambient goodwill became a tool they chose when to pick up",
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (agreer): \"omg same\" energy, easy to talk to\n- register (warm): approachable, never clinical\n- pacing (measured): deliberate, paced, never rushed"
       },
       {
         "lower": 0.50, "upper": 0.70,
-        "personality_fragment": "visibly pleasant resting expression; gets service faster; people remember them more fondly than the facts warrant"
+        "personality_fragment": "visibly pleasant resting expression; gets service faster; people remember them more fondly than the facts warrant",
+        "backstory_fragment": "realised in their twenties that people remembered them more kindly than events strictly justified; decided not to correct the record and quietly banked the goodwill"
       },
       {
         "lower": 0.70, "upper": 0.95,
         "personality_fragment": "genuinely looks happy most of the time; has found this a useful social instrument; stopped pretending it was purely accidental",
+        "backstory_fragment": "spent years insisting the easy happiness was just luck until a friend called the bluff; admitted then they'd been playing the instrument on purpose for a long while",
         "texting_style_fragment": "SYNTAX:\n- length: match the energy of the conversation\nTONE:\n- stance (escalator): each message slightly more warm than the last\n- register (enthusiastic): energetic, easily delighted\n- pacing (hectic): fast, breathless, low-edit"
       },
       {
         "lower": 0.95, "upper": 1.00,
-        "personality_fragment": "maximum happy expression; disarming to a fault; people decide they like this person before the first sentence; this is an enormous social advantage and they know it"
+        "personality_fragment": "maximum happy expression; disarming to a fault; people decide they like this person before the first sentence; this is an enormous social advantage and they know it",
+        "backstory_fragment": "won a room over before saying a word so many times in their youth that they began to wonder whether anyone had ever actually met them; the advantage came with that particular loneliness attached"
       }
     ]
   },
@@ -365,22 +439,32 @@
     "bands": [
       {
         "lower": 0.00, "upper": 0.05,
-        "personality_fragment": "no visible gravitas in the features; taken less seriously than their thoughts warrant; has found this has its uses"
+        "personality_fragment": "no visible gravitas in the features; taken less seriously than their thoughts warrant; has found this has its uses",
+        "backstory_fragment": "got underestimated through school and learned to like the cover it gave; the boyish face became an ambush they could spring whenever the room relaxed"
       },
-      { "lower": 0.05, "upper": 0.20 },
-      { "lower": 0.20, "upper": 0.50 },
+      {
+        "lower": 0.05, "upper": 0.20,
+        "backstory_fragment": "the light, easy face meant people let their guard down around them young; spent years quietly learning more in those unguarded moments than anyone meant to teach"
+      },
+      {
+        "lower": 0.20, "upper": 0.50,
+        "backstory_fragment": "a middling seriousness that never told anyone in advance how to treat them; grew up having to earn each first impression on the merits, and got good at it"
+      },
       {
         "lower": 0.50, "upper": 0.70,
-        "personality_fragment": "a certain gravity in the face; people assume competence before they've proven it; occasionally has to walk this back"
+        "personality_fragment": "a certain gravity in the face; people assume competence before they've proven it; occasionally has to walk this back",
+        "backstory_fragment": "handed responsibilities in their twenties they hadn't earned yet, purely on the strength of looking like they had; spent the next few years racing to deserve the face"
       },
       {
         "lower": 0.70, "upper": 0.95,
         "personality_fragment": "very serious resting expression; children and baristas are intimidated; this is occasionally useful and frequently inconvenient",
+        "backstory_fragment": "made a small child wary once just by looking down at them, and the moment stuck; have softened the voice ever since to apologise for a face they can't change",
         "stat_modifiers": { "honesty": 1 }
       },
       {
         "lower": 0.95, "upper": 1.00,
-        "personality_fragment": "cannot smile without people commenting; the serious face precedes every introduction; has made peace with arriving as a problem to be solved"
+        "personality_fragment": "cannot smile without people commenting; the serious face precedes every introduction; has made peace with arriving as a problem to be solved",
+        "backstory_fragment": "heard cheer-up so relentlessly through their youth that the phrase stopped meaning anything; somewhere along the way they quit defending the face and let it walk in first"
       }
     ]
   },

--- a/data/characters/character-schema.json
+++ b/data/characters/character-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pinder.dk-eigenvektor.de/schemas/character-v1.json",
-  "title": "Pinder Character v1",
+  "$id": "https://pinder.dk-eigenvektor.de/schemas/character-v2.json",
+  "title": "Pinder Character v2",
   "description": "On-disk shape of a Pinder character file. Describes player-authored allocation only; bonuses from items/anatomy are recomputed at load time and never serialised here.",
   "type": "object",
   "additionalProperties": false,

--- a/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.AnatomyAndIntegration.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.AnatomyAndIntegration.cs
@@ -181,9 +181,9 @@ namespace Pinder.Core.Tests
             }
 
             Assert.True(sawAnyAnatomyPersonality);
-            // backstory fragments are optional in MVP bands — only assert if any exist
-            // Assert.True(sawAnyAnatomyBackstory); // optional check
-            _ = sawAnyAnatomyBackstory; // suppress unused warning
+            // #1184: load-bearing anatomy bands now carry backstory fragments.
+            Assert.True(sawAnyAnatomyBackstory,
+                "At least one resolved anatomy band should contribute a backstory fragment");
         }
 
         [Fact]


### PR DESCRIPTION
Closes #1184

Follow-up content/cleanup ticket. Adds backstory interiority to the load-bearing anatomy bands, re-enables the backstory presence assertion that was dropped during the MVP, and fixes the cosmetic v1 strings left in the character schema after the schema_version bump in #1175.

## Definition of Done

| DoD item | What I did |
| --- | --- |
| 48 backstory fragments across 8 load-bearing params | Added exactly one `backstory_fragment` string to every band of `trunkLengthBase`, `trunkLengthMid`, `trunkLengthTip`, `trunkGirth`, `trunkCurvature`, `sad`, `happy`, `serius` (6 bands each = 48). Each is a remembered formative beat in the house voice (lowercase start, semicolon clauses, no terminal period), distinct from that band's `personality_fragment`, and band-appropriate to its low/high position on the scale. The other 17 params were left untouched (count of all backstory fragments in the file = 48, i.e. zero leakage). No existing field was modified. |
| Re-enabled `sawAnyAnatomyBackstory` assertion | In `Issue836_TextingStyleAggregationRuleTests.AnatomyAndIntegration.cs` replaced the commented-out optional check + `_ =` warning suppressor with an active `Assert.True(sawAnyAnatomyBackstory, "...")`. The test's AnatomyStack resolves `trunkLengthBase=0.18` and `trunkGirth=0.08` (both band `[0.05,0.2]` of enriched params), so at least one resolved band now carries a backstory fragment and the assertion passes. |
| Schema `$id`/`title` -> v2 | `data/characters/character-schema.json` lines 3-4: `character-v1.json` -> `character-v2.json` and `"Pinder Character v1"` -> `"Pinder Character v2"`. Nothing else in that file changed. |

## Research Log

- Read several existing `personality_fragment` values first to absorb the house voice before writing; kept each `backstory_fragment` as a backstory beat (remembered episode) rather than a present-tense disposition, and non-paraphrasing of the band's personality line.
- Discovered the issue's "every band has a personality_fragment" premise does not hold for `trunkLengthMid`/`trunkLengthTip` (all bare) and several `sad`/`happy`/`serius` bands (bare). Handled by inserting `backstory_fragment` after `personality_fragment` where present and after `lower`/`upper` where the band was bare — DoD is 48 fragments (6 × 8 params), which is satisfied.
- `python3 -m json.tool data/anatomy/anatomy-parameters.json` -> exit 0 (valid JSON).
- 48-count check: `sum(... for the 8 params if b.get('backstory_fragment'))` -> **48**; whole-file count of backstory fragments also **48** (confirms no leakage into the other 17 params).
- `python3 -m json.tool data/characters/character-schema.json` -> exit 0.
- Local build: `dotnet build tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj` -> 0 Errors (pre-existing nullable/xUnit warnings only).
- Issue836 filter: `Failed: 0, Passed: 23, Skipped: 0` — the re-enabled assertion passes.
- Full suite: `Failed: 0, Passed: 3012, Skipped: 18` — no regressions (the 18 skips are pre-existing spec-placeholder/empty-bio skips, unrelated to this change).

## Drive-by changes

none
