### PR TITLE
feat(#1212): config-editable level table via IRuleResolver with code defaults as fallback

### DIFF
--- a/docs/modules/xp-progression.md
+++ b/docs/modules/xp-progression.md
@@ -36,6 +36,8 @@ public sealed class XpLedger
 
 ### LevelTable
 
+**Config-Editable Progression:** The level table (XP thresholds, roll bonuses, build points, and item slots) is config-editable via the rules layer (`IRuleResolver`). The `LevelTable` methods accept an optional `IRuleResolver? rules` parameter. If a YAML rule is defined under `§10.progression.level.N` (e.g. `xp_threshold`, `roll_bonus`, `build_points`, `item_slots`), it overrides the code defaults. If no rule is found, or `rules` is null, it falls back to the hardcoded C# arrays.
+
 ```csharp
 public static class LevelTable
 {

--- a/rules/extracted/rules-v3-enriched.yaml
+++ b/rules/extracted/rules-v3-enriched.yaml
@@ -3460,3 +3460,80 @@
   applies_to: dialogue_options_generation
   heading_level: 4
   compact_heading: true
+- id: §10.progression.level.1
+  title: Level 1 Progression
+  outcome:
+    xp_threshold: 0
+    build_points: 0
+    roll_bonus: 0
+    item_slots: 2
+- id: §10.progression.level.2
+  title: Level 2 Progression
+  outcome:
+    xp_threshold: 50
+    build_points: 2
+    roll_bonus: 0
+    item_slots: 2
+- id: §10.progression.level.3
+  title: Level 3 Progression
+  outcome:
+    xp_threshold: 150
+    build_points: 2
+    roll_bonus: 1
+    item_slots: 3
+- id: §10.progression.level.4
+  title: Level 4 Progression
+  outcome:
+    xp_threshold: 300
+    build_points: 2
+    roll_bonus: 1
+    item_slots: 3
+- id: §10.progression.level.5
+  title: Level 5 Progression
+  outcome:
+    xp_threshold: 500
+    build_points: 3
+    roll_bonus: 2
+    item_slots: 4
+- id: §10.progression.level.6
+  title: Level 6 Progression
+  outcome:
+    xp_threshold: 750
+    build_points: 3
+    roll_bonus: 2
+    item_slots: 4
+- id: §10.progression.level.7
+  title: Level 7 Progression
+  outcome:
+    xp_threshold: 1100
+    build_points: 3
+    roll_bonus: 3
+    item_slots: 5
+- id: §10.progression.level.8
+  title: Level 8 Progression
+  outcome:
+    xp_threshold: 1500
+    build_points: 4
+    roll_bonus: 3
+    item_slots: 5
+- id: §10.progression.level.9
+  title: Level 9 Progression
+  outcome:
+    xp_threshold: 2000
+    build_points: 4
+    roll_bonus: 4
+    item_slots: 6
+- id: §10.progression.level.10
+  title: Level 10 Progression
+  outcome:
+    xp_threshold: 2750
+    build_points: 5
+    roll_bonus: 4
+    item_slots: 6
+- id: §10.progression.level.11
+  title: Level 11 Progression
+  outcome:
+    xp_threshold: 3500
+    build_points: 0
+    roll_bonus: 5
+    item_slots: 6

--- a/src/Pinder.Core/Conversation/GameSessionHelpers.cs
+++ b/src/Pinder.Core/Conversation/GameSessionHelpers.cs
@@ -198,9 +198,10 @@ namespace Pinder.Core.Conversation
             DialogueOption chosen,
             DialogueOption[] options,
             CharacterProfile player,
-            CharacterProfile datee)
+            CharacterProfile datee,
+            Pinder.Core.Interfaces.IRuleResolver? rules = null)
         {
-            int levelBonus = LevelTable.GetBonus(player.Level);
+            int levelBonus = LevelTable.GetBonus(player.Level, rules);
 
             int chosenMargin = player.Stats.GetEffective(chosen.Stat) + levelBonus
                                - datee.Stats.GetDefenceDC(chosen.Stat);

--- a/src/Pinder.Core/Conversation/RollResolutionStage.cs
+++ b/src/Pinder.Core/Conversation/RollResolutionStage.cs
@@ -149,7 +149,8 @@ namespace Pinder.Core.Conversation
                 null, // consequenceCatalog is not needed inside EvaluateRolls
                 externalBonus,
                 dcAdjustment,
-                resolveHasDisadvantage);
+                resolveHasDisadvantage,
+                _rules);
 
             // 2. Compute interest delta from roll outcome
             int baseInterestDelta;
@@ -225,7 +226,7 @@ namespace Pinder.Core.Conversation
             _shadowGrowthEvaluator?.EvaluatePerTurn(
                 chosenOption, optionIndex, rollResult, interestAfter, comboTriggered, hasTellOption,
                 state.CurrentOptions,
-                (chosen, opts) => GameSessionHelpers.IsHighestProbabilityOption(chosen, opts, player, datee));
+                (chosen, opts) => GameSessionHelpers.IsHighestProbabilityOption(chosen, opts, player, datee, _rules));
 
             // Shadow reduction: Winning despite Overthinking disadvantage → Overthinking −1
             if (rollResult.IsSuccess

--- a/src/Pinder.Core/Conversation/TurnDiceEvaluator.cs
+++ b/src/Pinder.Core/Conversation/TurnDiceEvaluator.cs
@@ -28,7 +28,8 @@ namespace Pinder.Core.Conversation
             IConsequenceCatalog? consequenceCatalog,
             int externalBonus,
             int dcAdjustment,
-            bool resolveHasDisadvantage)
+            bool resolveHasDisadvantage,
+            IRuleResolver? rules = null)
         {
             // 1. Roll dice
             var chosenPool = state.InjectedNextPool != null
@@ -51,7 +52,8 @@ namespace Pinder.Core.Conversation
                 hasAdvantage: state.CurrentHasAdvantage,
                 hasDisadvantage: resolveHasDisadvantage,
                 externalBonus: externalBonus,
-                dcAdjustment: dcAdjustment);
+                dcAdjustment: dcAdjustment,
+                rules: rules);
 
             // #976: populate Consequence on the main option roll from i18n catalogue.
             if (consequenceCatalog != null && rollResult.Check != null)

--- a/src/Pinder.Core/Interfaces/IRuleResolver.cs
+++ b/src/Pinder.Core/Interfaces/IRuleResolver.cs
@@ -69,5 +69,25 @@ namespace Pinder.Core.Interfaces
         /// Returns null if no matching rule found.
         /// </summary>
         int? GetFlatXpAward(string awardType);
+
+        /// <summary>
+        /// XP required to REACH this 1-based level
+        /// </summary>
+        int? GetXpThresholdForLevel(int level);
+
+        /// <summary>
+        /// flat d20 bonus at this 1-based level
+        /// </summary>
+        int? GetLevelRollBonus(int level);
+
+        /// <summary>
+        /// build points granted on reaching this level
+        /// </summary>
+        int? GetBuildPointsForLevel(int level);
+
+        /// <summary>
+        /// max item slots at this level
+        /// </summary>
+        int? GetItemSlotsForLevel(int level);
     }
 }

--- a/src/Pinder.Core/Progression/LevelTable.cs
+++ b/src/Pinder.Core/Progression/LevelTable.cs
@@ -1,3 +1,5 @@
+using Pinder.Core.Interfaces;
+
 namespace Pinder.Core.Progression
 {
     /// <summary>
@@ -82,14 +84,16 @@ namespace Pinder.Core.Progression
         public const int BaseStatCap = 6;
 
         /// <summary>Resolve 1-based level from raw XP.</summary>
-        public static int GetLevel(int xp)
+        public static int GetLevel(int xp, IRuleResolver? rules = null)
         {
             int level = 1;
             for (int i = XpThresholds.Length - 1; i >= 0; i--)
             {
-                if (xp >= XpThresholds[i])
+                int l = i + 1;
+                int threshold = rules?.GetXpThresholdForLevel(l) ?? XpThresholds[i];
+                if (xp >= threshold)
                 {
-                    level = i + 1;
+                    level = l;
                     break;
                 }
             }
@@ -97,22 +101,28 @@ namespace Pinder.Core.Progression
         }
 
         /// <summary>Roll bonus for a given level (1-based).</summary>
-        public static int GetBonus(int level)
+        public static int GetBonus(int level, IRuleResolver? rules = null)
         {
+            var o = rules?.GetLevelRollBonus(level);
+            if (o.HasValue) return o.Value;
             int idx = System.Math.Max(0, System.Math.Min(level - 1, LevelBonuses.Length - 1));
             return LevelBonuses[idx];
         }
 
         /// <summary>Build points granted upon reaching a given level (1-based). 0 for L1 (creation budget).</summary>
-        public static int GetBuildPointsForLevel(int level)
+        public static int GetBuildPointsForLevel(int level, IRuleResolver? rules = null)
         {
+            var o = rules?.GetBuildPointsForLevel(level);
+            if (o.HasValue) return o.Value;
             int idx = System.Math.Max(0, System.Math.Min(level - 1, BuildPointsGranted.Length - 1));
             return BuildPointsGranted[idx];
         }
 
         /// <summary>Maximum item slots at a given level (1-based).</summary>
-        public static int GetItemSlots(int level)
+        public static int GetItemSlots(int level, IRuleResolver? rules = null)
         {
+            var o = rules?.GetItemSlotsForLevel(level);
+            if (o.HasValue) return o.Value;
             int idx = System.Math.Max(0, System.Math.Min(level - 1, ItemSlots.Length - 1));
             return ItemSlots[idx];
         }

--- a/src/Pinder.Core/Rolls/RollEngine.cs
+++ b/src/Pinder.Core/Rolls/RollEngine.cs
@@ -89,7 +89,8 @@ namespace Pinder.Core.Rolls
             bool hasAdvantage     = false,
             bool hasDisadvantage  = false,
             int externalBonus     = 0,
-            int dcAdjustment      = 0)
+            int dcAdjustment      = 0,
+            IRuleResolver? rules  = null)
         {
             // --- Determine advantage/disadvantage from active traps ---
             var activeTrap = attackerTraps.GetActive(stat);
@@ -118,7 +119,7 @@ namespace Pinder.Core.Rolls
             if (activeTrap != null && activeTrap.Definition.Effect == TrapEffect.StatPenalty)
                 statMod -= activeTrap.Definition.EffectValue;
 
-            int levelBonus = LevelTable.GetBonus(level);
+            int levelBonus = LevelTable.GetBonus(level, rules);
 
             // --- Compute DC ---
             int dc = defender.GetDefenceDC(stat) - dcAdjustment;
@@ -156,7 +157,8 @@ namespace Pinder.Core.Rolls
             IDiceRoller dice,
             bool hasAdvantage     = false,
             bool hasDisadvantage  = false,
-            int externalBonus     = 0)
+            int externalBonus     = 0,
+            IRuleResolver? rules  = null)
         {
             // --- Determine advantage/disadvantage from active traps ---
             var activeTrap = attackerTraps.GetActive(stat);
@@ -185,7 +187,7 @@ namespace Pinder.Core.Rolls
             if (activeTrap != null && activeTrap.Definition.Effect == TrapEffect.StatPenalty)
                 statMod -= activeTrap.Definition.EffectValue;
 
-            int levelBonus = LevelTable.GetBonus(level);
+            int levelBonus = LevelTable.GetBonus(level, rules);
 
             // Apply DateeDCIncrease trap effect
             int effectiveDc = fixedDc;

--- a/src/Pinder.Rules/RuleBookResolver.cs
+++ b/src/Pinder.Rules/RuleBookResolver.cs
@@ -301,6 +301,38 @@ namespace Pinder.Rules
             return null;
         }
 
+        public int? GetXpThresholdForLevel(int level)
+        {
+            var rule = FindById($"§10.progression.level.{level}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "xp_threshold");
+            return null;
+        }
+
+        public int? GetLevelRollBonus(int level)
+        {
+            var rule = FindById($"§10.progression.level.{level}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "roll_bonus");
+            return null;
+        }
+
+        public int? GetBuildPointsForLevel(int level)
+        {
+            var rule = FindById($"§10.progression.level.{level}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "build_points");
+            return null;
+        }
+
+        public int? GetItemSlotsForLevel(int level)
+        {
+            var rule = FindById($"§10.progression.level.{level}");
+            if (rule?.Outcome != null)
+                return GetOutcomeInt(rule.Outcome, "item_slots");
+            return null;
+        }
+
         // --- Helpers ---
 
         private RuleEntry? FindById(string id)

--- a/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue942_StartTurnTransactionalTests.cs
@@ -252,6 +252,10 @@ namespace Pinder.Core.Tests.Conversation
             public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
             public int? GetSuccessBaseXp(int dc) => null;
             public int? GetFlatXpAward(string awardType) => null;
+            public int? GetXpThresholdForLevel(int level) => null;
+            public int? GetLevelRollBonus(int level) => null;
+            public int? GetBuildPointsForLevel(int level) => null;
+            public int? GetItemSlotsForLevel(int level) => null;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1212_LevelTableConfigTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1212_LevelTableConfigTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Progression;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1212_LevelTableConfigTests
+    {
+        // PART A — defaults unchanged (these likely PASS already; regression guards)
+
+        [Fact]
+        public void GetLevel_DefaultThresholdEdges()
+        {
+            Assert.Equal(1, LevelTable.GetLevel(49));
+            Assert.Equal(2, LevelTable.GetLevel(50));
+            Assert.Equal(2, LevelTable.GetLevel(149));
+            Assert.Equal(3, LevelTable.GetLevel(150));
+            Assert.Equal(1, LevelTable.GetLevel(0));
+            Assert.Equal(11, LevelTable.GetLevel(3500));
+            Assert.Equal(11, LevelTable.GetLevel(99999));
+        }
+
+        [Fact]
+        public void GetBonus_GetItemSlots_GetBuildPoints_Defaults()
+        {
+            Assert.Equal(0, LevelTable.GetBonus(1));
+            Assert.Equal(2, LevelTable.GetBonus(5));
+            Assert.Equal(5, LevelTable.GetBonus(11));
+
+            Assert.Equal(2, LevelTable.GetItemSlots(1));
+            Assert.Equal(6, LevelTable.GetItemSlots(9));
+
+            Assert.Equal(2, LevelTable.GetBuildPointsForLevel(2));
+            Assert.Equal(5, LevelTable.GetBuildPointsForLevel(10));
+        }
+
+        // PART B — config override (these are the RED ones — they WON'T COMPILE until the optional rules param + IRuleResolver methods exist)
+
+        [Fact]
+        public void GetBonus_ConfigOverride_WinsOverDefault()
+        {
+            var fake = new FakeRuleResolver();
+            Assert.Equal(99, LevelTable.GetBonus(3, fake));
+            Assert.Equal(1, LevelTable.GetBonus(3, null));
+        }
+
+        [Fact]
+        public void GetLevel_ConfigOverride_UsesConfiguredThresholds()
+        {
+            var fake = new FakeRuleResolver();
+            // Default needs 50 for L2. Fake gives L2 at 10.
+            Assert.Equal(2, LevelTable.GetLevel(10, fake));
+            Assert.Equal(1, LevelTable.GetLevel(10, null));
+        }
+
+        [Fact]
+        public void ItemSlots_BuildPoints_ConfigOverride()
+        {
+            var fake = new FakeRuleResolver();
+            Assert.Equal(42, LevelTable.GetItemSlots(1, fake));
+            Assert.Equal(7, LevelTable.GetBuildPointsForLevel(1, fake));
+            
+            Assert.Equal(2, LevelTable.GetItemSlots(1, null));
+            Assert.Equal(0, LevelTable.GetBuildPointsForLevel(1, null));
+        }
+
+        // PART C — production wiring (end-to-end; proves config bonus applies in a live roll)
+
+        [Fact]
+        public async Task RollEngine_UsesConfiguredLevelBonus_InLiveTurn()
+        {
+            var fakeResolver = new FakeRuleResolver();
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), rules: fakeResolver);
+            var session = MakeSession(diceRoll: 10, config: config);
+            
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // FakeRuleResolver sets GetLevelRollBonus(level) = level == 1 ? 7 : 99
+            // Player level is 1
+            Assert.Equal(7, result.Roll.LevelBonus);
+        }
+
+        // Helpers
+
+        private static GameSession MakeSession(
+            int diceRoll,
+            GameSessionConfig? config = null)
+        {
+            var playerStats = MakeStatBlock();
+            var player = MakeProfile("player", playerStats);
+
+            var dateeStats = MakeStatBlock();
+            var datee = MakeProfile("datee", dateeStats);
+
+            return new GameSession(
+                player,
+                datee,
+                new NullLlmAdapter(),
+                new ConstantDice(diceRoll),
+                new NullTrapRegistry(),
+                config ?? new GameSessionConfig(clock: TestHelpers.MakeClock()));
+        }
+
+        private static StatBlock MakeStatBlock()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 2 },
+                    { StatType.Honesty, 2 }, { StatType.Chaos, 2 },
+                    { StatType.Wit, 2 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name, StatBlock stats)
+        {
+            var timing = new TimingProfile(5, 1.0f, 0.0f, "neutral");
+            return new CharacterProfile(stats, "system prompt", name, timing, 1);
+        }
+
+        private sealed class ConstantDice : IDiceRoller
+        {
+            private readonly int _value;
+            public ConstantDice(int value) => _value = value;
+            public int Roll(int sides) => _value;
+        }
+
+        private sealed class NullTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        // FAKE RESOLVER
+        private sealed class FakeRuleResolver : IRuleResolver
+        {
+            // Existing interface methods
+            public int? GetFailureInterestDelta(int missMargin, int naturalRoll) => null;
+            public int? GetSuccessInterestDelta(int beatMargin, int naturalRoll) => null;
+            public InterestState? GetInterestState(int interest) => null;
+            public int? GetShadowThresholdLevel(int shadowValue) => null;
+            public int? GetMomentumBonus(int streak) => null;
+            public double? GetRiskTierXpMultiplier(RiskTier riskTier) => null;
+            public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
+            public int? GetSuccessBaseXp(int dc) => null;
+            public int? GetFlatXpAward(string awardType) => null;
+
+            // NEW methods for issue #1212
+            int? IRuleResolver.GetXpThresholdForLevel(int level)
+            {
+                if (level == 2) return 10;
+                return null;
+            }
+
+            int? IRuleResolver.GetLevelRollBonus(int level)
+            {
+                if (level == 1) return 7;
+                return 99; // For level 3 test
+            }
+
+            int? IRuleResolver.GetBuildPointsForLevel(int level)
+            {
+                return 7;
+            }
+
+            int? IRuleResolver.GetItemSlotsForLevel(int level)
+            {
+                return 42;
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
+++ b/tests/Pinder.Core.Tests/Issue463_RuleResolverWiringTests.cs
@@ -77,6 +77,10 @@ namespace Pinder.Core.Tests
             public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
             public int? GetSuccessBaseXp(int dc) => null;
             public int? GetFlatXpAward(string awardType) => null;
+            public int? GetXpThresholdForLevel(int level) => null;
+            public int? GetLevelRollBonus(int level) => null;
+            public int? GetBuildPointsForLevel(int level) => null;
+            public int? GetItemSlotsForLevel(int level) => null;
         }
 
         private static CharacterProfile MakeProfile(string name, int allStats = 2)

--- a/tests/Pinder.Core.Tests/RuleResolverIntegrationTests.cs
+++ b/tests/Pinder.Core.Tests/RuleResolverIntegrationTests.cs
@@ -71,6 +71,10 @@ namespace Pinder.Core.Tests
         public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => null;
         public int? GetSuccessBaseXp(int dc) => null;
         public int? GetFlatXpAward(string awardType) => null;
+        public int? GetXpThresholdForLevel(int level) => null;
+        public int? GetLevelRollBonus(int level) => null;
+        public int? GetBuildPointsForLevel(int level) => null;
+        public int? GetItemSlotsForLevel(int level) => null;
     }
 
     [Trait("Category", "Rules")]


### PR DESCRIPTION
Closes #1212

## What
Makes the level/progression table editable via the game config (rules) layer, with the existing code arrays as fallback defaults. Lowest-blast-radius design: `LevelTable` stays a static class; each lookup gains an optional `IRuleResolver? rules = null` parameter and is config-first.

- **4 config dimensions** now overridable per level via new nullable `IRuleResolver` methods: `GetXpThresholdForLevel`, `GetLevelRollBonus`, `GetBuildPointsForLevel`, `GetItemSlotsForLevel` (null => fall back to the code default).
- `LevelTable.GetLevel` / `GetBonus` / `GetBuildPointsForLevel` / `GetItemSlots` are config-first with the current arrays as fallback. `GetLevel` merges per-level: a config can override a single level's threshold while the rest stay default. Behavior is **identical when `rules == null`** (default edges 49->1, 50->2, 149->2, 150->3, max->11 preserved).
- **Live-roll wiring**: the session resolver is threaded through `RollResolutionStage` -> `TurnDiceEvaluator.EvaluateRolls` -> `RollEngine.Resolve`/`ResolveFixedDC` -> `LevelTable.GetBonus`, plus `GameSessionHelpers.IsHighestProbabilityOption`, so a configured per-level roll bonus actually reaches `RollResult.LevelBonus` during a turn. All new params default to null, so steering/shadow/horniness paths and other callers are unaffected.
- **Rules data**: added `§10.progression.level.1..11` entries to `rules/extracted/rules-v3-enriched.yaml` mirroring the code defaults (so production behavior is unchanged); `RuleBookResolver` reads them via the existing `FindById`/outcome-int pattern.
- **Doc**: updated `docs/modules/xp-progression.md` to document the config-editable level table + fallback story.

## Out of scope (respected)
No persisted per-player level state (pinder-web), no frontend display.

## Verification (local only)
- `dotnet build Pinder.Core.sln -c Debug` -> 0 errors
- `Pinder.Core.Tests` -> 3042 passed, 0 failed (5 new Issue1212 tests incl. end-to-end `RollResult.LevelBonus` override; existing RulesSpec LevelTable default tests still green)
- `Pinder.Rules.Tests` -> 11 pre-existing failures (game-definition.yaml content tests, identical set on origin/main; the edited rules-v3 yaml still parses, no new failures)

Contract-test -> implementer -> independent reviewer (APPROVE) eigentakt loop.