### PR TITLE
fix(delivery): stop bad-roll messages from becoming all-caps cut-off fragments (#1245)

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryOverlay.cs
+++ b/src/Pinder.Core/Conversation/DeliveryOverlay.cs
@@ -75,13 +75,12 @@ namespace Pinder.Core.Conversation
                     return TrimTail(pickedLine, keepFraction: margin >= 8 ? 0.6 : 0.75);
 
                 case FailureTier.Catastrophe:
-                    // Missed by 10+: spectacular disaster — only a blurted
-                    // fragment survives, and it comes out far too loud.
-                    return Blurt(pickedLine, keepFraction: 0.4);
+                    // Missed by 10+: spectacular disaster — over-hedged, stumbling full line.
+                    return Flail(pickedLine);
 
                 case FailureTier.Legendary:
-                    // Nat 1: maximum humiliation — a tiny, shouted fragment.
-                    return Blurt(pickedLine, keepWords: 3);
+                    // Nat 1: maximum humiliation — extremely flustered nervous opener, full body trailing off.
+                    return Panic(pickedLine);
 
                 default:
                     return pickedLine;
@@ -127,33 +126,16 @@ namespace Pinder.Core.Conversation
             return kept + "...";
         }
 
-        /// <summary>
-        /// Blurt: keep only a short leading fragment and shout it. Either a
-        /// fraction of words or an absolute word cap (whichever is supplied).
-        /// </summary>
-        private static string Blurt(string line, double keepFraction = 0.0, int keepWords = 0)
+        /// <summary>Over-hedged, stumbling version of the full line.</summary>
+        private static string Flail(string line)
         {
-            var words = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (words.Length == 0)
-                return line.ToUpperInvariant();
+            return "well, i mean, " + Stumble(Hesitate(line));
+        }
 
-            int keep;
-            if (keepWords > 0)
-                keep = Math.Min(keepWords, words.Length);
-            else
-            {
-                keep = (int)Math.Floor(words.Length * keepFraction);
-                if (keep < 1) keep = 1;
-            }
-
-            var sb = new StringBuilder();
-            for (int i = 0; i < keep; i++)
-            {
-                if (i > 0) sb.Append(' ');
-                sb.Append(words[i]);
-            }
-            string kept = sb.ToString().TrimEnd('.', '!', '?', '…', ',');
-            return kept.ToUpperInvariant() + "—";
+        /// <summary>Extremely flustered nervous opener with a stumble.</summary>
+        private static string Panic(string line)
+        {
+            return "oh god, um, " + Stumble(Hesitate(line));
         }
 
         private static string LowerFirst(string s)

--- a/tests/Pinder.Core.Tests/Issue1245_BadRollDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1245_BadRollDeliveryTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Regression tests for #1245 — Bad-roll delivery degradation should not mechanically
+    /// force ALL CAPS and should not append a trailing em dash.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1245_BadRollDeliveryTests
+    {
+        [Theory]
+        [InlineData("I think the wizard hat is doing community theatre in your emotional support ecosystem and honestly I respect the commitment.", "wizard", FailureTier.Catastrophe, 10)]
+        [InlineData("I think the wizard hat is doing community theatre in your emotional support ecosystem and honestly I respect the commitment.", "hat", FailureTier.Legendary, 99)]
+        [InlineData("Maybe we could grab tacos this weekend if you are free?", "tacos", FailureTier.Catastrophe, 15)]
+        [InlineData("Maybe we could grab tacos this weekend if you are free?", "tacos", FailureTier.Legendary, 99)]
+        public void SevereDegradation_DoesNotForceAllCaps_NorTrailingEmDash(string input, string expectedTopic, FailureTier tier, int margin)
+        {
+            var output = DeliveryOverlay.Apply(input, tier, margin);
+
+            // a. Not entirely ALL CAPS (must retain lowercase letters)
+            Assert.NotEqual(output.ToUpperInvariant(), output);
+
+            // b. No trailing em dash (U+2014)
+            Assert.False(output.TrimEnd().EndsWith("—"), "Output should not end with an em dash.");
+
+            // c. Is a sendable message
+            Assert.False(string.IsNullOrWhiteSpace(output), "Output should not be empty or whitespace.");
+            Assert.NotEqual("...", output.Trim());
+
+            // d. Topic preserved
+            Assert.True(output.IndexOf(expectedTopic, StringComparison.OrdinalIgnoreCase) >= 0, $"Output must preserve the topic token '{expectedTopic}'.");
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Catastrophe, 12)]
+        [InlineData(FailureTier.Legendary, 99)]
+        public void SevereDegradation_IsDeterministic(FailureTier tier, int margin)
+        {
+            var input = "Determinism check line.";
+            var output1 = DeliveryOverlay.Apply(input, tier, margin);
+            var output2 = DeliveryOverlay.Apply(input, tier, margin);
+
+            Assert.Equal(output1, output2);
+        }
+
+        [Fact]
+        public void Success_CommitsVerbatim()
+        {
+            var input = "This is a perfect delivery.";
+            var output = DeliveryOverlay.Apply(input, FailureTier.Success, 0);
+
+            Assert.Equal(input, output);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1245

## Problem
Severe bad-roll delivery (Catastrophe and Nat1/Legendary) mechanically turned the
player's message into an ALL-CAPS leading fragment ending with an em dash, e.g.
`I THINK THE WIZARD HAT IS DOING COMMUNITY—` or `I THINK THE—`. This collapsed every
severe miss into the same shouty visual gag, implied shouting/interruption that the
move didn't warrant, and discarded the option's topic and character voice.

## Fix
Replaced the `Blurt(...)` transform (leading-fragment + `ToUpperInvariant()` + `"—"`)
for the two severe tiers with deterministic, non-LLM, believable texting degradation
that keeps the FULL body and trails off naturally:
- `Catastrophe` → `Flail`: over-hedged, stumbling version of the full line (`"well, i mean, " + Stumble(Hesitate(line))`).
- `Legendary`/Nat1 → `Panic`: more flustered nervous opener (`"oh god, um, " + Stumble(Hesitate(line))`).

Both reuse the existing deterministic `Hesitate`/`Stumble` helpers, so output stays
pure (same input → same output, no RNG/IO, total function). The now-unused `Blurt`
helper was removed. Fumble/Misfire/TropeTrap are unchanged.

Example (wizard-hat line):
- Catastrophe: `well, i mean, i uh, think the wizard hat is doing community theatre in your emotional support ecosystem and honestly I respect the commitment...`
- Legendary: `oh god, um, i uh, think the wizard hat is doing community theatre ... I respect the commitment...`

## Guarantees preserved (#1125)
- Success still commits the picked line verbatim.
- Only the committed line persists; no ephemeral pre-overlay leak.
- No old creative delivery LLM call returns (still deterministic/non-LLM).
- Roll thresholds, FailureTierLadder, and interest deltas untouched.

## Tests
- New `Issue1245_BadRollDeliveryTests` (test-first, RED→GREEN): for both Catastrophe
  and Legendary across two mixed-case inputs, asserts the output is NOT forced all-caps,
  does NOT end with a trailing em dash, remains a sendable message (non-empty, not `...`),
  preserves the topic token (e.g. `wizard`/`tacos`), and is deterministic. Plus a
  Success-verbatim lock.
- No existing test only mirrored the old caps/em-dash output, so none needed rewriting
  (the #1125/#364 tests recompute via `DeliveryOverlay.Apply` and stay green).

## Local verification
- `dotnet test ... --filter Issue1125` → 4/4 passed
- `dotnet test ... --filter Issue1245_BadRollDeliveryTests` → 7/7 passed
- full `Pinder.Core.Tests` → 3089 passed, 18 skipped (pre-existing), 0 failed

## Out of scope
No pinder-web or Unity changes. No deploy. No roll-threshold / interest-delta / overlay-semantics changes.