### PR TITLE
fix(#1216): make degraded overlay/steering explicit; remove silent fallbacks

### DIFF
--- a/src/Pinder.Core/Conversation/SteeringEngine.cs
+++ b/src/Pinder.Core/Conversation/SteeringEngine.cs
@@ -93,6 +93,10 @@ namespace Pinder.Core.Conversation
                 try
                 {
                     steeringQuestion = await stateful.GetSteeringQuestionAsync(steeringContext, ct).ConfigureAwait(false);
+                    if (string.IsNullOrWhiteSpace(steeringQuestion))
+                    {
+                        success = false;
+                    }
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -19,10 +19,23 @@ namespace Pinder.LlmAdapters.Groq
             string instruction,
             string? dateeContext = null,
             string? archetypeDirective = null,
-            CancellationToken ct = default)
+            CancellationToken ct = default,
+            Action<OverlayDegradedEvent>? onDegraded = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
+            {
+                if (string.IsNullOrWhiteSpace(instruction))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped
+                    ));
+                }
                 return message;
+            }
 
             string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
                 "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
@@ -57,18 +70,48 @@ namespace Pinder.LlmAdapters.Groq
             {
                 var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
                 var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode) return message;
+                if (!response.IsSuccessStatusCode)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "http_error",
+                        outcome: OverlayOutcome.Degraded,
+                        errorCode: ((int)response.StatusCode).ToString()
+                    ));
+                    return message;
+                }
 
                 var json = JObject.Parse(body);
                 var text = json["choices"]?[0]?["message"]?["content"]?.Value<string>()?.Trim();
 
-                if (string.IsNullOrWhiteSpace(text)) return message;
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
 
                 // Refusal detection
                 if (text!.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
                     text.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
                     text.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded
+                    ));
                     return message;
+                }
 
                 return text;
             }
@@ -76,8 +119,16 @@ namespace Pinder.LlmAdapters.Groq
             {
                 throw; // #794: cancellation must propagate.
             }
-            catch
+            catch (Exception ex)
             {
+                onDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "horniness_overlay",
+                    provider: "groq",
+                    model: model,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
                 return message;
             }
         }
@@ -95,10 +146,24 @@ namespace Pinder.LlmAdapters.Groq
             string trapName,
             string? dateeContext = null,
             string? archetypeDirective = null,
-            CancellationToken ct = default)
+            CancellationToken ct = default,
+            Action<OverlayDegradedEvent>? onDegraded = null)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+            {
+                if (string.IsNullOrWhiteSpace(trapInstruction))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped,
+                        trapName: trapName
+                    ));
+                }
                 return message;
+            }
 
             string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
                 "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
@@ -134,17 +199,50 @@ namespace Pinder.LlmAdapters.Groq
             {
                 var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
                 var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode) return message;
+                if (!response.IsSuccessStatusCode)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "http_error",
+                        outcome: OverlayOutcome.Degraded,
+                        errorCode: ((int)response.StatusCode).ToString(),
+                        trapName: trapName
+                    ));
+                    return message;
+                }
 
                 var json = JObject.Parse(body);
                 var text = json["choices"]?[0]?["message"]?["content"]?.Value<string>()?.Trim();
 
-                if (string.IsNullOrWhiteSpace(text)) return message;
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded,
+                        trapName: trapName
+                    ));
+                    return message;
+                }
 
                 if (text!.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
                     text.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
                     text.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "groq",
+                        model: model,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded,
+                        trapName: trapName
+                    ));
                     return message;
+                }
 
                 return text;
             }
@@ -152,8 +250,17 @@ namespace Pinder.LlmAdapters.Groq
             {
                 throw; // #794: cancellation must propagate.
             }
-            catch
+            catch (Exception ex)
             {
+                onDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "trap_overlay",
+                    provider: "groq",
+                    model: model,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name,
+                    trapName: trapName
+                ));
                 return message;
             }
         }

--- a/src/Pinder.LlmAdapters/OverlayDegradedEvent.cs
+++ b/src/Pinder.LlmAdapters/OverlayDegradedEvent.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Pinder.LlmAdapters
+{
+    public enum OverlayOutcome
+    {
+        Degraded,
+        Skipped
+    }
+
+    public sealed class OverlayDegradedEvent
+    {
+        public string OverlayType { get; }
+        public string? Provider { get; }
+        public string? Model { get; }
+        public string Reason { get; }
+        public OverlayOutcome Outcome { get; }
+        public string? ErrorCode { get; }
+        public string? SessionId { get; }
+        public int? TurnId { get; }
+        public string? TrapName { get; }
+
+        public OverlayDegradedEvent(
+            string overlayType,
+            string? provider,
+            string? model,
+            string reason,
+            OverlayOutcome outcome,
+            string? errorCode = null,
+            string? sessionId = null,
+            int? turnId = null,
+            string? trapName = null)
+        {
+            OverlayType = overlayType;
+            Provider = provider;
+            Model = model;
+            Reason = reason;
+            Outcome = outcome;
+            ErrorCode = errorCode;
+            SessionId = sessionId;
+            TurnId = turnId;
+            TrapName = trapName;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -263,7 +263,16 @@ namespace Pinder.LlmAdapters
 
                 var trimmed = responseText?.Trim();
                 if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "interest_beat",
+                        provider: "primary",
+                        model: null,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
                     return null;
+                }
 
                 // Strip surrounding quotes if present
                 if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
@@ -277,8 +286,16 @@ namespace Pinder.LlmAdapters
                 // generic LLM-failure fallback (#794).
                 throw;
             }
-            catch
+            catch (Exception ex)
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "interest_beat",
+                    provider: "primary",
+                    model: null,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
                 return null;
             }
         }
@@ -287,13 +304,25 @@ namespace Pinder.LlmAdapters
         public async Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
+            {
+                if (string.IsNullOrWhiteSpace(instruction))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped
+                    ));
+                }
                 return message;
+            }
 
             // Route to Groq if configured
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, dateeContext, archetypeDirective, ct)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, dateeContext, archetypeDirective, ct, _options.OnOverlayDegraded)
                     .ConfigureAwait(false);
             }
 
@@ -319,7 +348,17 @@ namespace Pinder.LlmAdapters
                 var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
                     .ConfigureAwait(false);
 
-                if (string.IsNullOrWhiteSpace(result)) return message;
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
                 // #831: thinking-block stripping moved to
                 // ThinkingStrippingLlmTransport (transport decorator).
                 // The transport already strips, so we only trim here.
@@ -332,7 +371,16 @@ namespace Pinder.LlmAdapters
                     trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
                     trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "horniness_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded
+                    ));
                     return message;
+                }
 
                 return trimmed;
             }
@@ -340,8 +388,16 @@ namespace Pinder.LlmAdapters
             {
                 throw; // #794: cancellation must propagate.
             }
-            catch
+            catch (Exception ex)
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "horniness_overlay",
+                    provider: "primary",
+                    model: null,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
                 return message;
             }
         }
@@ -350,13 +406,26 @@ namespace Pinder.LlmAdapters
         public async Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(trapInstruction))
+            {
+                if (string.IsNullOrWhiteSpace(trapInstruction))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped,
+                        trapName: trapName
+                    ));
+                }
                 return message;
+            }
 
             // Route to Groq when configured — same path as horniness/shadow overlays.
             if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
             {
                 return await GroqOverlayApplier.ApplyTrapOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, dateeContext, archetypeDirective, ct)
+                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, dateeContext, archetypeDirective, ct, _options.OnOverlayDegraded)
                     .ConfigureAwait(false);
             }
 
@@ -381,7 +450,18 @@ namespace Pinder.LlmAdapters
                 var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay, ct: ct)
                     .ConfigureAwait(false);
 
-                if (string.IsNullOrWhiteSpace(result)) return message;
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded,
+                        trapName: trapName
+                    ));
+                    return message;
+                }
                 // #831: thinking-block stripping moved to
                 // ThinkingStrippingLlmTransport (transport decorator).
                 string trimmed = result.Trim();
@@ -391,7 +471,17 @@ namespace Pinder.LlmAdapters
                     trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
                     trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "trap_overlay",
+                        provider: "primary",
+                        model: null,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded,
+                        trapName: trapName
+                    ));
                     return message;
+                }
 
                 return trimmed;
             }
@@ -399,8 +489,17 @@ namespace Pinder.LlmAdapters
             {
                 throw; // #794: cancellation must propagate.
             }
-            catch
+            catch (Exception ex)
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "trap_overlay",
+                    provider: "primary",
+                    model: null,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name,
+                    trapName: trapName
+                ));
                 return message;
             }
         }
@@ -409,7 +508,19 @@ namespace Pinder.LlmAdapters
         public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
+            {
+                if (string.IsNullOrWhiteSpace(instruction))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped
+                    ));
+                }
                 return message;
+            }
 
             string systemPrompt = "You are editing a text message for Pinder, a satirical comedy dating app. " +
                 "Apply the shadow corruption instruction to rewrite the delivered message. " +
@@ -429,7 +540,17 @@ namespace Pinder.LlmAdapters
                 var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption, ct: ct)
                     .ConfigureAwait(false);
 
-                if (string.IsNullOrWhiteSpace(result)) return message;
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
                 // #831: thinking-block stripping moved to
                 // ThinkingStrippingLlmTransport (transport decorator).
                 string trimmed = result.Trim();
@@ -439,7 +560,16 @@ namespace Pinder.LlmAdapters
                     trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
                     trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded
+                    ));
                     return message;
+                }
 
                 return trimmed;
             }
@@ -447,8 +577,16 @@ namespace Pinder.LlmAdapters
             {
                 throw; // #794: cancellation must propagate.
             }
-            catch
+            catch (Exception ex)
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "shadow_corruption",
+                    provider: "primary",
+                    model: null,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
                 return message;
             }
         }
@@ -468,6 +606,13 @@ namespace Pinder.LlmAdapters
 
             if (string.IsNullOrWhiteSpace(template))
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "success_improvement",
+                    provider: "primary",
+                    model: null,
+                    reason: "skipped_no_template",
+                    outcome: OverlayOutcome.Skipped
+                ));
                 return context.DeliveredMessage;
             }
 
@@ -493,6 +638,13 @@ namespace Pinder.LlmAdapters
             var improved = (responseText ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(improved) || string.Equals(improved, "...", StringComparison.OrdinalIgnoreCase))
             {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "success_improvement",
+                    provider: "primary",
+                    model: null,
+                    reason: "empty_output",
+                    outcome: OverlayOutcome.Degraded
+                ));
                 return context.DeliveredMessage;
             }
 
@@ -538,7 +690,16 @@ namespace Pinder.LlmAdapters
             // trim here.
             var question = (responseText ?? string.Empty).Trim();
             if (string.IsNullOrWhiteSpace(question))
-                return "so... when are we doing this?";
+            {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "steering",
+                    provider: "primary",
+                    model: null,
+                    reason: "empty_output",
+                    outcome: OverlayOutcome.Degraded
+                ));
+                return string.Empty;
+            }
 
             if (question.Length >= 2 && question[0] == '"' && question[question.Length - 1] == '"')
                 question = question.Substring(1, question.Length - 2).Trim();

--- a/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapterOptions.cs
@@ -78,5 +78,10 @@ namespace Pinder.LlmAdapters
         /// Receives structured metadata about the violation.
         /// </summary>
         public System.Action<LlmContractViolation>? OnLlmContractViolation { get; set; }
+
+        /// <summary>
+        /// Optional callback invoked when an overlay or steering rewrite degraded, failed, or was skipped.
+        /// </summary>
+        public System.Action<OverlayDegradedEvent>? OnOverlayDegraded { get; set; }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue1216_ExplicitOverlayFallbackTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1216_ExplicitOverlayFallbackTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1216_ExplicitOverlayFallbackTests
+    {
+        private sealed class FixedResponseTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public FixedResponseTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+
+        // 1. STEERING HARDCODED FALLBACK REMOVED (RED)
+        [Fact]
+        public async Task GetSteeringQuestionAsync_WhenTransportReturnsEmpty_DoesNotReturnHardcodedFallback()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+            var context = new SteeringContext(
+                playerAvatarPrompt: "player spec",
+                dateeName: "O",
+                playerName: "P",
+                deliveredMessage: "Hello",
+                conversationHistory: new List<(string, string)> { ("O", "Hi") }
+            );
+
+            // Act
+            var result = await adapter.GetSteeringQuestionAsync(context);
+
+            // Assert
+            Assert.NotEqual("so... when are we doing this?", result);
+            Assert.True(string.IsNullOrWhiteSpace(result));
+        }
+
+        // 2. OVERLAY-DEGRADATION CALLBACK EXISTS (RED via reflection)
+        [Fact]
+        public void PinderLlmAdapterOptions_ExposesPublicSettablePropertyForOverlayDegradation()
+        {
+            // Arrange
+            var properties = typeof(PinderLlmAdapterOptions).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            // Act
+            var matchingProperty = properties.FirstOrDefault(p =>
+            {
+                var name = p.Name;
+                bool containsOverlay = name.Contains("Overlay", StringComparison.OrdinalIgnoreCase);
+                bool containsOneOf = name.Contains("Degrad", StringComparison.OrdinalIgnoreCase) ||
+                                    name.Contains("Outcome", StringComparison.OrdinalIgnoreCase) ||
+                                    name.Contains("Fallback", StringComparison.OrdinalIgnoreCase);
+                bool hasSetter = p.CanWrite && p.GetSetMethod() != null;
+                return containsOverlay && containsOneOf && hasSetter;
+            });
+
+            // Assert
+            Assert.NotNull(matchingProperty);
+        }
+
+        // 3. GUARD — SUCCESSFUL OVERLAY UNCHANGED (must PASS before & after)
+        [Fact]
+        public async Task ApplyHorninessOverlayAsync_WhenTransportReturnsValidMessage_ReturnsRewrittenMessage()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("rewritten horny text");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyHorninessOverlayAsync(message: "orig", instruction: "make it horny");
+
+            // Assert
+            Assert.Equal("rewritten horny text", result.Trim());
+        }
+
+        // 4. GUARD — LEGIT NO-OP (must PASS before & after)
+        [Fact]
+        public async Task ApplyHorninessOverlayAsync_WhenInstructionIsEmpty_ReturnsOriginalMessageUnchanged()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("some alternative text");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyHorninessOverlayAsync(message: "orig", instruction: string.Empty);
+
+            // Assert
+            Assert.Equal("orig", result);
+        }
+
+        // 5. GUARD — DEGRADED-ON-EMPTY NOT BRITTLE (must PASS before & after)
+        [Fact]
+        public async Task ApplyHorninessOverlayAsync_WhenTransportReturnsEmpty_ReturnsOriginalMessage()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyHorninessOverlayAsync(message: "orig msg", instruction: "make it horny");
+
+            // Assert
+            Assert.Equal("orig msg", result);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1216

## Problem
Overlay/steering/improvement paths silently returned the original message (or hardcoded fallback text) on active LLM failure/refusal/empty output, pretending a fallback delivery was a successful overlay. Steering returned hardcoded `so... when are we doing this?` on empty output.

## Fix
- New structured `OverlayDegradedEvent` (+ `OverlayOutcome` enum: Degraded vs Skipped) and opt-in `OnOverlayDegraded` callback on `PinderLlmAdapterOptions` (follows the existing `OnStakeSkipWarning`/`OnLlmContractViolation` precedent; no `Microsoft.Extensions.Logging` dependency).
- Instrumented every silent-fallback site to fire the event before returning its fallback: `ApplyHorninessOverlayAsync`, `ApplyTrapOverlayAsync`, `ApplyShadowCorruptionAsync` (empty/refusal/error/skip-no-instruction), `GetInterestChangeBeatAsync` (empty/error), `GetSuccessImprovementAsync` (empty-template skip, empty/`...` degraded), `GetSteeringQuestionAsync` (empty), and the `GroqOverlayApplier` horniness+trap static methods (http-error/empty/refusal/error).
- Legitimate no-op (no active instruction/template) is marked `Skipped`, not `Degraded` — so an active failure never masquerades as a benign no-op and vice versa.
- Removed the hardcoded steering fallback text: empty steering output now fires the event and returns `string.Empty`. `SteeringEngine` treats empty as not-successful; `DeliveryStage` only appends a steering question when `SteeringSucceeded`, so no crash and no stray empty append.

## No brittleness
Delivered-text behavior is unchanged except steering: overlays still return the original message on degradation (no new throw, no hard-fail). Cancellation (`OperationCanceledException`) still propagates unchanged and fires no event.

## Privacy
`OverlayDegradedEvent` carries only structured metadata (overlay type, provider `primary`/`groq`, model, reason token, error code, session/turn ids, trap-name label). No raw prompts, message text, LLM response bodies, secrets/API keys, or conversation.

## Signatures
No `ILlmAdapter`/`IStatefulLlmAdapter` method signature changed — the ~14 test fakes and `NullLlmAdapter` are untouched.

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.LlmAdapters.Tests` => 1065 passed, 0 failed
- `Pinder.Core.Tests` => 3050 passed, 0 failed, 18 skipped

## Scope
No overlay-copy retune. No Unity. #1209 already closed (no horniness-behavior change beyond observability).