### PR TITLE
fix(conversation): steering question must not contaminate roll/tier text diffs

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -76,27 +76,6 @@ namespace Pinder.Core.Conversation
                 TurnProgressStage.SteeringCompleted,
                 steeringResult.SteeringSucceeded ? steeringResult.SteeringQuestion : null));
 
-            // #1125 — the picked option now carries the FULL sendable line
-            // (avatar GM emits final candidate lines; no second "delivery" LLM
-            // call expands a gist). Steering, when it fires, appends its
-            // question to that full line; this stays the pre-overlay "picked
-            // line".
-            string pickedLine = originalIntendedText;
-            if (steeringResult.SteeringSucceeded && steeringResult.SteeringQuestion != null)
-            {
-                pickedLine = originalIntendedText.Length == 0
-                    ? steeringResult.SteeringQuestion
-                    : originalIntendedText.TrimEnd() + " " + steeringResult.SteeringQuestion;
-
-                if (pickedLine != originalIntendedText
-                    && !string.IsNullOrEmpty(originalIntendedText)
-                    && originalIntendedText != "...")
-                {
-                    var steeringSpans = WordDiff.Compute(originalIntendedText, pickedLine);
-                    textDiffs.Add(new TextDiff("Steering", steeringSpans, originalIntendedText, pickedLine));
-                }
-            }
-
             string playerArchetypeDirectiveForDelivery = player.ActiveArchetype?.Directive;
             // #1125: the stat-specific failure instruction and trap/beatDcBy
             // inputs that previously fed the creative delivery PROMPT are gone —
@@ -116,7 +95,7 @@ namespace Pinder.Core.Conversation
             // and this commit overlay are ephemeral; only the committed line is
             // persisted (by TurnOrchestrator), preserving the clean-history rule.
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
-            string deliveredMessage = DeliveryOverlay.Apply(pickedLine, rollResult.Tier, rollResult.MissMargin);
+            string deliveredMessage = DeliveryOverlay.Apply(originalIntendedText, rollResult.Tier, rollResult.MissMargin);
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryCompleted, deliveredMessage));
 
             // #902 / SANITIZATION-INVARIANTS-MUST-RUN-AFTER-EACH-STAGE: meta-prefix
@@ -125,17 +104,34 @@ namespace Pinder.Core.Conversation
             // before downstream overlays. Emits a TextDiff layer when it fires.
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, MetaPrefixStripper.LayerName, textDiffs);
 
-            // Tier modifier diff: the deterministic degrade vs the picked line.
-            if (deliveredMessage != pickedLine
-                && !string.IsNullOrEmpty(pickedLine)
-                && pickedLine != "...")
+            // Tier modifier diff: the deterministic degrade vs the original pre-steering base.
+            if (deliveredMessage != originalIntendedText
+                && !string.IsNullOrEmpty(originalIntendedText)
+                && originalIntendedText != "...")
             {
                 string layerLabel = rollResult.IsNatTwenty ? "Nat 20" :
                                     rollResult.IsNatOne    ? "Nat 1"  :
                                     rollResult.Tier == Rolls.FailureTier.Success ? "Strong success" :
                                     rollResult.Tier.ToString();
-                var tierSpans = WordDiff.Compute(pickedLine, deliveredMessage);
-                textDiffs.Add(new TextDiff(layerLabel, tierSpans, pickedLine, deliveredMessage));
+                var tierSpans = WordDiff.Compute(originalIntendedText, deliveredMessage);
+                textDiffs.Add(new TextDiff(layerLabel, tierSpans, originalIntendedText, deliveredMessage));
+            }
+
+            // Steering, when it fires, appends its question to the degraded and sanitized delivery base as its own later layer
+            if (steeringResult.SteeringSucceeded && steeringResult.SteeringQuestion != null)
+            {
+                string beforeSteering = deliveredMessage;
+                deliveredMessage = beforeSteering.Length == 0
+                    ? steeringResult.SteeringQuestion
+                    : beforeSteering.TrimEnd() + " " + steeringResult.SteeringQuestion;
+
+                if (deliveredMessage != beforeSteering
+                    && !string.IsNullOrEmpty(beforeSteering)
+                    && beforeSteering != "...")
+                {
+                    var steeringSpans = WordDiff.Compute(beforeSteering, deliveredMessage);
+                    textDiffs.Add(new TextDiff("Steering", steeringSpans, beforeSteering, deliveredMessage));
+                }
             }
 
             // ---- Speculative Overlay Dispatcher ----

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -105,10 +105,8 @@ namespace Pinder.Core.Tests
 
         /// <summary>
         /// AC: On a Nat-1/Catastrophe-tier failure with a successful steering
-        /// roll, the deterministic overlay degrades the WHOLE combined
-        /// intended+steering line — the committed text is the overlay output of
-        /// "picked + question", proving the question was folded in before
-        /// degradation (no lucid question survives intact).
+        /// roll, the deterministic overlay degrades only the pre-steering base,
+        /// and then appends the clean steering question.
         /// </summary>
         [Fact]
         public async Task Catastrophe_with_steering_success_degrades_combined_text()
@@ -131,19 +129,20 @@ namespace Pinder.Core.Tests
             Assert.NotNull(result.Steering.SteeringQuestion);
             Assert.False(result.Roll.IsSuccess);
 
-            // The committed line is the deterministic overlay of the COMBINED line.
-            string combined = PickedOption + " " + result.Steering.SteeringQuestion;
-            string expected = DeliveryOverlay.Apply(combined, result.Roll.Tier, result.Roll.MissMargin);
+            // The committed line is the deterministic overlay of PickedOption, with the clean steering question appended.
+            string degradedBase = DeliveryOverlay.Apply(PickedOption, result.Roll.Tier, result.Roll.MissMargin);
+            string expected = degradedBase.TrimEnd() + " " + result.Steering.SteeringQuestion;
             Assert.Equal(expected, result.DeliveredMessage);
 
-            // And it actually degraded (differs from the clean combined line).
-            Assert.NotEqual(combined, result.DeliveredMessage);
+            // And it actually degraded (differs from the clean PickedOption plus question).
+            string combinedClean = PickedOption + " " + result.Steering.SteeringQuestion;
+            Assert.NotEqual(combinedClean, result.DeliveredMessage);
         }
 
         /// <summary>
-        /// AC: textDiffs are emitted in order Steering FIRST, tier modifier
-        /// SECOND. The Steering diff goes picked → picked+question; the tier diff
-        /// goes picked+question → committed (overlay output).
+        /// AC: textDiffs are emitted in order tier modifier FIRST, Steering SECOND.
+        /// The tier diff goes picked → degraded base; the Steering diff goes
+        /// degraded base → degraded base + question.
         /// </summary>
         [Fact]
         public async Task TextDiffs_ordering_steering_first_then_tier_modifier()
@@ -178,17 +177,17 @@ namespace Pinder.Core.Tests
 
             Assert.True(steeringIdx >= 0, "Steering diff layer must be present");
             Assert.True(tierIdx >= 0, "Tier-modifier diff layer must be present");
-            Assert.True(steeringIdx < tierIdx, $"Steering diff (idx {steeringIdx}) must appear before tier diff (idx {tierIdx})");
+            Assert.True(tierIdx < steeringIdx, $"Tier diff (idx {tierIdx}) must appear before steering diff (idx {steeringIdx})");
 
-            // Steering diff goes picked → picked+question
-            Assert.Equal(PickedOption, diffs[steeringIdx].Before);
-            Assert.Contains(result.Steering.SteeringQuestion!, diffs[steeringIdx].After);
-
-            // Tier diff goes picked+question → committed (deterministic overlay output)
-            Assert.Equal(diffs[steeringIdx].After, diffs[tierIdx].Before);
+            // Tier diff goes picked → degraded base
+            Assert.Equal(PickedOption, diffs[tierIdx].Before);
             Assert.Equal(
-                DeliveryOverlay.Apply(diffs[steeringIdx].After, result.Roll.Tier, result.Roll.MissMargin),
+                DeliveryOverlay.Apply(PickedOption, result.Roll.Tier, result.Roll.MissMargin),
                 diffs[tierIdx].After);
+
+            // Steering diff goes degraded base → degraded base + question
+            Assert.Equal(diffs[tierIdx].After, diffs[steeringIdx].Before);
+            Assert.Contains(result.Steering.SteeringQuestion!, diffs[steeringIdx].After);
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/SteeringRollTests.cs
+++ b/tests/Pinder.Core.Tests/SteeringRollTests.cs
@@ -215,5 +215,59 @@ namespace Pinder.Core.Tests
             Assert.Empty(result.DefenderGroup);
             Assert.Equal(0, result.DcBase);
         }
+
+        /// <summary>
+        /// Issue #1201: steering question must not contaminate roll/tier text diffs.
+        /// </summary>
+        [Fact]
+        public async Task SteeringQuestion_DoesNotContaminate_TierTextDiff()
+        {
+            // Player stats: Charm=5, Wit=5, SA=5 → steering mod = 5
+            var playerStats = MakeStatBlockWithValues(charm: 5, wit: 5, sa: 5);
+            // Datee stats: SA=0, Rizz=0, Honesty=0 → steering DC = 16
+            var dateeStats = MakeStatBlockWithValues(sa: 0, rizz: 0, honesty: 0);
+
+            var player = new CharacterProfile(
+                playerStats, "You are Player.", "Player",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+            var datee = new CharacterProfile(
+                dateeStats, "You are Datee.", "Datee",
+                new TimingProfile(5, 0.0f, 0.0f, "neutral"), 1);
+
+            // Dice: main d20 is 1 to force Nat 1 failure and trigger degradation
+            var dice = new FixedDice(
+                1,     // horniness roll
+                1,     // main d20 roll (Nat 1 / failure)
+                50     // response delay d100
+            );
+
+            // Steering uses separate RNG: Next(1,21) returns 20 → steering succeeds
+            var steeringRng = new FixedRandom(20);
+
+            var llm = new NullLlmAdapter();
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), steeringRng: steeringRng);
+            var session = new GameSession(player, datee, llm, dice, new NullTrapRegistry(), config);
+
+            var turnStart = await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Steering.SteeringSucceeded);
+            Assert.False(result.Roll.IsSuccess);
+            Assert.NotNull(result.Steering.SteeringQuestion);
+
+            string steeringQuestion = result.Steering.SteeringQuestion!;
+            Assert.Contains(steeringQuestion, result.DeliveredMessage);
+
+            // Find the Steering and tier-modifier layers
+            var tierDiff = result.TextDiffs.Single(d => d.LayerName == "Nat 1" || d.LayerName == "Catastrophe");
+            var steeringDiff = result.TextDiffs.Single(d => d.LayerName == "Steering");
+
+            // The tier diff Before (and After) must NOT contain the SteeringQuestion
+            Assert.DoesNotContain(steeringQuestion, tierDiff.Before);
+            Assert.DoesNotContain(steeringQuestion, tierDiff.After);
+
+            // The Steering diff After must contain the SteeringQuestion
+            Assert.Contains(steeringQuestion, steeringDiff.After);
+        }
     }
 }


### PR DESCRIPTION
Closes #1201

### Summary
Currently, when a steering question is successfully generated, it is appended to the dialogue option's text (`originalIntendedText`) to form `pickedLine` *before* the deterministic `DeliveryOverlay` is applied. This means the roll/tier degradation is performed on the combined line, causing the steering question to be degraded/contaminated, and causing the tier diff's `Before` text to include the steering question.

This PR fixes this contamination by executing the deterministic delivery degradation and meta-prefix sanitization on the pre-steering base (`originalIntendedText`). The successful steering question is then appended to the resulting base string as its own subsequent modification layer. This ensures:
1. The successful steering question appears *only* in the "Steering" `TextDiff`/layer.
2. The roll/tier diff's input/output do not contain the steering question.
3. `TurnResult.TextDiffs` remains in the actual text-modification order (Tier/Roll diff first, Steering diff second) and preserves the final `DeliveredMessage`.

### Test Plan
We added a new regression test `SteeringQuestion_DoesNotContaminate_TierTextDiff` in `SteeringRollTests.cs` and updated existing steering/delivery tests in `Issue364_SteeringBeforeDeliveryTests.cs` to align with the correct, non-contaminated behavior.

Run the test suite:
```bash
dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj -c Debug
```
Output Summary:
- Passed: 3015, Skipped: 18, Failed: 0, Total: 3033.

### DoD/Research-Log
- **Hypothesis/Design**: Separating degradation from steering by applying the `DeliveryOverlay` to `originalIntendedText` instead of the pre-combined `pickedLine`, then appending the steering question to the degraded/sanitized base ensures the tier diff is computed purely on the pre-steering base.
- **TDD**: Created `SteeringQuestion_DoesNotContaminate_TierTextDiff` test asserting that under a failed (degraded) roll with successful steering, the steering question does not appear in the tier diff `Before`/`After` values, but appears in the Steering diff, and the final delivered message includes the clean steering question. The test compiled and failed as expected on the master branch, then passed completely after implementing the production fix.
- **Verification**: Verified that all 3,000+ unit and integration tests under `Pinder.Core.Tests` pass successfully.

## Drive-by changes
None.
