### PR TITLE
cleanup(#1221): label session-runner scoring as engine vs heuristic (slice 1)

### DIFF
--- a/session-runner/HighestModAgent.cs
+++ b/session-runner/HighestModAgent.cs
@@ -14,6 +14,9 @@ namespace Pinder.SessionRunner
     {
         public string LastExplanation { get; private set; } = "";
 
+        public ScoringMode ScoringMode => ScoringMode.Heuristic;
+        public string MechanicsSource => "heuristic:HighestModAgent highest-effective-modifier baseline";
+
         public Task<PlayerDecision> DecideAsync(TurnStart turn, PlayerAgentContext context)
         {
             if (turn == null) throw new ArgumentNullException(nameof(turn));

--- a/session-runner/HumanPlayerAgent.cs
+++ b/session-runner/HumanPlayerAgent.cs
@@ -12,6 +12,9 @@ namespace Pinder.SessionRunner
     {
         public string LastExplanation { get; private set; } = "";
 
+        public ScoringMode ScoringMode => ScoringMode.Human;
+        public string MechanicsSource => "human:interactive";
+
         public Task<PlayerDecision> DecideAsync(TurnStart turn, PlayerAgentContext context)
         {
             var options = turn.Options;

--- a/session-runner/IPlayerAgent.cs
+++ b/session-runner/IPlayerAgent.cs
@@ -10,6 +10,16 @@ namespace Pinder.SessionRunner
     public interface IPlayerAgent
     {
         /// <summary>
+        /// How this agent's scores/decisions are derived.
+        /// </summary>
+        ScoringMode ScoringMode { get; }
+
+        /// <summary>
+        /// Honest label describing the source of the mechanics and logic.
+        /// </summary>
+        string MechanicsSource { get; }
+
+        /// <summary>
         /// Given a TurnStart (options + game state snapshot) and additional agent context,
         /// returns a decision: which option to pick, why, and score breakdowns for all options.
         /// </summary>

--- a/session-runner/LlmPlayerAgent.cs
+++ b/session-runner/LlmPlayerAgent.cs
@@ -96,6 +96,9 @@ namespace Pinder.SessionRunner
         /// </summary>
         public string LastExplanation { get; private set; } = "";
 
+        public ScoringMode ScoringMode => ScoringMode.Llm;
+        public string MechanicsSource => "llm+heuristic:LlmPlayerAgent wraps ScoringPlayerAgent heuristic and makes strategic LLM choices";
+
         /// <summary>Returns per-call token stats for each llm-player-pick call made.</summary>
         public IReadOnlyList<CallSummaryStat> GetTokenStats() => _tokenStats.AsReadOnly();
 

--- a/session-runner/PlaytestFormatter.cs
+++ b/session-runner/PlaytestFormatter.cs
@@ -18,8 +18,14 @@ namespace Pinder.SessionRunner
         /// </summary>
         /// <param name="decision">The PlayerDecision returned by the agent.</param>
         /// <param name="agentTypeName">The simple class name of the agent (e.g. "ScoringPlayerAgent").</param>
+        /// <param name="scoringMode">The optional ScoringMode. If null, inferred from agentTypeName.</param>
+        /// <param name="mechanicsSource">The optional mechanics source string. If null, inferred from agentTypeName.</param>
         /// <returns>A multi-line string containing the formatted reasoning block.</returns>
-        public static string FormatReasoningBlock(PlayerDecision? decision, string agentTypeName)
+        public static string FormatReasoningBlock(
+            PlayerDecision? decision,
+            string agentTypeName,
+            ScoringMode? scoringMode = null,
+            string? mechanicsSource = null)
         {
             if (decision == null)
             {
@@ -27,6 +33,23 @@ namespace Pinder.SessionRunner
             }
 
             var sb = new StringBuilder();
+
+            ScoringMode realMode;
+            string realSource;
+            if (scoringMode.HasValue && mechanicsSource != null)
+            {
+                realMode = scoringMode.Value;
+                realSource = mechanicsSource;
+            }
+            else
+            {
+                var inferred = InferScoringModeAndSourceFromTypeName(agentTypeName);
+                realMode = scoringMode ?? inferred.Item1;
+                realSource = mechanicsSource ?? inferred.Item2;
+            }
+
+            sb.AppendLine($"> scoring_mode={realMode.ToString().ToLowerInvariant()} (mechanics_source={realSource})");
+
             string reasoning = decision.Reasoning;
             if (string.IsNullOrEmpty(reasoning))
             {
@@ -42,6 +65,28 @@ namespace Pinder.SessionRunner
             }
 
             return sb.ToString();
+        }
+
+        private static (ScoringMode, string) InferScoringModeAndSourceFromTypeName(string agentTypeName)
+        {
+            if (string.Equals(agentTypeName, "ScoringPlayerAgent", StringComparison.OrdinalIgnoreCase))
+            {
+                return (ScoringMode.Heuristic, "heuristic:ScoringPlayerAgent expected-value (duplicates engine rules — NOT engine-derived)");
+            }
+            if (string.Equals(agentTypeName, "HighestModAgent", StringComparison.OrdinalIgnoreCase))
+            {
+                return (ScoringMode.Heuristic, "heuristic:HighestModAgent highest-effective-modifier baseline");
+            }
+            if (string.Equals(agentTypeName, "LlmPlayerAgent", StringComparison.OrdinalIgnoreCase))
+            {
+                return (ScoringMode.Llm, "llm+heuristic:LlmPlayerAgent wraps ScoringPlayerAgent heuristic and makes strategic LLM choices");
+            }
+            if (string.Equals(agentTypeName, "HumanPlayerAgent", StringComparison.OrdinalIgnoreCase))
+            {
+                return (ScoringMode.Human, "human:interactive");
+            }
+            // default fallback if none match
+            return (ScoringMode.Heuristic, "heuristic");
         }
 
         /// <summary>

--- a/session-runner/Program.Loop.cs
+++ b/session-runner/Program.Loop.cs
@@ -137,7 +137,7 @@ partial class Program
             var chosen = turnStart.Options[pick];
             Console.WriteLine($"**► Player picks: {letters[pick]} ({StatLabel(chosen.Stat)})**");
             Console.WriteLine();
-            Console.WriteLine(PlaytestFormatter.FormatReasoningBlock(decision, setup.Agent.GetType().Name));
+            Console.WriteLine(PlaytestFormatter.FormatReasoningBlock(decision, setup.Agent.GetType().Name, setup.Agent.ScoringMode, setup.Agent.MechanicsSource));
             Console.WriteLine(PlaytestFormatter.FormatScoreTable(decision, turnStart.Options));
             Console.WriteLine();
 

--- a/session-runner/ScoringMode.cs
+++ b/session-runner/ScoringMode.cs
@@ -1,0 +1,13 @@
+namespace Pinder.SessionRunner
+{
+    /// <summary>
+    /// Describes how an agent's scoring was derived (engine, heuristic, llm, or human).
+    /// </summary>
+    public enum ScoringMode
+    {
+        Engine,
+        Heuristic,
+        Llm,
+        Human
+    }
+}

--- a/session-runner/ScoringPlayerAgent.cs
+++ b/session-runner/ScoringPlayerAgent.cs
@@ -15,6 +15,9 @@ namespace Pinder.SessionRunner
     {
         public string LastExplanation { get; private set; } = "";
 
+        public ScoringMode ScoringMode => ScoringMode.Heuristic;
+        public string MechanicsSource => "heuristic:ScoringPlayerAgent expected-value (duplicates engine rules — NOT engine-derived)";
+
         // Trap activation cost added to TropeTrap/Catastrophe/Legendary failure tiers
         // Represents ~1.5 turns of reduced effectiveness from activated trap
         private const float TrapActivationCost = 1.5f;

--- a/tests/Pinder.Core.Tests/Issue1221_HarnessScoringModeLabelTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1221_HarnessScoringModeLabelTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Stats;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Regression tests for GitHub Issue #1221: Making the harness honest via engine-vs-heuristic scoring labels.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1221_HarnessScoringModeLabelTests
+    {
+        #region Test 1: AGENTS EXPOSE A SCORING-MODE LABEL (RED, reflection)
+        [Fact]
+        public void Test1_AgentsExposeScoringModeLabel()
+        {
+            var scoringAgent = new ScoringPlayerAgent();
+            var highestModAgent = new HighestModAgent();
+
+            CheckAgentHasProperty(scoringAgent);
+            CheckAgentHasProperty(highestModAgent);
+        }
+
+        private void CheckAgentHasProperty(object agent)
+        {
+            var properties = agent.GetType().GetProperties();
+            var match = properties.Any(p => 
+                p.Name.Contains("ScoringMode", StringComparison.OrdinalIgnoreCase) ||
+                p.Name.Contains("Mode", StringComparison.OrdinalIgnoreCase) ||
+                p.Name.Contains("MechanicsSource", StringComparison.OrdinalIgnoreCase));
+            
+            Assert.True(match, $"Expected type {agent.GetType().Name} to expose a public instance property containing 'ScoringMode', 'Mode', or 'MechanicsSource'.");
+        }
+        #endregion
+
+        #region Test 2: SCORING-MODE TYPE/ENUM EXISTS (RED, reflection)
+        [Fact]
+        public void Test2_ScoringModeTypeExists()
+        {
+            var assembly = typeof(ScoringPlayerAgent).Assembly;
+            var types = assembly.GetTypes();
+            var match = types.Any(t => t.Name.Contains("ScoringMode", StringComparison.OrdinalIgnoreCase));
+            
+            Assert.True(match, "Expected a type containing 'ScoringMode' in its name to exist in the Pinder.SessionRunner assembly.");
+        }
+        #endregion
+
+        #region Test 3: HARNESS OUTPUT CARRIES scoring_mode LABEL (RED)
+        [Fact]
+        public async Task Test3_HarnessOutputCarriesScoringModeLabel()
+        {
+            var agent = new ScoringPlayerAgent();
+            var playerStats = MakeStats(charm: 3, rizz: 3, honesty: 3, chaos: 3, wit: 3, selfAwareness: 3);
+            var dateeStats = MakeStats();
+            var options = new[] { new DialogueOption(StatType.Charm, "test") };
+            var turn = MakeTurn(options);
+            var ctx = MakeContext(playerStats, dateeStats);
+
+            var decision = await agent.DecideAsync(turn, ctx);
+            var formatterOutput = PlaytestFormatter.FormatReasoningBlock(decision, "ScoringPlayerAgent");
+            
+            bool hasScoringModeLabelInOutput = formatterOutput != null && formatterOutput.Contains("scoring_mode", StringComparison.OrdinalIgnoreCase);
+            
+            bool agentHasScoringModePropertyWithHeuristic = false;
+            var scoringModeProp = agent.GetType().GetProperties()
+                .FirstOrDefault(p => p.Name.Contains("ScoringMode", StringComparison.OrdinalIgnoreCase) ||
+                                     p.Name.Contains("Mode", StringComparison.OrdinalIgnoreCase) ||
+                                     p.Name.Contains("MechanicsSource", StringComparison.OrdinalIgnoreCase));
+            if (scoringModeProp != null)
+            {
+                var val = scoringModeProp.GetValue(agent);
+                if (val != null && val.ToString()!.Contains("heuristic", StringComparison.OrdinalIgnoreCase))
+                {
+                    agentHasScoringModePropertyWithHeuristic = true;
+                }
+            }
+            
+            Assert.True(hasScoringModeLabelInOutput || agentHasScoringModePropertyWithHeuristic,
+                "Expected either the playtest formatter output to contain 'scoring_mode' (case-insensitive) or the agent to have a ScoringMode property whose value contains 'heuristic' (case-insensitive). PlaytestFormatter output: " + (formatterOutput ?? "null"));
+        }
+        #endregion
+
+        #region Test 4: PARITY GUARD — DECISIONS UNCHANGED (must PASS before & after)
+        [Fact]
+        public async Task Test4_ParityGuard_ScoringPlayerAgentDecisionsUnchanged()
+        {
+            var agent = new ScoringPlayerAgent();
+            var playerStats = MakeStats(charm: 4, rizz: 2, honesty: 1, chaos: 3);
+            var dateeStats = MakeStats(selfAwareness: 2, wit: 1, chaos: 0, charm: 1);
+
+            var options = new[]
+            {
+                new DialogueOption(StatType.Charm, "a"),
+                new DialogueOption(StatType.Rizz, "b"),
+                new DialogueOption(StatType.Honesty, "c", hasTellBonus: true),
+                new DialogueOption(StatType.Chaos, "d", comboName: "The Switcheroo")
+            };
+
+            var turn = MakeTurn(options);
+            var ctx = MakeContext(playerStats: playerStats, dateeStats: dateeStats);
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.NotNull(decision);
+            Assert.NotNull(decision.Scores);
+            Assert.True(decision.OptionIndex >= 0 && decision.OptionIndex < options.Length);
+        }
+        #endregion
+
+        #region Test 5: PARITY GUARD — HighestModAgent picks highest-mod (must PASS before & after)
+        [Fact]
+        public async Task Test5_ParityGuard_HighestModAgentPicksHighestModifierOption()
+        {
+            var agent = new HighestModAgent();
+            var player = MakePlayerStats(); // Charm=4 is highest
+            var options = new[]
+            {
+                new DialogueOption(StatType.Rizz, "low"),     // mod +1
+                new DialogueOption(StatType.Charm, "high"),    // mod +4
+                new DialogueOption(StatType.Honesty, "mid"),   // mod +3
+            };
+            var turn = MakeHighestModTurn(options);
+            var ctx = MakeHighestModContext(player, MakeDateeStats());
+
+            var decision = await agent.DecideAsync(turn, ctx);
+
+            Assert.Equal(1, decision.OptionIndex);
+        }
+        #endregion
+
+        #region Helpers
+        private static StatBlock MakeStats(
+            int charm = 0, int rizz = 0, int honesty = 0,
+            int chaos = 0, int wit = 0, int selfAwareness = 0,
+            int madness = 0, int horniness = 0, int denial = 0,
+            int fixation = 0, int dread = 0, int overthinking = 0)
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, charm },
+                    { StatType.Rizz, rizz },
+                    { StatType.Honesty, honesty },
+                    { StatType.Chaos, chaos },
+                    { StatType.Wit, wit },
+                    { StatType.SelfAwareness, selfAwareness }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, madness },
+                    { ShadowStatType.Despair, horniness },
+                    { ShadowStatType.Denial, denial },
+                    { ShadowStatType.Fixation, fixation },
+                    { ShadowStatType.Dread, dread },
+                    { ShadowStatType.Overthinking, overthinking }
+                });
+        }
+
+        private static TurnStart MakeTurn(params DialogueOption[] options)
+        {
+            var snapshot = new GameStateSnapshot(
+                interest: 12,
+                state: InterestState.Interested,
+                momentumStreak: 0,
+                activeTrapNames: Array.Empty<string>(),
+                turnNumber: 3);
+            return new TurnStart(options, snapshot);
+        }
+
+        private static PlayerAgentContext MakeContext(
+            StatBlock? playerStats = null,
+            StatBlock? dateeStats = null,
+            int currentInterest = 12,
+            InterestState interestState = InterestState.Interested,
+            int momentumStreak = 0,
+            string[]? activeTrapNames = null,
+            int sessionHorniness = 0,
+            Dictionary<ShadowStatType, int>? shadowValues = null,
+            int turnNumber = 3)
+        {
+            return new PlayerAgentContext(
+                playerStats ?? MakeStats(charm: 3, rizz: 3, honesty: 3, chaos: 3, wit: 3, selfAwareness: 3),
+                dateeStats ?? MakeStats(),
+                currentInterest,
+                interestState,
+                momentumStreak,
+                activeTrapNames ?? Array.Empty<string>(),
+                sessionHorniness,
+                shadowValues,
+                turnNumber);
+        }
+
+        private static StatBlock MakePlayerStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 4 }, { StatType.Rizz, 1 }, { StatType.Honesty, 3 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 2 }, { StatType.SelfAwareness, 3 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static StatBlock MakeDateeStats()
+        {
+            return new StatBlock(
+                new Dictionary<StatType, int>
+                {
+                    { StatType.Charm, 2 }, { StatType.Rizz, 3 }, { StatType.Honesty, 1 },
+                    { StatType.Chaos, 2 }, { StatType.Wit, 1 }, { StatType.SelfAwareness, 2 }
+                },
+                new Dictionary<ShadowStatType, int>
+                {
+                    { ShadowStatType.Madness, 0 }, { ShadowStatType.Despair, 0 },
+                    { ShadowStatType.Denial, 0 }, { ShadowStatType.Fixation, 0 },
+                    { ShadowStatType.Dread, 0 }, { ShadowStatType.Overthinking, 0 }
+                });
+        }
+
+        private static PlayerAgentContext MakeHighestModContext(StatBlock player, StatBlock datee,
+            int interest = 12, InterestState state = InterestState.Interested, int momentum = 0)
+        {
+            return new PlayerAgentContext(player, datee, interest, state, momentum,
+                Array.Empty<string>(), 0, null, 1);
+        }
+
+        private static TurnStart MakeHighestModTurn(DialogueOption[] options, int interest = 12,
+            InterestState state = InterestState.Interested, int momentum = 0, int turn = 1)
+        {
+            return new TurnStart(options,
+                new GameStateSnapshot(interest, state, momentum, Array.Empty<string>(), turn));
+        }
+        #endregion
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue1221_ScoringModeDriftGuardTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1221_ScoringModeDriftGuardTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Pinder.SessionRunner;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Drift guard tests for GitHub Issue #1221: Asserting honest agent scoring labeling.
+    /// Re-imprinted logic from the harness should never report as true engine-derived scoring.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1221_ScoringModeDriftGuardTests
+    {
+        [Fact]
+        public void Test_ScoringPlayerAgent_DoesNotClaimEngineScoring()
+        {
+            var agent = new ScoringPlayerAgent();
+            
+            // ScoringPlayerAgent duplicates or maps formulas but does not call into core rules engine.
+            // Therefore, it must be labeled Heuristic, not Engine.
+            Assert.NotEqual(ScoringMode.Engine, agent.ScoringMode);
+            Assert.Equal(ScoringMode.Heuristic, agent.ScoringMode);
+            Assert.Contains("heuristic", agent.MechanicsSource, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_HighestModAgent_DoesNotClaimEngineScoring()
+        {
+            var agent = new HighestModAgent();
+
+            // HighestModAgent is a simple modifier baseline heuristic.
+            Assert.NotEqual(ScoringMode.Engine, agent.ScoringMode);
+            Assert.Equal(ScoringMode.Heuristic, agent.ScoringMode);
+            Assert.Contains("heuristic", agent.MechanicsSource, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_LlmPlayerAgent_DoesNotClaimEngineScoring()
+        {
+            // LlmPlayerAgent relies on the ScoringPlayerAgent expected value heuristic and LLM decisions.
+            // We can check its default ScoringMode property without fully initializing it.
+            var agentType = typeof(LlmPlayerAgent);
+            var modeProp = agentType.GetProperty("ScoringMode");
+            Assert.NotNull(modeProp);
+            
+            // HighestModAgent or other property check
+            var mechanicsProp = agentType.GetProperty("MechanicsSource");
+            Assert.NotNull(mechanicsProp);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1221

> Note: #1221 is a lower-priority cleanup. This PR implements the issue's recommended **first step — make the harness honest** by labeling scoring as `engine` vs `heuristic`. It does **not** replace duplicated harness mechanics with core APIs (that is a follow-up step, only worthwhile where a small core seam exists).

## Problem
`session-runner` agents (`ScoringPlayerAgent`, `HighestModAgent`) re-implement engine momentum/EV/threshold/trap-name math but are presented as if authoritative — their output could be mistaken for rules/spec evidence.

## Fix (honest labeling, no behavior change)
- New `ScoringMode` enum (`Engine`, `Heuristic`, `Llm`, `Human`).
- `IPlayerAgent` gains read-only `ScoringMode ScoringMode` + `string MechanicsSource`. Implemented honestly on all 4 agents — **none** is labeled `Engine`:
  - `ScoringPlayerAgent` → `Heuristic` ("duplicates engine rules — NOT engine-derived")
  - `HighestModAgent` → `Heuristic` (highest-effective-modifier baseline)
  - `LlmPlayerAgent` → `Llm` (wraps the heuristic + LLM choice)
  - `HumanPlayerAgent` → `Human`
- `PlaytestFormatter.FormatReasoningBlock` now emits a `scoring_mode=<mode> (mechanics_source=<src>)` line (new params optional + at the end; a type-name inference keeps the 2-arg path labeling heuristic agents correctly). The real call-site (`Program.Loop.cs`) passes the agent's actual `ScoringMode`/`MechanicsSource`.
- New drift-guard test asserts the heuristic agents never report `ScoringMode.Engine`.

## Parity / discipline
- No `DecideAsync` logic, scoring formula, threshold, or decision/score value changed (get-only label properties only).
- Existing `Issue351_PlaytestFormatterTests`/`Issue351_PickReasoningTests` are unchanged and pass (the label line is additive).
- No harness mechanics replaced with core APIs; no second architecture; no retune.

## Verification (local only, no GitHub CI)
- `dotnet build Pinder.Core.sln -c Debug` => 0 errors
- `Pinder.Core.Tests` => 3077 passed, 0 failed, 18 skipped (Issue1221 8/8)

> Reviewer note: the protocol's pinned reviewer model (gpt-5.5 via openai-api) was quota-exhausted during this drain, so review was performed by an independent fallback reviewer leaf (separate context, did not write the code) which verified honest labeling, zero value change, formatter additivity, and all local checks.

## Scope
No Unity. No engine API expansion for the harness. Replacing duplicated scoring with core calls remains a follow-up.