### PR TITLE
cleanup(#1223): make setup-generator failures typed and observable

### DIFF
--- a/src/Pinder.SessionSetup/LlmBackgroundGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmBackgroundGenerator.cs
@@ -78,6 +78,11 @@ namespace Pinder.SessionSetup
             }
         }
 
+        /// <summary>
+        /// Generates the narrative background story asynchronously.
+        /// This generation is OPTIONAL/degradable; if a transport failure or empty output occurs,
+        /// it will trigger the <see cref="Options.OnDegraded"/> callback and return <see cref="string.Empty"/>.
+        /// </summary>
         public async Task<string> GenerateAsync(
             string characterName,
             string assembledSystemPrompt,
@@ -91,10 +96,21 @@ namespace Pinder.SessionSetup
                 string response = await _transport
                     .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.BackgroundStory)
                     .ConfigureAwait(false);
-                return (response ?? string.Empty).Trim();
+                string trimmed = (response ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("background", "empty_output"));
+                }
+                return trimmed;
+            }
+            catch (OperationCanceledException)
+            {
+                // Do not fire OnDegraded on cancellation; preserve existing behavior of returning empty string.
+                return string.Empty;
             }
             catch
             {
+                _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("background", "transport_error"));
                 // Mirror stake generator: transport failure → empty string.
                 return string.Empty;
             }
@@ -152,6 +168,11 @@ CHARACTER PROFILE:
             /// prose; allows ~250-300 tokens with a small safety margin).
             /// </summary>
             public int MaxTokens { get; set; } = 350;
+
+            /// <summary>
+            /// Opt-in callback triggered when generation is degraded (e.g. transport failure or empty output).
+            /// </summary>
+            public Action<SetupGenerationResult>? OnDegraded { get; set; }
         }
     }
 }

--- a/src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs
@@ -36,6 +36,11 @@ namespace Pinder.SessionSetup
             _options = options ?? new Options();
         }
 
+        /// <summary>
+        /// Generates a light dramatic arc asynchronously.
+        /// This generation is OPTIONAL/degradable; if a transport failure or empty output occurs,
+        /// it will trigger the <see cref="Options.OnDegraded"/> callback and return <see cref="string.Empty"/>.
+        /// </summary>
         public async Task<string> GenerateAsync(
             string playerName,
             string playerStake,
@@ -60,10 +65,21 @@ namespace Pinder.SessionSetup
                 string response = await _transport
                     .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.DramaticArc)
                     .ConfigureAwait(false);
-                return (response ?? string.Empty).Trim();
+                string trimmed = (response ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("dramatic_arc", "empty_output"));
+                }
+                return trimmed;
+            }
+            catch (OperationCanceledException)
+            {
+                // Do not fire OnDegraded on cancellation; preserve existing behavior of returning empty string.
+                return string.Empty;
             }
             catch
             {
+                _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("dramatic_arc", "transport_error"));
                 // Parity with IStakeGenerator and IOutfitDescriber: transport failure → empty string.
                 // The caller decides what to do (skip arc, or fail setup).
                 return string.Empty;
@@ -99,6 +115,11 @@ namespace Pinder.SessionSetup
 
             /// <summary>Max output tokens. Default 300 (paragraph-sized).</summary>
             public int MaxTokens { get; set; } = 300;
+
+            /// <summary>
+            /// Opt-in callback triggered when generation is degraded (e.g. transport failure or empty output).
+            /// </summary>
+            public Action<SetupGenerationResult>? OnDegraded { get; set; }
         }
     }
 }

--- a/src/Pinder.SessionSetup/LlmOutfitDescriber.cs
+++ b/src/Pinder.SessionSetup/LlmOutfitDescriber.cs
@@ -37,6 +37,11 @@ namespace Pinder.SessionSetup
             _options = options ?? new Options();
         }
 
+        /// <summary>
+        /// Generates the outfit scene setting asynchronously.
+        /// This generation is OPTIONAL/degradable; if a transport failure or empty output occurs,
+        /// it will trigger the <see cref="Options.OnDegraded"/> callback and return <see cref="string.Empty"/>.
+        /// </summary>
         public async Task<string> GenerateAsync(
             string playerName,
             IReadOnlyList<string> playerItems,
@@ -58,11 +63,22 @@ namespace Pinder.SessionSetup
                 string response = await _transport
                     .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.OutfitDescription)
                     .ConfigureAwait(false);
-                return (response ?? string.Empty).Trim();
+                string trimmed = (response ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("outfit", "empty_output"));
+                }
+                return trimmed;
+            }
+            catch (OperationCanceledException)
+            {
+                // Do not fire OnDegraded on cancellation; preserve existing behavior of returning empty string.
+                return string.Empty;
             }
             catch
             {
-                // Parity with IStakeGenerator: transport failure \u2192 empty string.
+                _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("outfit", "transport_error"));
+                // Parity with IStakeGenerator: transport failure → empty string.
                 // The caller decides what to do (skip scene entry, or fail setup).
                 return string.Empty;
             }
@@ -99,6 +115,11 @@ namespace Pinder.SessionSetup
 
             /// <summary>Max output tokens. Default 250 (paragraph-sized).</summary>
             public int MaxTokens { get; set; } = 250;
+
+            /// <summary>
+            /// Opt-in callback triggered when generation is degraded (e.g. transport failure or empty output).
+            /// </summary>
+            public Action<SetupGenerationResult>? OnDegraded { get; set; }
         }
     }
 }

--- a/src/Pinder.SessionSetup/LlmStakeGenerator.cs
+++ b/src/Pinder.SessionSetup/LlmStakeGenerator.cs
@@ -114,6 +114,12 @@ namespace Pinder.SessionSetup
             }
         }
 
+        /// <summary>
+        /// Generates the stake psychological fragments asynchronously.
+        /// This generation is OPTIONAL/degradable; if a transport failure or empty output occurs,
+        /// it will trigger the <see cref="Options.OnDegraded"/> callback and return <see cref="string.Empty"/>,
+        /// whereas the streaming <see cref="StreamStakeAsync"/> is required and will throw.
+        /// </summary>
         public async Task<string> GenerateAsync(
             string characterName,
             string assembledSystemPrompt,
@@ -127,10 +133,21 @@ namespace Pinder.SessionSetup
                 string response = await _transport
                     .SendAsync(SystemPrompt, userMessage, _options.Temperature, _options.MaxTokens, phase: LlmPhase.PsychologicalStake)
                     .ConfigureAwait(false);
-                return (response ?? string.Empty).Trim();
+                string trimmed = (response ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("stake", "empty_output"));
+                }
+                return trimmed;
+            }
+            catch (OperationCanceledException)
+            {
+                // Do not fire OnDegraded on cancellation; preserve existing behavior of returning empty string.
+                return string.Empty;
             }
             catch
             {
+                _options.OnDegraded?.Invoke(SetupGenerationResult.DegradedFailure("stake", "transport_error"));
                 // Parity with legacy helper: transport failure → empty string.
                 return string.Empty;
             }
@@ -292,6 +309,11 @@ CHARACTER PROFILE:
             /// per character, so 300 leaves a small safety margin).
             /// </summary>
             public int MaxTokens { get; set; } = 300;
+
+            /// <summary>
+            /// Opt-in callback triggered when generation is degraded (e.g. transport failure or empty output).
+            /// </summary>
+            public Action<SetupGenerationResult>? OnDegraded { get; set; }
         }
     }
 }

--- a/src/Pinder.SessionSetup/SetupGenerationResult.cs
+++ b/src/Pinder.SessionSetup/SetupGenerationResult.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Pinder.SessionSetup
+{
+    /// <summary>
+    /// Represents the privacy-safe structured outcome of a session setup generator.
+    /// Never stores raw LLM prompts, raw responses, secrets, or conversation histories.
+    /// Only contains structured metadata and the produced value.
+    /// </summary>
+    public sealed class SetupGenerationResult
+    {
+        /// <summary>
+        /// The generated text value (e.g. the trimmed content or empty string).
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Whether the generation was degraded (e.g. failed and fell back, or empty output).
+        /// </summary>
+        public bool Degraded { get; }
+
+        /// <summary>
+        /// Whether the generation was skipped.
+        /// </summary>
+        public bool Skipped { get; }
+
+        /// <summary>
+        /// Structured error code representing the degradation reason (e.g. 'transport_error', 'empty_output', or null for success).
+        /// </summary>
+        public string? ErrorCode { get; }
+
+        /// <summary>
+        /// The source of the generation (e.g. 'llm', 'fallback').
+        /// </summary>
+        public string? Source { get; }
+
+        /// <summary>
+        /// The name of the generator / phase that produced this result (e.g. 'stake', 'background', 'outfit', 'dramatic_arc').
+        /// </summary>
+        public string GeneratorName { get; }
+
+        public SetupGenerationResult(
+            string value,
+            bool degraded,
+            bool skipped,
+            string? errorCode,
+            string? source,
+            string generatorName)
+        {
+            Value = value ?? string.Empty;
+            Degraded = degraded;
+            Skipped = skipped;
+            ErrorCode = errorCode;
+            Source = source;
+            GeneratorName = generatorName ?? throw new ArgumentNullException(nameof(generatorName));
+        }
+
+        public static SetupGenerationResult Ok(string value, string generatorName, string source = "llm")
+        {
+            return new SetupGenerationResult(value, false, false, null, source, generatorName);
+        }
+
+        public static SetupGenerationResult DegradedFailure(string generatorName, string errorCode, string source = "fallback")
+        {
+            return new SetupGenerationResult(string.Empty, true, false, errorCode, source, generatorName);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/SessionSetup/Issue1223_SetupGeneratorObservableFailureTests.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/Issue1223_SetupGeneratorObservableFailureTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Interfaces;
+using Pinder.SessionSetup;
+using Xunit;
+
+namespace Pinder.Core.Tests.SessionSetup
+{
+    public class Issue1223_SetupGeneratorObservableFailureTests
+    {
+        // ── 1. OPTIONS EXPOSE DEGRADATION CALLBACK (RED, reflection) ─────────────────
+        [Fact]
+        public void OptionsExposeDegradationCallback_ShouldExist()
+        {
+            AssertOptionsExposesCallback(typeof(LlmStakeGenerator.Options));
+            AssertOptionsExposesCallback(typeof(LlmOutfitDescriber.Options));
+        }
+
+        // ── 2. SHARED RESULT TYPE EXISTS (RED, reflection) ──────────────────────────
+        [Fact]
+        public void SharedResultTypeExists_InSessionSetupAssembly()
+        {
+            var assembly = typeof(LlmStakeGenerator).Assembly;
+            Type? resultType = null;
+            
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.Name.Contains("SetupGenerationResult", StringComparison.OrdinalIgnoreCase))
+                {
+                    resultType = type;
+                    break;
+                }
+            }
+
+            Assert.NotNull(resultType);
+        }
+
+        // ── 3. PARITY GUARD — FAILURE STILL RETURNS EMPTY (must PASS now) ───────────
+        [Fact]
+        public async Task ParityGuard_FailureStillReturnsEmpty_StakeAndDramaticArc()
+        {
+            var throwingTransport = new ThrowingLlmTransport();
+
+            // Test LlmStakeGenerator
+            var stakeGen = new LlmStakeGenerator(throwingTransport);
+            string stakeResult = await stakeGen.GenerateAsync("Alice", "some system prompt");
+            Assert.Equal(string.Empty, stakeResult);
+
+            // Test LlmDramaticArcGenerator
+            var arcGen = new LlmDramaticArcGenerator(throwingTransport);
+            string arcResult = await arcGen.GenerateAsync(
+                "Player", "PlayerStake", "PlayerBio",
+                "Datee", "DateeStake", "DateeBio");
+            Assert.Equal(string.Empty, arcResult);
+        }
+
+        // ── 4. PARITY GUARD — SUCCESS RETURNS TRIMMED TEXT (must PASS now) ──────────
+        [Fact]
+        public async Task ParityGuard_SuccessReturnsTrimmedText()
+        {
+            var successTransport = new FakeLlmTransport("  hello stake  ");
+            var stakeGen = new LlmStakeGenerator(successTransport);
+            
+            string stakeResult = await stakeGen.GenerateAsync("Alice", "some system prompt");
+            Assert.Equal("hello stake", stakeResult);
+        }
+
+        // ── 5. BEHAVIORAL RED (SKIPPED) ─────────────────────────────────────────────
+        // We chose to SKIP test #5 (wiring the currently-nonexistent degradation callback via reflection
+        // and asserting it fires on transport failure) because attempting to dynamically invoke or cast 
+        // to a callback whose delegate signature and types (including SetupGenerationResult) are 
+        // completely missing at compile time would be extremely brittle and complex (requiring Reflection.Emit
+        // or DynamicMethod stubbing), which is prone to false positives/negatives. 
+        // We rely on tests #1 and #2 as our solid RED gates to enforce the contract.
+
+        // ── Helpers ───────────────────────────────────────────────────────────────
+
+        private void AssertOptionsExposesCallback(Type optionsType)
+        {
+            var properties = optionsType.GetProperties(
+                BindingFlags.Public | BindingFlags.Instance);
+
+            PropertyInfo? targetProp = null;
+            foreach (var prop in properties)
+            {
+                string name = prop.Name;
+                bool nameMatches = name.Contains("Degrad", StringComparison.OrdinalIgnoreCase) ||
+                                   name.Contains("Outcome", StringComparison.OrdinalIgnoreCase) ||
+                                   name.Contains("Result", StringComparison.OrdinalIgnoreCase);
+
+                bool isDelegate = typeof(Delegate).IsAssignableFrom(prop.PropertyType);
+                bool isSettable = prop.CanWrite && prop.GetSetMethod(nonPublic: false) != null;
+
+                if (nameMatches && isDelegate && isSettable)
+                {
+                    targetProp = prop;
+                    break;
+                }
+            }
+
+            Assert.True(targetProp != null, $"Expected a public settable delegate-typed property with name containing Degrad/Outcome/Result on type {optionsType.FullName}, but none was found.");
+        }
+    }
+
+    internal sealed class ThrowingLlmTransport : ILlmTransport
+    {
+        public Task<string> SendAsync(
+            string systemPrompt,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken ct = default)
+        {
+            throw new LlmTransportException("boom");
+        }
+    }
+
+    internal sealed class FakeLlmTransport : ILlmTransport
+    {
+        private readonly string _response;
+
+        public FakeLlmTransport(string response)
+        {
+            _response = response;
+        }
+
+        public Task<string> SendAsync(
+            string systemPrompt,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/SessionSetup/Issue1223_SetupGeneratorObservableFailureTests.cs
+++ b/tests/Pinder.Core.Tests/SessionSetup/Issue1223_SetupGeneratorObservableFailureTests.cs
@@ -68,13 +68,128 @@ namespace Pinder.Core.Tests.SessionSetup
             Assert.Equal("hello stake", stakeResult);
         }
 
-        // ── 5. BEHAVIORAL RED (SKIPPED) ─────────────────────────────────────────────
-        // We chose to SKIP test #5 (wiring the currently-nonexistent degradation callback via reflection
-        // and asserting it fires on transport failure) because attempting to dynamically invoke or cast 
-        // to a callback whose delegate signature and types (including SetupGenerationResult) are 
-        // completely missing at compile time would be extremely brittle and complex (requiring Reflection.Emit
-        // or DynamicMethod stubbing), which is prone to false positives/negatives. 
-        // We rely on tests #1 and #2 as our solid RED gates to enforce the contract.
+        // ── 5. BEHAVIORAL TESTS (IMPLEMENTED & GREEN) ─────────────────────────────
+        [Fact]
+        public async Task DegradationCallback_FiresOnTransportFailure_ForAllGenerators()
+        {
+            var throwingTransport = new ThrowingLlmTransport();
+
+            // 1. Stake Generator
+            SetupGenerationResult? stakeResult = null;
+            var stakeGen = new LlmStakeGenerator(throwingTransport, new LlmStakeGenerator.Options
+            {
+                OnDegraded = r => stakeResult = r
+            });
+            await stakeGen.GenerateAsync("Alice", "system prompt");
+            Assert.NotNull(stakeResult);
+            Assert.True(stakeResult.Degraded);
+            Assert.Equal("transport_error", stakeResult.ErrorCode);
+            Assert.Equal("stake", stakeResult.GeneratorName);
+
+            // 2. Background Generator
+            SetupGenerationResult? backgroundResult = null;
+            var backgroundGen = new LlmBackgroundGenerator(throwingTransport, new LlmBackgroundGenerator.Options
+            {
+                OnDegraded = r => backgroundResult = r
+            });
+            await backgroundGen.GenerateAsync("Alice", "system prompt");
+            Assert.NotNull(backgroundResult);
+            Assert.True(backgroundResult.Degraded);
+            Assert.Equal("transport_error", backgroundResult.ErrorCode);
+            Assert.Equal("background", backgroundResult.GeneratorName);
+
+            // 3. Outfit Describer
+            SetupGenerationResult? outfitResult = null;
+            var outfitGen = new LlmOutfitDescriber(throwingTransport, new LlmOutfitDescriber.Options
+            {
+                OnDegraded = r => outfitResult = r
+            });
+            await outfitGen.GenerateAsync("Alice", new List<string>(), "Bob", new List<string>());
+            Assert.NotNull(outfitResult);
+            Assert.True(outfitResult.Degraded);
+            Assert.Equal("transport_error", outfitResult.ErrorCode);
+            Assert.Equal("outfit", outfitResult.GeneratorName);
+
+            // 4. Dramatic Arc Generator
+            SetupGenerationResult? arcResult = null;
+            var arcGen = new LlmDramaticArcGenerator(throwingTransport, new LlmDramaticArcGenerator.Options
+            {
+                OnDegraded = r => arcResult = r
+            });
+            await arcGen.GenerateAsync("Alice", "stake", "bio", "Bob", "stake", "bio");
+            Assert.NotNull(arcResult);
+            Assert.True(arcResult.Degraded);
+            Assert.Equal("transport_error", arcResult.ErrorCode);
+            Assert.Equal("dramatic_arc", arcResult.GeneratorName);
+        }
+
+        [Fact]
+        public async Task DegradationCallback_FiresOnEmptyOutput_ForAllGenerators()
+        {
+            var emptyTransport = new FakeLlmTransport("   ");
+
+            // 1. Stake Generator
+            SetupGenerationResult? stakeResult = null;
+            var stakeGen = new LlmStakeGenerator(emptyTransport, new LlmStakeGenerator.Options
+            {
+                OnDegraded = r => stakeResult = r
+            });
+            await stakeGen.GenerateAsync("Alice", "system prompt");
+            Assert.NotNull(stakeResult);
+            Assert.True(stakeResult.Degraded);
+            Assert.Equal("empty_output", stakeResult.ErrorCode);
+            Assert.Equal("stake", stakeResult.GeneratorName);
+
+            // 2. Background Generator
+            SetupGenerationResult? backgroundResult = null;
+            var backgroundGen = new LlmBackgroundGenerator(emptyTransport, new LlmBackgroundGenerator.Options
+            {
+                OnDegraded = r => backgroundResult = r
+            });
+            await backgroundGen.GenerateAsync("Alice", "system prompt");
+            Assert.NotNull(backgroundResult);
+            Assert.True(backgroundResult.Degraded);
+            Assert.Equal("empty_output", backgroundResult.ErrorCode);
+            Assert.Equal("background", backgroundResult.GeneratorName);
+
+            // 3. Outfit Describer
+            SetupGenerationResult? outfitResult = null;
+            var outfitGen = new LlmOutfitDescriber(emptyTransport, new LlmOutfitDescriber.Options
+            {
+                OnDegraded = r => outfitResult = r
+            });
+            await outfitGen.GenerateAsync("Alice", new List<string>(), "Bob", new List<string>());
+            Assert.NotNull(outfitResult);
+            Assert.True(outfitResult.Degraded);
+            Assert.Equal("empty_output", outfitResult.ErrorCode);
+            Assert.Equal("outfit", outfitResult.GeneratorName);
+
+            // 4. Dramatic Arc Generator
+            SetupGenerationResult? arcResult = null;
+            var arcGen = new LlmDramaticArcGenerator(emptyTransport, new LlmDramaticArcGenerator.Options
+            {
+                OnDegraded = r => arcResult = r
+            });
+            await arcGen.GenerateAsync("Alice", "stake", "bio", "Bob", "stake", "bio");
+            Assert.NotNull(arcResult);
+            Assert.True(arcResult.Degraded);
+            Assert.Equal("empty_output", arcResult.ErrorCode);
+            Assert.Equal("dramatic_arc", arcResult.GeneratorName);
+        }
+
+        [Fact]
+        public async Task HappyPath_DoesNotFireOnDegraded()
+        {
+            var happyTransport = new FakeLlmTransport("actual content");
+
+            SetupGenerationResult? stakeResult = null;
+            var stakeGen = new LlmStakeGenerator(happyTransport, new LlmStakeGenerator.Options
+            {
+                OnDegraded = r => stakeResult = r
+            });
+            await stakeGen.GenerateAsync("Alice", "system prompt");
+            Assert.Null(stakeResult);
+        }
 
         // ── Helpers ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #1223

## Problem
Setup generators (stake/background/outfit/dramatic-arc) silently swallowed transport failures into empty strings, so a failed/degraded setup looked identical to a successful empty value.

## Fix (small, parity-preserving slice)
- New shared `SetupGenerationResult` (Value, Degraded, Skipped, ErrorCode, Source, GeneratorName) — structured, privacy-safe (no raw prompts/secrets/stack traces).
- Added an opt-in `Action<SetupGenerationResult>? OnDegraded` callback to each generator's nested `Options`.
- Each `GenerateAsync` now fires `OnDegraded` on transport failure (`transport_error`) and on empty/whitespace provider output (`empty_output`) before returning — so degradation is observable.
- Classified required vs optional in xmldoc: the non-streaming `GenerateAsync` paths are optional/degradable (empty fallback acceptable but now observable); the required failure path remains `LlmStakeGenerator.StreamStakeAsync`, which already throws `LlmTransportException`.

## Parity (no brittleness)
- `Task<string> GenerateAsync` signatures and the four interfaces are unchanged (pinder-web consumes `Task<string>`).
- Return values are byte-identical to before: `string.Empty` on failure/empty, trimmed text on success. Only the observability callback is added.
- `StreamStakeAsync` throw behavior untouched.

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.Core.Tests` => 3057 passed, 0 failed, 18 skipped (Issue1223 7/7)

## Scope
No prompt/product-rule changes. No consumer (session-runner/pinder-web) changes. No Unity.