### PR TITLE
feat(#1179): wire archetypes_enabled ON path through session-runner + HarnessCharacterLoader; remove dead GameSession field

### DIFF
--- a/session-runner/Program.CharacterLoader.cs
+++ b/session-runner/Program.CharacterLoader.cs
@@ -14,13 +14,14 @@ partial class Program
         string? defPath,
         string? name,
         ref IItemRepository? itemRepo,
-        ref IAnatomyRepository? anatomyRepo)
+        ref IAnatomyRepository? anatomyRepo,
+        bool archetypesEnabled = false)
     {
         // Explicit --player-def / --datee-def takes priority.
         if (defPath != null)
         {
             EnsureReposLoaded(ref itemRepo, ref anatomyRepo);
-            return CharacterDefinitionLoader.Load(defPath, itemRepo!, anatomyRepo!);
+            return CharacterDefinitionLoader.Load(defPath, itemRepo!, anatomyRepo!, archetypesEnabled);
         }
 
         // --player / --datee name: resolve through DirectoryCharacterStore
@@ -49,7 +50,7 @@ partial class Program
             if (def == null)
                 throw new InvalidOperationException(
                     $"DirectoryCharacterStore at {charactersDir} did not surface character_id {id} from {charDefPath}");
-            return CharacterDefinitionLoader.Assemble(def, itemRepo!, anatomyRepo!);
+            return CharacterDefinitionLoader.Assemble(def, itemRepo!, anatomyRepo!, archetypesEnabled);
         }
 
         throw new InvalidOperationException("Neither definition path nor name provided");

--- a/session-runner/Program.Setup.cs
+++ b/session-runner/Program.Setup.cs
@@ -82,6 +82,25 @@ partial class Program
             Path.Combine(AppContext.BaseDirectory, "data", "prompts"),
             Console.Error);
 
+        // Load game-definition.yaml if present. Hoisted above character
+        // loading (#1179) so result.GameDef.ArchetypesEnabled is known before
+        // characters are assembled — the assembler gates archetype injection on
+        // this flag. The load depends only on AppContext.BaseDirectory +
+        // DataFileLocator and has no dependency on character data.
+        string? gameDefPath = DataFileLocator.FindDataFile(AppContext.BaseDirectory, Path.Combine("data", "game-definition.yaml"));
+        result.GameDef = null;
+        if (gameDefPath != null)
+        {
+            try
+            {
+                result.GameDef = GameDefinition.LoadFrom(File.ReadAllText(gameDefPath));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WARN] Failed to load game-definition.yaml: {ex.Message}");
+            }
+        }
+
         if (result.IsResimulation)
         {
             result.PlaytestDir = SessionFileCounter.ResolvePlaytestDirectory(AppContext.BaseDirectory);
@@ -106,8 +125,9 @@ partial class Program
 
             try
             {
-                result.Sable = LoadCharacter(playerDefArg, playerArg, ref itemRepo, ref anatomyRepo);
-                result.Brick = LoadCharacter(dateeDefArg, dateeArg, ref itemRepo, ref anatomyRepo);
+                bool archetypesEnabled = result.GameDef?.ArchetypesEnabled ?? false;
+                result.Sable = LoadCharacter(playerDefArg, playerArg, ref itemRepo, ref anatomyRepo, archetypesEnabled);
+                result.Brick = LoadCharacter(dateeDefArg, dateeArg, ref itemRepo, ref anatomyRepo, archetypesEnabled);
             }
             catch (FileNotFoundException ex)
             {
@@ -178,21 +198,6 @@ partial class Program
         PrintSetupDetails(result);
 
         // ── LLM + session setup ───────────────────────────────────────────
-        // Load game-definition.yaml if present
-        string? gameDefPath = DataFileLocator.FindDataFile(AppContext.BaseDirectory, Path.Combine("data", "game-definition.yaml"));
-        result.GameDef = null;
-        if (gameDefPath != null)
-        {
-            try
-            {
-                result.GameDef = GameDefinition.LoadFrom(File.ReadAllText(gameDefPath));
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[WARN] Failed to load game-definition.yaml: {ex.Message}");
-            }
-        }
-
         // Resolve maxTurns: CLI arg overrides YAML, YAML overrides default (30)
         result.MaxTurns = maxTurnsArg > 0 ? maxTurnsArg : (result.GameDef?.MaxTurns ?? 30);
 

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -142,7 +142,6 @@ namespace Pinder.Core.Conversation
         private readonly IConsequenceCatalog? _consequenceCatalog;
         private readonly int _maxDialogueOptions;
         private readonly int _maxDeliveryWords;
-        private readonly bool _archetypesEnabled;
 
         internal GameSessionState State => _state;
 
@@ -235,7 +234,6 @@ namespace Pinder.Core.Conversation
             _consequenceCatalog = config.ConsequenceCatalog;
             _maxDialogueOptions = config.MaxDialogueOptions ?? 3;
             _maxDeliveryWords = config.MaxDeliveryWords ?? 80;
-            _archetypesEnabled = config.ArchetypesEnabled;
             _steeringEngine = new SteeringEngine(steeringRng);
             _horninessEngine = new HorninessEngine(steeringRng, _consequenceCatalog, _horninessDcBias);
             _shadowCheckEngine = new ShadowCheckEngine(steeringRng, _consequenceCatalog, _shadowDcBias);

--- a/src/Pinder.NarrativeHarness/HarnessCharacterLoader.cs
+++ b/src/Pinder.NarrativeHarness/HarnessCharacterLoader.cs
@@ -56,7 +56,7 @@ namespace Pinder.Tools.NarrativeHarness
                     nameof(slug));
         }
 
-        public static LoadedCharacter Load(string slug)
+        public static LoadedCharacter Load(string slug, bool archetypesEnabled = false)
         {
             // Guard first: reject structurally-unsafe slugs before constructing
             // any filesystem path. Valid-but-missing slugs still fall through to
@@ -97,7 +97,7 @@ namespace Pinder.Tools.NarrativeHarness
                 throw new InvalidOperationException(
                     $"DirectoryCharacterStore at {charactersDir} did not surface character_id {id}.");
 
-            CharacterProfile profile = CharacterDefinitionLoader.Assemble(def, itemRepo, anatomyRepo);
+            CharacterProfile profile = CharacterDefinitionLoader.Assemble(def, itemRepo, anatomyRepo, archetypesEnabled);
             return new LoadedCharacter(profile, def);
         }
 

--- a/tests/Pinder.Core.Tests/Issue1179_ArchetypesEnabledOnPathTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1179_ArchetypesEnabledOnPathTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using Pinder.Core.Characters;
+using Pinder.Core.Data;
+using Pinder.Core.Interfaces;
+using Pinder.SessionSetup;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Issue #1179: prove the archetypes_enabled ON path is wired end-to-end
+    /// through the production load entry point
+    /// (<see cref="CharacterDefinitionLoader.Load"/>). #1174 added the flag and
+    /// the suppression (OFF) path; this verifies that passing
+    /// archetypesEnabled:true genuinely injects archetype content into the
+    /// assembled system prompt of a REAL character (zyx) with REAL data files,
+    /// and that the default / false path suppresses it.
+    ///
+    /// The PromptCatalog framing strings ("ACTIVE ARCHETYPE") are wired by the
+    /// test assembly's module initializer (CoreTestWiring) before any [Fact]
+    /// runs, so the production prompt assembly has the catalog available.
+    /// </summary>
+    [Collection("StaticWiring")]
+    public class Issue1179_ArchetypesEnabledOnPathTests
+    {
+        // Resolved by running the real production load against zyx with the real
+        // archetype catalog (see Research Log in the PR). Asserting on the
+        // concrete name proves the injection is non-vacuous.
+        private const string ZyxArchetypeName = "The Wall of Text";
+
+        private readonly ITestOutputHelper _output;
+
+        public Issue1179_ArchetypesEnabledOnPathTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private static string RepoRoot
+        {
+            get
+            {
+                string? dir = AppContext.BaseDirectory;
+                while (dir != null)
+                {
+                    if (Directory.Exists(Path.Combine(dir, "data")) &&
+                        Directory.Exists(Path.Combine(dir, "src")))
+                        return dir;
+                    dir = Directory.GetParent(dir)?.FullName;
+                }
+                throw new InvalidOperationException("Cannot find repo root from " + AppContext.BaseDirectory);
+            }
+        }
+
+        private static IItemRepository LoadItemRepo()
+        {
+            string json = File.ReadAllText(
+                Path.Combine(RepoRoot, "data", "items", "starter-items.json"));
+            return new JsonItemRepository(json);
+        }
+
+        private static IAnatomyRepository LoadAnatomyRepo()
+        {
+            string json = File.ReadAllText(
+                Path.Combine(RepoRoot, "data", "anatomy", "anatomy-parameters.json"));
+            return new JsonAnatomyRepository(json);
+        }
+
+        private static string ZyxPath =>
+            Path.Combine(RepoRoot, "data", "characters", "zyx.json");
+
+        [Fact]
+        public void Load_Zyx_ArchetypesEnabled_InjectsArchetypeContent()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            var profile = CharacterDefinitionLoader.Load(
+                ZyxPath, itemRepo, anatomyRepo, archetypesEnabled: true);
+
+            _output.WriteLine($"Resolved ActiveArchetype: {profile.ActiveArchetype?.Name ?? "(null)"}");
+
+            Assert.NotNull(profile.ActiveArchetype);
+            Assert.Equal(ZyxArchetypeName, profile.ActiveArchetype!.Name);
+
+            Assert.Contains("ACTIVE ARCHETYPE", profile.AssembledSystemPrompt, StringComparison.Ordinal);
+            // Non-vacuous: the concrete resolved archetype name must appear.
+            Assert.Contains(ZyxArchetypeName, profile.AssembledSystemPrompt, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Load_Zyx_ArchetypesDisabled_SuppressesArchetypeContent()
+        {
+            var itemRepo = LoadItemRepo();
+            var anatomyRepo = LoadAnatomyRepo();
+
+            // Explicit false.
+            var profileFalse = CharacterDefinitionLoader.Load(
+                ZyxPath, itemRepo, anatomyRepo, archetypesEnabled: false);
+
+            Assert.Null(profileFalse.ActiveArchetype);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", profileFalse.AssembledSystemPrompt, StringComparison.Ordinal);
+            Assert.DoesNotContain(ZyxArchetypeName, profileFalse.AssembledSystemPrompt, StringComparison.Ordinal);
+
+            // Default 3-arg overload must also suppress (default flag is false/OFF).
+            var profileDefault = CharacterDefinitionLoader.Load(ZyxPath, itemRepo, anatomyRepo);
+
+            Assert.Null(profileDefault.ActiveArchetype);
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", profileDefault.AssembledSystemPrompt, StringComparison.Ordinal);
+            Assert.DoesNotContain(ZyxArchetypeName, profileDefault.AssembledSystemPrompt, StringComparison.Ordinal);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue1179_HarnessArchetypesOnPathTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1179_HarnessArchetypesOnPathTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Pinder.Tools.NarrativeHarness;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Issue #1179: prove the archetypes_enabled ON path is wired through the
+    /// narrative-harness load entry point (<see cref="HarnessCharacterLoader.Load"/>).
+    ///
+    /// #1174 added the flag plumbing; this verifies the new optional
+    /// archetypesEnabled parameter threads through to
+    /// CharacterDefinitionLoader.Assemble so the harness can produce the same
+    /// archetype-injected system prompt the session-runner does when the flag is
+    /// ON — while the default (1-arg) call still suppresses archetypes (OFF).
+    /// </summary>
+    public class Issue1179_HarnessArchetypesOnPathTests
+    {
+        // The real archetype zyx resolves with the production catalog (verified
+        // by Pinder.Core.Tests.Issue1179_ArchetypesEnabledOnPathTests).
+        private const string ZyxArchetypeName = "The Wall of Text";
+
+        [Fact]
+        public void Load_Zyx_ArchetypesEnabled_InjectsArchetypeContent()
+        {
+            var loaded = HarnessCharacterLoader.Load("zyx", archetypesEnabled: true);
+
+            Assert.Contains("ACTIVE ARCHETYPE", loaded.AssembledSystemPrompt, StringComparison.Ordinal);
+            Assert.Contains(ZyxArchetypeName, loaded.AssembledSystemPrompt, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Load_Zyx_Default_SuppressesArchetypeContent()
+        {
+            // Default (1-arg) overload keeps the OFF behaviour.
+            var loaded = HarnessCharacterLoader.Load("zyx");
+
+            Assert.DoesNotContain("ACTIVE ARCHETYPE", loaded.AssembledSystemPrompt, StringComparison.Ordinal);
+            Assert.DoesNotContain(ZyxArchetypeName, loaded.AssembledSystemPrompt, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1179

Wires the `archetypes_enabled` game-definition flag's ON (injection) path
end-to-end. #1174 added the flag (default OFF) and wired the OFF/suppression
path, plus the plumbing in `CharacterDefinitionLoader.Load/Assemble`,
`CharacterAssembler.Assemble`, and `PromptBuilder.BuildSystemPrompt` (all gate
on a `bool archetypesEnabled = false` param). The two production LOAD entry
points never passed the flag, so `archetypes_enabled: true` could never actually
enable archetypes. This PR threads the flag through both entry points.

## Definition of Done

- [x] **ON path wired through session-runner** — `Program.Setup.cs`: the
  `game-definition.yaml` load block is **hoisted** to run before character
  loading (it depends only on `AppContext.BaseDirectory` + `DataFileLocator` and
  has no character-data dependency), so `result.GameDef.ArchetypesEnabled` is
  known when characters are assembled. The flag is then threaded into both
  `LoadCharacter` calls. `Program.CharacterLoader.cs`: `LoadCharacter` gains a
  `bool archetypesEnabled = false` param, passed into both
  `CharacterDefinitionLoader.Load` and `CharacterDefinitionLoader.Assemble`.
  No duplicate game-def load left behind; all later `result.GameDef?....` reads
  (MaxTurns, horniness modifiers, DC biases, config) remain after the (now
  earlier) load — verified by a clean solution build.
- [x] **ON path wired through HarnessCharacterLoader** —
  `HarnessCharacterLoader.Load` gains an optional `bool archetypesEnabled =
  false` param threaded into its `Assemble` call. The existing 1-arg callers
  (e.g. `Issue859_HarnessSlugHardeningTests`) compile and pass unchanged.
- [x] **Dead GameSession field removed** — `GameSession._archetypesEnabled`
  (assigned from `config.ArchetypesEnabled`, never read; archetype suppression
  happens upstream at character-assembly time) is deleted along with its
  assignment. `GameSessionConfig.ArchetypesEnabled` is **intentionally
  retained** as the canonical config property set by session-runner.
- [x] **Integration test proving flag-ON injects archetype content
  end-to-end** — new tests load the REAL `zyx` character with REAL data files
  through the production `CharacterDefinitionLoader.Load` path and assert the
  assembled system prompt contains both `ACTIVE ARCHETYPE` and the concrete
  resolved archetype name (non-vacuous), while OFF/default suppresses both and
  leaves `ActiveArchetype` null. A parallel harness-path test covers
  `HarnessCharacterLoader.Load`.

## Research Log

- **Archetype zyx resolves:** `The Wall of Text`. (The orchestrator's note
  guessed "The Philosopher" from item votes; I ran the real production load and
  printed `profile.ActiveArchetype?.Name` — the real catalog/level filtering
  resolves it to **"The Wall of Text"**, which the tests now assert on.)
- **Project references verified:** `Pinder.Core.Tests` does NOT reference the
  NarrativeHarness project, so the harness test lives in
  `tests/Pinder.LlmAdapters.Tests/Issue1179_HarnessArchetypesOnPathTests.cs`
  (which already references `Pinder.NarrativeHarness`, alongside
  `Issue859_HarnessSlugHardeningTests`). The core load-path test lives in
  `tests/Pinder.Core.Tests/Issue1179_ArchetypesEnabledOnPathTests.cs`.
- **Build:** `dotnet build Pinder.Core.sln` → 0 errors (session-runner reorder
  compiles clean).
- **Targeted tests:** `~Issue1179` (core) 2/2 passed; `~Issue1174|~Issue859|
  ~Issue1179` (LlmAdapters) 17/17 passed.
- **Full suites:**
  - `Pinder.Core.Tests`: **Passed 3014, Failed 0, Skipped 18** (Total 3032).
  - `Pinder.LlmAdapters.Tests`: **Passed 1037, Failed 1, Skipped 0** (Total
    1038). The single failure —
    `GameDefinitionTests.LoadFrom_RealGameDefinitionYaml_Parses` (asserts the
    yaml contains "RPG similar to D&D") — is **pre-existing on origin/main**,
    unrelated to this diff: verified by stashing all changes / removing the new
    test files and re-running on a clean tree, where it still fails identically.

## Drive-by changes

none
