### PR TITLE
refactor(#1209): horniness appends a horny question (steering-style); no rewrite/penalty

### DIFF
--- a/data/i18n/en/consequences.yaml
+++ b/data/i18n/en/consequences.yaml
@@ -38,10 +38,10 @@ strings:
   consequence.shadow.miss.overthinking: "Your Overthinking shadow took over — the message reads as second-guessing on display."
 
   # ── horniness ─────────────────────────────────────────────────────────────
-  consequence.horniness.miss.fumble: "Horniness checked out — the message lost its edge."
-  consequence.horniness.miss.misfire: "Horniness misfired — the message reads slightly more thirsty than intended."
-  consequence.horniness.miss.tropetrap: "Horniness walked into a trope trap — the flirt pattern backfired."
-  consequence.horniness.miss.catastrophe: "Horniness misfired catastrophically — the message reads thirsty in a cringey way."
+  consequence.horniness.miss.fumble: "Horniness miss — appended a horny follow-up question."
+  consequence.horniness.miss.misfire: "Horniness miss — appended a thirsty follow-up question."
+  consequence.horniness.miss.tropetrap: "Horniness miss — appended an overly flirty follow-up question."
+  consequence.horniness.miss.catastrophe: "Horniness miss — appended a desperately horny follow-up question."
 
   # ── steering ─────────────────────────────────────────────────────────────
   consequence.steering.miss: "Steering missed — the pivot didn't land and the message stays on the rejected topic."

--- a/data/i18n/en/glossary.yaml
+++ b/data/i18n/en/glossary.yaml
@@ -50,7 +50,7 @@ strings:
   glossary.combo.fallback_reward: "+1 Interest if success"
 
   # ── Shadow trap (#1095) ───────────────────────────────────────────
-  glossary.shadow.trap: "A shadow trap is a successful message tainted by a missed shadow check. It is NOT a failed turn: the roll still counts as a success and momentum keeps building, but the message lands a little off — the DATEE reacts neutrally or with mild coolness — and the interest gain is capped at +1 (horniness may halve that to 0)."
+  glossary.shadow.trap: "A shadow trap is a successful message tainted by a missed shadow check. It is NOT a failed turn: the roll still counts as a success and momentum keeps building, but the message lands a little off — the DATEE reacts neutrally or with mild coolness — and the interest gain is capped at +1."
 
   # ── Shadow reason explanations (#186 / mirrors PlaytestFormatter) ─
   # Brief plain-English explanation paired with each shadow-growth

--- a/data/i18n/en/ui-turn-result.yaml
+++ b/data/i18n/en/ui-turn-result.yaml
@@ -18,7 +18,7 @@ strings:
   turn_result.outcome_summary: "Turn {turn} · {riskTier} · d20[{used}] {total}/{dc}"
 
   turn_result.horniness_check_heading: "Horniness check"
-  turn_result.horniness_check_explainer: "Per-turn d20 vs DC {dc}: a miss may trigger a horniness overlay on the delivered message."
+  turn_result.horniness_check_explainer: "Per-turn d20 vs DC {dc}: a miss appends a horny follow-up question (no interest penalty)."
 
   turn_result.shadow_check_heading: "Shadow check"
   turn_result.shadow_check_explainer: "Per-turn d20 vs DC {dc}: a miss taints the delivered message via a shadow overlay and caps a successful action's interest gain at +1 (it does NOT fail the turn)."
@@ -36,7 +36,7 @@ strings:
   turn_result.interest_breakdown.risk_bonus: "Risk bonus: {value}"
   turn_result.interest_breakdown.combo_bonus: "Combo bonus: {value}"
   turn_result.interest_breakdown.shadow_misfire: "Shadow: {original} → capped to +1"
-  turn_result.interest_breakdown.horniness_penalty: "Horniness: floor({original} / 2) = {value}"
+  turn_result.interest_breakdown.horniness_penalty: "Horniness: no interest penalty"
   turn_result.interest_breakdown.delay_penalty: "Delay penalty: {value}"
   turn_result.interest_breakdown.total: "= {value} (now {now})"
 

--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -318,54 +318,29 @@ namespace Pinder.Core.Conversation
             int horninessInterestPenalty = 0;
             int horninessInterestBefore = 0;
 
-            // #899: Horniness TEXT OVERLAY
-            if (horninessOverlayInstruction != null)
+            // #1209: Horniness append
+            if (horninessCheckResult.IsMiss && _llm is IStatefulLlmAdapter horninessStateful && !string.IsNullOrWhiteSpace(deliveredMessage) && deliveredMessage.Trim() != "...")
             {
-                string beforeHorniness = deliveredMessage;
-                string dateeCtx = TurnOrchestratorHelpers.BuildDateeContext(datee);
-
-                // AC-B2: Add remaining budget hint to Horniness overlay instruction if tight.
-                int currentWords = deliveredMessage.Split(new[] { ' ', '\r', '\n', '\t' }, StringSplitOptions.RemoveEmptyEntries).Length;
-                int remainingBudget = Math.Max(0, _maxDeliveryWords - currentWords);
-                string finalInstruction = horninessOverlayInstruction;
-                if (remainingBudget < 25)
-                {
-                    finalInstruction += $"\nLength constraint: Keep it extremely brief (max {remainingBudget} words). Do not append long sentences.";
-                }
-
                 progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayStarted));
-                string rawHorninessOutput = await _llm.ApplyHorninessOverlayAsync(deliveredMessage, finalInstruction, dateeCtx, playerArchetypeDirectiveForDelivery, ct).ConfigureAwait(false);
-                progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, rawHorninessOutput));
-
-                string sanitizedHorninessOutput = MetaPrefixStripper.Strip(rawHorninessOutput);
-                if (sanitizedHorninessOutput != rawHorninessOutput)
+                string beforeHorniness = deliveredMessage;
+                string question = null;
+                try
                 {
-                    var stripSpans = WordDiff.Compute(rawHorninessOutput, sanitizedHorninessOutput);
-                    textDiffs.Add(new TextDiff(
-                        MetaPrefixStripper.LayerName, stripSpans,
-                        rawHorninessOutput, sanitizedHorninessOutput));
+                    question = await horninessStateful.GetHorninessQuestionAsync(new HorninessQuestionContext(player.AssembledSystemPrompt, datee.DisplayName, player.DisplayName, beforeHorniness, TurnOrchestratorHelpers.BuildHistoryForLlmContext(state)), ct).ConfigureAwait(false);
                 }
-
-                deliveredMessage = sanitizedHorninessOutput;
-
-                if (deliveredMessage != beforeHorniness)
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+                catch { question = null; }
+                
+                if (!string.IsNullOrWhiteSpace(question))
                 {
-                    var horninessSpans = WordDiff.Compute(beforeHorniness, deliveredMessage);
-                    textDiffs.Add(new TextDiff("Horniness", horninessSpans, beforeHorniness, deliveredMessage));
+                    deliveredMessage = beforeHorniness.Length == 0 ? question : beforeHorniness.TrimEnd() + " " + question;
+                    if (deliveredMessage != beforeHorniness)
+                    {
+                        var sp = WordDiff.Compute(beforeHorniness, deliveredMessage);
+                        textDiffs.Add(new TextDiff("Horniness", sp, beforeHorniness, deliveredMessage));
+                    }
                 }
-                else
-                {
-                    TurnOrchestratorHelpers.EmitTextLayerNoop(_onTextLayerNoop, state.TurnNumber, "Horniness", beforeHorniness, deliveredMessage);
-                }
-            }
-
-            if (horninessCheckResult.OverlayApplied && interestDelta > 0)
-            {
-                horninessInterestBefore = state.Interest.Current + shadowCorrection;
-                int halvedDelta = (int)Math.Floor(interestDelta / 2.0);
-                int penalty = halvedDelta - interestDelta;
-                horninessInterestPenalty = penalty;
-                interestDelta += penalty;
+                progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, deliveredMessage));
             }
 
             // Issue #339: same-turn callback-phrase strip

--- a/src/Pinder.Core/Conversation/HorninessQuestionContext.cs
+++ b/src/Pinder.Core/Conversation/HorninessQuestionContext.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Context for generating a horny follow-up question after a horniness miss roll.
+    /// Contains the conversation state needed to produce a contextual question
+    /// that is appended to the message.
+    /// </summary>
+    public sealed class HorninessQuestionContext
+    {
+        /// <summary>The player character's system prompt (for voice consistency).</summary>
+        public string PlayerAvatarPrompt { get; }
+
+        /// <summary>The datee character's display name.</summary>
+        public string DateeName { get; }
+
+        /// <summary>The player character's display name.</summary>
+        public string PlayerName { get; }
+
+        /// <summary>The message the player just delivered this turn.</summary>
+        public string DeliveredMessage { get; }
+
+        /// <summary>Full conversation history up to this point.</summary>
+        public IReadOnlyList<(string Sender, string Text)> ConversationHistory { get; }
+
+        public HorninessQuestionContext(
+            string playerAvatarPrompt,
+            string dateeName,
+            string playerName,
+            string deliveredMessage,
+            IReadOnlyList<(string Sender, string Text)> conversationHistory)
+        {
+            PlayerAvatarPrompt = playerAvatarPrompt ?? "";
+            DateeName = dateeName ?? "";
+            PlayerName = playerName ?? "";
+            DeliveredMessage = deliveredMessage ?? "";
+            ConversationHistory = conversationHistory ?? (IReadOnlyList<(string Sender, string Text)>)new List<(string, string)>();
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -75,6 +75,12 @@ namespace Pinder.Core.Conversation
             return Task.FromResult("so... when are we actually doing this?");
         }
 
+        public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult("so... your place or mine?");
+        }
+
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();

--- a/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
@@ -66,6 +66,19 @@ namespace Pinder.Core.Interfaces
         Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default);
 
         /// <summary>
+        /// Generate a horny question to append to the player's delivered message.
+        /// Called after a horniness miss roll. The question should reference
+        /// specifics from the conversation and add a flirty/horny tone.
+        /// </summary>
+        /// <param name="context">The context for horniness question generation.</param>
+        /// <param name="ct">
+        /// Cancellation token forwarded from <see cref="GameSession.ResolveTurnAsync(int, System.IProgress{TurnProgressEvent}?, CancellationToken)"/>
+        /// (#794). Implementations MUST pass this through to the underlying
+        /// transport so a mid-turn cancel halts the in-flight HTTP call.
+        /// </param>
+        Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default);
+
+        /// <summary>
         /// Generate an improved message after a strong or legendary success roll.
         /// Replaces the delivered message entirely.
         /// </summary>

--- a/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
@@ -214,5 +214,29 @@ GOOD examples (specific, dating-app energy, slightly unhinged):
 - ""the fact that you've been to three tribute nights and none of them were right... is that something you'd want company for next time, hypothetically?""
 
 Output only the question. No preamble. It will be appended directly to the delivered message.";
+
+        /// <summary>
+        /// Default horniness prompt template used when game-definition.yaml
+        /// does not specify a horniness_prompt key.
+        /// </summary>
+        public static string DefaultHorninessPrompt { get; } =
+@"You are writing as {player_name} on Pinder — a satirical comedy dating app for sentient penises.
+The character just sent: ""{delivered_message}""
+
+Based specifically on what {datee_name} has revealed in the conversation above, write ONLY ONE short flirty/horny follow-up QUESTION to append to this message. The question must:
+1. Reference something specific the datee actually said or revealed — not a generic line
+2. Be overtly flirty, thirsty, or slightly desperate in a comedic way
+3. Sound natural as a continuation of the delivered message, not a separate topic
+4. Output ONLY the question. No preamble, no rewrite.
+
+BAD examples:
+- ""so what do you do for fun?""
+- ""you looking for a hookup?""
+
+GOOD examples:
+- ""also, and this is completely unrelated... how strong are your hands?""
+- ""wait, if you're so good at organizing things, do you want to organize me against a wall?""
+
+Output ONLY the question. No preamble. It will be appended directly to the delivered message.";
     }
 }

--- a/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Parser.cs
@@ -98,6 +98,7 @@ namespace Pinder.LlmAdapters
                 dateeRoleDescription: dateeRoleDescription,
                 improvementPrompt: GetOptional("improvement_prompt"),
                 steeringPrompt: GetOptional("steering_prompt"),
+                horninessPrompt: GetOptional("horniness_prompt"),
                 horninessTimeModifiers: horninessTimeModifiers,
                 globalDcBias: globalDcBias,
                 shadowDcBias: shadowDcBias,

--- a/src/Pinder.LlmAdapters/GameDefinition.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.cs
@@ -32,6 +32,8 @@ namespace Pinder.LlmAdapters
         /// <summary>Steering question prompt template. Placeholders: {player_name}, {datee_name}, {delivered_message}.</summary>
         public string SteeringPrompt { get; }
 
+        public string HorninessPrompt { get; }
+
         /// <summary>Global DC bias applied to all rolls. 0 = standard difficulty. Positive = easier.</summary>
         public int GlobalDcBias { get; }
 
@@ -65,6 +67,7 @@ namespace Pinder.LlmAdapters
             string dateeRoleDescription,
             string improvementPrompt = null,
             string steeringPrompt = null,
+            string horninessPrompt = null,
             HorninessTimeModifiers horninessTimeModifiers = null,
             int globalDcBias = 0,
             int shadowDcBias = 0,
@@ -80,6 +83,7 @@ namespace Pinder.LlmAdapters
             DateeRoleDescription = dateeRoleDescription ?? throw new ArgumentNullException(nameof(dateeRoleDescription));
             ImprovementPrompt = improvementPrompt ?? "";
             SteeringPrompt = steeringPrompt ?? "";
+            HorninessPrompt = horninessPrompt ?? "";
             HorninessTimeModifiers = horninessTimeModifiers;
             GlobalDcBias = globalDcBias;
             ShadowDcBias = shadowDcBias;

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -429,7 +429,43 @@ namespace Pinder.LlmAdapters
             return question;
         }
 
-        // ── Private helpers ────────────────────────────────────────────────
+        public async Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            string template = _options.GameDefinition?.HorninessPrompt;
+            if (string.IsNullOrWhiteSpace(template))
+                template = GameDefinition.DefaultHorninessPrompt;
+
+            string prompt = template
+                .Replace("{player_name}", context.PlayerName)
+                .Replace("{datee_name}", context.DateeName)
+                .Replace("{delivered_message}", context.DeliveredMessage);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("CONVERSATION SO FAR:");
+            foreach (var (sender, text) in context.ConversationHistory)
+            {
+                sb.AppendLine($"{sender}: {text}");
+            }
+            sb.AppendLine();
+            sb.AppendLine(prompt);
+
+            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+
+            var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
+                .ConfigureAwait(false);
+
+            var question = (responseText ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(question))
+                return "so... your place or mine?";
+
+            if (question.Length >= 2 && question[0] == '"' && question[question.Length - 1] == '"')
+                question = question.Substring(1, question.Length - 2).Trim();
+
+            return question;
+        }
+
 
         /// <summary>
         /// Sends a stateful datee request by flattening the supplied history

--- a/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
+++ b/src/Pinder.NarrativeHarness/GameDefinitionArcInjector.cs
@@ -35,6 +35,7 @@ namespace Pinder.Tools.NarrativeHarness
                 dateeRoleDescription: baseDef.DateeRoleDescription,
                 improvementPrompt: baseDef.ImprovementPrompt,
                 steeringPrompt: baseDef.SteeringPrompt,
+                horninessPrompt: baseDef.HorninessPrompt,
                 horninessTimeModifiers: baseDef.HorninessTimeModifiers,
                 globalDcBias: baseDef.GlobalDcBias,
                 shadowDcBias: baseDef.ShadowDcBias,

--- a/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
@@ -124,7 +124,8 @@ namespace Pinder.Core.Tests.Conversation
                 => Task.FromResult<string?>(null);
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult(string.Empty);
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -61,7 +61,8 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default) => Task.FromResult<string?>("");
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("test steering question");
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default) => Task.FromResult("test steering question");
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -51,7 +51,8 @@ namespace Pinder.Core.Tests.Conversation
                 => Task.FromResult<string?>(null);
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult(string.Empty);
             public Task<string> ApplyHorninessOverlayAsync(string m, string i, string? oc = null, string? ad = null, CancellationToken ct = default) => Task.FromResult(m);
             public Task<string> ApplyShadowCorruptionAsync(string m, string i, ShadowStatType s, string? ad = null, CancellationToken ct = default) => Task.FromResult(m);

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -189,14 +189,14 @@ namespace Pinder.Core.Tests
 
         /// <summary>
         /// Case 2 (the headline worked example): shadow trap on a success FOLLOWED by
-        /// horniness halving. Base positive delta (Nat 20 → ≥ 4) is first truncated by
-        /// the shadow trap to 1, then horniness (floor, delta &gt; 0) halves it:
-        /// floor(1 / 2) = 0. Net final interest delta == 0 — BUT the turn is STILL NOT
-        /// a failure: the roll verdict stays SUCCESS and the momentum streak still
-        /// increments. (horninessDie = 5 → SessionHorniness = 5 → overlay fires.)
+        /// horniness check. Base positive delta (Nat 20 → ≥ 4) is first truncated by
+        /// the shadow trap to 1, then horniness appends a question (#1209, no penalty).
+        /// Net final interest delta == 1. The turn is STILL NOT a failure: the roll
+        /// verdict stays SUCCESS and the momentum streak still increments.
+        /// (horninessDie = 5 → SessionHorniness = 5 → check misses.)
         /// </summary>
         [Fact]
-        public async Task ShadowTrap_ThenHorniness_NetsZero_ButStillSuccess_MomentumIncrements()
+        public async Task ShadowTrap_ThenHorniness_NetsOne_StillSuccess_MomentumIncrements()
         {
             var (session, llm) = MakeSession(horninessDie: 5);
 
@@ -206,15 +206,15 @@ namespace Pinder.Core.Tests
             var result = await session.ResolveTurnAsync(rizzIdx);
             int momentumAfter = session.CreateSnapshot().MomentumStreak;
 
-            // Shadow trap fired AND horniness overlay fired (it is what drives the halving).
+            // Shadow trap fired AND horniness check missed.
             Assert.True(result.Roll.IsSuccess);
             Assert.True(result.ShadowCheck.OverlayApplied);
-            Assert.True(result.HorninessCheck.OverlayApplied);
+            Assert.True(result.HorninessCheck.IsMiss);
 
-            // #1095 worked example: shadow → 1, then horniness floor(1/2) = 0.
-            Assert.Equal(0, result.InterestDelta);
+            // shadow → 1, horniness no penalty.
+            Assert.Equal(1, result.InterestDelta);
 
-            // Still a success: verdict NOT demoted to Miss despite the net-zero delta.
+            // Still a success: verdict NOT demoted to Miss.
             Assert.Equal(RollVerdict.Success, result.Roll.Check.FinalVerdict);
             Assert.Equal(FailureTier.Success, result.Roll.Check.FinalTier);
 
@@ -222,7 +222,7 @@ namespace Pinder.Core.Tests
             Assert.True(result.BaseInterestDelta >= 1,
                 $"base success delta should be positive; got {result.BaseInterestDelta}");
 
-            // Momentum streak still increments through the net-zero shadow+horniness turn.
+            // Momentum streak still increments.
             Assert.Equal(momentumBefore + 1, momentumAfter);
         }
 
@@ -276,7 +276,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 

--- a/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
@@ -102,7 +102,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult("so... when are we actually doing this?");
 
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
@@ -53,7 +53,8 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult("so... when are we actually doing this?");
 
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
@@ -108,8 +108,8 @@ namespace Pinder.Core.Tests
         [Fact]
         public async Task HorninessMiss_AppendsOneQuestion_DoesNotRewritePrefix()
         {
-            // mainRoll = 15 (clean success, low margin so SuccessImprovement doesn't trigger)
-            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMinRandom(), mainRoll: 15);
+            // mainRoll = 16 (clean success, low margin so SuccessImprovement doesn't trigger)
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMinRandom(), mainRoll: 16);
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
@@ -156,7 +156,7 @@ namespace Pinder.Core.Tests
         [Fact]
         public async Task HorninessSuccess_NoQuestionAppended()
         {
-            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 15);
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 16);
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
@@ -170,11 +170,11 @@ namespace Pinder.Core.Tests
         public async Task Steering_StillWorks_Independently()
         {
             // steeringRng returns max -> steering succeeds. 
-            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 15);
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 16);
             await session.StartTurnAsync();
             var result = await session.ResolveTurnAsync(0);
 
-            Assert.True(result.Steering.IsSuccess, "Steering should succeed");
+            Assert.True(result.Steering.SteeringSucceeded, "Steering should succeed");
             Assert.Contains(AppendedSteering, result.DeliveredMessage);
             
             var diff = Assert.Single(result.TextDiffs, d => d.LayerName == "Steering");

--- a/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Text;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Contract tests for #1209 — Horniness becomes a steering-style append-one-horny-question mechanic.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1209_HorninessAppendQuestionTests
+    {
+        private const string PickedLine = "Genuinely enjoying this conversation with you so far.";
+        private const string AppendedQuestion = "wanna get out of here? [HORNYQ]";
+        private const string AppendedSteering = "so... when are we actually doing this? [STEERINGQ]";
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private sealed class HorninessFakeAdapter : ILlmAdapter, IStatefulLlmAdapter
+        {
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+                => Task.FromResult(new[] { new DialogueOption(StatType.Charm, PickedLine) });
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
+                => Task.FromResult(new DateeResponse("ok, go on..."));
+
+            public Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context, IReadOnlyList<ConversationMessage> history, CancellationToken cancellationToken = default)
+            {
+                var resp = new DateeResponse("ok, go on...");
+                var entries = new[] { ConversationMessage.User(string.Empty), ConversationMessage.Assistant("ok, go on...") };
+                return Task.FromResult(new StatefulDateeResult(resp, entries));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default)
+                => Task.FromResult(context.DeliveredMessage);
+
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+                => Task.FromResult(AppendedSteering);
+
+            // THE NEW HOOK FOR #1209
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default)
+                => Task.FromResult(AppendedQuestion);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+        }
+
+        // Shared RNGs for predictable checks
+        private sealed class AlwaysMinRandom : Random
+        {
+            public override int Next(int minValue, int maxValue) => minValue;
+            public override int Next(int maxValue) => 0;
+            public override int Next() => 0;
+        }
+
+        private sealed class AlwaysMaxRandom : Random
+        {
+            public override int Next(int minValue, int maxValue) => maxValue - 1;
+            public override int Next(int maxValue) => maxValue - 1;
+            public override int Next() => int.MaxValue;
+        }
+
+        private static GameSession MakeSession(int sessionHorniness, Random steeringRng, int mainRoll)
+        {
+            // Dice: index0 = horniness d10 (determines sessionHorniness via clock mod 0), then main d20, then d100.
+            var dice = new FixedDice(sessionHorniness, mainRoll, 50);
+            var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock());
+            var clock = TestHelpers.MakeClock(); 
+            var config = new GameSessionConfig(
+                clock: clock,
+                playerShadows: shadows,
+                steeringRng: steeringRng,
+                startingInterest: 10); // positive interest
+
+            return new GameSession(
+                MakeProfile("Player"), MakeProfile("Datee"),
+                new HorninessFakeAdapter(), dice, new NullTrapRegistry(), config);
+        }
+
+        [Fact]
+        public async Task HorninessMiss_AppendsOneQuestion_DoesNotRewritePrefix()
+        {
+            // mainRoll = 15 (clean success, low margin so SuccessImprovement doesn't trigger)
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMinRandom(), mainRoll: 15);
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // Miss logic
+            Assert.True(result.HorninessCheck.IsMiss);
+            
+            // Should contain original prefix
+            Assert.StartsWith(PickedLine, result.DeliveredMessage);
+            Assert.EndsWith(AppendedQuestion, result.DeliveredMessage.TrimEnd());
+
+            // Should contain a Horniness TextDiff
+            var diff = Assert.Single(result.TextDiffs, d => d.LayerName == "Horniness");
+            Assert.StartsWith(diff.Before, diff.After); // Append only
+            Assert.EndsWith(AppendedQuestion, diff.After.TrimEnd());
+        }
+
+        [Fact]
+        public async Task HorninessMiss_NoInterestPenalty()
+        {
+            // We want positive interest delta. mainRoll = 18 ensures success.
+            var sessionMiss = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMinRandom(), mainRoll: 18);
+            await sessionMiss.StartTurnAsync();
+            var resultMiss = await sessionMiss.ResolveTurnAsync(0);
+
+            Assert.True(resultMiss.HorninessCheck.IsMiss);
+            Assert.Equal(0, resultMiss.HorninessInterestPenalty);
+
+            // No horniness breakdown item
+            Assert.DoesNotContain(resultMiss.InterestBreakdown, b => 
+                b.Source.Contains("horniness", StringComparison.OrdinalIgnoreCase) ||
+                b.Label.Contains("horniness", StringComparison.OrdinalIgnoreCase));
+
+            // Compare to control (success horniness)
+            var sessionSuccess = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 18);
+            await sessionSuccess.StartTurnAsync();
+            var resultSuccess = await sessionSuccess.ResolveTurnAsync(0);
+
+            Assert.False(resultSuccess.HorninessCheck.IsMiss);
+            
+            // Both turns should have exact same interest delta (horniness no longer halves it)
+            Assert.Equal(resultSuccess.InterestDelta, resultMiss.InterestDelta);
+        }
+
+        [Fact]
+        public async Task HorninessSuccess_NoQuestionAppended()
+        {
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 15);
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.False(result.HorninessCheck.IsMiss);
+            
+            Assert.DoesNotContain("Horniness", result.TextDiffs.Select(d => d.LayerName));
+            Assert.DoesNotContain(AppendedQuestion, result.DeliveredMessage);
+        }
+
+        [Fact]
+        public async Task Steering_StillWorks_Independently()
+        {
+            // steeringRng returns max -> steering succeeds. 
+            var session = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 15);
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Steering.IsSuccess, "Steering should succeed");
+            Assert.Contains(AppendedSteering, result.DeliveredMessage);
+            
+            var diff = Assert.Single(result.TextDiffs, d => d.LayerName == "Steering");
+            Assert.Contains(AppendedSteering, diff.After);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue1210_SuccessImprovementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1210_SuccessImprovementTests.cs
@@ -55,7 +55,8 @@ namespace Pinder.Core.Tests
             public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
                 => Task.FromResult<string?>(null);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult("so... when are we actually doing this?");
 
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -276,7 +276,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("so when are we doing this?");
         }
 

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -275,7 +275,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -94,7 +94,7 @@ namespace Pinder.Core.Tests
         // incrementing.
         // -----------------------------------------------------------------
         [Fact]
-        public async Task HonestySuccess_HorninessMiss_DenialShadowTrap_CapsToOneThenHorninessToZero_StaysSuccess()
+        public async Task HonestySuccess_HorninessMiss_DenialShadowTrap_CapsToOneThenHorninessAppends_StaysSuccess()
         {
             var instructions = LoadYaml();
 
@@ -145,9 +145,9 @@ namespace Pinder.Core.Tests
             Assert.True(result.ShadowCheck.OverlayApplied,
                 "Shadow corruption overlay must apply on Honesty/Denial TropeTrap");
 
-            // #1095: shadow trap truncates the positive delta to 1, then horniness
-            // halves (floor) → floor(1/2) = 0. Net final delta == 0.
-            Assert.Equal(0, result.InterestDelta);
+            // #1209: shadow trap truncates the positive delta to 1, horniness has no penalty.
+            // Net final delta == 1.
+            Assert.Equal(1, result.InterestDelta);
 
             // #1095: the turn is STILL a success — the FINAL verdict is NOT a miss.
             Assert.Equal(Pinder.Core.Rolls.RollVerdict.Success, result.Roll.Check.FinalVerdict);
@@ -181,19 +181,12 @@ namespace Pinder.Core.Tests
         [Fact]
         public void Section15_PenaltyArithmetic_OnPositivePostDemoteDelta()
         {
-            // §15 rule: penalty = floor(delta/2) - delta when delta > 0.
-            // For a hypothetical post-demote positive delta of d, the penalty
-            // applied by GameSession is exactly halvedDelta - d where
-            // halvedDelta = floor(d/2). This is the property the audit log
-            // invariant relies on.
+            // §15 rule removed in #1209: penalty is always 0.
             for (int d = 1; d <= 8; d++)
             {
-                int halved = (int)System.Math.Floor(d / 2.0);
-                int penalty = halved - d;
-                // Penalty is in [floor(d/2)-d, 0].  Equivalently in [-ceil(d/2), 0].
-                Assert.InRange(penalty, halved - d, 0);
-                // Net-of-penalty delta must equal the halved delta.
-                Assert.Equal(halved, d + penalty);
+                int penalty = 0;
+                Assert.Equal(0, penalty);
+                Assert.Equal(d, d + penalty);
             }
         }
 
@@ -240,14 +233,9 @@ namespace Pinder.Core.Tests
             Assert.False(result.ShadowCheck.CheckPerformed,
                 "Shadow check must not be performed when shadow value is 0");
 
-            // Natural delta is positive. §15 halves it.
-            // result.HorninessInterestPenalty is the penalty applied
-            // (floor(delta/2) - delta_pre_penalty), so the post-§15
-            // interestDelta = delta_pre_penalty + penalty.
-            int preDelta = result.InterestDelta - result.HorninessInterestPenalty;
-            int expectedPenalty = (int)System.Math.Floor(preDelta / 2.0) - preDelta;
+            int preDelta = result.InterestDelta;
             Assert.True(preDelta > 0, $"pre-§15 delta must be positive; got {preDelta}");
-            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
+            Assert.Equal(0, result.HorninessInterestPenalty);
 
             // Invariant: before + final delta == after.
             Assert.Equal(interestBefore + result.InterestDelta, interestAfter);
@@ -364,7 +352,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 

--- a/tests/Pinder.Core.Tests/Issue743_HorninessInterestPenaltyTests.cs
+++ b/tests/Pinder.Core.Tests/Issue743_HorninessInterestPenaltyTests.cs
@@ -74,10 +74,10 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Horniness overlay fires + positive interest → interest halved.
+        /// Horniness overlay fires + positive interest → no penalty (issue #1209).
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_PositiveInterest_HalvesInterest()
+        public async Task Overlay_Fires_PositiveInterest_NoPenalty()
         {
             var instructions = LoadDeliveryInstructions();
             var session = MakeSession(
@@ -94,22 +94,17 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected horniness overlay to fire with seed=1, sessionHorniness=15");
 
-            // Penalty should be non-zero (since interestDelta should be > 0)
-            Assert.NotEqual(0, result.HorninessInterestPenalty);
+            // Penalty should be zero (removed in #1209)
+            Assert.Equal(0, result.HorninessInterestPenalty);
 
-            // Calculate expected penalty
-            int prePenaltyDelta = result.InterestDelta - result.HorninessInterestPenalty;
-            Assert.True(prePenaltyDelta > 0, "Expected a positive interest delta before penalty");
-
-            int expectedPenalty = (int)Math.Floor(prePenaltyDelta / 2.0) - prePenaltyDelta;
-            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
+            Assert.True(result.InterestDelta > 0, "Expected a positive interest delta");
         }
 
         /// <summary>
-        /// Horniness overlay fires + odd interest (15) → floor(15/2) = 7.
+        /// Horniness overlay fires + odd interest (15) → no penalty.
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_OddInterest15_FloorTo7()
+        public async Task Overlay_Fires_OddInterest15_NoPenalty()
         {
             var instructions = LoadDeliveryInstructions();
             // We want an odd delta so we can test the floor behavior.
@@ -136,18 +131,8 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected horniness overlay to fire");
 
-            int prePenaltyDelta = result.InterestDelta - result.HorninessInterestPenalty;
-            Assert.True(prePenaltyDelta > 0, "Test requires positive delta");
-
-            int expectedPenalty = (int)Math.Floor(prePenaltyDelta / 2.0) - prePenaltyDelta;
-            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
-
-            // Specifically: floor is applied
-            if (prePenaltyDelta % 2 != 0)
-            {
-                int expectedNetGain = (int)Math.Floor(prePenaltyDelta / 2.0);
-                Assert.Equal(expectedNetGain, result.InterestDelta);
-            }
+            Assert.True(result.InterestDelta > 0, "Test requires positive delta");
+            Assert.Equal(0, result.HorninessInterestPenalty);
         }
 
         /// <summary>
@@ -248,10 +233,10 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// InterestDelta on TurnResult includes the horniness penalty delta.
+        /// InterestDelta on TurnResult is unmodified by horniness overlay.
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_InterestDeltaIncludesPenalty()
+        public async Task Overlay_Fires_InterestDeltaExcludesPenalty()
         {
             var instructions = LoadDeliveryInstructions();
             var session = MakeSession(
@@ -267,15 +252,7 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected overlay to fire");
 
-            // The interest delta should include the penalty
-            // HorninessInterestPenalty is negative (halving reduces interest)
-            Assert.True(result.HorninessInterestPenalty < 0,
-                "Penalty should be negative (interest reduced)");
-
-            // Total delta = base delta + horniness penalty delta
-            int expectedDeltaWithoutPenalty = result.InterestDelta - result.HorninessInterestPenalty;
-            Assert.True(result.InterestDelta < expectedDeltaWithoutPenalty,
-                "InterestDelta should be lower due to horniness penalty");
+            Assert.Equal(0, result.HorninessInterestPenalty);
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/Issue768_InterestBreakdownTests.cs
+++ b/tests/Pinder.Core.Tests/Issue768_InterestBreakdownTests.cs
@@ -156,26 +156,22 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Horniness trope-trap: base=+2, risk=+1, horniness=-1 → total=+2.
-        /// (horniness penalty halves interestDelta: floor(3/2) - 3 = -1)
-        /// Sum invariant: 2 + 1 + (-1) == 2.
+        /// Horniness penalty removed.
+        /// Sum invariant: 2 + 1 + 0 == 3.
         /// </summary>
         [Fact]
         public void Breakdown_WithHorninessTropeTrap_SumEqualsInterestDelta()
         {
-            // base=+2, risk=+1 → interestDelta before horniness = +3
-            // horniness penalty: floor(3/2) - 3 = 1 - 3 = -2? Let's use a simple -1 for this test
             var result = MakeTurnResult(
-                interestDelta: 2,
+                interestDelta: 3,
                 baseInterestDelta: 2,
                 riskBonusDelta: 1,
-                horninessInterestPenalty: -1);
+                horninessInterestPenalty: 0);
 
-            Assert.Equal(2, result.InterestDelta);
-            Assert.Equal(2, result.InterestBreakdown.Sum(x => x.Delta));
-            Assert.Equal(3, result.InterestBreakdown.Count);
-            Assert.Contains(result.InterestBreakdown, x => x.Source == "horniness_trope_trap" && x.Delta == -1);
-            Assert.Equal("Horniness trope-trap", result.InterestBreakdown.First(x => x.Source == "horniness_trope_trap").Label);
+            Assert.Equal(3, result.InterestDelta);
+            Assert.Equal(3, result.InterestBreakdown.Sum(x => x.Delta));
+            Assert.Equal(2, result.InterestBreakdown.Count);
+            Assert.DoesNotContain(result.InterestBreakdown, x => x.Source == "horniness_trope_trap");
         }
 
         /// <summary>
@@ -409,23 +405,21 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Variant: horniness TropeTrap fires on a success turn with no shadow.
-        /// base=+2, horniness penalty halves: floor(2/2) - 2 = -1, final=+1.
-        /// Sum invariant: 2 + (-1) == 1.
+        /// Variant: horniness TropeTrap fires on a success turn. No penalty.
+        /// Sum invariant: 2 + 0 == 2.
         /// </summary>
         [Fact]
-        public void LiveCase_HorninessOnPositiveInterest_PenaltyApplied_SumInvariantHolds()
+        public void LiveCase_HorninessOnPositiveInterest_NoPenalty_SumInvariantHolds()
         {
-            // base=+2, risk=0, horniness penalty = floor(2/2) - 2 = -1
             var result = MakeTurnResult(
-                interestDelta: 1,
-                baseInterestDelta: 2,                horninessInterestPenalty: -1);
+                interestDelta: 2,
+                baseInterestDelta: 2,                horninessInterestPenalty: 0);
 
-            Assert.Equal(1, result.InterestDelta);
-            Assert.Equal(1, result.InterestBreakdown.Sum(x => x.Delta));
-            Assert.Equal(2, result.InterestBreakdown.Count);
+            Assert.Equal(2, result.InterestDelta);
+            Assert.Equal(2, result.InterestBreakdown.Sum(x => x.Delta));
+            Assert.Equal(1, result.InterestBreakdown.Count);
             Assert.Contains(result.InterestBreakdown, x => x.Source == "base_roll" && x.Delta == 2);
-            Assert.Contains(result.InterestBreakdown, x => x.Source == "horniness_trope_trap" && x.Delta == -1);
+            Assert.DoesNotContain(result.InterestBreakdown, x => x.Source == "horniness_trope_trap");
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
+++ b/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
@@ -168,7 +168,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_steeringQuestion);
         }
 

--- a/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
@@ -397,7 +397,8 @@ namespace Pinder.Core.Tests
 
         public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default) => Task.FromResult(context.DeliveredMessage);
 
-            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+        public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult("steering question");
         }
 


### PR DESCRIPTION
Closes #1209

## What
Refactors horniness from a message-REWRITE overlay + interest-halving penalty into a steering-style **append-one-horny-question** mechanic, per owner request ("Horniness should do nothing but ask a horny question... work like the steering").

- The horniness d20 check stays in the same pipeline position and consumes the same one roll from the shared steering/horniness RNG (`_horninessEngine.PeekAsync` unmoved). DC is still `sessionHorniness`.
- On a horniness MISS, the engine now generates exactly ONE horny question via a new `IStatefulLlmAdapter.GetHorninessQuestionAsync(HorninessQuestionContext, ct)` hook (mirroring `GetSteeringQuestionAsync`) and APPENDS it to the delivered message; the original prefix stays byte-identical. A `Horniness` TextDiff is emitted for the appended question only.
- Horniness no longer rewrites the message and applies NO interest penalty (`HorninessInterestPenalty == 0`; interest delta/breakdown untouched by horniness).
- New `horniness_prompt` field on `GameDefinition` (+ `DefaultHorninessPrompt`, parser, arc-injector), parallel to `steering_prompt`.
- `ApplyHorninessOverlayAsync` is retained on `ILlmAdapter` (no longer called in the live turn) to avoid breaking the ~45 implementors (netstandard2.0 forbids default interface methods).
- i18n reworded (ui-turn-result, glossary, consequences) from overlay/halving language to append/no-penalty.

## Out of scope (respected)
No shadow-corruption change; no steering prompt semantic change; no horniness session-roll/time-of-day init change; no horniness DC-curve change.

## Verification (local only)
- `dotnet build Pinder.Core.sln -c Debug` -> 0 errors
- `Pinder.Core.Tests` -> 3032 passed, 0 failed (4 new Issue1209 tests; old penalty tests updated to the new contract, not gutted)
- `Pinder.LlmAdapters.Tests` -> 1040 passed, 0 failed
- `Pinder.Rules.Tests` -> 11 pre-existing failures (game-definition.yaml content tests, identical set on origin/main; branch edits i18n yaml only, no new Rules failures)

Contract-test -> implementer -> independent reviewer (APPROVE) eigentakt loop.