### PR TITLE
feat(core): double tell, weakness window, and triple combo roll boosters

### DIFF
--- a/session-runner/PlaytestFormatter.cs
+++ b/session-runner/PlaytestFormatter.cs
@@ -153,7 +153,7 @@ namespace Pinder.SessionRunner
                 case "The Escalation": return "You played Chaos last turn, then Rizz this turn — the sequence earns +1 bonus interest.";
                 case "The Disarm": return "You played Wit last turn, then Honesty this turn — the sequence earns +1 bonus interest.";
                 case "The Recovery": return "You failed a roll last turn, then played SA this turn — the sequence earns +2 bonus interest.";
-                case "The Triple": return "You played 3 different stats in 3 consecutive turns — your next roll gains +1 bonus.";
+                case "The Triple": return "You played 3 different stats in 3 consecutive turns — your next roll gains +2 bonus.";
                 default: return "Unknown combo sequence.";
             }
         }
@@ -175,7 +175,7 @@ namespace Pinder.SessionRunner
             switch (comboName)
             {
                 case "The Recovery": return "+2 Interest if success";
-                case "The Triple": return "+1 to ALL rolls next turn";
+                case "The Triple": return "+2 to ALL rolls next turn";
                 default: return "+1 Interest if success";
             }
         }

--- a/src/Pinder.Core/Conversation/ComboResult.cs
+++ b/src/Pinder.Core/Conversation/ComboResult.cs
@@ -15,7 +15,7 @@ namespace Pinder.Core.Conversation
         public int InterestBonus { get; }
 
         /// <summary>
-        /// True only for The Triple — signals that next turn gets +1 roll bonus.
+        /// True only for The Triple — signals that next turn gets +2 roll bonus.
         /// </summary>
         public bool IsTriple { get; }
 

--- a/src/Pinder.Core/Conversation/ComboTracker.cs
+++ b/src/Pinder.Core/Conversation/ComboTracker.cs
@@ -25,7 +25,7 @@ namespace Pinder.Core.Conversation
         /// <summary>
         /// True if The Triple was completed on a previous turn and the bonus
         /// has not yet been consumed. GameSession reads this before calling
-        /// RollEngine.Resolve to pass +1 externalBonus.
+        /// RollEngine.Resolve to pass +2 externalBonus.
         /// </summary>
         public bool HasTripleBonus => _pendingTripleBonus;
 

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -26,7 +26,7 @@ namespace Pinder.Core.Conversation
         /// <summary>Current turn number (0-based before first turn).</summary>
         public int TurnNumber { get; }
 
-        /// <summary>True if The Triple bonus is active for the current turn (+1 to all rolls).</summary>
+        /// <summary>True if The Triple bonus is active for the current turn (+2 to all rolls).</summary>
         public bool TripleBonusActive { get; }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/RollResolutionStage.cs
+++ b/src/Pinder.Core/Conversation/RollResolutionStage.cs
@@ -93,14 +93,14 @@ namespace Pinder.Core.Conversation
 
             // Compute tell bonus (#50)
             bool hasTellOption = state.ActiveTell != null && chosenOption.Stat == state.ActiveTell.Stat;
-            int tellBonus = hasTellOption ? 2 : 0;
+            int tellBonus = hasTellOption ? 4 : 0;
 
             // Compute external bonus: tell + callback + Triple combo + momentum (#46, #47, #50, #268)
             int externalBonus = tellBonus + callbackBonus + state.PendingMomentumBonus;
             int tripleBonusApplied = 0;
             if (state.ComboTracker.HasTripleBonus)
             {
-                tripleBonusApplied = 1;
+                tripleBonusApplied = 2;
                 externalBonus += tripleBonusApplied;
                 state.ComboTracker.ConsumeTripleBonus(); // Consume after applying (#46 edge case 7)
             }

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs
@@ -90,7 +90,9 @@ namespace Pinder.Core.Conversation
             var dateeResponse = dateeStageResult.DateeResponse;
             string dateeMessage = dateeStageResult.DateeMessage;
 
-            state.ActiveWeakness = dateeResponse.WeaknessWindow;
+            state.ActiveWeakness = dateeResponse.WeaknessWindow != null 
+                ? new WeaknessWindow(dateeResponse.WeaknessWindow.DefendingStat, dateeResponse.WeaknessWindow.DcReduction * 2) 
+                : null;
             state.ActiveTell = dateeResponse.DetectedTell;
 
             state.History.Add((datee.DisplayName, dateeMessage));
@@ -124,13 +126,15 @@ namespace Pinder.Core.Conversation
                 comboTriggered: rollStage.ComboTriggered,
                 callbackBonusApplied: rollStage.CallbackBonus,
                 tellReadBonus: rollStage.TellBonus,
-                tellReadMessage: rollStage.TellBonus > 0 ? "📖 You read the moment. +2 bonus." : null,
+                tellReadMessage: rollStage.TellBonus > 0 ? $"📖 You read the moment. +{rollStage.TellBonus} bonus." : null,
                 xpEarned: rollStage.TurnXpEarned,
                 baseInterestDelta: rollStage.BaseInterestDelta,
                 riskBonusDelta: rollStage.RiskBonusDelta,
                 riskTier: rollStage.RollResult.RiskTier,
                 comboBonusDelta: rollStage.ComboBonusDelta,
-                detectedWindow: dateeResponse.WeaknessWindow,
+                detectedWindow: dateeResponse.WeaknessWindow != null 
+                    ? new WeaknessWindow(dateeResponse.WeaknessWindow.DefendingStat, dateeResponse.WeaknessWindow.DcReduction * 2) 
+                    : null,
                 steering: deliveryStage.SteeringResult,
                 horninessCheck: deliveryStage.HorninessCheckResult,
                 tripleBonusApplied: rollStage.TripleBonusApplied,

--- a/src/Pinder.Core/Conversation/TurnResult.cs
+++ b/src/Pinder.Core/Conversation/TurnResult.cs
@@ -95,7 +95,7 @@ namespace Pinder.Core.Conversation
         public ShadowCheckResult ShadowCheck { get; }
 
         /// <summary>
-        /// Roll bonus applied from a previous Triple combo (+1). 0 if no Triple bonus was consumed this turn.
+        /// Roll bonus applied from a previous Triple combo (+2). 0 if no Triple bonus was consumed this turn.
         /// </summary>
         public int TripleBonusApplied { get; }
 

--- a/tests/Pinder.Core.Tests/ComboGameSessionSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionSpecTests.cs
@@ -174,11 +174,11 @@ namespace Pinder.Core.Tests
             Assert.Equal("The Triple", r3.ComboTriggered);
             Assert.True(r3.StateAfter.TripleBonusActive);
 
-            // Turn 4: verify external bonus applied (triple +1 + momentum +2 from streak=3 at start, #268)
+            // Turn 4: verify external bonus applied (triple +2 + momentum +2 from streak=3 at start, #268)
             var start4 = await session.StartTurnAsync();
             Assert.True(start4.State.TripleBonusActive);
             var r4 = await session.ResolveTurnAsync(0);
-            Assert.Equal(3, r4.Roll.ExternalBonus);
+            Assert.Equal(4, r4.Roll.ExternalBonus);
             Assert.False(r4.StateAfter.TripleBonusActive); // consumed
         }
 

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -142,7 +142,7 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Tests The Triple combo: 3 distinct stats → +1 roll bonus next turn via externalBonus.
+        /// Tests The Triple combo: 3 distinct stats → +2 roll bonus next turn via externalBonus.
         /// </summary>
         [Fact]
         public async Task TheTriple_ThreeDistinctStats_RollBonusNextTurn()
@@ -154,7 +154,7 @@ namespace Pinder.Core.Tests
                 15, 50,      // Turn 1: Rizz (d20 + d100 timing)
                 15, 50,      // Turn 2: SA
                 15, 15, 50,  // Turn 3: Chaos → Triple triggers (VeryIntoIt advantage after turn 2)
-                15, 15, 50,  // Turn 4: advantage, +1 triple + 2 momentum = 3 external
+                15, 15, 50,  // Turn 4: advantage, +2 triple + 2 momentum = 4 external
                 15, 50       // Extra safety margin
             );
 
@@ -180,13 +180,13 @@ namespace Pinder.Core.Tests
             Assert.Equal(0, r3.TripleBonusApplied); // #693: bonus not yet consumed on triggering turn
             Assert.True(r3.StateAfter.TripleBonusActive);
 
-            // Turn 4: should have +1 external bonus from triple + +2 from momentum (streak=3 at start, #268)
+            // Turn 4: should have +2 external bonus from triple + +2 from momentum (streak=3 at start, #268)
             var start4 = await session.StartTurnAsync();
             Assert.True(start4.State.TripleBonusActive);
             var r4 = await session.ResolveTurnAsync(0);
-            // Roll: 15+2+0=17 base, +1 triple + 2 momentum = 3 external
-            Assert.Equal(3, r4.Roll.ExternalBonus);
-            Assert.Equal(1, r4.TripleBonusApplied); // #693: Triple bonus surfaced in TurnResult
+            // Roll: 15+2+0=17 base, +2 triple + 2 momentum = 4 external
+            Assert.Equal(4, r4.Roll.ExternalBonus);
+            Assert.Equal(2, r4.TripleBonusApplied); // #693: Triple bonus surfaced in TurnResult
             Assert.False(r4.StateAfter.TripleBonusActive); // consumed
         }
 

--- a/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
@@ -77,7 +77,7 @@ namespace Pinder.Core.Tests.Conversation
             var turn2Start = await session.StartTurnAsync();
 
             Assert.NotNull(turn2Start.WeaknessDcReduction);
-            Assert.Equal(expectedDcReduction, turn2Start.WeaknessDcReduction!.Value);
+            Assert.Equal(expectedDcReduction * 2, turn2Start.WeaknessDcReduction!.Value);
         }
 
         // ── AC3: Window consumed after resolve → next turn has null ──────────
@@ -94,9 +94,9 @@ namespace Pinder.Core.Tests.Conversation
             await session.StartTurnAsync();
             await session.ResolveTurnAsync(0);
 
-            // Turn 2 start: window is active.
+            // Turn 2 start: window is active (effective value is doubled).
             var turn2Start = await session.StartTurnAsync();
-            Assert.Equal(dcReduction, turn2Start.WeaknessDcReduction);
+            Assert.Equal(dcReduction * 2, turn2Start.WeaknessDcReduction);
 
             // Turn 2 resolve: window is consumed (cleared by ResolveTurnAsync regardless of match).
             await session.ResolveTurnAsync(0);
@@ -123,7 +123,7 @@ namespace Pinder.Core.Tests.Conversation
             string json = JsonSerializer.Serialize(turn2Start);
 
             Assert.Contains("\"weakness_dc_reduction\"", json);
-            Assert.Contains($":{dcReduction}", json);
+            Assert.Contains($":{dcReduction * 2}", json);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/Issue209_DiceQueueExhaustionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue209_DiceQueueExhaustionTests.cs
@@ -135,8 +135,8 @@ namespace Pinder.Core.Tests
             Assert.True(start4.State.TripleBonusActive, "TripleBonusActive should be visible at start of turn 4");
 
             var r4 = await session.ResolveTurnAsync(0);
-            // ExternalBonus = triple(+1) + momentum(+2 from streak=3 at start, #268)
-            Assert.Equal(3, r4.Roll.ExternalBonus);
+            // ExternalBonus = triple(+2) + momentum(+2 from streak=3 at start, #268)
+            Assert.Equal(4, r4.Roll.ExternalBonus);
             Assert.False(r4.StateAfter.TripleBonusActive, "TripleBonusActive should be consumed after turn 4");
         }
 
@@ -236,10 +236,10 @@ namespace Pinder.Core.Tests
             Assert.Contains("no more values", ex.Message);
         }
 
-        // What: AC1 — ExternalBonus includes +1 from Triple bonus (not 0 or 2)
-        // Mutation: would catch if Triple bonus applied +2 instead of +1
+        // What: AC1 — ExternalBonus includes +2 from Triple bonus (not 0 or 1)
+        // Mutation: would catch if Triple bonus applied +3 instead of +2
         [Fact]
-        public async Task TripleBonus_AppliesExactlyPlusOne_AsExternalBonus()
+        public async Task TripleBonus_AppliesExactlyPlusTwo_AsExternalBonus()
         {
             var dice = new FixedDice(
                 5,  // Constructor: horniness roll (1d10)
@@ -266,8 +266,8 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var r4 = await session.ResolveTurnAsync(0);
 
-            // ExternalBonus = triple(+1) + momentum(+2 from streak=3 at start, #268) = 3
-            Assert.Equal(3, r4.Roll.ExternalBonus);
+            // ExternalBonus = triple(+2) + momentum(+2 from streak=3 at start, #268) = 4
+            Assert.Equal(4, r4.Roll.ExternalBonus);
         }
 
         // What: Edge case — Turns before VeryIntoIt consume exactly 2 dice each (no advantage)

--- a/tests/Pinder.Core.Tests/Issue526_ComboExplanationTests.cs
+++ b/tests/Pinder.Core.Tests/Issue526_ComboExplanationTests.cs
@@ -18,7 +18,7 @@ namespace Pinder.Core.Tests
         [InlineData("The Escalation", "You played Chaos last turn, then Rizz this turn \u2014 the sequence earns +1 bonus interest.")]
         [InlineData("The Disarm", "You played Wit last turn, then Honesty this turn \u2014 the sequence earns +1 bonus interest.")]
         [InlineData("The Recovery", "You failed a roll last turn, then played SA this turn \u2014 the sequence earns +2 bonus interest.")]
-        [InlineData("The Triple", "You played 3 different stats in 3 consecutive turns \u2014 your next roll gains +1 bonus.")]
+        [InlineData("The Triple", "You played 3 different stats in 3 consecutive turns \u2014 your next roll gains +2 bonus.")]
         public void GetComboSequenceDescription_KnownCombos_ReturnsExpectedString(string comboName, string expected)
         {
             var result = PlaytestFormatter.GetComboSequenceDescription(comboName);
@@ -41,7 +41,7 @@ namespace Pinder.Core.Tests
         // Mutation: Would catch if summary strings are altered
         [Theory]
         [InlineData("The Recovery", "+2 Interest if success")]
-        [InlineData("The Triple", "+1 to ALL rolls next turn")]
+        [InlineData("The Triple", "+2 to ALL rolls next turn")]
         [InlineData("The Setup", "+1 Interest if success")]
         [InlineData("UnknownCombo", "+1 Interest if success")]
         [InlineData(null, "+1 Interest if success")]

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -20,8 +20,8 @@ namespace Pinder.Core.Tests
     public class TellBonusSpecTests
     {
         // ================================================================
-        // Edge Case 3 (explicit): Tell active + matching stat → TellReadBonus=2
-        // Mutation: Fails if tell bonus is not exactly 2, or if tell comparison
+        // Edge Case 3 (explicit): Tell active + matching stat → TellReadBonus=4
+        // Mutation: Fails if tell bonus is not exactly 4, or if tell comparison
         //           uses != instead of == for stat matching
         // ================================================================
 
@@ -43,10 +43,10 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            // Mutation: would catch if bonus was 1 or 3 instead of 2
-            Assert.Equal(2, result.TellReadBonus);
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
-            Assert.Equal(2, result.Roll.ExternalBonus);
+            // Mutation: would catch if bonus was 1 or 3 instead of 4
+            Assert.Equal(4, result.TellReadBonus);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
+            Assert.Equal(4, result.Roll.ExternalBonus);
         }
 
         // ================================================================
@@ -112,7 +112,7 @@ namespace Pinder.Core.Tests
 
             // Mutation: catches if FinalTotal doesn't include ExternalBonus
             Assert.Equal(result.Roll.Total + result.Roll.ExternalBonus, result.Roll.FinalTotal);
-            Assert.Equal(2, result.Roll.ExternalBonus);
+            Assert.Equal(4, result.Roll.ExternalBonus);
         }
 
         // ================================================================
@@ -197,7 +197,7 @@ namespace Pinder.Core.Tests
             var result = await session.ResolveTurnAsync(0);
 
             // Mutation: catches wrong emoji, missing period, different wording
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
             Assert.Contains("📖", result.TellReadMessage);
             Assert.EndsWith(".", result.TellReadMessage);
         }
@@ -270,7 +270,7 @@ namespace Pinder.Core.Tests
 
             var result = await session.ResolveTurnAsync(0);
             // Mutation: catches if any particular stat is excluded from tell matching
-            Assert.Equal(2, result.TellReadBonus);
+            Assert.Equal(4, result.TellReadBonus);
         }
 
         // ================================================================

--- a/tests/Pinder.Core.Tests/TellBonusTests.EdgeCases.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.EdgeCases.cs
@@ -87,7 +87,7 @@ namespace Pinder.Core.Tests
             // Turn 1: tell active → bonus
             await session.StartTurnAsync();
             var result1 = await session.ResolveTurnAsync(0);
-            Assert.Equal(2, result1.TellReadBonus);
+            Assert.Equal(4, result1.TellReadBonus);
 
             // Turn 2: tell consumed → no bonus
             var start2 = await session.StartTurnAsync();
@@ -172,8 +172,8 @@ namespace Pinder.Core.Tests
             var result = await session.ResolveTurnAsync(0);
 
             Assert.True(result.Roll.IsNatTwenty);
-            Assert.Equal(2, result.TellReadBonus);
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
+            Assert.Equal(4, result.TellReadBonus);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
         }
 
         // ================================================================
@@ -201,8 +201,8 @@ namespace Pinder.Core.Tests
 
             Assert.True(result.Roll.IsNatOne);
             Assert.False(result.Roll.IsSuccess); // Nat 1 is auto-fail
-            Assert.Equal(2, result.TellReadBonus);
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
+            Assert.Equal(4, result.TellReadBonus);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
         }
 
         // ================================================================
@@ -212,8 +212,8 @@ namespace Pinder.Core.Tests
         [Fact]
         public async Task EdgeCase9_TellMatchedButRollStillFails_BonusRecorded()
         {
-            // Player has allStats=2, datee allStats=2, so DC = 16 + 2 = 15
-            // d20=10, mod=2, total=12, externalBonus=2, finalTotal=14 < 15 → still fails
+            // Player has allStats=2, datee allStats=2, so DC = 16 + 2 = 18
+            // d20=10, mod=2, total=12, externalBonus=4, finalTotal=16 < 18 → still fails
             var llm = new TellTestLlm();
             llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Setup"));
             llm.EnqueueTell(new Tell(StatType.Wit, "Makes joke"));
@@ -230,9 +230,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            Assert.False(result.Roll.IsSuccess); // 10+2+2=14 < 15
-            Assert.Equal(2, result.TellReadBonus);
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
+            Assert.False(result.Roll.IsSuccess); // 10+2+4=16 < 18
+            Assert.Equal(4, result.TellReadBonus);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
         }
 
         // ================================================================
@@ -242,15 +242,15 @@ namespace Pinder.Core.Tests
         [Fact]
         public async Task TellBonusTurnsMissIntoHit()
         {
-            // DC = 16 + 2 = 18. d20=14 + mod=2 = total 16, externalBonus=2 → FinalTotal=18 = success
+            // DC = 16 + 2 = 18. d20=12 + mod=2 = total 14, externalBonus=4 → FinalTotal=18 = success
             var llm = new TellTestLlm();
             llm.EnqueueOptions(new DialogueOption(StatType.Charm, "Setup"));
             llm.EnqueueTell(new Tell(StatType.Wit, "Makes joke"));
             llm.EnqueueOptions(new DialogueOption(StatType.Wit, "Funny"));
             llm.EnqueueTell(null);
 
-            // Turn 0: d20=15, timing=5. Turn 1: d20=14, timing=5
-            var dice = new FixedDice(5, 15, 5, 14, 5);
+            // Turn 0: d20=15, timing=5. Turn 1: d20=12, timing=5
+            var dice = new FixedDice(5, 15, 5, 12, 5);
             var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry(), new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
             await session.StartTurnAsync();
@@ -259,10 +259,10 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            // Without bonus: 14+2=16 < 18 → fail
-            // With bonus: 14+2+2=18 >= 18 → success
+            // Without bonus: 12+2=14 < 18 → fail
+            // With bonus: 12+2+4=18 >= 18 → success
             Assert.True(result.Roll.IsSuccess);
-            Assert.Equal(2, result.TellReadBonus);
+            Assert.Equal(4, result.TellReadBonus);
         }
 
         // ================================================================

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -74,9 +74,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            // ExternalBonus should be 2
-            Assert.Equal(2, result.Roll.ExternalBonus);
-            Assert.Equal(result.Roll.Total + 2, result.Roll.FinalTotal);
+            // ExternalBonus should be 4
+            Assert.Equal(4, result.Roll.ExternalBonus);
+            Assert.Equal(result.Roll.Total + 4, result.Roll.FinalTotal);
         }
 
         // ================================================================
@@ -101,8 +101,8 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            Assert.Equal(2, result.TellReadBonus);
-            Assert.Equal("📖 You read the moment. +2 bonus.", result.TellReadMessage);
+            Assert.Equal(4, result.TellReadBonus);
+            Assert.Equal("📖 You read the moment. +4 bonus.", result.TellReadMessage);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -219,7 +219,7 @@ namespace Pinder.Core.Tests
             llm.EnqueueOptions(new DialogueOption(StatType.SelfAwareness, "Insight"));
             llm.EnqueueWeaknessWindow(null);
 
-            // Turn 0: roll 15, Turn 1: roll 14 (14+2=16, DC=18-2=16 → success)
+            // Turn 0: roll 15, Turn 1: roll 14 (14+2=16, DC=18-4=14 → success)
             var dice = new FixedDice(5, 15, 5, 14, 5, 15, 5);
             var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry(), new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
@@ -229,8 +229,8 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            // Verify the DC in the roll result is 16 (18 - 2)
-            Assert.Equal(16, result.Roll.DC);
+            // Verify the DC in the roll result is 14 (18 - 4)
+            Assert.Equal(14, result.Roll.DC);
             Assert.True(result.Roll.IsSuccess);
         }
 

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -107,7 +107,7 @@ namespace Pinder.Core.Tests
         public async Task T2_CorrectStatDcReduced()
         {
             // Datee has allStats=2, so Honesty mod = 2 → DC = 16+2 = 18
-            // With weakness window DcReduction=2 → DC should be 16
+            // With weakness window DcReduction=2 → effective DC reduction is 4 → DC should be 14
 
             var llm = new WeaknessTestLlm();
             // Turn 0: Charm option, datee returns window(Honesty, 2)
@@ -118,7 +118,7 @@ namespace Pinder.Core.Tests
             llm.EnqueueWeaknessWindow(null);
 
             // Turn 0: roll 15, timing roll
-            // Turn 1: roll 14 (SA mod=2, level bonus=0, total=16). Normal DC=18 → fail. With dcAdj=2 → DC=16 → success.
+            // Turn 1: roll 14 (SA mod=2, level bonus=0, total=16). Normal DC=18 → fail. With dcAdj=4 → DC=14 → success.
             var dice = new FixedDice(5, 15, 5, 14, 5, 15, 5, 15, 5);
             var session = new GameSession(MakeProfile("P"), MakeProfile("O"), llm, dice, new NullTrapRegistry(), new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
@@ -130,9 +130,9 @@ namespace Pinder.Core.Tests
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            // Roll=14, stat mod=2, DC should be 16 (18-2)
-            Assert.Equal(16, result.Roll.DC);
-            Assert.True(result.Roll.IsSuccess); // 14+2=16 >= 16
+            // Roll=14, stat mod=2, DC should be 14 (18-4)
+            Assert.Equal(14, result.Roll.DC);
+            Assert.True(result.Roll.IsSuccess); // 14+2=16 >= 14
         }
 
         // ================================================================
@@ -217,7 +217,7 @@ namespace Pinder.Core.Tests
 
             Assert.NotNull(result.DetectedWindow);
             Assert.Equal(StatType.Wit, result.DetectedWindow!.DefendingStat);
-            Assert.Equal(2, result.DetectedWindow.DcReduction);
+            Assert.Equal(4, result.DetectedWindow.DcReduction);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
This pull request completes the implementation of ticket #1203. It doubles three key mechanical roll bonuses/boosters to enhance gameplay impact:
1. **Matched Tell Option**: Doubled the external roll bonus from +2 to +4. Surfaced in `TurnResult.TellReadBonus` and `TurnResult.TellReadMessage` as +4.
2. **Weakness Window**: Doubled the effective DC reduction for a roll (effective value is now 4 if the raw value from the datee is 2).
3. **Pending Triple Combo**: Doubled the next-roll bonus from +1 to +2. Surfaced in `TurnResult.TripleBonusApplied` as +2.

All core gameplay rules (callback hidden strings, momentum mechanics, and two-stat combo InterestBonus values) remain completely unchanged as verified by diff/grep tests.

## Tests with real results
All 4058 tests pass successfully.
- **`Pinder.Core.Tests`**: 3020 passed, 0 failed, 18 skipped.
  ```
  Passed!  - Failed:     0, Passed:  3020, Skipped:    18, Total:  3038, Duration: 8 s - Pinder.Core.Tests.dll (net8.0)
  ```
- **`Pinder.LlmAdapters.Tests`**: 1038 passed, 0 failed, 0 skipped.
  ```
  Passed!  - Failed:     0, Passed:  1038, Skipped:     0, Total:  1038, Duration: 24 s - Pinder.LlmAdapters.Tests.dll (net8.0)
  ```

## Research Log/code pointers
- **Tell Option Booster**: Modified `src/Pinder.Core/Conversation/RollResolutionStage.cs` (line 96) and `src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs` (line 129) to apply and surface the +4 bonus.
- **Weakness Window Booster**: Modified `src/Pinder.Core/Conversation/TurnOrchestrator.Resolve.cs` (lines 93, 137) to double the `WeaknessWindow.DcReduction` from its raw value to its effective value of 4.
- **Pending Triple Combo Booster**: Modified `src/Pinder.Core/Conversation/RollResolutionStage.cs` (line 102) and updated related XML comments in `src/Pinder.Core/Conversation/ComboResult.cs`, `src/Pinder.Core/Conversation/ComboTracker.cs`, `src/Pinder.Core/Conversation/GameStateSnapshot.cs`, and `src/Pinder.Core/Conversation/TurnResult.cs` to apply and document the +2 bonus.
- **Playtest Formatter Updates**: Modified `session-runner/PlaytestFormatter.cs` (lines 156, 178) to display the correct +2 Triple Combo bonus in playtest logs.

## Drive-by changes
None. Only the uncommitted changes implementing ticket #1203 were verified and committed.

Closes #1203