### PR TITLE
feat(#1211): config-driven XP awards + reckless 10x + terminal outcome multipliers

### DIFF
--- a/rules/extracted/risk-reward-and-hidden-depth-enriched.yaml
+++ b/rules/extracted/risk-reward-and-hidden-depth-enriched.yaml
@@ -1,127 +1,104 @@
-- id: §0.riskreward-hidden-depth
-  section: §0
+- id: "\xA70.riskreward-hidden-depth"
+  section: "\xA70"
   title: Risk/Reward & Hidden Depth
   type: interest_change
   blocks:
   - kind: paragraph
-    text: Five layered mechanics that reward attentive players without punishing casual ones. Casual players see funny dialogue and roll dice. Strategic players are playing 4D chess with conversation mechanics.
-      The game works at every depth level.
+    text: Five layered mechanics that reward attentive players without punishing casual
+      ones. Casual players see funny dialogue and roll dice. Strategic players are
+      playing 4D chess with conversation mechanics. The game works at every depth
+      level.
   - kind: hr
-  description: Five layered mechanics that reward attentive players without punishing casual ones. Casual players see funny dialogue and roll dice. Strategic players are playing 4D chess with conversation
-    mechanics. The game works at every depth level.
+  description: Five layered mechanics that reward attentive players without punishing
+    casual ones. Casual players see funny dialogue and roll dice. Strategic players
+    are playing 4D chess with conversation mechanics. The game works at every depth
+    level.
   heading_level: 1
-- id: §1.the-ui-what-the-player-sees
-  section: §1
+- id: "\xA71.the-ui-what-the-player-sees"
+  section: "\xA71"
   title: 'The UI: What The Player Sees'
   type: template
   blocks:
   - kind: paragraph
-    text: This is the complete dialogue selection screen. Everything the player sees in one place. The sections below explain each element.
+    text: This is the complete dialogue selection screen. Everything the player sees
+      in one place. The sections below explain each element.
   - kind: code
-    text: '```
-
-      ╔══════════════════════════════════════════════════════╗
-
-      ║  Velvet: "i dropped out of art school"               ║
-
-      ║  "everyone said i was throwing my life away"          ║
-
-      ║  "turns out my life was in a tattoo parlor"           ║
-
-      ║  "lmao"                                              ║
-
-      ╠══════════════════════════════════════════════════════╣
-
-      ║  📈 Momentum: 2 wins (one more = Momentum bonus)     ║
-
-      ║                                                      ║
-
-      ║  A) 🎲 HONESTY (+5)                    🟢 Safe      ║
-
-      ║     "the lmao is doing a lot of work...              ║
-
-      ║     you''re proud but you still hear                   ║
-
-      ║     their voices sometimes"                           ║
-
-      ║     DC 7 🔓  |  Need: 2+  |  95%                    ║
-
-      ║     Reward: +1 to +3                                  ║
-
-      ║                                                      ║
-
-      ║  B) 🎲 WIT (+2)                        🟡 Medium    ║
-
-      ║     "art school to tattoo artist is the              ║
-
-      ║     most direct pipeline since ''tech bro             ║
-
-      ║     to mushroom guy''"                                 ║
-
-      ║     DC 11  |  Need: 9+  |  60%                      ║
-
-      ║     Reward: +1 to +3  |  1.5x XP        🔗          ║
-
-      ║                                                      ║
-
-      ║  C) 🎲 SELF-AWARENESS (+3)             🟡 Medium    ║
-
-      ║     "you told that story like a joke                  ║
-
-      ║     but it''s not a joke to you"                       ║
-
-      ║     DC 9  |  Need: 6+  |  75%                       ║
-
-      ║     Reward: +1 to +3  |  1.5x XP        ⭐          ║
-
-      ║                                                      ║
-
-      ║  D) 🎲 RIZZ (-2) 🔥                   🔴 Bold      ║
-
-      ║     "rebels are hot... especially ones               ║
-
-      ║     with tattoo guns"                                 ║
-
-      ║     DC 11  |  Need: 13+  |  40%                     ║
-
-      ║     Reward: +3 to +5  |  3x XP                      ║
-
-      ║                                                      ║
-
-      ║  ICONS: ⭐ Combo  🔗 Callback  🔓 Window  🔥 Forced ║
-
-      ╚══════════════════════════════════════════════════════╝
-
-      ```'
-  description: This is the complete dialogue selection screen. Everything the player sees in one place. The sections below explain each element.
+    text: "```\n\u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2557\n\u2551  Velvet: \"i dropped out of art\
+      \ school\"               \u2551\n\u2551  \"everyone said i was throwing my life\
+      \ away\"          \u2551\n\u2551  \"turns out my life was in a tattoo parlor\"\
+      \           \u2551\n\u2551  \"lmao\"                                       \
+      \       \u2551\n\u2560\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2563\n\u2551  \U0001F4C8 Momentum: 2 wins\
+      \ (one more = Momentum bonus)     \u2551\n\u2551                           \
+      \                           \u2551\n\u2551  A) \U0001F3B2 HONESTY (+5)     \
+      \               \U0001F7E2 Safe      \u2551\n\u2551     \"the lmao is doing\
+      \ a lot of work...              \u2551\n\u2551     you're proud but you still\
+      \ hear                   \u2551\n\u2551     their voices sometimes\"       \
+      \                    \u2551\n\u2551     DC 7 \U0001F513  |  Need: 2+  |  95%\
+      \                    \u2551\n\u2551     Reward: +1 to +3                   \
+      \               \u2551\n\u2551                                             \
+      \         \u2551\n\u2551  B) \U0001F3B2 WIT (+2)                        \U0001F7E1\
+      \ Medium    \u2551\n\u2551     \"art school to tattoo artist is the        \
+      \      \u2551\n\u2551     most direct pipeline since 'tech bro             \u2551\
+      \n\u2551     to mushroom guy'\"                                 \u2551\n\u2551\
+      \     DC 11  |  Need: 9+  |  60%                      \u2551\n\u2551     Reward:\
+      \ +1 to +3  |  1.5x XP        \U0001F517          \u2551\n\u2551           \
+      \                                           \u2551\n\u2551  C) \U0001F3B2 SELF-AWARENESS\
+      \ (+3)             \U0001F7E1 Medium    \u2551\n\u2551     \"you told that story\
+      \ like a joke                  \u2551\n\u2551     but it's not a joke to you\"\
+      \                       \u2551\n\u2551     DC 9  |  Need: 6+  |  75%       \
+      \                \u2551\n\u2551     Reward: +1 to +3  |  1.5x XP        \u2B50\
+      \          \u2551\n\u2551                                                  \
+      \    \u2551\n\u2551  D) \U0001F3B2 RIZZ (-2) \U0001F525                   \U0001F534\
+      \ Bold      \u2551\n\u2551     \"rebels are hot... especially ones         \
+      \      \u2551\n\u2551     with tattoo guns\"                               \
+      \  \u2551\n\u2551     DC 11  |  Need: 13+  |  40%                     \u2551\
+      \n\u2551     Reward: +3 to +5  |  3x XP                      \u2551\n\u2551\
+      \                                                      \u2551\n\u2551  ICONS:\
+      \ \u2B50 Combo  \U0001F517 Callback  \U0001F513 Window  \U0001F525 Forced \u2551\
+      \n\u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\
+      \u2550\u2550\u2550\u255D\n```"
+  description: This is the complete dialogue selection screen. Everything the player
+    sees in one place. The sections below explain each element.
   heading_level: 2
-- id: §1.icon-reference
-  section: §1
+- id: "\xA71.icon-reference"
+  section: "\xA71"
   title: Icon Reference
   type: table
   blocks:
   - kind: table
     rows:
-    - Icon: 🟢🟡🟠🔴
+    - Icon: "\U0001F7E2\U0001F7E1\U0001F7E0\U0001F534"
       Meaning: Risk tier (Safe / Medium / Hard / Bold)
       Visible to all?: 'Yes'
-    - Icon: 🔓
-      Meaning: Datee weakness window — DC reduced this turn
+    - Icon: "\U0001F513"
+      Meaning: "Datee weakness window \u2014 DC reduced this turn"
       Visible to all?: Semi-hidden (icon visible, reason isn't)
-    - Icon: 🔗
-      Meaning: Callback to an earlier topic — hidden roll bonus
+    - Icon: "\U0001F517"
+      Meaning: "Callback to an earlier topic \u2014 hidden roll bonus"
       Visible to all?: Semi-hidden
-    - Icon: ⭐
-      Meaning: Stat combo available — hidden bonus if you pick this
+    - Icon: "\u2B50"
+      Meaning: "Stat combo available \u2014 hidden bonus if you pick this"
       Visible to all?: Semi-hidden
-    - Icon: 📈
+    - Icon: "\U0001F4C8"
       Meaning: Momentum streak indicator
       Visible to all?: Visible in status bar
-    - Icon: 📖
+    - Icon: "\U0001F4D6"
       Meaning: Post-roll reveal when you read a tell correctly
       Visible to all?: Post-roll feedback
-    - Icon: 🔥
-      Meaning: Horniness-forced option — this stat is being pushed by your Horniness score
+    - Icon: "\U0001F525"
+      Meaning: "Horniness-forced option \u2014 this stat is being pushed by your Horniness\
+        \ score"
       Visible to all?: Visible (warning)
     sep_cells:
     - '------'
@@ -130,9 +107,9 @@
   - kind: hr
   description: ''
   heading_level: 3
-- id: §2.risk-tier.safe
-  section: §2
-  title: Risk Tier — Safe
+- id: "\xA72.risk-tier.safe"
+  section: "\xA72"
+  title: "Risk Tier \u2014 Safe"
   type: roll_modifier
   description: 'Need Need 5 or less: Safe. +0 bonus. 1x.'
   condition:
@@ -143,11 +120,11 @@
     risk_tier: Safe
     interest_bonus: 0
     xp_multiplier: 1.0
-- id: §2.risk-tier.medium
-  section: §2
-  title: Risk Tier — Medium
+- id: "\xA72.risk-tier.medium"
+  section: "\xA72"
+  title: "Risk Tier \u2014 Medium"
   type: roll_modifier
-  description: 'Need Need 6–10: Medium. +0 bonus. 1.5x.'
+  description: "Need Need 6\u201310: Medium. +0 bonus. 1.5x."
   condition:
     need_range:
     - 6
@@ -156,11 +133,11 @@
     risk_tier: Medium
     interest_bonus: 0
     xp_multiplier: 1.5
-- id: §2.risk-tier.hard
-  section: §2
-  title: Risk Tier — Hard
+- id: "\xA72.risk-tier.hard"
+  section: "\xA72"
+  title: "Risk Tier \u2014 Hard"
   type: roll_modifier
-  description: 'Need Need 11–15: Hard. +1 bonus Interest. 2x.'
+  description: "Need Need 11\u201315: Hard. +1 bonus Interest. 2x."
   condition:
     need_range:
     - 11
@@ -169,48 +146,62 @@
     risk_tier: Hard
     interest_bonus: 1
     xp_multiplier: 2.0
-- id: §2.risk-tier.bold
-  section: §2
-  title: Risk Tier — Bold
+- id: "\xA72.risk-tier.bold"
+  section: "\xA72"
+  title: "Risk Tier \u2014 Bold"
   type: roll_modifier
   description: 'Need Need 16+: Bold. +2 bonus Interest. 3x.'
   condition:
     need_range:
     - 16
-    - 99
+    - 19
   outcome:
     risk_tier: Bold
     interest_bonus: 2
     xp_multiplier: 3.0
-- id: §2.risk-tiers
-  section: §2
-  title: 🟢🟡🟠🔴 Risk Tiers
+- id: "\xA72.risk-tier.reckless"
+  section: "\xA72"
+  title: "Risk Tier \u2014 Reckless"
+  type: roll_modifier
+  description: 'Need 20+: Reckless. 10x.'
+  condition:
+    need_range:
+    - 20
+    - 99
+  outcome:
+    risk_tier: Reckless
+    interest_bonus: 2
+    xp_multiplier: 10.0
+- id: "\xA72.risk-tiers"
+  section: "\xA72"
+  title: "\U0001F7E2\U0001F7E1\U0001F7E0\U0001F534 Risk Tiers"
   type: table
   blocks:
   - kind: paragraph
-    text: Every option shows its risk tier based on how hard the roll is. Risk and reward are always visible — the player chooses their gamble.
+    text: "Every option shows its risk tier based on how hard the roll is. Risk and\
+      \ reward are always visible \u2014 the player chooses their gamble."
   - kind: table
     rows:
     - DC vs Your Modifier: Need 5 or less
       Risk Tier: Safe
       Interest Bonus on Success: +0 bonus
       XP Multiplier: 1x
-      Display: 🟢 Safe
-    - DC vs Your Modifier: Need 6–10
+      Display: "\U0001F7E2 Safe"
+    - DC vs Your Modifier: "Need 6\u201310"
       Risk Tier: Medium
       Interest Bonus on Success: +0 bonus
       XP Multiplier: 1.5x
-      Display: 🟡 Medium
-    - DC vs Your Modifier: Need 11–15
+      Display: "\U0001F7E1 Medium"
+    - DC vs Your Modifier: "Need 11\u201315"
       Risk Tier: Hard
       Interest Bonus on Success: +1 bonus Interest
       XP Multiplier: 2x
-      Display: 🟠 Hard
+      Display: "\U0001F7E0 Hard"
     - DC vs Your Modifier: Need 16+
       Risk Tier: Bold
       Interest Bonus on Success: +2 bonus Interest
       XP Multiplier: 3x
-      Display: 🔴 Bold
+      Display: "\U0001F534 Bold"
     sep_cells:
     - '---'
     - '---'
@@ -218,32 +209,41 @@
     - '---'
     - '---'
   - kind: paragraph
-    text: The percentage shown is the base probability of success before hidden bonuses. Hard and Bold options give more Interest on success AND more XP — but they can also miss by more, making failures
-      worse.
+    text: "The percentage shown is the base probability of success before hidden bonuses.\
+      \ Hard and Bold options give more Interest on success AND more XP \u2014 but\
+      \ they can also miss by more, making failures worse."
   - kind: hr
-  description: Every option shows its risk tier based on how hard the roll is. Risk and reward are always visible — the player chooses their gamble.
+  description: "Every option shows its risk tier based on how hard the roll is. Risk\
+    \ and reward are always visible \u2014 the player chooses their gamble."
   heading_level: 2
-- id: §3.datee-weakness-window
-  section: §3
-  title: 🔓 Datee Weakness Window
+- id: "\xA73.datee-weakness-window"
+  section: "\xA73"
+  title: "\U0001F513 Datee Weakness Window"
   type: interest_change
   blocks:
   - kind: paragraph
-    text: Some datee messages crack their own guard. When an datee contradicts themselves, laughs genuinely, or shares something unguarded — their defense DC drops for one turn. A 🔓 icon appears on
-      the option that exploits it. The DC shown is already reduced; the player doesn't see a "–2" explanation.
+    text: "Some datee messages crack their own guard. When an datee contradicts themselves,\
+      \ laughs genuinely, or shares something unguarded \u2014 their defense DC drops\
+      \ for one turn. A \U0001F513 icon appears on the option that exploits it. The\
+      \ DC shown is already reduced; the player doesn't see a \"\u20132\" explanation."
   - kind: paragraph
-    text: '**In the UI above:** Velvet''s message contains a crack ("lmao" — she''s making light of something that clearly hurt). Her Honesty defense drops. Option A shows DC 7 instead of the normal 9.
-      The player sees a suspiciously high 95% and a 🔓 icon. The attentive player: "she cracked her own wall." The casual player: high percentage, pick it anyway.'
-  description: Some datee messages crack their own guard. When an datee contradicts themselves, laughs genuinely, or shares something unguarded — their defense DC drops for one turn. A 🔓 icon appears
-    on the option that exploits it. The DC shown is already reduced; the player doesn't see a "–2" explanation.
+    text: "**In the UI above:** Velvet's message contains a crack (\"lmao\" \u2014\
+      \ she's making light of something that clearly hurt). Her Honesty defense drops.\
+      \ Option A shows DC 7 instead of the normal 9. The player sees a suspiciously\
+      \ high 95% and a \U0001F513 icon. The attentive player: \"she cracked her own\
+      \ wall.\" The casual player: high percentage, pick it anyway."
+  description: "Some datee messages crack their own guard. When an datee contradicts\
+    \ themselves, laughs genuinely, or shares something unguarded \u2014 their defense\
+    \ DC drops for one turn. A \U0001F513 icon appears on the option that exploits\
+    \ it. The DC shown is already reduced; the player doesn't see a \"\u20132\" explanation."
   heading_level: 2
   condition:
     datee_behaviour: crack
   outcome:
     dc_adjustment: -2
-- id: §3.weakness-trigger.contradicts-themselves
-  section: §3
-  title: Weakness Trigger — Contradicts themselves
+- id: "\xA73.weakness-trigger.contradicts-themselves"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Contradicts themselves"
   type: roll_modifier
   description: 'When datee contradicts themselves: Honesty defense DC -2.'
   condition:
@@ -251,9 +251,9 @@
   outcome:
     dc_adjustment: -2
     defence_window: Honesty defense
-- id: §3.weakness-trigger.laughs-genuinely
-  section: §3
-  title: Weakness Trigger — Laughs genuinely
+- id: "\xA73.weakness-trigger.laughs-genuinely"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Laughs genuinely"
   type: roll_modifier
   description: 'When datee laughs genuinely: Charm defense DC -2.'
   condition:
@@ -261,19 +261,20 @@
   outcome:
     dc_adjustment: -2
     defence_window: Charm defense
-- id: §3.weakness-trigger.shares-something-personal-unpr
-  section: §3
-  title: Weakness Trigger — Shares something personal unprompted
+- id: "\xA73.weakness-trigger.shares-something-personal-unpr"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Shares something personal unprompted"
   type: roll_modifier
-  description: 'When datee shares something personal unprompted: Self-Awareness defense DC -3.'
+  description: 'When datee shares something personal unprompted: Self-Awareness defense
+    DC -3.'
   condition:
     datee_behaviour: Shares something personal unprompted
   outcome:
     dc_adjustment: -3
     defence_window: Self-Awareness defense
-- id: §3.weakness-trigger.gets-flustered---responds-too-
-  section: §3
-  title: Weakness Trigger — Gets flustered / responds too fast
+- id: "\xA73.weakness-trigger.gets-flustered---responds-too-"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Gets flustered / responds too fast"
   type: roll_modifier
   description: 'When datee gets flustered / responds too fast: Wit defense DC -2.'
   condition:
@@ -281,9 +282,9 @@
   outcome:
     dc_adjustment: -2
     defence_window: Wit defense
-- id: §3.weakness-trigger.asks-you-a-personal-question
-  section: §3
-  title: Weakness Trigger — Asks YOU a personal question
+- id: "\xA73.weakness-trigger.asks-you-a-personal-question"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Asks YOU a personal question"
   type: roll_modifier
   description: 'When datee asks you a personal question: Honesty defense DC -2.'
   condition:
@@ -291,9 +292,9 @@
   outcome:
     dc_adjustment: -2
     defence_window: Honesty defense
-- id: §3.weakness-trigger.makes-a-risky-joke
-  section: §3
-  title: Weakness Trigger — Makes a risky joke
+- id: "\xA73.weakness-trigger.makes-a-risky-joke"
+  section: "\xA73"
+  title: "Weakness Trigger \u2014 Makes a risky joke"
   type: roll_modifier
   description: 'When datee makes a risky joke: Chaos defense DC -2.'
   condition:
@@ -301,8 +302,8 @@
   outcome:
     dc_adjustment: -2
     defence_window: Chaos defense
-- id: §3.weakness-triggers
-  section: §3
+- id: "\xA73.weakness-triggers"
+  section: "\xA73"
   title: Weakness Triggers
   type: table
   blocks:
@@ -333,53 +334,60 @@
   - kind: hr
   description: ''
   heading_level: 3
-- id: §4.callback-bonus
-  section: §4
-  title: 🔗 Callback Bonus
+- id: "\xA74.callback-bonus"
+  section: "\xA74"
+  title: "\U0001F517 Callback Bonus"
   type: interest_change
   blocks:
   - kind: paragraph
-    text: If a dialogue option references something introduced earlier in the conversation, it gets a hidden roll bonus and a 🔗 icon. The LLM tracks topics as they're introduced and flags options that call
-      back to them. The roll probability shown does not include the callback bonus — attentive players who recognise the reference are getting better odds than the number says.
+    text: "If a dialogue option references something introduced earlier in the conversation,\
+      \ it gets a hidden roll bonus and a \U0001F517 icon. The LLM tracks topics as\
+      \ they're introduced and flags options that call back to them. The roll probability\
+      \ shown does not include the callback bonus \u2014 attentive players who recognise\
+      \ the reference are getting better odds than the number says."
   - kind: paragraph
-    text: '**In the UI above:** Option B references "tech bro to mushroom guy" — Zyx''s own life story, introduced early in the conversation. The 🔗 icon marks it. Displayed at 60%; actual odds are closer
-      to 70%.'
-  description: If a dialogue option references something introduced earlier in the conversation, it gets a hidden roll bonus and a 🔗 icon. The LLM tracks topics as they're introduced and flags options that
-    call back to them. The roll probability shown does not include the callback bonus — attentive players who recognise the reference are getting better odds than the number says.
+    text: "**In the UI above:** Option B references \"tech bro to mushroom guy\" \u2014\
+      \ Zyx's own life story, introduced early in the conversation. The \U0001F517\
+      \ icon marks it. Displayed at 60%; actual odds are closer to 70%."
+  description: "If a dialogue option references something introduced earlier in the\
+    \ conversation, it gets a hidden roll bonus and a \U0001F517 icon. The LLM tracks\
+    \ topics as they're introduced and flags options that call back to them. The roll\
+    \ probability shown does not include the callback bonus \u2014 attentive players\
+    \ who recognise the reference are getting better odds than the number says."
   heading_level: 2
   condition:
     callback_distance: 2
   outcome:
     roll_bonus: 1
-- id: §4.callback-bonus.2-turns
-  section: §4
-  title: Callback Bonus — 2 turns ago
+- id: "\xA74.callback-bonus.2-turns"
+  section: "\xA74"
+  title: "Callback Bonus \u2014 2 turns ago"
   type: roll_modifier
   description: Referencing a topic from 2 turns ago grants +1 to roll.
   condition:
     callback_distance: 2
   outcome:
     roll_bonus: 1
-- id: §4.callback-bonus.4-plus
-  section: §4
-  title: Callback Bonus — 4+ turns ago
+- id: "\xA74.callback-bonus.4-plus"
+  section: "\xA74"
+  title: "Callback Bonus \u2014 4+ turns ago"
   type: roll_modifier
   description: Referencing a topic from 4+ turns ago grants +2 to roll.
   condition:
     callback_distance: 4
   outcome:
     roll_bonus: 2
-- id: §4.callback-bonus.opener
-  section: §4
-  title: Callback Bonus — From the opener
+- id: "\xA74.callback-bonus.opener"
+  section: "\xA74"
+  title: "Callback Bonus \u2014 From the opener"
   type: roll_modifier
   description: Referencing a topic from from the opener grants +3 to roll.
   condition:
     callback_distance: 0
   outcome:
     roll_bonus: 3
-- id: §4.callback-distances
-  section: §4
+- id: "\xA74.callback-distances"
+  section: "\xA74"
   title: Callback Distances
   type: table
   blocks:
@@ -396,163 +404,172 @@
     - '---'
   description: ''
   heading_level: 3
-- id: §4.llm-instruction
-  section: §4
+- id: "\xA74.llm-instruction"
+  section: "\xA74"
   title: LLM Instruction
   type: template
   blocks:
   - kind: paragraph
-    text: 'When generating dialogue options, the LLM receives a list of callback-eligible topics with turn numbers:'
+    text: 'When generating dialogue options, the LLM receives a list of callback-eligible
+      topics with turn numbers:'
   - kind: code
-    text: '```
-
-      CALLBACK OPPORTUNITIES
-
-      - "art school" — introduced turn 4 (4 turns ago, +2 bonus eligible)
-
-      - "mushroom guy" — introduced turn 1 (opener, +3 bonus eligible)
-
-      ```'
+    text: "```\nCALLBACK OPPORTUNITIES\n- \"art school\" \u2014 introduced turn 4\
+      \ (4 turns ago, +2 bonus eligible)\n- \"mushroom guy\" \u2014 introduced turn\
+      \ 1 (opener, +3 bonus eligible)\n```"
   - kind: paragraph
-    text: 'Instruction: *"For 1–2 options, incorporate a natural reference to an earlier topic. Mark with `[CALLBACK: turn_number]` in metadata."* The engine applies the distance bonus automatically.'
+    text: "Instruction: *\"For 1\u20132 options, incorporate a natural reference to\
+      \ an earlier topic. Mark with `[CALLBACK: turn_number]` in metadata.\"* The\
+      \ engine applies the distance bonus automatically."
   - kind: hr
-  description: 'When generating dialogue options, the LLM receives a list of callback-eligible topics with turn numbers:'
+  description: 'When generating dialogue options, the LLM receives a list of callback-eligible
+    topics with turn numbers:'
   heading_level: 3
-- id: §5.stat-combo
-  section: §5
-  title: ⭐ Stat Combo
+- id: "\xA75.stat-combo"
+  section: "\xA75"
+  title: "\u2B50 Stat Combo"
   type: interest_change
   blocks:
   - kind: paragraph
-    text: Certain stat sequences across consecutive turns create **combos** — bonus effects triggered by using the right stats in the right order. The ⭐ icon appears on an option that would *complete* a
-      combo. The icon doesn't explain the combo; players learn the patterns through play.
+    text: "Certain stat sequences across consecutive turns create **combos** \u2014\
+      \ bonus effects triggered by using the right stats in the right order. The \u2B50\
+      \ icon appears on an option that would *complete* a combo. The icon doesn't\
+      \ explain the combo; players learn the patterns through play."
   - kind: paragraph
-    text: '**In the UI above:** Option C (Self-Awareness) shows ⭐. This means the player''s previous stat + Self-Awareness completes a known combo sequence. The attentive player starts recognising these
-      patterns. The casual player picks it because it sounds right — which is fine.'
-  description: Certain stat sequences across consecutive turns create **combos** — bonus effects triggered by using the right stats in the right order. The ⭐ icon appears on an option that would *complete*
-    a combo. The icon doesn't explain the combo; players learn the patterns through play.
+    text: "**In the UI above:** Option C (Self-Awareness) shows \u2B50. This means\
+      \ the player's previous stat + Self-Awareness completes a known combo sequence.\
+      \ The attentive player starts recognising these patterns. The casual player\
+      \ picks it because it sounds right \u2014 which is fine."
+  description: "Certain stat sequences across consecutive turns create **combos**\
+    \ \u2014 bonus effects triggered by using the right stats in the right order.\
+    \ The \u2B50 icon appears on an option that would *complete* a combo. The icon\
+    \ doesn't explain the combo; players learn the patterns through play."
   heading_level: 2
-- id: §5.combo.setup
-  section: §5
-  title: Combo — The Setup
+- id: "\xA75.combo.setup"
+  section: "\xA75"
+  title: "Combo \u2014 The Setup"
   type: roll_modifier
-  description: 'The Setup: Wit → Charm → +1 Interest on Charm.'
+  description: "The Setup: Wit \u2192 Charm \u2192 +1 Interest on Charm."
   condition:
     combo_sequence:
     - Wit
     - Charm
   outcome:
     interest_bonus: 1
-- id: §5.combo.reveal
-  section: §5
-  title: Combo — The Reveal
+- id: "\xA75.combo.reveal"
+  section: "\xA75"
+  title: "Combo \u2014 The Reveal"
   type: roll_modifier
-  description: 'The Reveal: Charm → Honesty → +1 Interest on Honesty.'
+  description: "The Reveal: Charm \u2192 Honesty \u2192 +1 Interest on Honesty."
   condition:
     combo_sequence:
     - Charm
     - Honesty
   outcome:
     interest_bonus: 1
-- id: §5.combo.read
-  section: §5
-  title: Combo — The Read
+- id: "\xA75.combo.read"
+  section: "\xA75"
+  title: "Combo \u2014 The Read"
   type: roll_modifier
-  description: 'The Read: Self-Awareness → Honesty → +1 Interest on Honesty.'
+  description: "The Read: Self-Awareness \u2192 Honesty \u2192 +1 Interest on Honesty."
   condition:
     combo_sequence:
     - Self-Awareness
     - Honesty
   outcome:
     interest_bonus: 1
-- id: §5.combo.pivot
-  section: §5
-  title: Combo — The Pivot
+- id: "\xA75.combo.pivot"
+  section: "\xA75"
+  title: "Combo \u2014 The Pivot"
   type: roll_modifier
-  description: 'The Pivot: Honesty → Chaos → +1 Interest on Chaos.'
+  description: "The Pivot: Honesty \u2192 Chaos \u2192 +1 Interest on Chaos."
   condition:
     combo_sequence:
     - Honesty
     - Chaos
   outcome:
     interest_bonus: 1
-- id: §5.combo.recovery
-  section: §5
-  title: Combo — The Recovery
+- id: "\xA75.combo.recovery"
+  section: "\xA75"
+  title: "Combo \u2014 The Recovery"
   type: roll_modifier
-  description: 'The Recovery: Any failed stat → Self-Awareness → **+2** Interest.'
+  description: "The Recovery: Any failed stat \u2192 Self-Awareness \u2192 **+2**\
+    \ Interest."
   condition:
     combo_sequence:
     - Any failed stat
     - Self-Awareness
   outcome:
     interest_bonus: 2
-- id: §5.combo.escalation
-  section: §5
-  title: Combo — The Escalation
+- id: "\xA75.combo.escalation"
+  section: "\xA75"
+  title: "Combo \u2014 The Escalation"
   type: roll_modifier
-  description: 'The Escalation: Chaos → Rizz → +1 Interest on Rizz.'
+  description: "The Escalation: Chaos \u2192 Rizz \u2192 +1 Interest on Rizz."
   condition:
     combo_sequence:
     - Chaos
     - Rizz
   outcome:
     interest_bonus: 1
-- id: §5.combo.disarm
-  section: §5
-  title: Combo — The Disarm
+- id: "\xA75.combo.disarm"
+  section: "\xA75"
+  title: "Combo \u2014 The Disarm"
   type: roll_modifier
-  description: 'The Disarm: Wit → Honesty → +1 Interest on Honesty.'
+  description: "The Disarm: Wit \u2192 Honesty \u2192 +1 Interest on Honesty."
   condition:
     combo_sequence:
     - Wit
     - Honesty
   outcome:
     interest_bonus: 1
-- id: §5.combo.triple
-  section: §5
-  title: Combo — The Triple
+- id: "\xA75.combo.triple"
+  section: "\xA75"
+  title: "Combo \u2014 The Triple"
   type: roll_modifier
-  description: 'The Triple: 3 different stats in 3 turns → +1 to all rolls next turn.'
+  description: "The Triple: 3 different stats in 3 turns \u2192 +1 to all rolls next\
+    \ turn."
   condition:
     combo_sequence:
     - 3 different stats in 3 turns
   outcome:
     interest_bonus: 1
     roll_bonus: 1
-- id: §5.combo-list
-  section: §5
+- id: "\xA75.combo-list"
+  section: "\xA75"
   title: Combo List
   type: table
   blocks:
   - kind: table
     rows:
     - Combo: '**The Setup**'
-      Sequence: Wit → Charm
+      Sequence: "Wit \u2192 Charm"
       Bonus: +1 Interest on Charm
-      Narrative logic: You made them laugh, then charmed them. The joke lowered their guard.
+      Narrative logic: You made them laugh, then charmed them. The joke lowered their
+        guard.
     - Combo: '**The Reveal**'
-      Sequence: Charm → Honesty
+      Sequence: "Charm \u2192 Honesty"
       Bonus: +1 Interest on Honesty
       Narrative logic: You were smooth, then dropped the act. The contrast is disarming.
     - Combo: '**The Read**'
-      Sequence: Self-Awareness → Honesty
+      Sequence: "Self-Awareness \u2192 Honesty"
       Bonus: +1 Interest on Honesty
-      Narrative logic: You showed you understood them, then let them understand you. Reciprocity.
+      Narrative logic: You showed you understood them, then let them understand you.
+        Reciprocity.
     - Combo: '**The Pivot**'
-      Sequence: Honesty → Chaos
+      Sequence: "Honesty \u2192 Chaos"
       Bonus: +1 Interest on Chaos
-      Narrative logic: You were real, then you were wild. Emotional whiplash in the best way.
+      Narrative logic: You were real, then you were wild. Emotional whiplash in the
+        best way.
     - Combo: '**The Recovery**'
-      Sequence: Any failed stat → Self-Awareness
+      Sequence: "Any failed stat \u2192 Self-Awareness"
       Bonus: '**+2** Interest'
       Narrative logic: You messed up, then acknowledged it. Growth, live on stage.
     - Combo: '**The Escalation**'
-      Sequence: Chaos → Rizz
+      Sequence: "Chaos \u2192 Rizz"
       Bonus: +1 Interest on Rizz
       Narrative logic: You were unpredictable, then you made a move. Chaos as foreplay.
     - Combo: '**The Disarm**'
-      Sequence: Wit → Honesty
+      Sequence: "Wit \u2192 Honesty"
       Bonus: +1 Interest on Honesty
       Narrative logic: You were clever, then you were real. Shows range.
     - Combo: '**The Triple**'
@@ -567,36 +584,36 @@
   - kind: hr
   description: ''
   heading_level: 3
-- id: §6.momentum.2-wins
-  section: §6
-  title: Momentum — 2 wins
+- id: "\xA76.momentum.2-wins"
+  section: "\xA76"
+  title: "Momentum \u2014 2 wins"
   type: roll_modifier
   description: '2 wins: Nothing mechanical yet.'
   condition:
     streak: 2
   outcome:
     effect: none
-- id: §6.momentum.3-wins
-  section: §6
-  title: Momentum — 3 wins
+- id: "\xA76.momentum.3-wins"
+  section: "\xA76"
+  title: "Momentum \u2014 3 wins"
   type: roll_modifier
   description: '3 wins: +2 to next roll, all options improve in quality.'
   condition:
     streak: 3
   outcome:
     roll_bonus: 2
-- id: §6.momentum.4-wins
-  section: §6
-  title: Momentum — 4 wins
+- id: "\xA76.momentum.4-wins"
+  section: "\xA76"
+  title: "Momentum \u2014 4 wins"
   type: roll_modifier
   description: '4 wins: +2 to next 2 rolls, datee''s next reply is warmer.'
   condition:
     streak: 4
   outcome:
     roll_bonus: 2
-- id: §6.momentum.5plus-wins
-  section: §6
-  title: Momentum — 5+ wins
+- id: "\xA76.momentum.5plus-wins"
+  section: "\xA76"
+  title: "Momentum \u2014 5+ wins"
   type: roll_modifier
   description: '5+ wins: +3 to next roll, datee may spontaneously +1 Interest.'
   condition:
@@ -604,58 +621,70 @@
   outcome:
     roll_bonus: 3
     interest_delta: 1
-- id: §6.momentum
-  section: §6
-  title: 📈 Momentum
+- id: "\xA76.momentum"
+  section: "\xA76"
+  title: "\U0001F4C8 Momentum"
   type: table
   blocks:
   - kind: paragraph
-    text: Three successes in a row builds **Momentum** — a hidden state shown in the status bar. Momentum boosts the next roll AND visibly improves the writing quality of all options (the LLM knows you're
-      on a streak). An attentive player notices their character sounds smoother and more assured. That's the tell.
+    text: "Three successes in a row builds **Momentum** \u2014 a hidden state shown\
+      \ in the status bar. Momentum boosts the next roll AND visibly improves the\
+      \ writing quality of all options (the LLM knows you're on a streak). An attentive\
+      \ player notices their character sounds smoother and more assured. That's the\
+      \ tell."
   - kind: table
     rows:
     - Streak: 2 wins
-      Status bar: '📈 Momentum: 2 wins (one more = Momentum bonus)'
+      Status bar: "\U0001F4C8 Momentum: 2 wins (one more = Momentum bonus)"
       Effect: Nothing mechanical yet
     - Streak: 3 wins
-      Status bar: 📈 **Momentum**
+      Status bar: "\U0001F4C8 **Momentum**"
       Effect: +2 to next roll, all options improve in quality
     - Streak: 4 wins
-      Status bar: 📈 **Flow State**
+      Status bar: "\U0001F4C8 **Flow State**"
       Effect: +2 to next 2 rolls, datee's next reply is warmer
     - Streak: 5+ wins
-      Status bar: 📈 **In The Zone**
+      Status bar: "\U0001F4C8 **In The Zone**"
       Effect: +3 to next roll, datee may spontaneously +1 Interest
     sep_cells:
     - '---'
     - '---'
     - '---'
   - kind: paragraph
-    text: Momentum breaks on any failure. Good runs feel great — and the eventual failure stings more.
+    text: "Momentum breaks on any failure. Good runs feel great \u2014 and the eventual\
+      \ failure stings more."
   - kind: hr
-  description: Three successes in a row builds **Momentum** — a hidden state shown in the status bar. Momentum boosts the next roll AND visibly improves the writing quality of all options (the LLM knows
-    you're on a streak). An attentive player notices their character sounds smoother and more assured. That's the tell.
+  description: "Three successes in a row builds **Momentum** \u2014 a hidden state\
+    \ shown in the status bar. Momentum boosts the next roll AND visibly improves\
+    \ the writing quality of all options (the LLM knows you're on a streak). An attentive\
+    \ player notices their character sounds smoother and more assured. That's the\
+    \ tell."
   heading_level: 2
-- id: §7.datee-tells-post-roll-feedback
-  section: §7
-  title: 📖 Datee Tells (Post-Roll Feedback)
+- id: "\xA77.datee-tells-post-roll-feedback"
+  section: "\xA77"
+  title: "\U0001F4D6 Datee Tells (Post-Roll Feedback)"
   type: roll_modifier
   blocks:
   - kind: paragraph
-    text: 'The datee''s message contains subtle clues about which stat will work best next turn. Reading a tell gives a hidden **+2** to the matching option. The player doesn''t see "+2" before the roll
-      — instead, the tell option has visibly better writing: more specific, more responsive, more alive.'
+    text: "The datee's message contains subtle clues about which stat will work best\
+      \ next turn. Reading a tell gives a hidden **+2** to the matching option. The\
+      \ player doesn't see \"+2\" before the roll \u2014 instead, the tell option\
+      \ has visibly better writing: more specific, more responsive, more alive."
   - kind: paragraph
-    text: 'After a successful tell read, the UI reveals: **"📖 You read the moment. +2 bonus."** — teaching the player to look for them.'
-  description: 'The datee''s message contains subtle clues about which stat will work best next turn. Reading a tell gives a hidden **+2** to the matching option. The player doesn''t see "+2" before
-    the roll — instead, the tell option has visibly better writing: more specific, more responsive, more alive.'
+    text: "After a successful tell read, the UI reveals: **\"\U0001F4D6 You read the\
+      \ moment. +2 bonus.\"** \u2014 teaching the player to look for them."
+  description: "The datee's message contains subtle clues about which stat will work\
+    \ best next turn. Reading a tell gives a hidden **+2** to the matching option.\
+    \ The player doesn't see \"+2\" before the roll \u2014 instead, the tell option\
+    \ has visibly better writing: more specific, more responsive, more alive."
   heading_level: 2
   condition:
     action: tell_read
   outcome:
     roll_bonus: 2
-- id: §7.tell.compliments-you
-  section: §7
-  title: Tell — Compliments you
+- id: "\xA77.tell.compliments-you"
+  section: "\xA77"
+  title: "Tell \u2014 Compliments you"
   type: roll_modifier
   description: 'Datee compliments you: Tell stat Honesty (+2).'
   condition:
@@ -663,19 +692,20 @@
   outcome:
     roll_bonus: 2
     tell_stat: Honesty
-- id: §7.tell.asks-a-personal-question
-  section: §7
-  title: Tell — Asks a personal question
+- id: "\xA77.tell.asks-a-personal-question"
+  section: "\xA77"
+  title: "Tell \u2014 Asks a personal question"
   type: roll_modifier
-  description: 'Datee asks a personal question: Tell stat Honesty or Self-Awareness (+2).'
+  description: 'Datee asks a personal question: Tell stat Honesty or Self-Awareness
+    (+2).'
   condition:
     datee_behaviour: Asks a personal question
   outcome:
     roll_bonus: 2
     tell_stat: Honesty or Self-Awareness
-- id: §7.tell.makes-a-joke
-  section: §7
-  title: Tell — Makes a joke
+- id: "\xA77.tell.makes-a-joke"
+  section: "\xA77"
+  title: "Tell \u2014 Makes a joke"
   type: roll_modifier
   description: 'Datee makes a joke: Tell stat Wit or Chaos (+2).'
   condition:
@@ -683,9 +713,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Wit or Chaos
-- id: §7.tell.shares-something-vulnerable
-  section: §7
-  title: Tell — Shares something vulnerable
+- id: "\xA77.tell.shares-something-vulnerable"
+  section: "\xA77"
+  title: "Tell \u2014 Shares something vulnerable"
   type: roll_modifier
   description: 'Datee shares something vulnerable: Tell stat Honesty (+2).'
   condition:
@@ -693,9 +723,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Honesty
-- id: §7.tell.pulls-back---gets-guarded
-  section: §7
-  title: Tell — Pulls back / gets guarded
+- id: "\xA77.tell.pulls-back---gets-guarded"
+  section: "\xA77"
+  title: "Tell \u2014 Pulls back / gets guarded"
   type: roll_modifier
   description: 'Datee pulls back / gets guarded: Tell stat Self-Awareness (+2).'
   condition:
@@ -703,9 +733,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Self-Awareness
-- id: §7.tell.tests-you---challenges
-  section: §7
-  title: Tell — Tests you / challenges
+- id: "\xA77.tell.tests-you---challenges"
+  section: "\xA77"
+  title: "Tell \u2014 Tests you / challenges"
   type: roll_modifier
   description: 'Datee tests you / challenges: Tell stat Wit or Chaos (+2).'
   condition:
@@ -713,9 +743,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Wit or Chaos
-- id: §7.tell.sends-a-short-reply
-  section: §7
-  title: Tell — Sends a short reply
+- id: "\xA77.tell.sends-a-short-reply"
+  section: "\xA77"
+  title: "Tell \u2014 Sends a short reply"
   type: roll_modifier
   description: 'Datee sends a short reply: Tell stat Charm or Chaos (+2).'
   condition:
@@ -723,9 +753,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Charm or Chaos
-- id: §7.tell.flirts
-  section: §7
-  title: Tell — Flirts
+- id: "\xA77.tell.flirts"
+  section: "\xA77"
+  title: "Tell \u2014 Flirts"
   type: roll_modifier
   description: 'Datee flirts: Tell stat Rizz or Charm (+2).'
   condition:
@@ -733,9 +763,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Rizz or Charm
-- id: §7.tell.changes-subject
-  section: §7
-  title: Tell — Changes subject
+- id: "\xA77.tell.changes-subject"
+  section: "\xA77"
+  title: "Tell \u2014 Changes subject"
   type: roll_modifier
   description: 'Datee changes subject: Tell stat Chaos (+2).'
   condition:
@@ -743,9 +773,9 @@
   outcome:
     roll_bonus: 2
     tell_stat: Chaos
-- id: §7.tell.goes-silent-for-a-while
-  section: §7
-  title: Tell — Goes silent for a while
+- id: "\xA77.tell.goes-silent-for-a-while"
+  section: "\xA77"
+  title: "Tell \u2014 Goes silent for a while"
   type: roll_modifier
   description: 'Datee goes silent for a while: Tell stat Self-Awareness (+2).'
   condition:
@@ -753,8 +783,8 @@
   outcome:
     roll_bonus: 2
     tell_stat: Self-Awareness
-- id: §7.tell-categories
-  section: §7
+- id: "\xA77.tell-categories"
+  section: "\xA77"
   title: Tell Categories
   type: table
   blocks:
@@ -762,7 +792,7 @@
     rows:
     - Datee says/does: Compliments you
       Tell stat (+2): Honesty
-      Why: They're warm — be real back
+      Why: "They're warm \u2014 be real back"
     - Datee says/does: Asks a personal question
       Tell stat (+2): Honesty or Self-Awareness
       Why: They want depth
@@ -797,28 +827,33 @@
   - kind: hr
   description: ''
   heading_level: 3
-- id: §8.horniness-forced-options
-  section: §8
-  title: 🔥 Horniness-Forced Options
+- id: "\xA78.horniness-forced-options"
+  section: "\xA78"
+  title: "\U0001F525 Horniness-Forced Options"
   type: shadow_growth
   blocks:
   - kind: paragraph
-    text: 'When Horniness is high, it pushes a Rizz option into the lineup whether the player wants it or not. The 🔥 icon is a warning: this option is here because your body is doing the thinking. It may
-      or may not be appropriate for this moment in the conversation.'
+    text: "When Horniness is high, it pushes a Rizz option into the lineup whether\
+      \ the player wants it or not. The \U0001F525 icon is a warning: this option\
+      \ is here because your body is doing the thinking. It may or may not be appropriate\
+      \ for this moment in the conversation."
   - kind: paragraph
-    text: The option always shows with 🔥 so the player can consciously choose to pick it or avoid it. Unlike all other hidden mechanics, this one is fully flagged — the comedy is in the player seeing it
-      and making a decision.
+    text: "The option always shows with \U0001F525 so the player can consciously choose\
+      \ to pick it or avoid it. Unlike all other hidden mechanics, this one is fully\
+      \ flagged \u2014 the comedy is in the player seeing it and making a decision."
   - kind: hr
-  description: 'When Horniness is high, it pushes a Rizz option into the lineup whether the player wants it or not. The 🔥 icon is a warning: this option is here because your body is doing the thinking.
-    It may or may not be appropriate for this moment in the conversation.'
+  description: "When Horniness is high, it pushes a Rizz option into the lineup whether\
+    \ the player wants it or not. The \U0001F525 icon is a warning: this option is\
+    \ here because your body is doing the thinking. It may or may not be appropriate\
+    \ for this moment in the conversation."
   heading_level: 2
   condition:
     shadow: Horniness
     threshold: 6
   outcome:
     forced_stat: Rizz
-- id: §9.the-depth-gradient
-  section: §9
+- id: "\xA79.the-depth-gradient"
+  section: "\xA79"
   title: The Depth Gradient
   type: table
   blocks:
@@ -828,18 +863,74 @@
       What they use: Risk tiers and percentages
       How they play: Picks what feels safe or what sounds fun
     - Player Type: '**Engaged**'
-      What they use: Risk tiers + icons (⭐🔗🔓)
+      What they use: "Risk tiers + icons (\u2B50\U0001F517\U0001F513)"
       How they play: Notices the markers, starts learning patterns
     - Player Type: '**Strategic**'
       What they use: Everything + mental model of combos/windows/callbacks
-      How they play: Plans 2–3 turns ahead, chains combos, reads tells
+      How they play: "Plans 2\u20133 turns ahead, chains combos, reads tells"
     sep_cells:
     - '---'
     - '---'
     - '---'
   - kind: paragraph
-    text: All three player types have fun. The casual player sees funny dialogue and rolls dice. The strategic player is playing 4D chess with conversation mechanics. The game doesn't punish casuals or
-      bore strategists.
-  description: All three player types have fun. The casual player sees funny dialogue and rolls dice. The strategic player is playing 4D chess with conversation mechanics. The game doesn't punish casuals
-    or bore strategists.
+    text: All three player types have fun. The casual player sees funny dialogue and
+      rolls dice. The strategic player is playing 4D chess with conversation mechanics.
+      The game doesn't punish casuals or bore strategists.
+  description: All three player types have fun. The casual player sees funny dialogue
+    and rolls dice. The strategic player is playing 4D chess with conversation mechanics.
+    The game doesn't punish casuals or bore strategists.
   heading_level: 2
+- id: "\xA710.xp.terminal.date-secured"
+  section: "\xA710"
+  title: "Terminal XP \u2014 Date Secured"
+  type: xp_modifier
+  outcome:
+    multiplier: 3.0
+- id: "\xA710.xp.terminal.unmatched"
+  section: "\xA710"
+  title: "Terminal XP \u2014 Unmatched"
+  type: xp_modifier
+  outcome:
+    multiplier: 1.0
+- id: "\xA710.xp.terminal.ghosted"
+  section: "\xA710"
+  title: "Terminal XP \u2014 Ghosted"
+  type: xp_modifier
+  outcome:
+    multiplier: 1.0
+- id: "\xA710.xp.success.dc-16"
+  section: "\xA710"
+  title: "Success Base XP \u2014 Low DC"
+  type: xp_modifier
+  outcome:
+    base_xp: 5
+- id: "\xA710.xp.success.dc-20"
+  section: "\xA710"
+  title: "Success Base XP \u2014 Mid DC"
+  type: xp_modifier
+  outcome:
+    base_xp: 10
+- id: "\xA710.xp.success.dc-99"
+  section: "\xA710"
+  title: "Success Base XP \u2014 High DC"
+  type: xp_modifier
+  outcome:
+    base_xp: 15
+- id: "\xA710.xp.flat.nat20"
+  section: "\xA710"
+  title: "Flat XP \u2014 Nat 20"
+  type: xp_modifier
+  outcome:
+    xp: 25
+- id: "\xA710.xp.flat.nat1"
+  section: "\xA710"
+  title: "Flat XP \u2014 Nat 1"
+  type: xp_modifier
+  outcome:
+    xp: 10
+- id: "\xA710.xp.flat.failure"
+  section: "\xA710"
+  title: "Flat XP \u2014 Failure"
+  type: xp_modifier
+  outcome:
+    xp: 2

--- a/src/Pinder.Core/Conversation/SessionXpRecorder.cs
+++ b/src/Pinder.Core/Conversation/SessionXpRecorder.cs
@@ -29,21 +29,31 @@ namespace Pinder.Core.Conversation
         {
             if (rollResult.IsNatTwenty)
             {
-                _xpLedger.Record("Nat20", 25);
+                int award = _rules?.GetFlatXpAward("Nat20") ?? 25;
+                _xpLedger.Record("Nat20", award);
             }
             else if (rollResult.IsNatOne)
             {
-                _xpLedger.Record("Nat1", 10);
+                int award = _rules?.GetFlatXpAward("Nat1") ?? 10;
+                _xpLedger.Record("Nat1", award);
             }
             else if (rollResult.IsSuccess)
             {
                 int baseXp;
-                if (rollResult.DC <= 16)
-                    baseXp = 5;
-                else if (rollResult.DC <= 20)
-                    baseXp = 10;
+                int? configBaseXp = _rules?.GetSuccessBaseXp(rollResult.DC);
+                if (configBaseXp.HasValue)
+                {
+                    baseXp = configBaseXp.Value;
+                }
                 else
-                    baseXp = 15;
+                {
+                    if (rollResult.DC <= 16)
+                        baseXp = 5;
+                    else if (rollResult.DC <= 20)
+                        baseXp = 10;
+                    else
+                        baseXp = 15;
+                }
 
                 int xp = ApplyRiskTierMultiplier(baseXp, rollResult.RiskTier);
 
@@ -54,7 +64,8 @@ namespace Pinder.Core.Conversation
             }
             else
             {
-                _xpLedger.Record("Failure", 2);
+                int award = _rules?.GetFlatXpAward("Failure") ?? 2;
+                _xpLedger.Record("Failure", award);
             }
         }
 
@@ -78,6 +89,8 @@ namespace Pinder.Core.Conversation
                 multiplier = 2.0;
             else if (riskTier == RiskTier.Medium)
                 multiplier = 1.5;
+            else if (riskTier == RiskTier.Reckless)
+                multiplier = 10.0;
             else
                 multiplier = 1.0;
 
@@ -86,14 +99,15 @@ namespace Pinder.Core.Conversation
 
         /// <summary>
         /// Records end-of-game XP based on the game outcome.
-        /// DateSecured → 50, Unmatched/Ghosted → 5.
+        /// Uses terminal outcome multipliers.
         /// </summary>
         public void RecordEndOfGameXp(GameOutcome outcome)
         {
-            if (outcome == GameOutcome.DateSecured)
-                _xpLedger.Record("DateSecured", 50);
-            else if (outcome == GameOutcome.Unmatched || outcome == GameOutcome.Ghosted)
-                _xpLedger.Record("ConversationComplete", 5);
+            double multiplier = _rules?.GetTerminalOutcomeMultiplier(outcome) ?? (outcome == GameOutcome.DateSecured ? 3.0 : 1.0);
+            int collected = _xpLedger.TotalXp;
+            int delta = (int)Math.Round(collected * multiplier) - collected;
+            if (delta > 0)
+                _xpLedger.Record($"OutcomeBonus_{outcome}", delta);
         }
     }
 }

--- a/src/Pinder.Core/Interfaces/IRuleResolver.cs
+++ b/src/Pinder.Core/Interfaces/IRuleResolver.cs
@@ -51,5 +51,23 @@ namespace Pinder.Core.Interfaces
         /// Returns null if no matching rule found.
         /// </summary>
         double? GetRiskTierXpMultiplier(RiskTier riskTier);
+
+        /// <summary>
+        /// §10 terminal outcome → XP multiplier.
+        /// Returns null if no matching rule found.
+        /// </summary>
+        double? GetTerminalOutcomeMultiplier(GameOutcome outcome);
+
+        /// <summary>
+        /// Success base XP based on DC.
+        /// Returns null if no matching rule found.
+        /// </summary>
+        int? GetSuccessBaseXp(int dc);
+
+        /// <summary>
+        /// Flat XP award based on string type (e.g. Nat20, Nat1, Failure).
+        /// Returns null if no matching rule found.
+        /// </summary>
+        int? GetFlatXpAward(string awardType);
     }
 }

--- a/src/Pinder.Rules/RuleBookResolver.cs
+++ b/src/Pinder.Rules/RuleBookResolver.cs
@@ -255,6 +255,7 @@ namespace Pinder.Rules
                 case RiskTier.Medium: targetId = "§2.risk-tier.medium"; break;
                 case RiskTier.Hard: targetId = "§2.risk-tier.hard"; break;
                 case RiskTier.Bold: targetId = "§2.risk-tier.bold"; break;
+                case RiskTier.Reckless: targetId = "§2.risk-tier.reckless"; break;
                 default: return null;
             }
 
@@ -262,6 +263,41 @@ namespace Pinder.Rules
             if (rule?.Outcome != null)
                 return GetOutcomeDouble(rule.Outcome, "xp_multiplier");
 
+            return null;
+        }
+
+        public double? GetTerminalOutcomeMultiplier(GameOutcome outcome)
+        {
+            string id = outcome switch
+            {
+                GameOutcome.DateSecured => "§10.xp.terminal.date-secured",
+                GameOutcome.Unmatched => "§10.xp.terminal.unmatched",
+                GameOutcome.Ghosted => "§10.xp.terminal.ghosted",
+                _ => null
+            };
+
+            if (id == null) return null;
+
+            var rule = FindById(id);
+            if (rule?.Outcome != null)
+                return GetOutcomeDouble(rule.Outcome, "multiplier");
+
+            return null;
+        }
+
+        public int? GetSuccessBaseXp(int dc)
+        {
+            var rule = FindById($"§10.xp.success.dc-{dc}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "base_xp");
+            return null;
+        }
+
+        public int? GetFlatXpAward(string awardType)
+        {
+            var rule = FindById($"§10.xp.flat.{awardType.ToLowerInvariant()}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "xp");
             return null;
         }
 

--- a/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
@@ -248,7 +248,10 @@ namespace Pinder.Core.Tests.Conversation
             public int? GetMomentumBonus(int streak) => null;
             public InterestState? GetInterestState(int interest) => null;
             public int? GetShadowThresholdLevel(int shadowValue) => null;
-            public double? GetRiskTierXpMultiplier(Pinder.Core.Rolls.RiskTier riskTier) => null;
+            public double? GetRiskTierXpMultiplier(RiskTier riskTier) => null;
+            public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
+            public int? GetSuccessBaseXp(int dc) => null;
+            public int? GetFlatXpAward(string awardType) => null;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
+++ b/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
@@ -93,25 +93,33 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public void SessionXpRecorder_EndOfGame_DateSecured_Records50Xp()
+        public void SessionXpRecorder_EndOfGame_DateSecured_Multiplies3x()
         {
             var ledger = new XpLedger();
             var recorder = new SessionXpRecorder(ledger, rules: null);
+
+            // Add some base XP to multiply
+            ledger.Record("Base", 10);
 
             recorder.RecordEndOfGameXp(GameOutcome.DateSecured);
 
-            Assert.Equal(50, ledger.TotalXp);
+            Assert.Equal(30, ledger.TotalXp);
+            Assert.Contains(ledger.Events, e => e.Source == "OutcomeBonus_DateSecured" && e.Amount == 20);
         }
 
         [Fact]
-        public void SessionXpRecorder_EndOfGame_Unmatched_Records5Xp()
+        public void SessionXpRecorder_EndOfGame_Unmatched_Multiplies1x()
         {
             var ledger = new XpLedger();
             var recorder = new SessionXpRecorder(ledger, rules: null);
 
+            // Add some base XP to multiply
+            ledger.Record("Base", 10);
+
             recorder.RecordEndOfGameXp(GameOutcome.Unmatched);
 
-            Assert.Equal(5, ledger.TotalXp);
+            Assert.Equal(10, ledger.TotalXp);
+            Assert.DoesNotContain(ledger.Events, e => e.Source.StartsWith("OutcomeBonus_"));
         }
 
         [Theory]

--- a/tests/Pinder.Core.Tests/Issue1211_XpConfigDrivenTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1211_XpConfigDrivenTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Progression;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1211_XpConfigDrivenTests
+    {
+        [Fact]
+        public void RiskMultiplier_Reckless_Is10x_Fallback()
+        {
+            var rec = new SessionXpRecorder(new XpLedger(), null);
+            var result = rec.ApplyRiskTierMultiplier(10, RiskTier.Reckless);
+            Assert.Equal(100, result);
+        }
+
+        [Fact]
+        public void RiskMultiplier_FullLadder_Fallback()
+        {
+            var rec = new SessionXpRecorder(new XpLedger(), null);
+            Assert.Equal(10, rec.ApplyRiskTierMultiplier(10, RiskTier.Safe));
+            Assert.Equal(15, rec.ApplyRiskTierMultiplier(10, RiskTier.Medium));
+            Assert.Equal(20, rec.ApplyRiskTierMultiplier(10, RiskTier.Hard));
+            Assert.Equal(30, rec.ApplyRiskTierMultiplier(10, RiskTier.Bold));
+            Assert.Equal(100, rec.ApplyRiskTierMultiplier(10, RiskTier.Reckless));
+        }
+
+        [Fact]
+        public async Task Terminal_DateSecured_Multiplies_CollectedXp_By3x()
+        {
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 24);
+            var session = MakeSession(diceRoll: 15, dateeStatValue: 0, playerStatValue: 3, config: config);
+            
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.DateSecured, result.Outcome);
+
+            var events = session.XpLedger.Events;
+            Assert.DoesNotContain(events, e => e.Source == "DateSecured" && e.Amount == 50);
+
+            var rollEvents = events.Where(e => e.Source.StartsWith("Success") || e.Source.StartsWith("Nat20") || e.Source.StartsWith("Nat1") || e.Source.StartsWith("Failure")).ToList();
+            var C = rollEvents.Sum(e => e.Amount);
+
+            Assert.Equal(3 * C, session.XpLedger.TotalXp);
+        }
+
+        [Fact]
+        public async Task Terminal_Unmatched_Is1x_NoBonusEvent()
+        {
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 1);
+            var session = MakeSession(diceRoll: 2, dateeStatValue: 0, playerStatValue: 3, config: config);
+            
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.Equal(GameOutcome.Unmatched, result.Outcome);
+
+            var events = session.XpLedger.Events;
+            Assert.DoesNotContain(events, e => e.Source == "ConversationComplete");
+            
+            var rollEvents = events.Where(e => e.Source.StartsWith("Success") || e.Source.StartsWith("Nat20") || e.Source.StartsWith("Nat1") || e.Source.StartsWith("Failure")).ToList();
+            var C = rollEvents.Sum(e => e.Amount);
+
+            Assert.Equal(C, session.XpLedger.TotalXp);
+        }
+
+        // ====================== Helpers ======================
+
+        private static GameSession MakeSession(
+            int diceRoll,
+            int dateeStatValue,
+            int playerStatValue = 3,
+            GameSessionConfig? config = null)
+        {
+            var playerStats = MakeStatBlock(allStats: playerStatValue);
+            var player = MakeProfile("player", playerStats);
+
+            var dateeStats = MakeStatBlock(allStats: dateeStatValue);
+            var datee = MakeProfile("datee", dateeStats);
+
+            config = config ?? new GameSessionConfig(clock: TestHelpers.MakeClock());
+
+            return new GameSession(
+                player,
+                datee,
+                new NullLlmAdapter(),
+                new ConstantDice(diceRoll),
+                new NullTrapRegistry(),
+                config);
+        }
+
+        private static StatBlock MakeStatBlock(int allStats = 2)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, allStats }, { StatType.Rizz, allStats },
+                    { StatType.Honesty, allStats }, { StatType.Chaos, allStats },
+                    { StatType.Wit, allStats }, { StatType.SelfAwareness, allStats }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+        {
+            var timing = new TimingProfile(5, 1.0f, 0.0f, "neutral");
+            return new CharacterProfile(stats, "system prompt", name, timing, 1);
+        }
+
+        private sealed class ConstantDice : IDiceRoller
+        {
+            private readonly int _value;
+            public ConstantDice(int value) => _value = value;
+            public int Roll(int sides) => _value;
+        }
+
+        private sealed class NullTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
+++ b/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
@@ -73,6 +73,10 @@ namespace Pinder.Core.Tests
                 XpMultiplierCalls.Add(riskTier);
                 return XpMultiplierReturn;
             }
+
+            public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
+            public int? GetSuccessBaseXp(int dc) => null;
+            public int? GetFlatXpAward(string awardType) => null;
         }
 
         private static CharacterProfile MakeProfile(string name, int allStats = 2)

--- a/tests/Pinder.Core.Tests/RuleResolverIntegrationTests.cs
+++ b/tests/Pinder.Core.Tests/RuleResolverIntegrationTests.cs
@@ -67,6 +67,10 @@ namespace Pinder.Core.Tests
             XpMultiplierCalls++;
             return XpMultiplier;
         }
+
+        public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
+        public int? GetSuccessBaseXp(int dc) => null;
+        public int? GetFlatXpAward(string awardType) => null;
     }
 
     [Trait("Category", "Rules")]

--- a/tests/Pinder.Core.Tests/XpLedgerTests.cs
+++ b/tests/Pinder.Core.Tests/XpLedgerTests.cs
@@ -228,7 +228,7 @@ namespace Pinder.Core.Tests
 
         // AC-4: Date secured grants 50 XP on final turn
         [Fact]
-        public async Task ResolveTurnAsync_DateSecured_Awards50XpPlusRollXp()
+        public async Task ResolveTurnAsync_DateSecured_Multiplies3xPlusRollXp()
         {
             // Start at interest 24 (AlmostThere), roll success → +1 or more → 25 → DateSecured
             var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 24);
@@ -239,20 +239,20 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.DateSecured, result.Outcome);
 
-            // Should have roll XP + DateSecured 50
-            var dateEvent = session.XpLedger.Events.FirstOrDefault(e => e.Source == "DateSecured");
+            // Roll XP is 10 (5 base * 2x Hard), 3x multiplier means delta is 20
+            var dateEvent = session.XpLedger.Events.FirstOrDefault(e => e.Source == "OutcomeBonus_DateSecured");
             Assert.NotNull(dateEvent);
-            Assert.Equal(50, dateEvent!.Amount);
+            Assert.Equal(20, dateEvent!.Amount);
 
-            // TurnResult.XpEarned includes both roll XP and date XP
-            Assert.True(result.XpEarned >= 58); // at minimum: 8 (DC low * 1.5x Medium) + 50 (date)
+            // TurnResult.XpEarned includes both roll XP and bonus
+            Assert.Equal(30, result.XpEarned);
         }
 
-        // AC-2: Conversation complete (Unmatched) → 5 XP
+        // AC-2: Conversation complete (Unmatched) → 1x XP multiplier
         [Fact]
-        public async Task ResolveTurnAsync_Unmatched_Awards5XpConversationComplete()
+        public async Task ResolveTurnAsync_Unmatched_Multiplies1xConversationComplete()
         {
-            // Start at interest 1, large failure → push to 0 → Unmatched
+            // Start at interest 1, failure drops to 0 → Unmatched
             var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 1);
             var session = MakeSession(diceRoll: 2, dateeStatValue: 0, config: config);
             await session.StartTurnAsync();
@@ -261,9 +261,8 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.Unmatched, result.Outcome);
 
-            var endEvent = session.XpLedger.Events.FirstOrDefault(e => e.Source == "ConversationComplete");
-            Assert.NotNull(endEvent);
-            Assert.Equal(5, endEvent!.Amount);
+            Assert.DoesNotContain(session.XpLedger.Events, e => e.Source.StartsWith("OutcomeBonus_"));
+            Assert.DoesNotContain(session.XpLedger.Events, e => e.Source == "ConversationComplete");
         }
 
         // AC-6: DC boundary test — DC exactly 13, Medium risk → 5*1.5=8 XP

--- a/tests/Pinder.Core.Tests/XpTrackingSpecTests.ResolveTurn.cs
+++ b/tests/Pinder.Core.Tests/XpTrackingSpecTests.ResolveTurn.cs
@@ -127,7 +127,7 @@ namespace Pinder.Core.Tests
         // What: AC-4 — Date secured awards exactly 50 XP with label "DateSecured" (spec §2, §5.5)
         // Mutation: Fails if DateSecured amount is not 50 or label is wrong
         [Fact]
-        public async Task ResolveTurn_DateSecured_Awards50XpEndOfGame()
+        public async Task ResolveTurn_DateSecured_Multiplies3xEndOfGame()
         {
             // Start at 24 interest, success pushes to 25+ → DateSecured
             var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 24);
@@ -138,17 +138,18 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.DateSecured, result.Outcome);
 
-            var dateEvent = session.XpLedger.Events.Single(e => e.Source == "DateSecured");
-            Assert.Equal(50, dateEvent.Amount);
+            var dateEvent = session.XpLedger.Events.Single(e => e.Source == "OutcomeBonus_DateSecured");
+            // Roll XP is 10 (5 base * 2x Hard), 3x multiplier means delta is 20
+            Assert.Equal(20, dateEvent.Amount);
 
             // TurnResult includes both roll XP and date XP
-            Assert.True(result.XpEarned >= 58); // 8 (DC low * 1.5x Medium) + 50
+            Assert.True(result.XpEarned >= 30);
         }
 
-        // What: AC-2 — Conversation complete (Unmatched) awards 5 XP (spec §2, §5.5)
+        // What: AC-2 — Conversation complete (Unmatched) awards 1x XP multiplier
         // Mutation: Fails if Unmatched doesn't record ConversationComplete event
         [Fact]
-        public async Task ResolveTurn_Unmatched_Awards5XpConversationComplete()
+        public async Task ResolveTurn_Unmatched_Multiplies1xEndOfGame()
         {
             // Start at 1 interest, failure drops to 0 → Unmatched
             var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), startingInterest: 1);
@@ -159,8 +160,8 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.Unmatched, result.Outcome);
 
-            var endEvent = session.XpLedger.Events.Single(e => e.Source == "ConversationComplete");
-            Assert.Equal(5, endEvent.Amount);
+            Assert.DoesNotContain(session.XpLedger.Events, e => e.Source.StartsWith("OutcomeBonus_"));
+            Assert.DoesNotContain(session.XpLedger.Events, e => e.Source == "ConversationComplete");
         }
 
         // What: Edge case — Wait action awards 0 XP (spec §10, Wait not in XP sources)
@@ -347,13 +348,13 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.DateSecured, result.Outcome);
 
-            // Roll XP (8 for DC low * 1.5x Medium) + DateSecured (50) = at least 58
-            Assert.True(result.XpEarned >= 58);
+            // Roll XP (10 for DC 16 * 2x Hard) * 3x DateSecured multiplier = 30 total
+            Assert.True(result.XpEarned >= 30);
             Assert.Equal(result.XpEarned, session.TotalXpEarned);
         }
 
         // What: Spec §8 ex 8 — Failure + conversation complete on same turn
-        // Mutation: Fails if end-of-game XP replaces rather than adds to roll XP
+        // Mutation: Fails if one of the XP sources is dropped on a terminal failure
         [Fact]
         public async Task ResolveTurn_FailurePlusUnmatched_BothXpRecorded()
         {
@@ -365,9 +366,10 @@ namespace Pinder.Core.Tests
             Assert.True(result.IsGameOver);
             Assert.Equal(GameOutcome.Unmatched, result.Outcome);
 
-            // Should have both failure (2) and conversation complete (5)
-            Assert.True(session.XpLedger.Events.Count >= 2);
-            Assert.True(result.XpEarned >= 7); // 2 + 5
+            // Should have failure (2), 1x multiplier means no bonus event
+            Assert.Contains(session.XpLedger.Events, e => e.Source == "Failure");
+            Assert.DoesNotContain(session.XpLedger.Events, e => e.Source.StartsWith("OutcomeBonus_"));
+            Assert.True(result.XpEarned >= 2);
         }
 
         // What: Edge case — Game ends on first turn with both types of XP (spec §10 edge case)
@@ -382,7 +384,7 @@ namespace Pinder.Core.Tests
 
             Assert.True(result.IsGameOver);
             Assert.True(session.XpLedger.Events.Count >= 2);
-            Assert.True(session.XpLedger.Events.Any(e => e.Source == "DateSecured"));
+            Assert.True(session.XpLedger.Events.Any(e => e.Source == "OutcomeBonus_DateSecured"));
         }
 
         // ====================== Session-Level Ledger Tests ======================


### PR DESCRIPTION
Closes #1211

## What
Moves XP product constants out of `SessionXpRecorder` into the config/rules layer, keeping current values as fallback defaults used only when the resolver is absent.

- **Risk multipliers** now include `Reckless` (default 10x): Safe 1 / Medium 1.5 / Hard 2 / Bold 3 / Reckless 10. Config-first via `IRuleResolver.GetRiskTierXpMultiplier`, hardcoded fallback otherwise.
- **Terminal outcomes** are now multipliers over the XP collected in the completed session, not flat bonuses: `DateSecured = 3x`, `Unmatched = 1x`, `Ghosted = 1x`. The flat `DateSecured=50` and `ConversationComplete=5` bonuses are removed. `RecordEndOfGameXp` computes `delta = round(TotalXp * mult) - TotalXp` and records an `OutcomeBonus_{outcome}` ledger event only when `delta > 0` (so 1x outcomes and zero-collected DateSecured add no event; `XpLedger.Record` requires amount > 0).
- **Success base / Nat20 / Nat1 / failure** awards are config-first via new nullable `IRuleResolver` methods (`GetSuccessBaseXp`, `GetFlatXpAward`, `GetTerminalOutcomeMultiplier`) with the existing values (5/10/15, 25, 10, 2) retained as documented fallback defaults. `SessionXpRecorder` no longer owns product constants except those fallbacks.
- **Rule data**: added a Reckless risk-tier entry (xp_multiplier 10.0) and terminal/success/flat XP entries to `rules/extracted/risk-reward-and-hidden-depth-enriched.yaml`; `RuleBookResolver` reads them.
- XP totals stay auditable via distinct `XpLedger` event labels (incl. the `OutcomeBonus_*` terminal event).

## Out of scope (respected)
No player-account persistence / shop currency (pinder-web), no frontend XP display.

## Verification (local only)
- `dotnet build Pinder.Core.sln -c Debug` -> 0 errors
- `Pinder.Core.Tests` -> 3036 passed, 0 failed (4 new Issue1211 tests; old flat-terminal tests converted to the multiplier model; XpRiskTierMultiplierSpec fallbacks unchanged)
- `Pinder.Rules.Tests` -> 11 pre-existing failures (game-definition.yaml content tests, identical set on origin/main; the edited risk-reward rules yaml still parses, no new failures)

Contract-test -> implementer -> independent reviewer (APPROVE) eigentakt loop.