### PR TITLE
fix(delivery): fail closed on invalid success-improvement output

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -157,7 +157,16 @@ namespace Pinder.Core.Conversation
                     if (improved != null)
                     {
                         improved = improved.Trim();
-                        if (!string.IsNullOrWhiteSpace(improved) && improved != "...")
+                        if (SuccessImprovementValidator.IsRejected(improved))
+                        {
+                            TurnOrchestratorHelpers.EmitTextLayerNoop(
+                                _onTextLayerNoop,
+                                state.TurnNumber,
+                                "Success improvement",
+                                beforeImprovement,
+                                beforeImprovement);
+                        }
+                        else if (!string.IsNullOrWhiteSpace(improved) && improved != "...")
                         {
                             deliveredMessage = improved;
                         }

--- a/src/Pinder.Core/Conversation/SuccessImprovementValidator.cs
+++ b/src/Pinder.Core/Conversation/SuccessImprovementValidator.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Validates success improvement model responses to ensure they do not leak meta/control text (see #1243).
+    /// </summary>
+    public static class SuccessImprovementValidator
+    {
+        private static readonly string[] CaseInsensitiveMarkers = new[]
+        {
+            "INVALID_ENGINE_STATE",
+            "I need to analyze",
+            "I need ENGINE_STATE",
+            "generate OPTIONS"
+        };
+
+        private static readonly string[] OrdinalMarkers = new[]
+        {
+            "<ENGINE_STATE>",
+            "OPTION_",
+            "[STAT:"
+        };
+
+        public static bool IsRejected(string? response)
+        {
+            if (string.IsNullOrWhiteSpace(response))
+                return false;
+
+            foreach (var marker in CaseInsensitiveMarkers)
+            {
+                if (response.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+
+            foreach (var marker in OrdinalMarkers)
+            {
+                if (response.IndexOf(marker, StringComparison.Ordinal) >= 0)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -622,6 +622,14 @@ namespace Pinder.LlmAdapters
                 .Replace("{delivered_message}", context.DeliveredMessage);
 
             var sb = new StringBuilder();
+            sb.AppendLine("<ENGINE_STATE>");
+            sb.AppendLine("[ENGINE — CALL PURPOSE: SUCCESS_IMPROVEMENT]");
+            sb.AppendLine($"Delivery outcome / tier: {(context.TierKey ?? "").ToUpperInvariant()}");
+            sb.AppendLine($"Selected stat: {context.Stat}");
+            sb.AppendLine($"Current delivered PLAYER AVATAR message: \"{context.DeliveredMessage}\"");
+            sb.AppendLine("Output requirement: return ONE rewritten PLAYER AVATAR message only — sharper wording, same voice. No analysis, no OPTIONS, no engine commentary, no ENGINE_STATE echo.");
+            sb.AppendLine("</ENGINE_STATE>");
+            sb.AppendLine();
             sb.AppendLine("CONVERSATION SO FAR:");
             foreach (var (sender, text) in context.ConversationHistory)
             {
@@ -643,6 +651,18 @@ namespace Pinder.LlmAdapters
                     provider: "primary",
                     model: null,
                     reason: "empty_output",
+                    outcome: OverlayOutcome.Degraded
+                ));
+                return context.DeliveredMessage;
+            }
+
+            if (Pinder.Core.Conversation.SuccessImprovementValidator.IsRejected(improved))
+            {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "success_improvement",
+                    provider: "primary",
+                    model: null,
+                    reason: "meta_control_output",
                     outcome: OverlayOutcome.Degraded
                 ));
                 return context.DeliveredMessage;

--- a/tests/Pinder.Core.Tests/Issue1243_SuccessImprovementFailClosedTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1243_SuccessImprovementFailClosedTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.Core.Text;
+using Pinder.Core.Traps;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1243_SuccessImprovementFailClosedTests
+    {
+        private const string DeterministicLine = "That sounds like a perfectly reasonable answer to me.";
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1);
+        }
+
+        private sealed class DeliveryAdapterWithFailClosed : ILlmAdapter, IStatefulLlmAdapter
+        {
+            private readonly string _improvementResponse;
+            public string? CapturedTrapMessage { get; private set; }
+
+            public DeliveryAdapterWithFailClosed(string improvementResponse)
+            {
+                _improvementResponse = improvementResponse;
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+                => Task.FromResult(new[] { new DialogueOption(StatType.Charm, DeterministicLine) });
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
+                => Task.FromResult(new DateeResponse("ok, go on..."));
+
+            public Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context, IReadOnlyList<ConversationMessage> history, CancellationToken cancellationToken = default)
+            {
+                var resp = new DateeResponse("ok, go on...");
+                var entries = new[] { ConversationMessage.User(string.Empty), ConversationMessage.Assistant("ok, go on...") };
+                return Task.FromResult(new StatefulDateeResult(resp, entries));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+                => Task.FromResult<string?>(null);
+
+            public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
+            public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
+                => Task.FromResult("so... when are we actually doing this?");
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
+                => Task.FromResult(message);
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                CapturedTrapMessage = message;
+                return Task.FromResult(message + " [TRAPPED]");
+            }
+
+            public Task<string> GetSuccessImprovementAsync(SuccessImprovementContext context, CancellationToken ct = default)
+            {
+                return Task.FromResult(_improvementResponse);
+            }
+        }
+
+        private sealed class AlwaysMinRandom : Random
+        {
+            public override int Next(int minValue, int maxValue) => minValue;
+        }
+
+        private static GameSession NewSession(
+            ILlmAdapter llm,
+            IDiceRoller dice,
+            ITrapRegistry traps,
+            Action<TextLayerNoopEvent>? onNoop = null,
+            int playerStats = 5,
+            int dateeStats = 0)
+        {
+            return new GameSession(
+                MakeProfile("Player", playerStats), MakeProfile("Datee", dateeStats),
+                llm, dice, traps,
+                new GameSessionConfig(clock: TestHelpers.MakeClock(), steeringRng: new AlwaysMinRandom(), onTextLayerNoop: onNoop));
+        }
+
+        [Fact]
+        public async Task A1_InvalidEngineStateSentinel_RejectsAndRetainsOriginalLine()
+        {
+            var dice = new FixedDice(5, 16, 50); // strong success
+            var llm = new DeliveryAdapterWithFailClosed("Here are your options: \n INVALID_ENGINE_STATE detected.");
+            var session = NewSession(llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.Equal(DeterministicLine, result.DeliveredMessage);
+            Assert.DoesNotContain("INVALID_ENGINE_STATE", result.DeliveredMessage);
+            // No success improvement textdiff is retained
+            
+            // To be precise: the original rule is "No 'Strong success' improvement TextDiff was added that contains the meta text".
+            // If the layer is totally skipped, it's safer. Let's just assert it doesn't contain the diff.
+            Assert.DoesNotContain(result.TextDiffs, d => d.LayerName == "Strong success");
+        }
+
+        [Fact]
+        public async Task A2_MetaAnalysisOutput_RejectsAndRetainsOriginalLine()
+        {
+            var dice = new FixedDice(5, 16, 50); // strong success
+            var llm = new DeliveryAdapterWithFailClosed("I need to analyze the conversation. I need ENGINE_STATE. Now I need to generate OPTIONS for the PLAYER AVATAR.");
+            var session = NewSession(llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.Equal(DeterministicLine, result.DeliveredMessage);
+            Assert.DoesNotContain("generate OPTIONS", result.DeliveredMessage);
+            Assert.DoesNotContain(result.TextDiffs, d => d.LayerName == "Strong success");
+        }
+
+        [Fact]
+        public async Task A3_DegradedTelemetryObservable_WhenRejected()
+        {
+            var captured = new List<TextLayerNoopEvent>();
+            var dice = new FixedDice(5, 16, 50); // strong success
+            var llm = new DeliveryAdapterWithFailClosed("<ENGINE_STATE> INVALID_ENGINE_STATE");
+            var session = NewSession(llm, dice, new NullTrapRegistry(), onNoop: evt => captured.Add(evt));
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.Contains(captured, e => e.Layer == "Success improvement");
+        }
+
+        [Fact]
+        public async Task A4_ValidRewrite_AppliesNormally()
+        {
+            var dice = new FixedDice(5, 16, 50); // strong success
+            var validRewrite = "That's a delightfully chaotic origin story.";
+            var llm = new DeliveryAdapterWithFailClosed(validRewrite);
+            var session = NewSession(llm, dice, new NullTrapRegistry());
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            Assert.True(result.Roll.IsSuccess);
+            Assert.Contains(validRewrite, result.DeliveredMessage);
+            Assert.Contains(result.TextDiffs, d => d.LayerName == "Strong success");
+        }
+
+        [Fact]
+        public async Task A5_DownstreamOverlayReceivesOriginal_AfterRejection()
+        {
+            var trapRegistry = new TestTrapRegistry();
+            var trapDef = new TrapDefinition("id", StatType.Charm, TrapEffect.Disadvantage, 0, 3, "AWKWARD_INSTRUCTION", "Roll Charm DC 15", "nat1 bonus");
+            trapRegistry.Register(trapDef);
+
+            var llm = new DeliveryAdapterWithFailClosed("INVALID_ENGINE_STATE - meta text");
+            var captured = new List<TextLayerNoopEvent>();
+            // Turn 1: roll 4 to miss DC 15 (with allStats=2, total=6, miss by 9 => TropeTrap tier)
+            // Turn 2: roll 16 to strong success on DC 15 (total=18)
+            var dice = new FixedDice(
+                5,  // ctor horniness
+                4,  // Turn 1 roll: troptrap miss
+                10, // Turn 1 delay
+                20, // Turn 2 roll: strong success
+                50, 10, 10, 10, 10  // padding
+            );
+
+            var session = NewSession(llm, dice, trapRegistry, onNoop: evt => captured.Add(evt), playerStats: 2, dateeStats: 2);
+
+            // Turn 1: Miss and trigger trap
+            await session.StartTurnAsync();
+            await session.ResolveTurnAsync(0);
+
+            // Turn 2: Success improvement fires, rejects, then trap applies
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0); // strong success with active trap
+
+            Assert.True(result.Roll.IsSuccess);
+            
+            // Trap apply should have been called
+            Assert.NotNull(llm.CapturedTrapMessage);
+            
+            // Should equal the deterministic line, not the meta text
+            Assert.Equal(DeterministicLine, llm.CapturedTrapMessage);
+            Assert.DoesNotContain("INVALID_ENGINE_STATE", llm.CapturedTrapMessage);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue1243_SuccessImprovementEnvelopeTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1243_SuccessImprovementEnvelopeTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1243_SuccessImprovementEnvelopeTests
+    {
+        private sealed class CapturingTransport : ILlmTransport
+        {
+            public string UserMessage { get; private set; } = "";
+            public string SystemPrompt { get; private set; } = "";
+            private readonly string _response;
+
+            public CapturingTransport(string response)
+            {
+                _response = response;
+            }
+
+            public Task<string> SendAsync(string systemPrompt, string userMessage, double temperature = 0.9, int maxTokens = 1024, string? phase = null, CancellationToken ct = default)
+            {
+                SystemPrompt = systemPrompt;
+                UserMessage = userMessage;
+                return Task.FromResult(_response);
+            }
+        }
+
+        private static PinderLlmAdapter CreateAdapter(string response, out CapturingTransport transport, out List<OverlayDegradedEvent> degradedEvents)
+        {
+            transport = new CapturingTransport(response);
+            var capturedEvents = new List<OverlayDegradedEvent>();
+
+            var yamlContent = @"
+delivery_instructions:
+  charm:
+    strong: ""rewrite the intended message so it lands harder: {delivered_message}""
+";
+            var instructions = StatDeliveryInstructions.LoadFrom(yamlContent);
+
+            var options = new PinderLlmAdapterOptions
+            {
+                GameDefinition = GameDefinition.PinderDefaults,
+                StatDeliveryInstructions = instructions,
+                OnOverlayDegraded = evt => capturedEvents.Add(evt)
+            };
+
+            degradedEvents = capturedEvents;
+            return new PinderLlmAdapter(transport, options);
+        }
+
+        private static SuccessImprovementContext CreateContext()
+        {
+            var history = new List<(string Sender, string Text)>
+            {
+                ("Datee", "Tell me about yourself.")
+            };
+            
+            return new SuccessImprovementContext(
+                playerAvatarPrompt: "You are the Player.",
+                dateeName: "Datee",
+                playerName: "Player",
+                deliveredMessage: "I like to code.",
+                stat: StatType.Charm,
+                tierKey: "strong",
+                conversationHistory: history
+            );
+        }
+
+        [Fact]
+        public async Task B1_EnvelopeContent_IncludesPurposeTierStatAndFormatReqs()
+        {
+            var adapter = CreateAdapter("Some response.", out var transport, out _);
+            var context = CreateContext();
+
+            await adapter.GetSuccessImprovementAsync(context);
+
+            var promptText = transport.UserMessage + transport.SystemPrompt;
+
+            Assert.Contains("SUCCESS_IMPROVEMENT", promptText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("STRONG", promptText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Charm", promptText, StringComparison.OrdinalIgnoreCase);
+            // Must contain a strict format constraint for the player avatar message
+            Assert.Matches("(?i)(ONE|single|only).*PLAYER AVATAR message", promptText);
+        }
+
+        [Fact]
+        public async Task B2_InvalidEngineStateRejection_ReturnsOriginalAndFiresDegraded()
+        {
+            var adapter = CreateAdapter("<ENGINE_STATE> INVALID_ENGINE_STATE </ENGINE_STATE>", out _, out var degradedEvents);
+            var context = CreateContext();
+
+            var result = await adapter.GetSuccessImprovementAsync(context);
+
+            Assert.Equal("I like to code.", result);
+            Assert.Single(degradedEvents);
+            var evt = degradedEvents[0];
+            Assert.Equal("success_improvement", evt.OverlayType);
+            Assert.Equal(OverlayOutcome.Degraded, evt.Outcome);
+        }
+
+        [Fact]
+        public async Task B3_MetaControlRejection_ReturnsOriginalAndFiresDegraded()
+        {
+            var adapter = CreateAdapter("I need to analyze the conversation. Now I need to generate OPTIONS.", out _, out var degradedEvents);
+            var context = CreateContext();
+
+            var result = await adapter.GetSuccessImprovementAsync(context);
+
+            Assert.Equal("I like to code.", result);
+            Assert.Single(degradedEvents);
+            var evt = degradedEvents[0];
+            Assert.Equal("success_improvement", evt.OverlayType);
+            Assert.Equal(OverlayOutcome.Degraded, evt.Outcome);
+        }
+
+        [Fact]
+        public async Task B4_ValidShortRewrite_AppliesNormally_NoDegradedEvent()
+        {
+            var validRewrite = "\"I'm secretly a hacker.\"";
+            var adapter = CreateAdapter(validRewrite, out _, out var degradedEvents);
+            var context = CreateContext();
+
+            var result = await adapter.GetSuccessImprovementAsync(context);
+
+            Assert.Equal("I'm secretly a hacker.", result);
+            Assert.Empty(degradedEvents);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an explicit `SUCCESS_IMPROVEMENT` engine envelope to the success-improvement rewrite prompt while preserving player profile/background and visible chat context.
- Adds fail-closed validation for invalid success-improvement outputs, including hard rejection of `INVALID_ENGINE_STATE` and obvious meta/control output.
- Ensures rejected success-improvement output falls back to the deterministic pre-improvement delivered message before downstream overlays run, with degraded telemetry.

## Test Plan
- [x] `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj -c Release --filter Issue1243 --no-restore`
- [x] `dotnet test tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj -c Release --filter Issue1243 --no-restore`
- [x] `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj -c Release --no-restore`

## Drive-by changes
- None.

Closes #1243
