### PR TITLE
cleanup(#1219): rule-resolver miss tracing + explicit source selection (slice 1)

### DIFF
--- a/src/Pinder.Core/Conversation/GameSession.Clone.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Clone.cs
@@ -31,7 +31,8 @@ namespace Pinder.Core.Conversation
         ///     <see cref="_llm"/>, <see cref="_dice"/>,
         ///     <see cref="_trapRegistry"/>, <see cref="_clock"/>,
         ///     <see cref="_rules"/>, <see cref="_statDeliveryInstructions"/>,
-        ///     <see cref="_onTextLayerNoop"/>. The active fast-gameplay
+        ///     <see cref="_onTextLayerNoop"/>, <see cref="_onShadowFilterTrace"/>,
+        ///     <see cref="_onRuleResolution"/>. The active fast-gameplay
         ///     scheduler (#425) is expected to inject branch-specific
         ///     <see cref="Pinder.Core.Rolls.PerOptionDicePool"/> via
         ///     <see cref="InjectNextDicePool"/>; <see cref="_dice"/> itself
@@ -83,6 +84,8 @@ namespace Pinder.Core.Conversation
             _horninessDcBias = src._horninessDcBias;
             _statDeliveryInstructions = src._statDeliveryInstructions;
             _onTextLayerNoop = src._onTextLayerNoop;
+            _onShadowFilterTrace = src._onShadowFilterTrace;
+            _onRuleResolution = src._onRuleResolution;
             _consequenceCatalog = src._consequenceCatalog;
             _maxDialogueOptions = src._maxDialogueOptions;
             _maxDeliveryWords = src._maxDeliveryWords;

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -117,6 +117,9 @@ namespace Pinder.Core.Conversation
         // #1218: optional callback invoked when shadow filtering changes the option/stat pool.
         private readonly Action<ShadowFilterTraceEvent>? _onShadowFilterTrace;
 
+        // #1219: optional callback invoked when a rule resolution occurs.
+        private readonly Action<RuleResolutionTraceEvent>? _onRuleResolution;
+
         // Stored between StartTurnAsync and ResolveTurnAsync
         private DialogueOption[]? _currentOptions { get => _state.CurrentOptions; set => _state.CurrentOptions = value; }
         private bool _currentHasAdvantage { get => _state.CurrentHasAdvantage; set => _state.CurrentHasAdvantage = value; }
@@ -184,6 +187,7 @@ namespace Pinder.Core.Conversation
             _statDeliveryInstructions = config.StatDeliveryInstructions;
             _onTextLayerNoop = config.OnTextLayerNoop;
             _onShadowFilterTrace = config.OnShadowFilterTrace;
+            _onRuleResolution = config.OnRuleResolution;
 
             // Determine starting interest: explicit config > Dread T3 > default
             if (config.StartingInterest.HasValue)
@@ -259,7 +263,8 @@ namespace Pinder.Core.Conversation
                 _rules,
                 _shadowGrowthEvaluator,
                 _xpRecorder,
-                _globalDcBias);
+                _globalDcBias,
+                _onRuleResolution);
 
             var deliveryStage = new DeliveryStage(
                 _llm,
@@ -282,7 +287,8 @@ namespace Pinder.Core.Conversation
                 deliveryStage,
                 dateeResponseStage,
                 _maxDialogueOptions,
-                _onShadowFilterTrace);
+                _onShadowFilterTrace,
+                _onRuleResolution);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSessionConfig.cs
+++ b/src/Pinder.Core/Conversation/GameSessionConfig.cs
@@ -104,6 +104,12 @@ namespace Pinder.Core.Conversation
         public Action<ShadowFilterTraceEvent>? OnShadowFilterTrace { get; }
 
         /// <summary>
+        /// Optional callback fired when a rule resolution occurs (#1219).
+        /// When null, no callback is fired.
+        /// </summary>
+        public Action<RuleResolutionTraceEvent>? OnRuleResolution { get; }
+
+        /// <summary>
         /// Consequence catalogue for engine-side population of
         /// Consequence fields on roll/shadow/horniness result DTOs (#976).
         /// When null, engines leave <c>Consequence</c> null.
@@ -138,7 +144,8 @@ namespace Pinder.Core.Conversation
             IConsequenceCatalog? consequenceCatalog = null,
             int? maxDialogueOptions = null,
             int? maxDeliveryWords = null,
-            bool archetypesEnabled = false)
+            bool archetypesEnabled = false,
+            Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             Clock = clock;
             PlayerShadows = playerShadows;
@@ -155,6 +162,7 @@ namespace Pinder.Core.Conversation
             StatDrawRng = statDrawRng;
             OnTextLayerNoop = onTextLayerNoop;
             OnShadowFilterTrace = onShadowFilterTrace;
+            OnRuleResolution = onRuleResolution;
             ConsequenceCatalog = consequenceCatalog;
             MaxDialogueOptions = maxDialogueOptions;
             MaxDeliveryWords = maxDeliveryWords;

--- a/src/Pinder.Core/Conversation/RollResolutionStage.cs
+++ b/src/Pinder.Core/Conversation/RollResolutionStage.cs
@@ -42,6 +42,7 @@ namespace Pinder.Core.Conversation
         private readonly ShadowGrowthEvaluator? _shadowGrowthEvaluator;
         private readonly SessionXpRecorder _xpRecorder;
         private readonly int _globalDcBias;
+        private readonly Action<RuleResolutionTraceEvent>? _onRuleResolution;
 
         public RollResolutionStage(
             IDiceRoller dice,
@@ -49,7 +50,8 @@ namespace Pinder.Core.Conversation
             IRuleResolver? rules,
             ShadowGrowthEvaluator? shadowGrowthEvaluator,
             SessionXpRecorder xpRecorder,
-            int globalDcBias)
+            int globalDcBias,
+            Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             _dice = dice ?? throw new ArgumentNullException(nameof(dice));
             _trapRegistry = trapRegistry ?? throw new ArgumentNullException(nameof(trapRegistry));
@@ -57,6 +59,7 @@ namespace Pinder.Core.Conversation
             _shadowGrowthEvaluator = shadowGrowthEvaluator;
             _xpRecorder = xpRecorder ?? throw new ArgumentNullException(nameof(xpRecorder));
             _globalDcBias = globalDcBias;
+            _onRuleResolution = onRuleResolution;
         }
 
         public RollStageResult Execute(
@@ -157,12 +160,12 @@ namespace Pinder.Core.Conversation
             int riskBonusDelta = 0;
             if (rollResult.IsSuccess)
             {
-                baseInterestDelta = TurnOrchestratorHelpers.ResolveSuccessInterestDelta(rollResult, _rules);
+                baseInterestDelta = TurnOrchestratorHelpers.ResolveSuccessInterestDelta(rollResult, _rules, _onRuleResolution);
                 riskBonusDelta = RiskTierBonus.GetInterestBonus(rollResult);
             }
             else
             {
-                baseInterestDelta = TurnOrchestratorHelpers.ResolveFailureInterestDelta(rollResult, _rules);
+                baseInterestDelta = TurnOrchestratorHelpers.ResolveFailureInterestDelta(rollResult, _rules, _onRuleResolution);
             }
             int interestDelta = baseInterestDelta + riskBonusDelta;
 
@@ -214,13 +217,13 @@ namespace Pinder.Core.Conversation
 
             // 4. Record interest before applying delta
             int interestBefore = state.Interest.Current;
-            InterestState stateBefore = TurnOrchestratorHelpers.ResolveInterestState(state, _rules);
+            InterestState stateBefore = TurnOrchestratorHelpers.ResolveInterestState(state, _rules, _onRuleResolution);
 
             // 5. Apply interest delta
             state.Interest.Apply(interestDelta);
 
             int interestAfter = state.Interest.Current;
-            InterestState stateAfter = TurnOrchestratorHelpers.ResolveInterestState(state, _rules);
+            InterestState stateAfter = TurnOrchestratorHelpers.ResolveInterestState(state, _rules, _onRuleResolution);
 
             // ---- Shadow growth evaluation (#44) ----
             _shadowGrowthEvaluator?.EvaluatePerTurn(

--- a/src/Pinder.Core/Conversation/RuleResolutionTraceEvent.cs
+++ b/src/Pinder.Core/Conversation/RuleResolutionTraceEvent.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Issue #1219: structured event payload for the
+    /// <c>GameSessionConfig.OnRuleResolution</c> callback.
+    /// Fired when a game rule value is resolved (either via resolver or hardcoded fallback).
+    /// </summary>
+    public sealed class RuleResolutionTraceEvent
+    {
+        /// <summary>
+        /// The key of the rule being resolved, e.g. 'momentum_bonus', 'failure_interest_delta',
+        /// 'success_interest_delta', 'interest_state', or 'shadow_threshold_level'.
+        /// </summary>
+        public string RuleKey { get; }
+
+        /// <summary>
+        /// The source of the selection: 'resolver' or 'hardcoded_fallback'.
+        /// </summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// Whether a resolver was configured at all.
+        /// </summary>
+        public bool ResolverConfigured { get; }
+
+        /// <summary>
+        /// The resolved numeric value, if applicable.
+        /// </summary>
+        public int? NumericValue { get; }
+
+        /// <summary>
+        /// The resolved state value (e.g. enum name or string), if applicable.
+        /// </summary>
+        public string? StateValue { get; }
+
+        public RuleResolutionTraceEvent(
+            string ruleKey,
+            string source,
+            bool resolverConfigured,
+            int? numericValue = null,
+            string? stateValue = null)
+        {
+            RuleKey = ruleKey ?? throw new ArgumentNullException(nameof(ruleKey));
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            ResolverConfigured = resolverConfigured;
+            NumericValue = numericValue;
+            StateValue = stateValue;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
@@ -10,62 +10,87 @@ namespace Pinder.Core.Conversation
 {
     internal static class TurnOrchestratorHelpers
     {
-        internal static int GetMomentumBonus(int streak, IRuleResolver? rules)
+        internal static int GetMomentumBonus(int streak, IRuleResolver? rules, Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             if (rules != null)
             {
                 var resolved = rules.GetMomentumBonus(streak);
                 if (resolved.HasValue)
+                {
+                    onRuleResolution?.Invoke(new RuleResolutionTraceEvent("momentum_bonus", "resolver", resolverConfigured: true, numericValue: resolved.Value, stateValue: null));
                     return resolved.Value;
+                }
             }
-            if (streak >= 5) return 3;
-            if (streak >= 3) return 2;
-            return 0;
+            int fallback = 0;
+            if (streak >= 5) fallback = 3;
+            else if (streak >= 3) fallback = 2;
+            onRuleResolution?.Invoke(new RuleResolutionTraceEvent("momentum_bonus", "hardcoded_fallback", resolverConfigured: rules != null, numericValue: fallback, stateValue: null));
+            return fallback;
         }
 
-        internal static int ResolveFailureInterestDelta(RollResult rollResult, IRuleResolver? rules)
+        internal static int ResolveFailureInterestDelta(RollResult rollResult, IRuleResolver? rules, Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             if (rules != null)
             {
                 var resolved = rules.GetFailureInterestDelta(rollResult.MissMargin, rollResult.UsedDieRoll);
                 if (resolved.HasValue)
+                {
+                    onRuleResolution?.Invoke(new RuleResolutionTraceEvent("failure_interest_delta", "resolver", resolverConfigured: true, numericValue: resolved.Value, stateValue: null));
                     return resolved.Value;
+                }
             }
-            return FailureScale.GetInterestDelta(rollResult);
+            int fallback = FailureScale.GetInterestDelta(rollResult);
+            onRuleResolution?.Invoke(new RuleResolutionTraceEvent("failure_interest_delta", "hardcoded_fallback", resolverConfigured: rules != null, numericValue: fallback, stateValue: null));
+            return fallback;
         }
 
-        internal static int ResolveSuccessInterestDelta(RollResult rollResult, IRuleResolver? rules)
+        internal static int ResolveSuccessInterestDelta(RollResult rollResult, IRuleResolver? rules, Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             if (rules != null)
             {
                 int beatMargin = rollResult.FinalTotal - rollResult.DC;
                 var resolved = rules.GetSuccessInterestDelta(beatMargin, rollResult.UsedDieRoll);
                 if (resolved.HasValue)
+                {
+                    onRuleResolution?.Invoke(new RuleResolutionTraceEvent("success_interest_delta", "resolver", resolverConfigured: true, numericValue: resolved.Value, stateValue: null));
                     return resolved.Value;
+                }
             }
-            return SuccessScale.GetInterestDelta(rollResult);
+            int fallback = SuccessScale.GetInterestDelta(rollResult);
+            onRuleResolution?.Invoke(new RuleResolutionTraceEvent("success_interest_delta", "hardcoded_fallback", resolverConfigured: rules != null, numericValue: fallback, stateValue: null));
+            return fallback;
         }
 
-        internal static InterestState ResolveInterestState(GameSessionState state, IRuleResolver? rules)
+        internal static InterestState ResolveInterestState(GameSessionState state, IRuleResolver? rules, Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             if (rules != null)
             {
                 var resolved = rules.GetInterestState(state.Interest.Current);
                 if (resolved.HasValue)
+                {
+                    onRuleResolution?.Invoke(new RuleResolutionTraceEvent("interest_state", "resolver", resolverConfigured: true, numericValue: null, stateValue: resolved.Value.ToString()));
                     return resolved.Value;
+                }
             }
-            return state.Interest.GetState();
+            InterestState fallback = state.Interest.GetState();
+            onRuleResolution?.Invoke(new RuleResolutionTraceEvent("interest_state", "hardcoded_fallback", resolverConfigured: rules != null, numericValue: null, stateValue: fallback.ToString()));
+            return fallback;
         }
 
-        internal static int ResolveThresholdLevel(int shadowValue, IRuleResolver? rules)
+        internal static int ResolveThresholdLevel(int shadowValue, IRuleResolver? rules, Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             if (rules != null)
             {
                 var resolved = rules.GetShadowThresholdLevel(shadowValue);
                 if (resolved.HasValue)
+                {
+                    onRuleResolution?.Invoke(new RuleResolutionTraceEvent("shadow_threshold_level", "resolver", resolverConfigured: true, numericValue: resolved.Value, stateValue: null));
                     return resolved.Value;
+                }
             }
-            return ShadowThresholdEvaluator.GetThresholdLevel(shadowValue);
+            int fallback = ShadowThresholdEvaluator.GetThresholdLevel(shadowValue);
+            onRuleResolution?.Invoke(new RuleResolutionTraceEvent("shadow_threshold_level", "hardcoded_fallback", resolverConfigured: rules != null, numericValue: fallback, stateValue: null));
+            return fallback;
         }
 
         internal static GameStateSnapshot CreateSnapshot(GameSessionState state, IRuleResolver? rules)

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.cs
@@ -25,6 +25,7 @@ namespace Pinder.Core.Conversation
         private readonly DateeResponseStage _dateeResponseStage;
         private readonly int _maxDialogueOptions;
         private readonly Action<ShadowFilterTraceEvent>? _onShadowFilterTrace;
+        private readonly Action<RuleResolutionTraceEvent>? _onRuleResolution;
 
         public TurnOrchestrator(
             ILlmAdapter llm,
@@ -35,7 +36,8 @@ namespace Pinder.Core.Conversation
             DeliveryStage deliveryStage,
             DateeResponseStage dateeResponseStage,
             int maxDialogueOptions,
-            Action<ShadowFilterTraceEvent>? onShadowFilterTrace = null)
+            Action<ShadowFilterTraceEvent>? onShadowFilterTrace = null,
+            Action<RuleResolutionTraceEvent>? onRuleResolution = null)
         {
             _llm = llm ?? throw new ArgumentNullException(nameof(llm));
             _dice = dice ?? throw new ArgumentNullException(nameof(dice));
@@ -47,6 +49,7 @@ namespace Pinder.Core.Conversation
             _dateeResponseStage = dateeResponseStage ?? throw new ArgumentNullException(nameof(dateeResponseStage));
             _maxDialogueOptions = maxDialogueOptions;
             _onShadowFilterTrace = onShadowFilterTrace;
+            _onRuleResolution = onRuleResolution;
         }
 
         internal async Task<TurnStart> StartTurnAsync(
@@ -78,7 +81,7 @@ namespace Pinder.Core.Conversation
             }
 
             // Ghost trigger: if Bored state, 25% chance per turn
-            if (TurnOrchestratorHelpers.ResolveInterestState(state, _rules) == InterestState.Bored)
+            if (TurnOrchestratorHelpers.ResolveInterestState(state, _rules, _onRuleResolution) == InterestState.Bored)
             {
                 int ghostRoll = _dice.Roll(4);
                 if (ghostRoll == 1)
@@ -122,7 +125,7 @@ namespace Pinder.Core.Conversation
                 {
                     int effectiveVal = state.PlayerShadows.GetEffectiveShadow(shadow);
                     shadowThresholds[shadow] = effectiveVal;
-                    int tier = TurnOrchestratorHelpers.ResolveThresholdLevel(effectiveVal, _rules);
+                    int tier = TurnOrchestratorHelpers.ResolveThresholdLevel(effectiveVal, _rules, _onRuleResolution);
                     // T2+ disadvantage for paired stats is removed: shadow check IS the disadvantage (#755)
                     _ = tier; // suppress unused warning
                 }
@@ -204,7 +207,7 @@ namespace Pinder.Core.Conversation
             state.CurrentOptions = options;
 
             // Compute pending momentum bonus for the upcoming roll (#268)
-            state.PendingMomentumBonus = TurnOrchestratorHelpers.GetMomentumBonus(state.MomentumStreak, _rules);
+            state.PendingMomentumBonus = TurnOrchestratorHelpers.GetMomentumBonus(state.MomentumStreak, _rules, _onRuleResolution);
 
             state.CurrentDicePools = new Pinder.Core.Rolls.PerOptionDicePool[options.Length];
             for (int i = 0; i < options.Length; i++)

--- a/tests/Pinder.Core.Tests/Issue1219_RuleResolverMissTracingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1219_RuleResolverMissTracingTests.cs
@@ -108,5 +108,40 @@ namespace Pinder.Core.Tests
             var actual = TurnOrchestratorHelpers.GetMomentumBonus(streak, fakeResolver);
             Assert.Equal(resolverValue, actual);
         }
+
+        [Fact]
+        public void Test5_ResolverHit_TracesExpectedEvent()
+        {
+            var fakeResolver = new FakeRuleResolver { MomentumBonus = 42 };
+            RuleResolutionTraceEvent? trace = null;
+            Action<RuleResolutionTraceEvent> callback = ev => trace = ev;
+
+            var result = TurnOrchestratorHelpers.GetMomentumBonus(5, fakeResolver, callback);
+
+            Assert.Equal(42, result);
+            Assert.NotNull(trace);
+            Assert.Equal("momentum_bonus", trace.RuleKey);
+            Assert.Equal("resolver", trace.Source);
+            Assert.True(trace.ResolverConfigured);
+            Assert.Equal(42, trace.NumericValue);
+            Assert.Null(trace.StateValue);
+        }
+
+        [Fact]
+        public void Test6_ResolverMiss_TracesExpectedEvent()
+        {
+            RuleResolutionTraceEvent? trace = null;
+            Action<RuleResolutionTraceEvent> callback = ev => trace = ev;
+
+            var result = TurnOrchestratorHelpers.GetMomentumBonus(5, null, callback);
+
+            Assert.Equal(3, result);
+            Assert.NotNull(trace);
+            Assert.Equal("momentum_bonus", trace.RuleKey);
+            Assert.Equal("hardcoded_fallback", trace.Source);
+            Assert.False(trace.ResolverConfigured);
+            Assert.Equal(3, trace.NumericValue);
+            Assert.Null(trace.StateValue);
+        }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1219_RuleResolverMissTracingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1219_RuleResolverMissTracingTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1219_RuleResolverMissTracingTests
+    {
+        private class FakeRuleResolver : IRuleResolver
+        {
+            public int? MomentumBonus { get; set; }
+            public int? FailureInterestDelta { get; set; }
+            public int? SuccessInterestDelta { get; set; }
+            public InterestState? InterestState { get; set; }
+            public int? ShadowThresholdLevel { get; set; }
+            public double? RiskTierXpMultiplierValue { get; set; }
+            public double? TerminalOutcomeMultiplierValue { get; set; }
+            public int? SuccessBaseXpValue { get; set; }
+            public int? FlatXpAwardValue { get; set; }
+            public int? XpThresholdForLevelValue { get; set; }
+            public int? LevelRollBonusValue { get; set; }
+            public int? BuildPointsForLevelValue { get; set; }
+            public int? ItemSlotsForLevelValue { get; set; }
+
+            public int? GetFailureInterestDelta(int missMargin, int naturalRoll) => FailureInterestDelta;
+            public int? GetSuccessInterestDelta(int beatMargin, int naturalRoll) => SuccessInterestDelta;
+            public InterestState? GetInterestState(int interest) => InterestState;
+            public int? GetShadowThresholdLevel(int shadowValue) => ShadowThresholdLevel;
+            public int? GetMomentumBonus(int streak) => MomentumBonus;
+            public double? GetRiskTierXpMultiplier(RiskTier riskTier) => RiskTierXpMultiplierValue;
+            public double? GetTerminalOutcomeMultiplier(GameOutcome outcome) => TerminalOutcomeMultiplierValue;
+            public int? GetSuccessBaseXp(int dc) => SuccessBaseXpValue;
+            public int? GetFlatXpAward(string awardType) => FlatXpAwardValue;
+            public int? GetXpThresholdForLevel(int level) => XpThresholdForLevelValue;
+            public int? GetLevelRollBonus(int level) => LevelRollBonusValue;
+            public int? GetBuildPointsForLevel(int level) => BuildPointsForLevelValue;
+            public int? GetItemSlotsForLevel(int level) => ItemSlotsForLevelValue;
+        }
+
+        [Fact]
+        public void Test1_GameSessionConfig_CallbackProperty_Exists()
+        {
+            // Assert GameSessionConfig exposes a public property whose name CONTAINS 'Rule'
+            // AND ('Resolution' OR 'Resolver' OR 'Trace' OR 'Source') (case-insensitive)
+            // and whose type is a delegate (assignable to System.Delegate).
+            var properties = typeof(GameSessionConfig).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var matched = properties.Where(p =>
+            {
+                var lowerName = p.Name.ToLowerInvariant();
+                bool containsRule = lowerName.Contains("rule");
+                bool containsSub = lowerName.Contains("resolution") ||
+                                  lowerName.Contains("resolver") ||
+                                  lowerName.Contains("trace") ||
+                                  lowerName.Contains("source");
+                bool isDelegate = typeof(Delegate).IsAssignableFrom(p.PropertyType);
+                return containsRule && containsSub && isDelegate;
+            }).ToList();
+
+            Assert.True(matched.Count > 0, 
+                "Expected GameSessionConfig to expose a public property representing a Rule Resolution trace callback delegate, but none was found.");
+        }
+
+        [Fact]
+        public void Test2_RuleResolutionTraceEventType_Exists()
+        {
+            // Assert a type whose name contains 'RuleResolution' OR 'RuleResolverTrace' exists in the Pinder.Core assembly.
+            var assembly = typeof(GameSessionConfig).Assembly;
+            var types = assembly.GetTypes();
+            var matchedTypes = types.Where(t =>
+                t.Name.Contains("RuleResolution") ||
+                t.Name.Contains("RuleResolverTrace")).ToList();
+
+            Assert.True(matchedTypes.Count > 0,
+                "Expected a structured rule resolution trace type (e.g. RuleResolutionEvent) to exist in the Pinder.Core assembly, but none was found.");
+        }
+
+        [Theory]
+        [InlineData(5, 3)]
+        [InlineData(4, 2)]
+        [InlineData(3, 2)]
+        [InlineData(2, 0)]
+        [InlineData(0, 0)]
+        public void Test3_ParityGuard_ResolverMiss_ReturnsHardcodedValue(int streak, int expectedBonus)
+        {
+            // With a resolver returning null (MISS), it must fall back to the hardcoded value.
+            var fakeResolver = new FakeRuleResolver { MomentumBonus = null };
+            var actualWithResolver = TurnOrchestratorHelpers.GetMomentumBonus(streak, fakeResolver);
+            Assert.Equal(expectedBonus, actualWithResolver);
+
+            // With no resolver (null), it must return the same hardcoded value.
+            var actualWithNoResolver = TurnOrchestratorHelpers.GetMomentumBonus(streak, null);
+            Assert.Equal(expectedBonus, actualWithNoResolver);
+        }
+
+        [Theory]
+        [InlineData(5, 7)]
+        [InlineData(3, 10)]
+        [InlineData(0, -1)]
+        public void Test4_ParityGuard_ResolverHit_ReturnsResolverValue(int streak, int resolverValue)
+        {
+            // When resolver returns a value (HIT), that value must win.
+            var fakeResolver = new FakeRuleResolver { MomentumBonus = resolverValue };
+            var actual = TurnOrchestratorHelpers.GetMomentumBonus(streak, fakeResolver);
+            Assert.Equal(resolverValue, actual);
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Phase4/Phase4_GameSessionCloneTests.cs
+++ b/tests/Pinder.Core.Tests/Phase4/Phase4_GameSessionCloneTests.cs
@@ -243,6 +243,8 @@ namespace Pinder.Core.Tests.Phase4
                 "_globalDcBias",            // value-type, primitive int
                 "_statDeliveryInstructions",// opaque immutable bag
                 "_onTextLayerNoop",         // delegate (stateless callback)
+                "_onShadowFilterTrace",     // delegate (stateless callback)
+                "_onRuleResolution",        // delegate (stateless callback)
             };
 
             var missing = new List<string>();


### PR DESCRIPTION
Closes #1219

> Note: #1219 is a cleanup **umbrella** that explicitly must not be done in one PR. This PR implements **only one small parity-preserving slice** — the issue's recommended split step 2: *"unresolved required rules become observable first (trace/log + typed source selection)."* The remaining bullets (RollEngine parity extraction, prompt threshold descriptor service, removing duplicated paths) are deliberately left for follow-up slices.

## Problem
When an `IRuleResolver` is configured but returns null for a rule (a miss), the engine silently falls back to the hardcoded value with no observability — you can't tell whether a mechanic value came from the resolver or the code default.

## Fix (pure observability, exact parity)
- New `RuleResolutionTraceEvent` (RuleKey, Source = `resolver` vs `hardcoded_fallback`, ResolverConfigured, numeric/state value) — structured metadata only.
- New opt-in `GameSessionConfig.OnRuleResolution` callback (optional ctor param at the end; mirrors `OnShadowFilterTrace`/`OnTextLayerNoop`; no `Microsoft.Extensions.Logging`).
- The 5 `TurnOrchestratorHelpers` resolver methods (`GetMomentumBonus`, `ResolveFailureInterestDelta`, `ResolveSuccessInterestDelta`, `ResolveInterestState`, `ResolveThresholdLevel`) gained an optional trace param and now fire the event with explicit source selection, then return the **exact same value as before**.
- Wired the callback through the main turn path (`TurnOrchestrator`, `RollResolutionStage`, `GameSession`) and carried by reference in `GameSession.Clone`.

## Parity / discipline
- No computed mechanic value changed (resolver-hit returns resolved value; miss/no-resolver returns the identical hardcoded fallback). Reviewer confirmed byte-identical returns.
- `IRuleResolver` unchanged (no new members). New params are optional and back-compat.
- The duplicated hardcoded fallback paths REMAIN (removing them is a separate slice).

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.Core.Tests` => 3069 passed, 0 failed, 18 skipped (Issue1219 12/12)

## Scope
No RollEngine extraction, no descriptor-service move, no tuning, no Unity.