### PR TITLE
fix(#1217): require explicit production GameDefinition; remove silent PinderDefaults fallback

### DIFF
--- a/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
@@ -3,7 +3,7 @@ namespace Pinder.LlmAdapters
     public partial class GameDefinition
     {
         /// <summary>
-        /// Hardcoded Pinder defaults used when YAML file is unavailable.
+        /// Hardcoded Pinder defaults used when YAML file is unavailable. TEST/DEV-only fallback; not for production.
         /// </summary>
         public static GameDefinition PinderDefaults { get; } = new GameDefinition(
             name: "Pinder",
@@ -37,7 +37,7 @@ has been dressed up, given a personality through equipped items and
 anatomy choices, and uploaded by their player.
 
 Every character has 6 positive stats and 6 shadow stats that form
-paired opposites: Charm/Madness, Rizz/Horniness, Honesty/Denial,
+paired opposites: Charm/Madness, Rizz/Despair, Honesty/Denial,
 Chaos/Fixation, Wit/Dread, Self-Awareness/Overthinking.
 
 Shadows start at 0 and grow from in-conversation events. Every 3 points

--- a/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
+++ b/src/Pinder.LlmAdapters/GameDefinition.Defaults.cs
@@ -27,7 +27,7 @@ feelings (that their shadow stats are slowly corrupting).
 The mechanical identity is a d20 RPG: six positive stats paired with
 six shadow stats that grow on their own and penalize their paired stat.
 Shadows represent the psychological cost of prolonged app use — Madness,
-Horniness, Denial, Fixation, Dread, Overthinking. You level up to fight
+Despair, Denial, Fixation, Dread, Overthinking. You level up to fight
 the darkness, but the darkness levels up too.
 
 == WORLD RULES ==

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -44,15 +44,16 @@ namespace Pinder.LlmAdapters
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
+            var gameDef = RequireGameDefinition();
             var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(context);
-            var systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+            var systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, gameDef);
             double temperature = _options.DialogueOptionsTemperature ?? DefaultDialogueOptionsTemperature;
 
             var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions, ct: ct)
                 .ConfigureAwait(false);
 
             var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText, context.AvailableStats);
-            int maxOptions = _options.GameDefinition?.MaxDialogueOptions ?? 99;
+            int maxOptions = gameDef.MaxDialogueOptions;
             if (parsedOptions.Length > maxOptions)
             {
                 var capped = new DialogueOption[maxOptions];
@@ -74,6 +75,7 @@ namespace Pinder.LlmAdapters
         /// <inheritdoc />
         public async Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
         {
+            RequireGameDefinition();
             // #788: stateless single-turn fallback path. Stateful callers route
             // through the IStatefulLlmAdapter overload that takes a history.
             var result = await GetDateeResponseAsync(context, System.Array.Empty<ConversationMessage>(), ct).ConfigureAwait(false);
@@ -89,8 +91,9 @@ namespace Pinder.LlmAdapters
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (history == null) throw new ArgumentNullException(nameof(history));
 
+            var gameDef = RequireGameDefinition();
             var userContent = SessionDocumentBuilder.BuildDateePrompt(context);
-            var systemPrompt = SessionSystemPromptBuilder.BuildDatee(context.DateePrompt, _options.GameDefinition);
+            var systemPrompt = SessionSystemPromptBuilder.BuildDatee(context.DateePrompt, gameDef);
             double temperature = _options.DateeResponseTemperature ?? DefaultDateeResponseTemperature;
 
             string responseText;
@@ -127,6 +130,8 @@ namespace Pinder.LlmAdapters
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
+            var gameDef = RequireGameDefinition();
+
             // Build user content with history context
             var userContent = SessionDocumentBuilder.BuildInterestChangeBeatPrompt(
                 context.DateeName,
@@ -138,8 +143,8 @@ namespace Pinder.LlmAdapters
 
             // Use datee system prompt if provided, otherwise skip system prompt
             string systemPrompt = string.IsNullOrWhiteSpace(context.DateePrompt)
-                ? SessionSystemPromptBuilder.BuildDatee("", _options.GameDefinition)
-                : SessionSystemPromptBuilder.BuildDatee(context.DateePrompt, _options.GameDefinition);
+                ? SessionSystemPromptBuilder.BuildDatee("", gameDef)
+                : SessionSystemPromptBuilder.BuildDatee(context.DateePrompt, gameDef);
 
             double temperature = _options.Temperature;
 
@@ -345,6 +350,8 @@ namespace Pinder.LlmAdapters
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
+            var gameDef = RequireGameDefinition();
+
             string template = null;
             if (_options.StatDeliveryInstructions != null)
             {
@@ -370,7 +377,7 @@ namespace Pinder.LlmAdapters
             sb.AppendLine();
             sb.AppendLine(prompt);
 
-            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, gameDef);
 
             var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.8, _options.MaxTokens, phase: LlmPhase.Delivery, ct: ct)
                 .ConfigureAwait(false);
@@ -392,7 +399,9 @@ namespace Pinder.LlmAdapters
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            string template = _options.GameDefinition?.SteeringPrompt;
+            var gameDef = RequireGameDefinition();
+
+            string template = gameDef.SteeringPrompt;
             if (string.IsNullOrWhiteSpace(template))
                 template = GameDefinition.DefaultSteeringPrompt;
 
@@ -410,7 +419,7 @@ namespace Pinder.LlmAdapters
             sb.AppendLine();
             sb.AppendLine(prompt);
 
-            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, gameDef);
 
             var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.Steering, ct: ct)
                 .ConfigureAwait(false);
@@ -433,7 +442,9 @@ namespace Pinder.LlmAdapters
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            string template = _options.GameDefinition?.HorninessPrompt;
+            var gameDef = RequireGameDefinition();
+
+            string template = gameDef.HorninessPrompt;
             if (string.IsNullOrWhiteSpace(template))
                 template = GameDefinition.DefaultHorninessPrompt;
 
@@ -451,7 +462,7 @@ namespace Pinder.LlmAdapters
             sb.AppendLine();
             sb.AppendLine(prompt);
 
-            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, _options.GameDefinition);
+            string systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, gameDef);
 
             var responseText = await _transport.SendAsync(systemPrompt, sb.ToString(), 0.9, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
                 .ConfigureAwait(false);
@@ -571,6 +582,15 @@ namespace Pinder.LlmAdapters
                 System.Diagnostics.Trace.TraceWarning(warning);
                 _options.OnStakeSkipWarning?.Invoke(warning);
             }
+        }
+
+        private GameDefinition RequireGameDefinition([System.Runtime.CompilerServices.CallerMemberName] string methodName = "")
+        {
+            if (_options.GameDefinition == null)
+            {
+                throw new InvalidOperationException($"Production path '{methodName}' is missing GameDefinition. GameDefinition is required at the production adapter boundary to avoid silent fallbacks.");
+            }
+            return _options.GameDefinition;
         }
 
         public void Dispose()

--- a/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
@@ -8,7 +8,8 @@ namespace Pinder.LlmAdapters
     {
         /// <summary>
         /// Game definition containing vision, world rules, prompts, steering prompt, etc.
-        /// When null, GameDefinition.PinderDefaults is used.
+        /// Production REQUIRES this to be set explicitly. A null value will cause the production adapter
+        /// to throw an InvalidOperationException at call time (no silent PinderDefaults fallbacks in production).
         /// </summary>
         public GameDefinition? GameDefinition { get; set; }
 

--- a/tests/Pinder.Core.Tests/Phase0/Phase0Fixtures.cs
+++ b/tests/Pinder.Core.Tests/Phase0/Phase0Fixtures.cs
@@ -75,6 +75,7 @@ namespace Pinder.Core.Tests.Phase0
         {
             return new PinderLlmAdapter(transport, new PinderLlmAdapterOptions
             {
+                GameDefinition = GameDefinition.PinderDefaults,
                 MaxTokens = 256,
                 Temperature = 0.9,
             });

--- a/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_datee.txt
+++ b/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_datee.txt
@@ -28,7 +28,7 @@ has been dressed up, given a personality through equipped items and
 anatomy choices, and uploaded by their player.
 
 Every character has 6 positive stats and 6 shadow stats that form
-paired opposites: Charm/Madness, Rizz/Horniness, Honesty/Denial,
+paired opposites: Charm/Madness, Rizz/Despair, Honesty/Denial,
 Chaos/Fixation, Wit/Dread, Self-Awareness/Overthinking.
 
 Shadows start at 0 and grow from in-conversation events. Every 3 points

--- a/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_datee.txt
+++ b/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_datee.txt
@@ -18,7 +18,7 @@ feelings (that their shadow stats are slowly corrupting).
 The mechanical identity is a d20 RPG: six positive stats paired with
 six shadow stats that grow on their own and penalize their paired stat.
 Shadows represent the psychological cost of prolonged app use — Madness,
-Horniness, Denial, Fixation, Dread, Overthinking. You level up to fight
+Despair, Denial, Fixation, Dread, Overthinking. You level up to fight
 the darkness, but the darkness levels up too.
 
 == WORLD RULES ==

--- a/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_pa.txt
+++ b/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_pa.txt
@@ -28,7 +28,7 @@ has been dressed up, given a personality through equipped items and
 anatomy choices, and uploaded by their player.
 
 Every character has 6 positive stats and 6 shadow stats that form
-paired opposites: Charm/Madness, Rizz/Horniness, Honesty/Denial,
+paired opposites: Charm/Madness, Rizz/Despair, Honesty/Denial,
 Chaos/Fixation, Wit/Dread, Self-Awareness/Overthinking.
 
 Shadows start at 0 and grow from in-conversation events. Every 3 points

--- a/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_pa.txt
+++ b/tests/Pinder.LlmAdapters.Tests/Fixtures/Issue1153/golden_pa.txt
@@ -18,7 +18,7 @@ feelings (that their shadow stats are slowly corrupting).
 The mechanical identity is a d20 RPG: six positive stats paired with
 six shadow stats that grow on their own and penalize their paired stat.
 Shadows represent the psychological cost of prolonged app use — Madness,
-Horniness, Denial, Fixation, Dread, Overthinking. You level up to fight
+Despair, Denial, Fixation, Dread, Overthinking. You level up to fight
 the darkness, but the darkness levels up too.
 
 == WORLD RULES ==

--- a/tests/Pinder.LlmAdapters.Tests/Issue1217_ExplicitGameDefinitionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1217_ExplicitGameDefinitionTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1217_ExplicitGameDefinitionTests
+    {
+        // ── 1. PRODUCTION FAIL-LOUD ────────────────────────────────────────
+
+        [Fact]
+        public async Task Production_GetDialogueOptions_ThrowsInvalidOperationException_WhenGameDefinitionIsNull()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n\"Hi\"");
+            var options = new PinderLlmAdapterOptions { GameDefinition = null };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var context = new DialogueContext(
+                playerAvatarPrompt: "player spec",
+                dateePrompt: "datee spec",
+                conversationHistory: new List<(string, string)> { ("O", "Hi") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerName: "P",
+                dateeName: "O",
+                availableStats: new[] { StatType.Charm }
+            );
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => adapter.GetDialogueOptionsAsync(context));
+            Assert.Contains("GameDefinition", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Production_GetDateeResponse_ThrowsInvalidOperationException_WhenGameDefinitionIsNull()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("some datee response");
+            var options = new PinderLlmAdapterOptions { GameDefinition = null };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var context = new DateeContext(
+                dateePrompt: "datee spec",
+                conversationHistory: new List<(string, string)> { ("O", "Hi") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hello",
+                interestBefore: 10,
+                interestAfter: 10,
+                responseDelayMinutes: 0.5,
+                playerName: "P",
+                dateeName: "O"
+            );
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => adapter.GetDateeResponseAsync(context));
+            Assert.Contains("GameDefinition", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ── 2. TEST/DEV FALLBACK PARITY ────────────────────────────────────
+
+        [Fact]
+        public void PinderDefaults_GameMasterPrompt_DoesNotContainStaleRizzHorniness_AndContainsDespair()
+        {
+            var gmPrompt = GameDefinition.PinderDefaults.GameMasterPrompt;
+
+            // Assert the stale token 'Rizz/Horniness' is not present
+            Assert.DoesNotContain("Rizz/Horniness", gmPrompt);
+
+            // Assert that 'Despair' is present in the Rizz-pairing context
+            Assert.Contains("Rizz/Despair", gmPrompt);
+            Assert.Contains("Despair", gmPrompt);
+        }
+
+        // ── 3. GUARD (provided definition still works) ──────────────────────
+
+        [Fact]
+        public async Task Production_GetDialogueOptions_DoesNotThrow_WhenGameDefinitionIsProvided()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n\"Hi\"");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var context = new DialogueContext(
+                playerAvatarPrompt: "player spec",
+                dateePrompt: "datee spec",
+                conversationHistory: new List<(string, string)> { ("O", "Hi") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerName: "P",
+                dateeName: "O",
+                availableStats: new[] { StatType.Charm }
+            );
+
+            // Act & Assert
+            var exception = await Record.ExceptionAsync(() => adapter.GetDialogueOptionsAsync(context));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public async Task Production_GetDateeResponse_DoesNotThrow_WhenGameDefinitionIsProvided()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("some datee response");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var context = new DateeContext(
+                dateePrompt: "datee spec",
+                conversationHistory: new List<(string, string)> { ("O", "Hi") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 10,
+                playerDeliveredMessage: "Hello",
+                interestBefore: 10,
+                interestAfter: 10,
+                responseDelayMinutes: 0.5,
+                playerName: "P",
+                dateeName: "O"
+            );
+
+            // Act & Assert
+            var exception = await Record.ExceptionAsync(() => adapter.GetDateeResponseAsync(context));
+            Assert.Null(exception);
+        }
+
+        // ── Fake Transport ─────────────────────────────────────────────────
+
+        private sealed class FixedResponseTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public FixedResponseTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
@@ -114,6 +114,7 @@ namespace Pinder.LlmAdapters.Tests
             var transport = new FixedResponseTransport(fakeResponse);
             var options = new PinderLlmAdapterOptions
             {
+                GameDefinition = GameDefinition.PinderDefaults,
                 OnStakeSkipWarning = w => capturedWarning = w,
             };
             var adapter = new PinderLlmAdapter(transport, options);
@@ -146,6 +147,7 @@ namespace Pinder.LlmAdapters.Tests
             var transport = new FixedResponseTransport(fakeResponse);
             var options = new PinderLlmAdapterOptions
             {
+                GameDefinition = GameDefinition.PinderDefaults,
                 OnStakeSkipWarning = w => capturedWarning = w,
             };
             var adapter = new PinderLlmAdapter(transport, options);


### PR DESCRIPTION
Closes #1217

## Problem
Production prompt builders silently fell back to the stale hardcoded `GameDefinition.PinderDefaults` when no `GameDefinition` was supplied, bypassing YAML/content SSOT and risking silent game-semantics drift. The stale defaults also mispaired `Rizz/Horniness` where canonical SSOT is `Rizz/Despair`.

## Fix
- `PinderLlmAdapter` now enforces an explicit `GameDefinition` at the production boundary via a private `RequireGameDefinition()` guard: every production prompt path (dialogue options, datee response, delivery, steering) throws `InvalidOperationException` with privacy-safe structured context (method/path + reason) when `GameDefinition` is null. No silent `PinderDefaults` substitution in production.
- The low-level static `SessionSystemPromptBuilder` stays lenient (`?? PinderDefaults`) so the ~50 existing tests and the NarrativeHarness keep working; `PinderDefaults` is retained as an explicit test/dev-only fallback (xmldoc clarified).
- Corrected stale fallback content in `GameDefinition.Defaults.cs`: the Rizz-paired shadow is now `Despair` (not `Horniness`) in both the paired-opposites line and the six-shadow enumeration, matching `StatType.cs` and `data/game-definition.yaml`. The separate horniness overlay/DC mechanic text is left intact.

## Dangerous-spot
- Production now fails loudly instead of silently degrading; the exception message carries only method/path + reason (no raw prompts, secrets, or conversation text). No `Microsoft.Extensions.Logging` dependency added.

## Migrations (test/dev call sites)
- `Phase0Fixtures.MakeAdapter` and `Issue950_StakeSurfacingTests` now pass an explicit `GameDefinition` (the intended migration).
- 2 Issue1153 golden fixtures regenerated minimally (only the corrected `Despair` enumeration lines).

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.LlmAdapters.Tests` => 1049 passed, 0 failed (Issue1217 5/5)
- `Pinder.Core.Tests` => 3050 passed, 0 failed, 18 skipped

## Scope
No setup-generator refactor (deferred to #1223). No authored `game-definition.yaml` content change. No Unity changes.