### PR TITLE
fix(#1218): Denial removes Honesty only at T3 (>=18) SSOT

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -114,6 +114,9 @@ namespace Pinder.Core.Conversation
         // before the field existed.
         private readonly Action<TextLayerNoopEvent>? _onTextLayerNoop;
 
+        // #1218: optional callback invoked when shadow filtering changes the option/stat pool.
+        private readonly Action<ShadowFilterTraceEvent>? _onShadowFilterTrace;
+
         // Stored between StartTurnAsync and ResolveTurnAsync
         private DialogueOption[]? _currentOptions { get => _state.CurrentOptions; set => _state.CurrentOptions = value; }
         private bool _currentHasAdvantage { get => _state.CurrentHasAdvantage; set => _state.CurrentHasAdvantage = value; }
@@ -180,6 +183,7 @@ namespace Pinder.Core.Conversation
             _statDrawRng = config.StatDrawRng;
             _statDeliveryInstructions = config.StatDeliveryInstructions;
             _onTextLayerNoop = config.OnTextLayerNoop;
+            _onShadowFilterTrace = config.OnShadowFilterTrace;
 
             // Determine starting interest: explicit config > Dread T3 > default
             if (config.StartingInterest.HasValue)
@@ -277,7 +281,8 @@ namespace Pinder.Core.Conversation
                 rollResolutionStage,
                 deliveryStage,
                 dateeResponseStage,
-                _maxDialogueOptions);
+                _maxDialogueOptions,
+                _onShadowFilterTrace);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -98,6 +98,12 @@ namespace Pinder.Core.Conversation
         public Action<TextLayerNoopEvent>? OnTextLayerNoop { get; }
 
         /// <summary>
+        /// Optional callback fired when shadow filtering changes the option/stat pool (#1218).
+        /// When null, no callback is fired.
+        /// </summary>
+        public Action<ShadowFilterTraceEvent>? OnShadowFilterTrace { get; }
+
+        /// <summary>
         /// Consequence catalogue for engine-side population of
         /// Consequence fields on roll/shadow/horniness result DTOs (#976).
         /// When null, engines leave <c>Consequence</c> null.
@@ -128,6 +134,7 @@ namespace Pinder.Core.Conversation
             IDiceRoller? diceRoller = null,
             Random? statDrawRng = null,
             Action<TextLayerNoopEvent>? onTextLayerNoop = null,
+            Action<ShadowFilterTraceEvent>? onShadowFilterTrace = null,
             IConsequenceCatalog? consequenceCatalog = null,
             int? maxDialogueOptions = null,
             int? maxDeliveryWords = null,
@@ -147,6 +154,7 @@ namespace Pinder.Core.Conversation
             DiceRoller = diceRoller;
             StatDrawRng = statDrawRng;
             OnTextLayerNoop = onTextLayerNoop;
+            OnShadowFilterTrace = onShadowFilterTrace;
             ConsequenceCatalog = consequenceCatalog;
             MaxDialogueOptions = maxDialogueOptions;
             MaxDeliveryWords = maxDeliveryWords;

--- a/src/Pinder.Core/Conversation/OptionFilterEngine.cs
+++ b/src/Pinder.Core/Conversation/OptionFilterEngine.cs
@@ -15,7 +15,7 @@ namespace Pinder.Core.Conversation
     {
         /// <summary>
         /// Draws N random stats from the pool, applying shadow-based exclusions.
-        /// Denial T3 (≥12): removes HONESTY from pool.
+        /// Denial T3 (≥18): removes HONESTY from pool.
         ///
         /// <para>
         /// <paramref name="rng"/> is used to shuffle the eligible pool. When null a
@@ -29,16 +29,27 @@ namespace Pinder.Core.Conversation
             StatType[] pool,
             int count,
             Dictionary<ShadowStatType, int>? shadowThresholds,
-            Random? rng = null)
+            Random? rng = null,
+            Action<ShadowFilterTraceEvent>? onTrace = null)
         {
             var eligible = new List<StatType>(pool);
 
-            // Denial T3 (≥12): remove HONESTY from pool
+            // Denial T3 (≥18): remove HONESTY from pool
             if (shadowThresholds != null
                 && shadowThresholds.TryGetValue(ShadowStatType.Denial, out int denVal)
-                && denVal >= 12)
+                && ShadowThresholdEvaluator.GetThresholdLevel(denVal) == 3)
             {
-                eligible.Remove(StatType.Honesty);
+                if (eligible.Contains(StatType.Honesty))
+                {
+                    eligible.Remove(StatType.Honesty);
+                    onTrace?.Invoke(new ShadowFilterTraceEvent(
+                        ShadowStatType.Denial,
+                        denVal,
+                        3,
+                        new[] { StatType.Honesty },
+                        "pre_llm_stat_draw"
+                    ));
+                }
             }
 
             // Shuffle using the provided RNG (or a fresh non-deterministic one if none
@@ -70,7 +81,8 @@ namespace Pinder.Core.Conversation
             DialogueOption[] options,
             Dictionary<ShadowStatType, int> shadowThresholds,
             StatType? lastStatUsed,
-            IDiceRoller dice)
+            IDiceRoller dice,
+            Action<ShadowFilterTraceEvent>? onTrace = null)
         {
             // Fixation T3: force all options to use the same stat as last turn
             if (shadowThresholds.TryGetValue(ShadowStatType.Fixation, out int fixRaw)
@@ -88,15 +100,26 @@ namespace Pinder.Core.Conversation
 
             // Denial T3: remove Honesty options
             if (shadowThresholds.TryGetValue(ShadowStatType.Denial, out int denRaw)
-                && denRaw >= 18)
+                && ShadowThresholdEvaluator.GetThresholdLevel(denRaw) == 3)
             {
+                var originalLength = options.Length;
                 var filtered = options.Where(o => o.Stat != StatType.Honesty).ToArray();
-                if (filtered.Length == 0)
+                if (filtered.Length < originalLength)
                 {
-                    var chaos = options.FirstOrDefault(o => o.Stat == StatType.Chaos);
-                    filtered = new[] { chaos ?? options[0] };
+                    if (filtered.Length == 0)
+                    {
+                        var chaos = options.FirstOrDefault(o => o.Stat == StatType.Chaos);
+                        filtered = new[] { chaos ?? options[0] };
+                    }
+                    options = filtered;
+                    onTrace?.Invoke(new ShadowFilterTraceEvent(
+                        ShadowStatType.Denial,
+                        denRaw,
+                        3,
+                        new[] { StatType.Honesty },
+                        "post_llm_filter"
+                    ));
                 }
-                options = filtered;
             }
 
             // Madness T3: replace one random option with unhinged replacement marker

--- a/src/Pinder.Core/Conversation/ShadowFilterTraceEvent.cs
+++ b/src/Pinder.Core/Conversation/ShadowFilterTraceEvent.cs
@@ -1,0 +1,42 @@
+using System;
+using Pinder.Core.Stats;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Issue #1218: structured event payload for the
+    /// <c>GameSessionConfig.OnShadowFilterTrace</c> callback.
+    /// Fired when shadow filtering changes the option/stat pool.
+    /// </summary>
+    public sealed class ShadowFilterTraceEvent
+    {
+        /// <summary>The shadow stat that triggered the filter.</summary>
+        public ShadowStatType ShadowStat { get; }
+
+        /// <summary>The raw value of the shadow stat.</summary>
+        public int RawValue { get; }
+
+        /// <summary>The computed tier of the shadow stat.</summary>
+        public int ComputedTier { get; }
+
+        /// <summary>The stats that were removed due to filtering.</summary>
+        public StatType[] RemovedStats { get; }
+
+        /// <summary>Where the filter was applied: 'pre_llm_stat_draw' or 'post_llm_filter'.</summary>
+        public string SourcePath { get; }
+
+        public ShadowFilterTraceEvent(
+            ShadowStatType shadowStat,
+            int rawValue,
+            int computedTier,
+            StatType[] removedStats,
+            string sourcePath)
+        {
+            ShadowStat = shadowStat;
+            RawValue = rawValue;
+            ComputedTier = computedTier;
+            RemovedStats = removedStats ?? Array.Empty<StatType>();
+            SourcePath = sourcePath ?? string.Empty;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.cs
@@ -24,6 +24,7 @@ namespace Pinder.Core.Conversation
         private readonly DeliveryStage _deliveryStage;
         private readonly DateeResponseStage _dateeResponseStage;
         private readonly int _maxDialogueOptions;
+        private readonly Action<ShadowFilterTraceEvent>? _onShadowFilterTrace;
 
         public TurnOrchestrator(
             ILlmAdapter llm,
@@ -33,7 +34,8 @@ namespace Pinder.Core.Conversation
             RollResolutionStage rollResolutionStage,
             DeliveryStage deliveryStage,
             DateeResponseStage dateeResponseStage,
-            int maxDialogueOptions)
+            int maxDialogueOptions,
+            Action<ShadowFilterTraceEvent>? onShadowFilterTrace = null)
         {
             _llm = llm ?? throw new ArgumentNullException(nameof(llm));
             _dice = dice ?? throw new ArgumentNullException(nameof(dice));
@@ -44,6 +46,7 @@ namespace Pinder.Core.Conversation
             _deliveryStage = deliveryStage ?? throw new ArgumentNullException(nameof(deliveryStage));
             _dateeResponseStage = dateeResponseStage ?? throw new ArgumentNullException(nameof(dateeResponseStage));
             _maxDialogueOptions = maxDialogueOptions;
+            _onShadowFilterTrace = onShadowFilterTrace;
         }
 
         internal async Task<TurnStart> StartTurnAsync(
@@ -137,7 +140,7 @@ namespace Pinder.Core.Conversation
 
             // Draw N random stats for this turn's options
             var allStats = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
-            var availableStats = OptionFilterEngine.DrawRandomStats(allStats, _maxDialogueOptions, shadowThresholds, _statDrawRng);
+            var availableStats = OptionFilterEngine.DrawRandomStats(allStats, _maxDialogueOptions, shadowThresholds, _statDrawRng, _onShadowFilterTrace);
 
             var context = new DialogueContext(
                 playerAvatarPrompt: player.AssembledSystemPrompt,
@@ -195,7 +198,7 @@ namespace Pinder.Core.Conversation
             // T3 option filtering (#45)
             if (state.PlayerShadows != null && shadowThresholds != null)
             {
-                options = OptionFilterEngine.ApplyT3Filters(options, shadowThresholds, state.LastStatUsed, _dice);
+                options = OptionFilterEngine.ApplyT3Filters(options, shadowThresholds, state.LastStatUsed, _dice, _onShadowFilterTrace);
             }
 
             state.CurrentOptions = options;

--- a/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
+++ b/tests/Pinder.Core.Tests/DecomposedModuleTests.cs
@@ -155,7 +155,7 @@ namespace Pinder.Core.Tests
             var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
             var thresholds = new Dictionary<ShadowStatType, int>
             {
-                { ShadowStatType.Denial, 12 }
+                { ShadowStatType.Denial, 18 }
             };
 
             // Draw all 5 remaining stats

--- a/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Traps;
+using Pinder.Core.TestCommon;
+
+namespace Pinder.Core.Tests
+{
+    public class Issue1218_DenialThresholdSsotTests
+    {
+        [Fact]
+        public void DrawRandomStats_DenialAt17_ContainsHonesty()
+        {
+            var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 17 }
+            };
+            var rng = new Random(12345);
+
+            var drawn = OptionFilterEngine.DrawRandomStats(pool, pool.Length, thresholds, rng);
+
+            Assert.Contains(StatType.Honesty, drawn);
+        }
+
+        [Fact]
+        public void DrawRandomStats_DenialAt12_ContainsHonesty()
+        {
+            var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 12 }
+            };
+            var rng = new Random(12345);
+
+            var drawn = OptionFilterEngine.DrawRandomStats(pool, pool.Length, thresholds, rng);
+
+            Assert.Contains(StatType.Honesty, drawn);
+        }
+
+        [Fact]
+        public void DrawRandomStats_DenialAt18_DoesNotContainHonesty()
+        {
+            var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 18 }
+            };
+            var rng = new Random(12345);
+
+            var drawn = OptionFilterEngine.DrawRandomStats(pool, pool.Length, thresholds, rng);
+
+            Assert.DoesNotContain(StatType.Honesty, drawn);
+        }
+
+        [Fact]
+        public void DrawRandomStats_DenialAt6_ContainsHonesty()
+        {
+            var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 6 }
+            };
+            var rng = new Random(12345);
+
+            var drawn = OptionFilterEngine.DrawRandomStats(pool, pool.Length, thresholds, rng);
+
+            Assert.Contains(StatType.Honesty, drawn);
+        }
+
+        [Fact]
+        public async Task StartTurnAsync_DenialAt17_DialogueContextAvailableStatsContainsHonesty()
+        {
+            var shadows = MakeShadowTracker(denial: 17);
+            var llm = new DialogueContextCapturingLlmAdapter();
+            var session = MakeSessionWithLlm(diceValues: new[] { 15, 50 }, shadows: shadows, llm: llm);
+
+            await session.StartTurnAsync();
+
+            Assert.NotNull(llm.CapturedContext);
+            Assert.NotNull(llm.CapturedContext.AvailableStats);
+            Assert.Contains(StatType.Honesty, llm.CapturedContext.AvailableStats);
+        }
+
+        [Fact]
+        public async Task StartTurnAsync_DenialAt18_DialogueContextAvailableStatsDoesNotContainHonesty()
+        {
+            var shadows = MakeShadowTracker(denial: 18);
+            var llm = new DialogueContextCapturingLlmAdapter();
+            var session = MakeSessionWithLlm(diceValues: new[] { 15, 50 }, shadows: shadows, llm: llm);
+
+            await session.StartTurnAsync();
+
+            Assert.NotNull(llm.CapturedContext);
+            Assert.NotNull(llm.CapturedContext.AvailableStats);
+            Assert.DoesNotContain(StatType.Honesty, llm.CapturedContext.AvailableStats);
+        }
+
+        // ---- Test Helpers ----
+
+        private static SessionShadowTracker MakeShadowTracker(int denial)
+        {
+            var stats = new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 2 }, { StatType.Honesty, 2 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Denial, denial },
+                    { ShadowStatType.Fixation, 0 }, { ShadowStatType.Madness, 0 },
+                    { ShadowStatType.Overthinking, 0 }, { ShadowStatType.Despair, 0 }
+                });
+            return new SessionShadowTracker(stats);
+        }
+
+        private static StatBlock MakeStatBlock()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 2 }, { StatType.Honesty, 2 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static CharacterProfile MakeProfile(string name)
+        {
+            var stats = MakeStatBlock();
+            var timing = new TimingProfile(5, 1.0f, 0.0f, "neutral");
+            return new CharacterProfile(stats, "system prompt", name, timing, 1);
+        }
+
+        private static GameSession MakeSessionWithLlm(
+            int[] diceValues,
+            SessionShadowTracker? shadows,
+            ILlmAdapter llm)
+        {
+            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), playerShadows: shadows);
+
+            var allDice = new int[diceValues.Length + 1];
+            allDice[0] = 5;
+            Array.Copy(diceValues, 0, allDice, 1, diceValues.Length);
+
+            return new GameSession(
+                MakeProfile("player"),
+                MakeProfile("datee"),
+                llm,
+                new QueueDice(allDice),
+                new EmptyTrapRegistry(),
+                config);
+        }
+
+        // ---- Test Doubles ----
+
+        private sealed class QueueDice : IDiceRoller
+        {
+            private readonly Queue<int> _values;
+            public QueueDice(int[] values) => _values = new Queue<int>(values);
+            public int Roll(int sides) => _values.Count > 0 ? _values.Dequeue() : 10;
+        }
+
+        private sealed class EmptyTrapRegistry : ITrapRegistry
+        {
+            public TrapDefinition? GetTrap(StatType stat) => null;
+            public string? GetLlmInstruction(StatType stat) => null;
+        }
+
+        private sealed class DialogueContextCapturingLlmAdapter : ILlmAdapter
+        {
+            public DialogueContext? CapturedContext { get; private set; }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, System.Threading.CancellationToken ct = default)
+            {
+                CapturedContext = context;
+                return Task.FromResult(new[]
+                {
+                    new DialogueOption(StatType.Charm, "Hey"),
+                    new DialogueOption(StatType.Wit, "Clever")
+                });
+            }
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(new DateeResponse("..."));
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, System.Threading.CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+                => Task.FromResult(message);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
@@ -102,6 +102,55 @@ namespace Pinder.Core.Tests
             Assert.DoesNotContain(StatType.Honesty, llm.CapturedContext.AvailableStats);
         }
 
+        [Fact]
+        public void DrawRandomStats_DenialAt18_EmitsTrace()
+        {
+            var pool = new[] { StatType.Charm, StatType.Rizz, StatType.Honesty, StatType.Chaos, StatType.Wit, StatType.SelfAwareness };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 18 }
+            };
+
+            ShadowFilterTraceEvent? captured = null;
+            Action<ShadowFilterTraceEvent> onTrace = ev => captured = ev;
+
+            var drawn = OptionFilterEngine.DrawRandomStats(pool, pool.Length, thresholds, new Random(12345), onTrace);
+
+            Assert.NotNull(captured);
+            Assert.Equal(ShadowStatType.Denial, captured!.ShadowStat);
+            Assert.Equal(18, captured.RawValue);
+            Assert.Equal(3, captured.ComputedTier);
+            Assert.Contains(StatType.Honesty, captured.RemovedStats);
+            Assert.Equal("pre_llm_stat_draw", captured.SourcePath);
+        }
+
+        [Fact]
+        public void ApplyT3Filters_DenialAt18_EmitsTrace()
+        {
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "Hi"),
+                new DialogueOption(StatType.Honesty, "Truth"),
+                new DialogueOption(StatType.Wit, "Joke")
+            };
+            var thresholds = new Dictionary<ShadowStatType, int>
+            {
+                { ShadowStatType.Denial, 18 }
+            };
+
+            ShadowFilterTraceEvent? captured = null;
+            Action<ShadowFilterTraceEvent> onTrace = ev => captured = ev;
+
+            var filtered = OptionFilterEngine.ApplyT3Filters(options, thresholds, lastStatUsed: null, dice: new QueueDice(new[] { 1 }), onTrace);
+
+            Assert.NotNull(captured);
+            Assert.Equal(ShadowStatType.Denial, captured!.ShadowStat);
+            Assert.Equal(18, captured.RawValue);
+            Assert.Equal(3, captured.ComputedTier);
+            Assert.Contains(StatType.Honesty, captured.RemovedStats);
+            Assert.Equal("post_llm_filter", captured.SourcePath);
+        }
+
         // ---- Test Helpers ----
 
         private static SessionShadowTracker MakeShadowTracker(int denial)
@@ -149,7 +198,10 @@ namespace Pinder.Core.Tests
             SessionShadowTracker? shadows,
             ILlmAdapter llm)
         {
-            var config = new GameSessionConfig(clock: TestHelpers.MakeClock(), playerShadows: shadows);
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                playerShadows: shadows,
+                maxDialogueOptions: 6);
 
             var allDice = new int[diceValues.Length + 1];
             allDice[0] = 5;


### PR DESCRIPTION
Closes #1218

## Problem
Pre-LLM stat draw (`OptionFilterEngine.DrawRandomStats`) removed Honesty at Denial `>=12` (T2), while the spec and post-LLM filter (`ApplyT3Filters`) remove it only at T3 (`>=18`). Threshold mismatch between the two paths.

## Fix
- Both pre-LLM and post-LLM Denial->Honesty filtering now consult the SSOT helper `ShadowThresholdEvaluator.GetThresholdLevel(denVal) == 3` instead of raw magic numbers, so they agree.
- Corrected misleading `T3 (>=12)` xmldoc comments to `>=18`.
- Denial T2 (12..17) keeps Honesty in both pre-LLM stat draw and post-LLM options; T3 (>=18) removes it consistently.

## Dangerous-spot trace
- New `ShadowFilterTraceEvent` (shadow stat, raw value, computed tier, removed stats, source path `pre_llm_stat_draw` vs `post_llm_filter`) emitted via an optional `Action<ShadowFilterTraceEvent>` callback on `GameSessionConfig` (no `Microsoft.Extensions.Logging` dependency). Structured metadata only — no raw prompts/secrets.

## Tests
- New `Issue1218_DenialThresholdSsotTests.cs`: Denial 12/17 keep Honesty, 18 removes it (direct), plus end-to-end capture of `DialogueContext.AvailableStats` at 17 vs 18, plus trace-event assertions.
- Updated stale `DecomposedModuleTests` Denial threshold from 12 -> 18.

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `dotnet test Pinder.Core.Tests` => 3050 passed, 0 failed, 18 skipped

## Scope
No Denial product-rule retune. No Unity changes.