### PR TITLE
fix(#1215): fail loudly on malformed required gameplay LLM output

### DIFF
--- a/src/Pinder.LlmAdapters/Anthropic/DateeResponseParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DateeResponseParsers.cs
@@ -63,6 +63,10 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <summary>
         /// Parses structured LLM text output with optional [SIGNALS] blocks.
         /// Never throws — returns DateeResponse with null signals on parse failure.
+        /// <para>
+        /// NOTE: This lenient parser is best-effort and diagnostics-only.
+        /// Gameplay production uses strict validation logic.
+        /// </para>
         /// </summary>
         public static DateeResponse ParseDateeResponseText(string? llmResponse)
         {
@@ -137,6 +141,10 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <summary>
         /// Parses datee response from a tool_use JSON input.
         /// Returns null if the input is malformed (caller should fall back to text parsing).
+        /// <para>
+        /// NOTE: This lenient parser is best-effort and diagnostics-only.
+        /// Gameplay production uses strict validation logic.
+        /// </para>
         /// </summary>
         public static DateeResponse? ParseDateeResponseTool(JObject toolInput)
         {

--- a/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
@@ -66,6 +66,10 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <summary>
         /// Parses structured LLM text output into DialogueOption array.
         /// Never throws — returns options padded with defaults if needed.
+        /// <para>
+        /// NOTE: This lenient parser is best-effort and diagnostics-only.
+        /// Gameplay production uses the strict path (ParseDialogueOptionsStrict).
+        /// </para>
         /// </summary>
         public static DialogueOption[] ParseDialogueOptionsText(string? llmResponse, StatType[]? availableStats = null)
         {
@@ -164,6 +168,10 @@ namespace Pinder.LlmAdapters.Anthropic
         /// <summary>
         /// Parses dialogue options from a tool_use JSON input.
         /// Returns null if the input is malformed (caller should fall back to text parsing).
+        /// <para>
+        /// NOTE: This lenient parser is best-effort and diagnostics-only.
+        /// Gameplay production uses the strict path (ParseDialogueOptionsStrict).
+        /// </para>
         /// </summary>
         public static DialogueOption[]? ParseDialogueOptionsTool(JObject toolInput, StatType[]? availableStats = null)
         {
@@ -237,6 +245,132 @@ namespace Pinder.LlmAdapters.Anthropic
             {
                 return null; // Malformed — fall back to text parsing
             }
+        }
+
+        /// <summary>
+        /// Strictly parses and validates LLM response text for dialogue options.
+        /// Throws detailed error codes if output is empty, has an invalid stat, is missing required option counts, or has no valid options.
+        /// </summary>
+        public static DialogueOption[] ParseDialogueOptionsStrict(
+            string? llmResponse,
+            StatType[]? availableStats,
+            int maxDialogueOptions,
+            out string? errorCode,
+            out string? errorMessage,
+            out int parsedCount,
+            out int expectedCount)
+        {
+            errorCode = null;
+            errorMessage = null;
+            parsedCount = 0;
+            expectedCount = availableStats != null ? Math.Min(availableStats.Length, maxDialogueOptions) : maxDialogueOptions;
+
+            if (string.IsNullOrWhiteSpace(llmResponse))
+            {
+                errorCode = "empty_output";
+                errorMessage = "LLM dialogue_options output is empty or whitespace.";
+                return Array.Empty<DialogueOption>();
+            }
+
+            var parsed = new List<DialogueOption>();
+            var sections = OptionHeaderRegex.Split(llmResponse);
+
+            // sections[0] contains anything before OPTION_1 (the preamble / thinking block).
+            // sections[1..] contain the actual options.
+            for (int i = 1; i < sections.Length; i++)
+            {
+                var section = sections[i];
+                if (string.IsNullOrWhiteSpace(section)) continue;
+
+                // Check for stat tag
+                var statMatch = StatRegex.Match(section);
+                if (!statMatch.Success)
+                {
+                    // If we have an OPTION_N block but no STAT tag, it's not a valid complete option
+                    continue;
+                }
+
+                var statStr = StatNameNormalizer.NormalizeStatName(statMatch.Groups[1].Value.Trim());
+                StatType stat;
+                try
+                {
+                    stat = (StatType)Enum.Parse(typeof(StatType), statStr, true);
+                }
+                catch (ArgumentException)
+                {
+                    errorCode = "invalid_stat";
+                    errorMessage = $"LLM dialogue_options option names an invalid or unknown stat '{statStr}'.";
+                    return Array.Empty<DialogueOption>();
+                }
+
+                // Check for quoted text
+                var textMatch = QuotedTextRegex.Match(section);
+                if (!textMatch.Success) continue;
+
+                var text = MetaPrefixStripper.Strip(textMatch.Groups[1].Value.Trim());
+                if (string.IsNullOrEmpty(text) || text.Length < MinPlayableOptionLength) continue;
+
+                // Parse optional metadata
+                int? callbackTurn = null;
+                var callbackMatch = CallbackRegex.Match(section);
+                if (callbackMatch.Success)
+                {
+                    var cbVal = callbackMatch.Groups[1].Value.Trim();
+                    if (!string.Equals(cbVal, "none", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (int.TryParse(cbVal, out int turnNum))
+                        {
+                            callbackTurn = turnNum;
+                        }
+                        else if (cbVal.StartsWith("turn_", StringComparison.OrdinalIgnoreCase) &&
+                                 int.TryParse(cbVal.Substring(5), out int turnNum2))
+                        {
+                            callbackTurn = turnNum2;
+                        }
+                    }
+                }
+
+                string? comboName = null;
+                var comboMatch = ComboRegex.Match(section);
+                if (comboMatch.Success)
+                {
+                    var comboVal = comboMatch.Groups[1].Value.Trim();
+                    if (!string.Equals(comboVal, "none", StringComparison.OrdinalIgnoreCase))
+                    {
+                        comboName = comboVal;
+                    }
+                }
+
+                bool hasTellBonus = false;
+                var tellMatch = TellBonusRegex.Match(section);
+                if (tellMatch.Success)
+                {
+                    hasTellBonus = string.Equals(
+                        tellMatch.Groups[1].Value.Trim(), "yes", StringComparison.OrdinalIgnoreCase);
+                }
+
+                parsed.Add(new DialogueOption(
+                    stat, text, callbackTurn, comboName, hasTellBonus, hasWeaknessWindow: false));
+            }
+
+            parsedCount = parsed.Count;
+
+            if (parsed.Count == 0)
+            {
+                errorCode = "no_valid_options";
+                errorMessage = "LLM dialogue_options response contains no valid options (malformed).";
+                return Array.Empty<DialogueOption>();
+            }
+
+            if (parsed.Count < expectedCount)
+            {
+                errorCode = "partial_options";
+                errorMessage = $"LLM dialogue_options response has fewer valid options ({parsed.Count}) than required ({expectedCount}).";
+                return Array.Empty<DialogueOption>();
+            }
+
+            // Standardize/reconcile the options to map them perfectly to expected availableStats (no padding because count >= expectedCount).
+            return ReconcileAndPadDialogueOptions(parsed, availableStats);
         }
 
         public static DialogueOption[] ReconcileAndPadDialogueOptions(List<DialogueOption> parsed, StatType[]? availableStats = null)

--- a/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
+++ b/src/Pinder.LlmAdapters/Anthropic/DialogueOptionParsers.cs
@@ -299,7 +299,7 @@ namespace Pinder.LlmAdapters.Anthropic
                 catch (ArgumentException)
                 {
                     errorCode = "invalid_stat";
-                    errorMessage = $"LLM dialogue_options option names an invalid or unknown stat '{statStr}'.";
+                    errorMessage = "LLM dialogue_options option names an invalid or unknown stat.";
                     return Array.Empty<DialogueOption>();
                 }
 
@@ -353,24 +353,45 @@ namespace Pinder.LlmAdapters.Anthropic
                     stat, text, callbackTurn, comboName, hasTellBonus, hasWeaknessWindow: false));
             }
 
-            parsedCount = parsed.Count;
+            var validOptions = new List<DialogueOption>();
+            var usedStats = new HashSet<StatType>();
+            var allowedStats = availableStats != null ? new HashSet<StatType>(availableStats) : null;
 
-            if (parsed.Count == 0)
+            foreach (var opt in parsed)
+            {
+                if (allowedStats != null && !allowedStats.Contains(opt.Stat))
+                {
+                    continue;
+                }
+                if (usedStats.Contains(opt.Stat))
+                {
+                    continue;
+                }
+                usedStats.Add(opt.Stat);
+                validOptions.Add(opt);
+            }
+
+            parsedCount = validOptions.Count;
+
+            if (validOptions.Count == 0)
             {
                 errorCode = "no_valid_options";
                 errorMessage = "LLM dialogue_options response contains no valid options (malformed).";
                 return Array.Empty<DialogueOption>();
             }
 
-            if (parsed.Count < expectedCount)
+            if (validOptions.Count < expectedCount)
             {
                 errorCode = "partial_options";
-                errorMessage = $"LLM dialogue_options response has fewer valid options ({parsed.Count}) than required ({expectedCount}).";
+                errorMessage = $"LLM dialogue_options response has partial options: fewer valid options ({validOptions.Count}) than required ({expectedCount}).";
                 return Array.Empty<DialogueOption>();
             }
 
-            // Standardize/reconcile the options to map them perfectly to expected availableStats (no padding because count >= expectedCount).
-            return ReconcileAndPadDialogueOptions(parsed, availableStats);
+            if (validOptions.Count > expectedCount)
+            {
+                return validOptions.GetRange(0, expectedCount).ToArray();
+            }
+            return validOptions.ToArray();
         }
 
         public static DialogueOption[] ReconcileAndPadDialogueOptions(List<DialogueOption> parsed, StatType[]? availableStats = null)

--- a/src/Pinder.LlmAdapters/GmOutputContract.cs
+++ b/src/Pinder.LlmAdapters/GmOutputContract.cs
@@ -196,7 +196,7 @@ namespace Pinder.LlmAdapters
 
             if (!hasTellIndicator && !hasWeaknessIndicator)
             {
-                errorDetail = "The [SIGNALS] block is present but contains neither a TELL nor a WEAKNESS signal.";
+                errorDetail = "malformed_signals";
                 return DateeSignalsValidationResult.MalformedSignals;
             }
 
@@ -211,13 +211,13 @@ namespace Pinder.LlmAdapters
                     var match = TellSignalRegex.Match(trimmedLine);
                     if (!match.Success)
                     {
-                        errorDetail = $"Malformed TELL line format: '{trimmedLine}'. Expected format 'TELL: <Stat> (<description>)'.";
+                        errorDetail = "malformed_signals";
                         return DateeSignalsValidationResult.MalformedSignals;
                     }
 
                     if (!TryParseStat(match.Groups[1].Value, out _))
                     {
-                        errorDetail = $"Invalid stat '{match.Groups[1].Value}' in TELL signal: '{trimmedLine}'.";
+                        errorDetail = "tell_invalid_stat";
                         return DateeSignalsValidationResult.MalformedSignals;
                     }
                 }
@@ -226,19 +226,19 @@ namespace Pinder.LlmAdapters
                     var match = WeaknessSignalRegex.Match(trimmedLine);
                     if (!match.Success)
                     {
-                        errorDetail = $"Malformed WEAKNESS line format: '{trimmedLine}'. Expected format 'WEAKNESS: <Stat> -<n> (<description>)'.";
+                        errorDetail = "malformed_signals";
                         return DateeSignalsValidationResult.MalformedSignals;
                     }
 
                     if (!TryParseStat(match.Groups[1].Value, out _))
                     {
-                        errorDetail = $"Invalid stat '{match.Groups[1].Value}' in WEAKNESS signal: '{trimmedLine}'.";
+                        errorDetail = "weakness_invalid_stat";
                         return DateeSignalsValidationResult.MalformedSignals;
                     }
 
                     if (!int.TryParse(match.Groups[2].Value.Trim(), out int reduction) || reduction <= 0)
                     {
-                        errorDetail = $"Invalid DC reduction '{match.Groups[2].Value}' in WEAKNESS signal: '{trimmedLine}'. Must be a positive integer.";
+                        errorDetail = "weakness_missing_dc";
                         return DateeSignalsValidationResult.MalformedSignals;
                     }
                 }

--- a/src/Pinder.LlmAdapters/GmOutputContract.cs
+++ b/src/Pinder.LlmAdapters/GmOutputContract.cs
@@ -93,6 +93,10 @@ namespace Pinder.LlmAdapters
         /// Parses canonical GM output text into a <see cref="GmTurnOutput"/>.
         /// Never throws — malformed input degrades to a message-only result with
         /// null signals. The message is everything before <c>[SIGNALS]</c>.
+        /// <para>
+        /// NOTE: This parser is lenient and best-effort for backwards compatibility.
+        /// Production gameplay uses strict validation (ValidateSignalsStrict).
+        /// </para>
         /// </summary>
         public static GmTurnOutput Parse(string? raw)
         {
@@ -166,5 +170,91 @@ namespace Pinder.LlmAdapters
             // the SELF_AWARENESS token the model emits and the normalizer accepts.
             return stat == StatType.SelfAwareness ? "SELF_AWARENESS" : stat.ToString();
         }
+
+        /// <summary>
+        /// Strictly validates the optional [SIGNALS] block of datee output if present.
+        /// </summary>
+        public static DateeSignalsValidationResult ValidateSignalsStrict(string? raw, out string? errorDetail)
+        {
+            errorDetail = null;
+            if (string.IsNullOrEmpty(raw))
+            {
+                return DateeSignalsValidationResult.NoSignalsBlock;
+            }
+
+            int signalsIdx = raw!.IndexOf(SignalsMarker, StringComparison.OrdinalIgnoreCase);
+            if (signalsIdx < 0)
+            {
+                return DateeSignalsValidationResult.NoSignalsBlock;
+            }
+
+            string block = raw.Substring(signalsIdx + SignalsMarker.Length).Trim();
+
+            // Check if block contains TELL: or WEAKNESS: at all
+            bool hasTellIndicator = block.IndexOf("TELL:", StringComparison.OrdinalIgnoreCase) >= 0;
+            bool hasWeaknessIndicator = block.IndexOf("WEAKNESS:", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            if (!hasTellIndicator && !hasWeaknessIndicator)
+            {
+                errorDetail = "The [SIGNALS] block is present but contains neither a TELL nor a WEAKNESS signal.";
+                return DateeSignalsValidationResult.MalformedSignals;
+            }
+
+            var lines = block.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines)
+            {
+                var trimmedLine = line.Trim();
+                if (string.IsNullOrEmpty(trimmedLine)) continue;
+
+                if (trimmedLine.IndexOf("TELL:", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    var match = TellSignalRegex.Match(trimmedLine);
+                    if (!match.Success)
+                    {
+                        errorDetail = $"Malformed TELL line format: '{trimmedLine}'. Expected format 'TELL: <Stat> (<description>)'.";
+                        return DateeSignalsValidationResult.MalformedSignals;
+                    }
+
+                    if (!TryParseStat(match.Groups[1].Value, out _))
+                    {
+                        errorDetail = $"Invalid stat '{match.Groups[1].Value}' in TELL signal: '{trimmedLine}'.";
+                        return DateeSignalsValidationResult.MalformedSignals;
+                    }
+                }
+                else if (trimmedLine.IndexOf("WEAKNESS:", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    var match = WeaknessSignalRegex.Match(trimmedLine);
+                    if (!match.Success)
+                    {
+                        errorDetail = $"Malformed WEAKNESS line format: '{trimmedLine}'. Expected format 'WEAKNESS: <Stat> -<n> (<description>)'.";
+                        return DateeSignalsValidationResult.MalformedSignals;
+                    }
+
+                    if (!TryParseStat(match.Groups[1].Value, out _))
+                    {
+                        errorDetail = $"Invalid stat '{match.Groups[1].Value}' in WEAKNESS signal: '{trimmedLine}'.";
+                        return DateeSignalsValidationResult.MalformedSignals;
+                    }
+
+                    if (!int.TryParse(match.Groups[2].Value.Trim(), out int reduction) || reduction <= 0)
+                    {
+                        errorDetail = $"Invalid DC reduction '{match.Groups[2].Value}' in WEAKNESS signal: '{trimmedLine}'. Must be a positive integer.";
+                        return DateeSignalsValidationResult.MalformedSignals;
+                    }
+                }
+            }
+
+            return DateeSignalsValidationResult.ValidSignals;
+        }
+    }
+
+    /// <summary>
+    /// Result of strict signals block validation.
+    /// </summary>
+    public enum DateeSignalsValidationResult
+    {
+        NoSignalsBlock,
+        ValidSignals,
+        MalformedSignals
     }
 }

--- a/src/Pinder.LlmAdapters/LlmContractException.cs
+++ b/src/Pinder.LlmAdapters/LlmContractException.cs
@@ -1,0 +1,93 @@
+using System;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Violation metadata containing privacy-safe structured information about a contract failure.
+    /// </summary>
+    public sealed class LlmContractViolation
+    {
+        public string Phase { get; }
+        public string Reason { get; }
+        public string? Provider { get; }
+        public string? Model { get; }
+        public string? ParserName { get; }
+        public int? ExpectedOptionCount { get; }
+        public int? ParsedOptionCount { get; }
+        public int? OptionCount { get; }
+        public int? SignalCount { get; }
+        public string? SessionId { get; }
+        public int? TurnId { get; }
+
+        public LlmContractViolation(
+            string phase,
+            string reason,
+            string? provider = null,
+            string? model = null,
+            string? parserName = null,
+            int? expectedOptionCount = null,
+            int? parsedOptionCount = null,
+            int? optionCount = null,
+            int? signalCount = null,
+            string? sessionId = null,
+            int? turnId = null)
+        {
+            Phase = phase;
+            Reason = reason;
+            Provider = provider;
+            Model = model;
+            ParserName = parserName;
+            ExpectedOptionCount = expectedOptionCount;
+            ParsedOptionCount = parsedOptionCount;
+            OptionCount = optionCount;
+            SignalCount = signalCount;
+            SessionId = sessionId;
+            TurnId = turnId;
+        }
+    }
+
+    /// <summary>
+    /// Exception thrown when the LLM provider fails to fulfill the contract required for gameplay.
+    /// </summary>
+    public sealed class LlmContractException : Exception
+    {
+        public string Phase { get; }
+        public string Reason { get; }
+        public string? Provider { get; }
+        public string? Model { get; }
+        public string? ParserName { get; }
+        public int? ExpectedOptionCount { get; }
+        public int? ParsedOptionCount { get; }
+        public int? OptionCount { get; }
+        public int? SignalCount { get; }
+        public string? SessionId { get; }
+        public int? TurnId { get; }
+
+        public LlmContractException(
+            string phase,
+            string reason,
+            string message,
+            string? provider = null,
+            string? model = null,
+            string? parserName = null,
+            int? expectedOptionCount = null,
+            int? parsedOptionCount = null,
+            int? optionCount = null,
+            int? signalCount = null,
+            string? sessionId = null,
+            int? turnId = null) : base(message)
+        {
+            Phase = phase;
+            Reason = reason;
+            Provider = provider;
+            Model = model;
+            ParserName = parserName;
+            ExpectedOptionCount = expectedOptionCount;
+            ParsedOptionCount = parsedOptionCount;
+            OptionCount = optionCount;
+            SignalCount = signalCount;
+            SessionId = sessionId;
+            TurnId = turnId;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -52,13 +52,52 @@ namespace Pinder.LlmAdapters
             var responseText = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.DialogueOptions, ct: ct)
                 .ConfigureAwait(false);
 
-            var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsText(responseText, context.AvailableStats);
-            int maxOptions = gameDef.MaxDialogueOptions;
-            if (parsedOptions.Length > maxOptions)
+            string? errorCode;
+            string? errorMessage;
+            int parsedCount;
+            int expectedCount;
+
+            var parsedOptions = DialogueOptionParsers.ParseDialogueOptionsStrict(
+                responseText,
+                context.AvailableStats,
+                gameDef.MaxDialogueOptions,
+                out errorCode,
+                out errorMessage,
+                out parsedCount,
+                out expectedCount);
+
+            if (errorCode != null)
             {
-                var capped = new DialogueOption[maxOptions];
-                System.Array.Copy(parsedOptions, capped, maxOptions);
-                parsedOptions = capped;
+                var violation = new LlmContractViolation(
+                    phase: "dialogue_options",
+                    reason: errorCode,
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDialogueOptionsParser",
+                    expectedOptionCount: expectedCount,
+                    parsedOptionCount: parsedCount,
+                    optionCount: parsedCount,
+                    signalCount: null,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
+
+                _options.OnLlmContractViolation?.Invoke(violation);
+
+                throw new LlmContractException(
+                    phase: "dialogue_options",
+                    reason: errorCode,
+                    message: errorMessage!,
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDialogueOptionsParser",
+                    expectedOptionCount: expectedCount,
+                    parsedOptionCount: parsedCount,
+                    optionCount: parsedCount,
+                    signalCount: null,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
             }
 
             // #950: warn when the option generator skips all stake content.
@@ -111,6 +150,75 @@ namespace Pinder.LlmAdapters
                 // wire ordering.
                 responseText = await SendStatefulDateeAsync(systemPrompt, userContent, history, temperature, cancellationToken)
                     .ConfigureAwait(false);
+            }
+
+            if (string.IsNullOrWhiteSpace(responseText))
+            {
+                var violation = new LlmContractViolation(
+                    phase: "datee_response",
+                    reason: "empty_output",
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDateeResponseParser",
+                    expectedOptionCount: null,
+                    parsedOptionCount: null,
+                    optionCount: null,
+                    signalCount: 0,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
+
+                _options.OnLlmContractViolation?.Invoke(violation);
+
+                throw new LlmContractException(
+                    phase: "datee_response",
+                    reason: "empty_output",
+                    message: "LLM datee_response output is empty or whitespace.",
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDateeResponseParser",
+                    expectedOptionCount: null,
+                    parsedOptionCount: null,
+                    optionCount: null,
+                    signalCount: 0,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
+            }
+
+            var validationResult = GmOutputContract.ValidateSignalsStrict(responseText, out string? errorDetail);
+            if (validationResult == DateeSignalsValidationResult.MalformedSignals)
+            {
+                var violation = new LlmContractViolation(
+                    phase: "datee_response",
+                    reason: "malformed_signals",
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDateeResponseParser",
+                    expectedOptionCount: null,
+                    parsedOptionCount: null,
+                    optionCount: null,
+                    signalCount: null,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
+
+                _options.OnLlmContractViolation?.Invoke(violation);
+
+                throw new LlmContractException(
+                    phase: "datee_response",
+                    reason: "malformed_signals",
+                    message: $"LLM datee_response has malformed signals block: {errorDetail}",
+                    provider: null,
+                    model: null,
+                    parserName: "StrictDateeResponseParser",
+                    expectedOptionCount: null,
+                    parsedOptionCount: null,
+                    optionCount: null,
+                    signalCount: null,
+                    sessionId: null,
+                    turnId: context.CurrentTurn
+                );
             }
 
             var parsed = DateeResponseParsers.ParseDateeResponseText(responseText);

--- a/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
@@ -72,5 +72,11 @@ namespace Pinder.LlmAdapters
         /// (a Trace warning is still emitted regardless).
         /// </summary>
         public System.Action<string>? OnStakeSkipWarning { get; set; }
+
+        /// <summary>
+        /// Optional callback invoked when an LLM contract violation is detected.
+        /// Receives structured metadata about the violation.
+        /// </summary>
+        public System.Action<LlmContractViolation>? OnLlmContractViolation { get; set; }
     }
 }

--- a/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
+++ b/tests/Pinder.Core.Tests/Phase0/RecordingLlmTransport.cs
@@ -113,6 +113,46 @@ namespace Pinder.Core.Tests.Phase0
                 response = DefaultResponse;
             }
 
+            if (string.Equals(ph, LlmPhase.DialogueOptions, StringComparison.Ordinal) && response != null && response.Contains("OPTION_"))
+            {
+                var statsInPrompt = new List<string>();
+                string combinedPrompt = (userMessage ?? "") + "\n" + (systemPrompt ?? "");
+                
+                string marker = "Be tagged with one of the available stats for this turn:";
+                int markerIdx = combinedPrompt.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+                if (markerIdx >= 0)
+                {
+                    string statsLine = combinedPrompt.Substring(markerIdx + marker.Length);
+                    int endLineIdx = statsLine.IndexOf('\n');
+                    if (endLineIdx >= 0)
+                    {
+                        statsLine = statsLine.Substring(0, endLineIdx);
+                    }
+                    foreach (Pinder.Core.Stats.StatType s in Enum.GetValues(typeof(Pinder.Core.Stats.StatType)))
+                    {
+                        string sName = s == Pinder.Core.Stats.StatType.SelfAwareness ? "SELF_AWARENESS" : s.ToString();
+                        if (statsLine.IndexOf(sName, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                            (s == Pinder.Core.Stats.StatType.SelfAwareness && statsLine.IndexOf("SELFAWARENESS", StringComparison.OrdinalIgnoreCase) >= 0))
+                        {
+                            statsInPrompt.Add(sName);
+                        }
+                    }
+                }
+
+                if (statsInPrompt.Count >= 3)
+                {
+                    int idx = 0;
+                    response = System.Text.RegularExpressions.Regex.Replace(response, @"\[STAT:\s*\w+\]", m =>
+                    {
+                        if (idx < statsInPrompt.Count)
+                        {
+                            return $"[STAT: {statsInPrompt[idx++].ToUpperInvariant()}]";
+                        }
+                        return m.Value;
+                    }, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                }
+            }
+
             var ex = new LlmExchange(
                 Phase: ph,
                 SystemPrompt: systemPrompt ?? "",

--- a/tests/Pinder.LlmAdapters.Tests/Issue1215_PrivacyAndNoPadFixTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1215_PrivacyAndNoPadFixTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Focused regression tests verifying that the strict LLM contract path
+    /// prevents privacy leaks (never exposes raw LLM input/lines in exceptions/violations)
+    /// and performs zero option padding or remapping fabrication.
+    /// </summary>
+    public class Issue1215_PrivacyAndNoPadFixTests
+    {
+        private static DialogueContext MakeDialogueContext(StatType[] availableStats)
+        {
+            return new DialogueContext(
+                playerAvatarPrompt: "player prompt",
+                dateePrompt: "datee prompt",
+                conversationHistory: new List<(string, string)> { ("O", "Hi"), ("P", "Hey there") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 12,
+                playerName: "P",
+                dateeName: "O",
+                currentTurn: 2,
+                availableStats: availableStats
+            );
+        }
+
+        private static DateeContext MakeDateeContext()
+        {
+            return new DateeContext(
+                dateePrompt: "datee system prompt",
+                conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
+                dateeLastMessage: "hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 15,
+                playerDeliveredMessage: "hello",
+                interestBefore: 14,
+                interestAfter: 15,
+                responseDelayMinutes: 2.0,
+                playerName: "Velvet",
+                dateeName: "Sable"
+            );
+        }
+
+        private sealed class FixedResponseTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public FixedResponseTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+
+        [Fact]
+        public async Task Test_PrivacyLeak_MalformedSignals_DoesNotLeakRawText()
+        {
+            var context = MakeDateeContext();
+            const string secretMarker = "SECRETLEAKMARKER12345";
+            var transport = new FixedResponseTransport(
+                "This is a message.\n" +
+                "[SIGNALS]\n" +
+                $"TELL: NotAStat ({secretMarker})"
+            );
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAsync<LlmContractException>(async () => await adapter.GetDateeResponseAsync(context));
+
+            Assert.NotNull(ex);
+            var msg = ex.Message;
+            var strRepresentation = ex.ToString();
+
+            // Verify no raw leak
+            Assert.DoesNotContain(secretMarker, msg, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(secretMarker, strRepresentation, StringComparison.OrdinalIgnoreCase);
+
+            // Verify message still contains structured indicators
+            Assert.Contains("datee", msg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("malformed", msg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("tell_invalid_stat", msg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Test_DialogueOptions_NoFabrication_ThrowsOnPartialOptions()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            // AvailableStats.Length = 3, but the LLM only returned 2 valid options.
+            // Under strict mode, it must throw LlmContractException (partial_options) rather than returning padded placeholders.
+            var transport = new FixedResponseTransport(
+                "OPTION_1\n[STAT: CHARM]\n\"This is options 1 text.\"\n\n" +
+                "OPTION_2\n[STAT: RIZZ]\n\"This is options 2 text.\""
+            );
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAsync<LlmContractException>(async () => await adapter.GetDialogueOptionsAsync(context));
+
+            Assert.NotNull(ex);
+            Assert.Equal("partial_options", ex.Reason);
+            Assert.Contains("option", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("partial", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue1215_StrictGameplayContractTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1215_StrictGameplayContractTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    /// <summary>
+    /// Regression tests for the STRICT gameplay LLM contract (Issue #1215).
+    /// </summary>
+    public class Issue1215_StrictGameplayContractTests
+    {
+        // ── helpers ──────────────────────────────────────────────────────
+
+        private static DialogueContext MakeDialogueContext(StatType[] availableStats)
+        {
+            return new DialogueContext(
+                playerAvatarPrompt: "player prompt",
+                dateePrompt: "datee prompt",
+                conversationHistory: new List<(string, string)> { ("O", "Hi"), ("P", "Hey there") },
+                dateeLastMessage: "Hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 12,
+                playerName: "P",
+                dateeName: "O",
+                currentTurn: 2,
+                availableStats: availableStats
+            );
+        }
+
+        private static DateeContext MakeDateeContext()
+        {
+            return new DateeContext(
+                dateePrompt: "datee system prompt",
+                conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
+                dateeLastMessage: "hi",
+                activeTraps: Array.Empty<string>(),
+                currentInterest: 15,
+                playerDeliveredMessage: "hello",
+                interestBefore: 14,
+                interestAfter: 15,
+                responseDelayMinutes: 2.0,
+                playerName: "Velvet",
+                dateeName: "Sable"
+            );
+        }
+
+        private static void AssertContractException(Exception ex, string phaseToken, string reasonToken)
+        {
+            Assert.NotNull(ex);
+            var name = ex.GetType().Name;
+            
+            // The implementer will name it something like LlmContractException / GameplayContractException
+            Assert.Contains("Contract", name, StringComparison.OrdinalIgnoreCase);
+            
+            // Exclude the missing GameDefinition / #1217 guard or generic null references
+            Assert.NotEqual(typeof(ArgumentNullException), ex.GetType());
+            Assert.NotEqual(typeof(InvalidOperationException), ex.GetType());
+            Assert.DoesNotContain("GameDefinition", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+            var msg = ex.Message;
+            Assert.NotNull(msg);
+            
+            // Check phaseToken leniently
+            if (phaseToken == "dialogue" || phaseToken == "option")
+            {
+                Assert.True(
+                    msg.Contains("dialogue", StringComparison.OrdinalIgnoreCase) ||
+                    msg.Contains("option", StringComparison.OrdinalIgnoreCase),
+                    $"Message should contain 'dialogue' or 'option'. Actual: '{msg}'"
+                );
+            }
+            else
+            {
+                Assert.Contains(phaseToken, msg, StringComparison.OrdinalIgnoreCase);
+            }
+
+            // Check reasonToken leniently
+            Assert.True(
+                msg.Contains("malformed", StringComparison.OrdinalIgnoreCase) ||
+                msg.Contains("missing", StringComparison.OrdinalIgnoreCase) ||
+                msg.Contains("empty", StringComparison.OrdinalIgnoreCase) ||
+                msg.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+                msg.Contains("required", StringComparison.OrdinalIgnoreCase),
+                $"Message should contain a reason like malformed/missing/empty/invalid/required. Actual: '{msg}'"
+            );
+        }
+
+        private sealed class FixedResponseTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public FixedResponseTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+
+        // ── tests ────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Test1_DialogueOptions_EmptyProviderOutput_ThrowsContractException()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDialogueOptionsAsync(context));
+            AssertContractException(ex, "option", "empty");
+        }
+
+        [Fact]
+        public async Task Test2_DialogueOptions_NoValidOptions_ThrowsContractException()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport("I refuse to give options.");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDialogueOptionsAsync(context));
+            AssertContractException(ex, "option", "malformed");
+        }
+
+        [Fact]
+        public async Task Test3_DialogueOptions_PartialOptions_ThrowsContractException()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport("OPTION_1\n[STAT: CHARM]\n\"This is a valid option.\"");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDialogueOptionsAsync(context));
+            AssertContractException(ex, "option", "missing");
+        }
+
+        [Fact]
+        public async Task Test4_DialogueOptions_InvalidStat_ThrowsContractException()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport(
+                "OPTION_1\n[STAT: Bogus]\n\"This option has an invalid stat.\"\n\n" +
+                "OPTION_2\n[STAT: CHARM]\n\"This is a valid option.\"\n\n" +
+                "OPTION_3\n[STAT: RIZZ]\n\"This is another valid option.\""
+            );
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDialogueOptionsAsync(context));
+            AssertContractException(ex, "option", "invalid");
+        }
+
+        [Fact]
+        public async Task Test5_DialogueOptions_NoFabrication_NeverReturnsPlaceholder()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            try
+            {
+                var results = await adapter.GetDialogueOptionsAsync(context);
+                foreach (var opt in results)
+                {
+                    Assert.DoesNotContain("Tell me more about you.", opt.IntendedText, StringComparison.OrdinalIgnoreCase);
+                }
+                Assert.Fail("The call succeeded with empty provider output, but it must throw a contract exception.");
+            }
+            catch (Exception ex) when (ex is not Xunit.Sdk.XunitException)
+            {
+                AssertContractException(ex, "option", "empty");
+            }
+        }
+
+        [Fact]
+        public async Task Test6_DateeResponse_EmptyProviderOutput_ThrowsContractException()
+        {
+            var context = MakeDateeContext();
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDateeResponseAsync(context));
+            AssertContractException(ex, "datee", "empty");
+        }
+
+        [Fact]
+        public async Task Test7_DateeResponse_MalformedPresentSignals_ThrowsContractException()
+        {
+            var context = MakeDateeContext();
+            var transport = new FixedResponseTransport(
+                "This is a valid message.\n" +
+                "[SIGNALS]\n" +
+                "TELL: NotAStat (This is a malformed tell because NotAStat is not a stat)"
+            );
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await adapter.GetDateeResponseAsync(context));
+            AssertContractException(ex, "datee", "malformed");
+        }
+
+        [Fact]
+        public async Task Test8_DateeResponse_OptionalAbsentSignals_Succeeds()
+        {
+            var context = MakeDateeContext();
+            const string expectedMessage = "This is a normal message without any signals block.";
+            var transport = new FixedResponseTransport(expectedMessage);
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var result = await adapter.GetDateeResponseAsync(context);
+
+            Assert.NotNull(result);
+            Assert.Equal(expectedMessage, result.MessageText);
+            Assert.Null(result.DetectedTell);
+            Assert.Null(result.WeaknessWindow);
+        }
+
+        [Fact]
+        public async Task Test9_DialogueOptions_ValidFullOutput_Succeeds()
+        {
+            var context = MakeDialogueContext(new[] { StatType.Charm, StatType.Rizz, StatType.Honesty });
+            var transport = new FixedResponseTransport(
+                "OPTION_1\n[STAT: CHARM]\n\"This is options 1 text.\"\n\n" +
+                "OPTION_2\n[STAT: RIZZ]\n\"This is options 2 text.\"\n\n" +
+                "OPTION_3\n[STAT: HONESTY]\n\"This is options 3 text.\""
+            );
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            var results = await adapter.GetDialogueOptionsAsync(context);
+
+            Assert.NotNull(results);
+            Assert.Equal(3, results.Length);
+
+            Assert.Equal(StatType.Charm, results[0].Stat);
+            Assert.Equal("This is options 1 text.", results[0].IntendedText);
+
+            Assert.Equal(StatType.Rizz, results[1].Stat);
+            Assert.Equal("This is options 2 text.", results[1].IntendedText);
+
+            Assert.Equal(StatType.Honesty, results[2].Stat);
+            Assert.Equal("This is options 3 text.", results[2].IntendedText);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue1217_ExplicitGameDefinitionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1217_ExplicitGameDefinitionTests.cs
@@ -88,7 +88,7 @@ namespace Pinder.LlmAdapters.Tests
         public async Task Production_GetDialogueOptions_DoesNotThrow_WhenGameDefinitionIsProvided()
         {
             // Arrange
-            var transport = new FixedResponseTransport("OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n\"Hi\"");
+            var transport = new FixedResponseTransport("OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n\"Hello\"");
             var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
             var adapter = new PinderLlmAdapter(transport, options);
 

--- a/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue950_StakeSurfacingTests.cs
@@ -103,7 +103,7 @@ namespace Pinder.LlmAdapters.Tests
             const string fakeResponse =
                 "OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"So what are you up to this weekend?\"\n\n" +
-                "OPTION_2\n[STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
+                "OPTION_2\n[STAT: RIZZ] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"You seem like someone who enjoys long walks.\"\n\n" +
                 "OPTION_3\n[STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"Honestly I have no idea what I'm doing here.\"\n\n" +
@@ -136,7 +136,7 @@ namespace Pinder.LlmAdapters.Tests
             const string fakeResponse =
                 "OPTION_1\n[STAT: CHARM] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"So what are you up to this weekend?\"\n\n" +
-                "OPTION_2\n[STAT: WIT] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
+                "OPTION_2\n[STAT: RIZZ] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"You seem like someone who enjoys long walks.\"\n\n" +
                 "OPTION_3\n[STAT: HONESTY] [CALLBACK: none] [COMBO: none] [TELL_BONUS: no]\n" +
                 "\"I deleted my thesis on purpose, actually. Watched it go.\"\n\n" +


### PR DESCRIPTION
Closes #1215

## Problem
Gameplay LLM output parsers degraded malformed/missing REQUIRED data into playable/default state: missing/short/invalid dialogue options were padded with the fabricated placeholder `Tell me more about you.`, and empty/malformed datee output (including present-but-malformed `[SIGNALS]`) collapsed silently to empty/raw message with null signals.

## Fix (additive strict path at the gameplay adapter boundary)
- New typed `LlmContractException` (+ structured `LlmContractViolation` metadata) and an opt-in `OnLlmContractViolation` callback on `PinderLlmAdapterOptions`.
- `DialogueOptionParsers.ParseDialogueOptionsStrict`: zero-fabrication, rejects empty / no-valid / partial (fewer than `min(AvailableStats.Length, MaxDialogueOptions)`) / invalid-stat with typed errors. Never calls the lenient padder; never returns the placeholder.
- `GmOutputContract.ValidateSignalsStrict`: distinguishes `NoSignalsBlock` (truly-absent optional signals → success with null Tell/Weakness) from `ValidSignals` vs `MalformedSignals` (present-but-malformed → typed rejection).
- `PinderLlmAdapter.GetDialogueOptionsAsync`/`GetDateeResponseAsync` now use the strict routines for REQUIRED gameplay data.
- The lenient parsers (`ParseDialogueOptionsText/Tool`, `ParseDateeResponseText/Tool`, `GmOutputContract.Parse`, `ReconcileAndPadDialogueOptions`) are unchanged and remain best-effort/diagnostics — gameplay no longer reaches them for required data.

## Optional stays optional
Truly-absent Tell/Weakness signals remain allowed (no new mandatory requirement). Only present-but-malformed signal blocks are rejected.

## Dangerous-spot trace (privacy-safe)
`LlmContractException`/`LlmContractViolation` carry only structured metadata (phase, reason token e.g. `malformed_signals`/`partial_options`/`invalid_stat`, counts, valid parsed stat name, turn id). No raw prompts, response bodies, descriptions, secrets, or conversation text. A regression test asserts a raw marker injected into a malformed signal line never appears in the thrown exception.

## Tests
- `Issue1215_StrictGameplayContractTests` (9): empty/no-valid/partial/invalid-stat options, no-fabrication, empty datee, malformed-present-signals; guards for optional-absent signals + valid full output.
- `Issue1215_PrivacyAndNoPadFixTests` (2): no raw leak in exception; partial throws instead of padding under count mismatch.
- Test harness `RecordingLlmTransport` canned options now follow the turn's offered `availableStats` (well-behaved-model simulation; production still rejects genuinely mismatched stats).

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.LlmAdapters.Tests` => 1060 passed, 0 failed
- `Pinder.Core.Tests` => 3050 passed, 0 failed, 18 skipped

## Scope
No overlay/steering changes (#1216). No Unity. No rule retune.