### PR TITLE
refactor(#1208): prompt-cache immutable-first ordering audit + regression tests

### DIFF
--- a/docs/prompt-cache-ordering.md
+++ b/docs/prompt-cache-ordering.md
@@ -1,0 +1,25 @@
+# Prompt-cache immutable-first ordering contract (#1208)
+
+## Contract
+The established rule for prompt construction to maximize cacheability is:
+(a) Immutable/static instructions must come first.
+(b) Cache breakpoints are placed on the last block of the stable prefix.
+(c) Volatile history, current-turn content, and state appear as a suffix.
+
+## System prompts (compliant)
+`SessionSystemPromptBuilder.BuildPlayerAvatarEx` and `BuildDateeEx` already emit the static GM base first and the per-character spec last (after '== CHARACTER YOU CONTROL =='). Anthropic/OpenRouter transports attach `cache_control` `ephemeral` to that stable system block (`AnthropicTransport.cs`, `OpenAiCacheControl.cs`). This is the GOOD pattern.
+
+## User-message prompts (documented exceptions)
+`BuildDialogueOptionsPromptEx` and `BuildDateePromptEx` are NOT fully immutable-first and CANNOT be safely reordered, because:
+- Their trailing output-format/engine instruction templates back-reference earlier volatile content positionally ('character profile above', 'messages above', 'system prompt above', 'profile below').
+- The `[ENGINE]` blocks interpolate volatile state (`{game_state}`, `{interest_narrative}`).
+- Golden/order regression tests (Issue1153 golden fixtures, EngineInjectionBlockTests, SessionDocumentBuilderTests, Issue489 voice tests) pin the current order.
+
+Reordering would change rendered semantics and model behavior. The current INTENDED order (history/state -> engine block -> trailing static instruction) is pinned by `tests/Pinder.LlmAdapters.Tests/Issue1208_PromptOrderingTests.cs` so it cannot silently regress.
+
+## User-message cache-control limitation (follow-up)
+Note that because the user message is flattened into one string mixing volatile history + static instructions, the Anthropic ephemeral marker on the current-turn user block does not sit on a pure stable prefix. Splitting the user payload into `[static_prefix, volatile_suffix]` content blocks is a larger follow-up beyond #1208's safe scope.
+
+## Regression tests
+Reference `tests/Pinder.LlmAdapters.Tests/Issue1208_PromptOrderingTests.cs`.
+These tests pin the current structure of the prompts and document the builders to ensure order does not silently regress and that exceptions to the immutable-first rule remain well documented.

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -19,6 +19,12 @@ namespace Pinder.LlmAdapters
         /// <summary>
         /// Builds the user-message content for GetDialogueOptionsAsync and returns the trace data.
         /// </summary>
+        /// <remarks>
+        /// <para><strong>#1208 immutable-first contract: DOCUMENTED EXCEPTION</strong></para>
+        /// <para>This builder CANNOT be safely reordered to immutable-first. Its engine blocks interpolate volatile state,
+        /// and trailing static instructions contain positional back-references. Changing this order breaks rendered semantics.
+        /// See docs/prompt-cache-ordering.md and pinning tests for details.</para>
+        /// </remarks>
         public static PromptTraceResult BuildDialogueOptionsPromptEx(DialogueContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -205,6 +211,12 @@ namespace Pinder.LlmAdapters
         /// <summary>
         /// Builds the user-message content for GetDateeResponseAsync and returns the trace data.
         /// </summary>
+        /// <remarks>
+        /// <para><strong>#1208 immutable-first contract: DOCUMENTED EXCEPTION</strong></para>
+        /// <para>This builder CANNOT be safely reordered to immutable-first. Its engine blocks interpolate volatile state,
+        /// and trailing static instructions contain positional back-references. Changing this order breaks rendered semantics.
+        /// See docs/prompt-cache-ordering.md and pinning tests for details.</para>
+        /// </remarks>
         public static PromptTraceResult BuildDateePromptEx(DateeContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));

--- a/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
@@ -20,6 +20,8 @@ namespace Pinder.LlmAdapters
     /// the VARIABLE character-spec block LAST. This keeps the stable cacheable
     /// prefix (GM base + game definition) ahead of the per-character delta and
     /// the volatile running transcript, so #1123's prompt caching still pays off.
+    /// 
+    /// #1208: This builder implements the COMPLIANT immutable-first ordering pattern (see docs/prompt-cache-ordering.md).
     /// </summary>
     public static class SessionSystemPromptBuilder
     {

--- a/tests/Pinder.LlmAdapters.Tests/Issue1208_PromptOrderingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1208_PromptOrderingTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Trait("Category", "LlmAdapters")]
+    public class Issue1208_PromptOrderingTests
+    {
+        private static DialogueContext MakeDialogueContext(IReadOnlyList<(string, string)> history)
+        {
+            return new DialogueContext(
+                playerAvatarPrompt: "player prompt",
+                dateePrompt: "datee prompt",
+                conversationHistory: history,
+                dateeLastMessage: history.Count > 0 ? history.Last().Item2 : "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                shadowThresholds: null,
+                callbackOpportunities: null,
+                horninessLevel: 0,
+                requiresRizzOption: false,
+                activeTrapInstructions: null,
+                playerName: "P",
+                dateeName: "O",
+                currentTurn: 1,
+                availableStats: new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+        }
+
+        private static DateeContext MakeDateeContext(IReadOnlyList<(string, string)> history)
+        {
+            return new DateeContext(
+                dateePrompt: "datee prompt",
+                conversationHistory: history,
+                dateeLastMessage: "",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hey",
+                interestBefore: 10,
+                interestAfter: 10,
+                responseDelayMinutes: 1.0,
+                shadowThresholds: null,
+                activeTrapInstructions: null,
+                playerName: "P",
+                dateeName: "O");
+        }
+
+        [Fact]
+        public void SystemPrompt_PlayerAvatar_StaticBasePrecedesCharacterSpec()
+        {
+            var result = SessionSystemPromptBuilder.BuildPlayerAvatarEx("My Player Prompt");
+            
+            Assert.Contains(SessionSystemPromptBuilder.CharacterSpecHeader, result.Text);
+            
+            int headerIndex = result.Text.IndexOf(SessionSystemPromptBuilder.CharacterSpecHeader, StringComparison.Ordinal);
+            
+            var gmBaseSpan = result.Spans.First(s => s.Key == "game_master_prompt");
+            var profileSpan = result.Spans.First(s => s.Key == "player-profile" || s.Key == "player_avatar_role_description");
+            
+            Assert.True(gmBaseSpan.Start < headerIndex, "Static GM base should precede the Character Spec Header");
+            Assert.True(profileSpan.Start > headerIndex, "Character profile should follow the Character Spec Header");
+        }
+
+        [Fact]
+        public void DialogueOptionsPrompt_OutputFormatInstruction_IsLastBlock()
+        {
+            var history = new List<(string, string)> { ("O", "Hello") };
+            var ctx = MakeDialogueContext(history);
+            var result = SessionDocumentBuilder.BuildDialogueOptionsPromptEx(ctx);
+
+            var historySpan = result.Spans.First(s => s.Key == "conversation-history");
+            var engineSpan = result.Spans.First(s => s.Key == "engine-options-block");
+            var instructionSpan = result.Spans.First(s => s.Key == "dialogue-options-instruction");
+
+            var maxStart = result.Spans.Max(s => s.Start);
+            Assert.Equal(maxStart, instructionSpan.Start);
+
+            Assert.True(historySpan.Start < engineSpan.Start, "History should precede engine block");
+            Assert.True(engineSpan.Start < instructionSpan.Start, "Engine block should precede instructions");
+        }
+
+        [Fact]
+        public void DateePrompt_ResponseInstruction_IsLastBlock()
+        {
+            var history = new List<(string, string)> { ("O", "Hello") };
+            var ctx = MakeDateeContext(history);
+            var result = SessionDocumentBuilder.BuildDateePromptEx(ctx);
+
+            var historySpan = result.Spans.First(s => s.Key == "conversation-history");
+            var engineSpan = result.Spans.First(s => s.Key == "engine-datee-block");
+            var instructionSpan = result.Spans.First(s => s.Key == "datee-response-instruction");
+
+            var maxStart = result.Spans.Max(s => s.Start);
+            Assert.Equal(maxStart, instructionSpan.Start);
+
+            Assert.True(historySpan.Start < engineSpan.Start, "History should precede engine block");
+            Assert.True(engineSpan.Start < instructionSpan.Start, "Engine block should precede instructions");
+        }
+
+        [Fact]
+        public void PromptOrdering_AuditDoc_Exists_AndDocumentsBuilders()
+        {
+            var currentDir = Directory.GetCurrentDirectory();
+            string repoRoot = null;
+            
+            var dir = new DirectoryInfo(currentDir);
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir.FullName, ".git")) || File.Exists(Path.Combine(dir.FullName, "Pinder.Core.sln")))
+                {
+                    repoRoot = dir.FullName;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            Assert.NotNull(repoRoot);
+
+            var docPath = Path.Combine(repoRoot, "docs", "prompt-cache-ordering.md");
+            Assert.True(File.Exists(docPath), $"Audit doc should exist at {docPath}");
+
+            var text = File.ReadAllText(docPath);
+            Assert.Contains("BuildDialogueOptionsPromptEx", text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("BuildDateePromptEx", text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("immutable", text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1208

## What
Audits prompt construction for prompt-cache immutable-first ordering and pins it with regression tests. Per the issue's own guidance ("if a prompt cannot be reordered safely, document why and add a test/comment"), this lands the **safe documented-exception path** rather than a risky reorder.

- **New audit doc** `docs/prompt-cache-ordering.md` — states the immutable-first contract (static instructions first, cache breakpoint on the last stable-prefix block, volatile history/state as suffix), documents the system prompt as the compliant reference pattern, and documents the two user-message builders as non-reorderable exceptions with the reasons.
- **System prompt** (`SessionSystemPromptBuilder`) is already immutable-first + cacheable (static GM base first, per-character spec after `== CHARACTER YOU CONTROL ==`; transports attach `cache_control: ephemeral` to that stable block). Annotated as the reference pattern (comment only).
- **User-message builders** (`BuildDialogueOptionsPromptEx`, `BuildDateePromptEx`) **cannot** be safely reordered: their trailing static instructions back-reference earlier volatile content positionally ("character profile above", "messages above", "system prompt above"), the `[ENGINE]` blocks interpolate volatile `{game_state}`/`{interest_narrative}`, and existing golden/IndexOf tests pin the current order. Annotated as documented exceptions (comment only — no prompt text/order changed).
- **Regression tests** (`Issue1208_PromptOrderingTests.cs`) pin: system-prompt static-base-before-character-spec, and user-builder ordering (history → engine block → trailing static instruction) via `PromptTraceResult.Spans`, plus the audit-doc presence.
- Noted as a future follow-up (out of #1208's safe scope): splitting the flattened user payload into `[static_prefix, volatile_suffix]` content blocks so a cache marker can land on a pure stable prefix.

## Out of scope (respected)
No prompt-text reorder, no template changes, no transport/cache-control code changes, no provider/model routing, no frontend.

## Verification (local only)
- `dotnet build Pinder.Core.sln -c Debug` -> 0 errors
- `Pinder.LlmAdapters.Tests` -> 1044 passed, 0 failed (4 new Issue1208 tests + golden/order tests still green)
- `Pinder.Core.Tests` -> 3032 passed, 0 failed

Contract-test -> implementer -> independent reviewer (APPROVE) eigentakt loop. Production src changes are comment/XML-doc only.