### PR TITLE
fix(#1207): Nat20 improves delivered message on critical success

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -117,17 +117,18 @@ namespace Pinder.Core.Conversation
                 textDiffs.Add(new TextDiff(layerLabel, tierSpans, originalIntendedText, deliveredMessage));
             }
 
-            // Success Improvement (Strong/Legendary)
+            // Success Improvement (Strong/Legendary/Nat20)
             bool isSuccess = rollResult.IsSuccess;
             bool isNat20 = rollResult.IsNatTwenty;
-            if (isSuccess && !isNat20 && !string.IsNullOrWhiteSpace(deliveredMessage) && deliveredMessage.Trim() != "..." && _llm is IStatefulLlmAdapter statefulAdapter)
+            if (isSuccess && !string.IsNullOrWhiteSpace(deliveredMessage) && deliveredMessage.Trim() != "..." && _llm is IStatefulLlmAdapter statefulAdapter)
             {
                 int beatDcBy = Math.Max(0, rollResult.FinalTotal - rollResult.DC);
-                string tierKey = beatDcBy >= 15 ? "exceptional" :
+                string tierKey = isNat20 ? "nat20" :
+                                 beatDcBy >= 15 ? "exceptional" :
                                  beatDcBy >= 10 ? "critical" :
                                  beatDcBy >= 5  ? "strong" : "clean";
 
-                if (beatDcBy >= 5) // strong, critical, exceptional
+                if (isNat20 || beatDcBy >= 5) // nat20, strong, critical, exceptional
                 {
                     string beforeImprovement = deliveredMessage;
                     string improved = null;
@@ -164,7 +165,7 @@ namespace Pinder.Core.Conversation
 
                     if (deliveredMessage != beforeImprovement)
                     {
-                        string layerName = tierKey == "exceptional" ? "Legendary success" : "Strong success";
+                        string layerName = isNat20 ? "Nat 20" : (tierKey == "exceptional" ? "Legendary success" : "Strong success");
                         var spans = WordDiff.Compute(beforeImprovement, deliveredMessage);
                         textDiffs.Add(new TextDiff(layerName, spans, beforeImprovement, deliveredMessage));
                     }

--- a/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1207_Nat20ImprovementTests
+    {
+        private const string PickedLine = "This is a carefully crafted charming statement.";
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private sealed class DeliveryAdapterWithSuccessImprovement : ILlmAdapter, IStatefulLlmAdapter
+        {
+            private readonly string _optionText;
+
+            public DeliveryAdapterWithSuccessImprovement(string optionText)
+            {
+                _optionText = optionText;
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+                => Task.FromResult(new[] { new DialogueOption(StatType.Charm, _optionText) });
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
+                => Task.FromResult(new DateeResponse("ok, go on..."));
+
+            public Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context, IReadOnlyList<ConversationMessage> history, CancellationToken cancellationToken = default)
+            {
+                var resp = new DateeResponse("ok, go on...");
+                var entries = new[] { ConversationMessage.User(string.Empty), ConversationMessage.Assistant("ok, go on...") };
+                return Task.FromResult(new StatefulDateeResult(resp, entries));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+                => Task.FromResult("so... when are we actually doing this?");
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default)
+            {
+                return Task.FromResult(context.DeliveredMessage + $" [IMPROVED:{context.TierKey}]");
+            }
+        }
+
+        private static GameSession NewSession(ILlmAdapter llm, IDiceRoller dice, int playerStats = 2, int dateeStats = 2)
+            => new GameSession(
+                MakeProfile("Player", playerStats), MakeProfile("Datee", dateeStats),
+                llm, dice, new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock(), steeringRng: new AlwaysMinRandom()));
+
+        private sealed class AlwaysMinRandom : Random
+        {
+            public override int Next(int minValue, int maxValue) => minValue;
+            public override int Next(int maxValue) => 0;
+            public override int Next() => 0;
+        }
+
+        [Fact]
+        public async Task Nat20_ImprovesDeliveredMessage_AndEmitsNat20Diff()
+        {
+            // Nat20 setup. Datee 0 stats -> DC 16. Player 2 stats. d20 = 20. Total = 22.
+            // Result is success, Nat20 = true.
+            var dice = new FixedDice(5, 20, 50);
+            var llm = new DeliveryAdapterWithSuccessImprovement(PickedLine);
+            var session = NewSession(llm, dice, playerStats: 2, dateeStats: 0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsNatTwenty);
+            Assert.Contains("[IMPROVED:nat20]", result.DeliveredMessage);
+            Assert.Contains(result.TextDiffs, d => d.LayerName == "Nat 20");
+        }
+
+        [Fact]
+        public async Task Nat20_TierKeyIsNat20_NotExceptional()
+        {
+            // High player stats so margin would be exceptional if it weren't Nat20.
+            // Datee 0 stats -> DC 16. Player 20 stats. d20 = 20. Total = 40.
+            // Margin = 24.
+            var dice = new FixedDice(5, 20, 50);
+            var llm = new DeliveryAdapterWithSuccessImprovement(PickedLine);
+            var session = NewSession(llm, dice, playerStats: 20, dateeStats: 0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsNatTwenty);
+            Assert.Contains("[IMPROVED:nat20]", result.DeliveredMessage);
+            Assert.DoesNotContain("[IMPROVED:exceptional]", result.DeliveredMessage);
+            Assert.Contains(result.TextDiffs, d => d.LayerName == "Nat 20");
+            Assert.DoesNotContain(result.TextDiffs, d => d.LayerName == "Legendary success");
+        }
+
+        [Fact]
+        public async Task PlainStrongSuccess_DoesNotEmitNat20Diff()
+        {
+            // Margin success, NOT Nat20.
+            // Datee 0 stats -> DC 16. Player 5 stats. d20 = 16. Total = 21. Margin = 5. (Strong).
+            var dice = new FixedDice(5, 16, 50);
+            var llm = new DeliveryAdapterWithSuccessImprovement(PickedLine);
+            var session = NewSession(llm, dice, playerStats: 5, dateeStats: 0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.False(result.Roll.IsNatTwenty);
+            Assert.DoesNotContain(result.TextDiffs, d => d.LayerName == "Nat 20");
+            // Optional: assert strong success presence
+            Assert.Contains(result.TextDiffs, d => d.LayerName == "Strong success");
+        }
+
+        [Fact]
+        public async Task PlainFailure_DoesNotEmitNat20Diff()
+        {
+            // Failure.
+            // Datee 0 stats -> DC 16. Player 2 stats. d20 = 2. Total = 4. Failure.
+            var dice = new FixedDice(5, 2, 50);
+            var llm = new DeliveryAdapterWithSuccessImprovement(PickedLine);
+            var session = NewSession(llm, dice, playerStats: 2, dateeStats: 0);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.Roll.IsSuccess);
+            Assert.DoesNotContain(result.TextDiffs, d => d.LayerName == "Nat 20");
+        }
+    }
+}


### PR DESCRIPTION
Closes #1207

## What
On a main option-roll **Nat 20**, the delivered player message now visibly improves, routed through the existing success-improvement hook introduced for #1210.

- `DeliveryStage` no longer excludes Nat 20 from the success-improvement path. A Nat 20 success calls `IStatefulLlmAdapter.GetSuccessImprovementAsync` with `tierKey == "nat20"` (taking precedence over the margin tiers), and emits a `TextDiff` layer labeled exactly `Nat 20` when the message changes.
- The improvement is grounded in the selected stat (`chosenOption.Stat`) and recent conversation context, and `PinderLlmAdapter` sources the prompt from the per-stat `nat20` instructions already present in `delivery-instructions.yaml` (no hard-coded prose).
- Non-Nat20 successes keep #1210 behavior (Strong/Legendary). Plain successes and failures do not trigger the Nat 20 path.

## Out of scope (respected)
No Nat 1 / failure changes; no interest-delta / advantage / shadow-reduction mechanic changes (Nat 20's mechanical rewards in `RollResolutionStage` are untouched); no frontend changes.

## Verification (local only)
- `dotnet build Pinder.Core.sln -c Debug` -> 0 errors
- `Pinder.Core.Tests` -> 3028 passed, 0 failed (4 new Issue1207 tests + existing Issue1210 tests pass)
- `Pinder.LlmAdapters.Tests` -> 1040 passed, 0 failed
- `Pinder.Rules.Tests` -> 11 pre-existing failures (game-definition.yaml content tests, identical on origin/main; branch touches no yaml/Rules files)

Contract-test -> implementer -> independent reviewer (APPROVE) eigentakt loop.