### PR TITLE
fix(#1247): restore horniness interest-halving on positive overlay turns

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -352,6 +352,15 @@ namespace Pinder.Core.Conversation
                 progress?.Report(new TurnProgressEvent(TurnProgressStage.HorninessOverlayCompleted, deliveredMessage));
             }
 
+            if (horninessCheckResult.OverlayApplied && interestDelta > 0)
+            {
+                horninessInterestBefore = state.Interest.Current + shadowCorrection;
+                int halvedDelta = (int)Math.Floor(interestDelta / 2.0);
+                int penalty = halvedDelta - interestDelta;
+                horninessInterestPenalty = penalty;
+                interestDelta += penalty;
+            }
+
             // Issue #339: same-turn callback-phrase strip
             deliveredMessage = TextSanitizer.Sanitize(deliveredMessage, CallbackStripper.LayerName, textDiffs);
 

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -191,12 +191,13 @@ namespace Pinder.Core.Tests
         /// Case 2 (the headline worked example): shadow trap on a success FOLLOWED by
         /// horniness check. Base positive delta (Nat 20 → ≥ 4) is first truncated by
         /// the shadow trap to 1, then horniness appends a question (#1209, no penalty).
-        /// Net final interest delta == 1. The turn is STILL NOT a failure: the roll
+        /// Net final interest delta == 0 (shadow truncates to 1, horniness halves 1 to 0).
+        /// The turn is STILL NOT a failure: the roll
         /// verdict stays SUCCESS and the momentum streak still increments.
         /// (horninessDie = 5 → SessionHorniness = 5 → check misses.)
         /// </summary>
         [Fact]
-        public async Task ShadowTrap_ThenHorniness_NetsOne_StillSuccess_MomentumIncrements()
+        public async Task ShadowTrap_ThenHorniness_NetsZero_StillSuccess_MomentumIncrements()
         {
             var (session, llm) = MakeSession(horninessDie: 5);
 
@@ -211,8 +212,8 @@ namespace Pinder.Core.Tests
             Assert.True(result.ShadowCheck.OverlayApplied);
             Assert.True(result.HorninessCheck.IsMiss);
 
-            // shadow → 1, horniness no penalty.
-            Assert.Equal(1, result.InterestDelta);
+            // shadow → 1, horniness halves 1 → 0.
+            Assert.Equal(0, result.InterestDelta);
 
             // Still a success: verdict NOT demoted to Miss.
             Assert.Equal(RollVerdict.Success, result.Roll.Check.FinalVerdict);

--- a/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
@@ -10,6 +10,8 @@ using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 using Pinder.Core.Text;
 using Pinder.Core.Traps;
+using System.IO;
+using Pinder.LlmAdapters;
 using Xunit;
 
 namespace Pinder.Core.Tests
@@ -88,6 +90,21 @@ namespace Pinder.Core.Tests
             public override int Next() => int.MaxValue;
         }
 
+        private static StatDeliveryInstructions LoadDeliveryInstructions()
+        {
+            string dir = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 10; i++)
+            {
+                string candidate = Path.Combine(dir, "data", "delivery-instructions.yaml");
+                if (File.Exists(candidate))
+                    return StatDeliveryInstructions.LoadFrom(File.ReadAllText(candidate));
+                dir = Path.GetDirectoryName(dir)!;
+                if (dir == null) break;
+            }
+            string fallback = Path.Combine("/root/.openclaw/workspace/pinder-core", "data", "delivery-instructions.yaml");
+            return StatDeliveryInstructions.LoadFrom(File.ReadAllText(fallback));
+        }
+
         private static GameSession MakeSession(int sessionHorniness, Random steeringRng, int mainRoll)
         {
             // Dice: index0 = horniness d10 (determines sessionHorniness via clock mod 0), then main d20, then d100.
@@ -98,6 +115,7 @@ namespace Pinder.Core.Tests
                 clock: clock,
                 playerShadows: shadows,
                 steeringRng: steeringRng,
+                statDeliveryInstructions: LoadDeliveryInstructions(),
                 startingInterest: 10); // positive interest
 
             return new GameSession(
@@ -127,7 +145,7 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
-        public async Task HorninessMiss_NoInterestPenalty()
+        public async Task HorninessMiss_HalvesInterestPenalty()
         {
             // We want positive interest delta. mainRoll = 18 ensures success.
             var sessionMiss = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMinRandom(), mainRoll: 18);
@@ -135,12 +153,13 @@ namespace Pinder.Core.Tests
             var resultMiss = await sessionMiss.ResolveTurnAsync(0);
 
             Assert.True(resultMiss.HorninessCheck.IsMiss);
-            Assert.Equal(0, resultMiss.HorninessInterestPenalty);
+            int pre = resultMiss.InterestDelta - resultMiss.HorninessInterestPenalty;
+            Assert.True(pre > 0, "Expected a positive pre-penalty interest delta");
+            Assert.Equal((int)Math.Floor(pre / 2.0) - pre, resultMiss.HorninessInterestPenalty);
 
-            // No horniness breakdown item
-            Assert.DoesNotContain(resultMiss.InterestBreakdown, b => 
-                b.Source.Contains("horniness", StringComparison.OrdinalIgnoreCase) ||
-                b.Label.Contains("horniness", StringComparison.OrdinalIgnoreCase));
+            // Horniness breakdown item should exist and match penalty
+            var horninessItem = Assert.Single(resultMiss.InterestBreakdown, b => b.Source.Contains("horniness", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(resultMiss.HorninessInterestPenalty, horninessItem.Delta);
 
             // Compare to control (success horniness)
             var sessionSuccess = MakeSession(sessionHorniness: 10, steeringRng: new AlwaysMaxRandom(), mainRoll: 18);
@@ -149,8 +168,8 @@ namespace Pinder.Core.Tests
 
             Assert.False(resultSuccess.HorninessCheck.IsMiss);
             
-            // Both turns should have exact same interest delta (horniness no longer halves it)
-            Assert.Equal(resultSuccess.InterestDelta, resultMiss.InterestDelta);
+            // Both turns start with the same base positive delta, but Miss gets halved
+            Assert.True(resultMiss.InterestDelta < resultSuccess.InterestDelta);
         }
 
         [Fact]

--- a/tests/Pinder.Core.Tests/Issue1247_HorninessAccountingAgreementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1247_HorninessAccountingAgreementTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests;
+
+[Trait("Category", "Core")]
+public class Issue1247_HorninessAccountingAgreementTests
+{
+    private const int OverlayFiredSeed = 1;
+    private const int OverlayNotFiredSeed = 0;
+
+    private static StatDeliveryInstructions LoadDeliveryInstructions()
+    {
+        string dir = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 10; i++)
+        {
+            string candidate = Path.Combine(dir, "data", "delivery-instructions.yaml");
+            if (File.Exists(candidate))
+                return StatDeliveryInstructions.LoadFrom(File.ReadAllText(candidate));
+            dir = Path.GetDirectoryName(dir)!;
+            if (dir == null) break;
+        }
+        string fallback = Path.Combine("/root/.openclaw/workspace/pinder-core", "data", "delivery-instructions.yaml");
+        return StatDeliveryInstructions.LoadFrom(File.ReadAllText(fallback));
+    }
+
+    private static CharacterProfile MakeProfile(string name, int allStats = 2)
+    {
+        return new CharacterProfile(
+            stats: TestHelpers.MakeStatBlock(allStats),
+            assembledSystemPrompt: $"You are {name}.",
+            displayName: name,
+            timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+            level: 1);
+    }
+
+    private static GameSession MakeSession(
+        int startingInterest,
+        int sessionHorniness,
+        int steeringSeed,
+        StatDeliveryInstructions? instructions = null,
+        int mainRoll = 15)
+    {
+        var dice = new FixedDice(sessionHorniness, mainRoll, 50);
+        var shadows = new SessionShadowTracker(TestHelpers.MakeStatBlock());
+        var rng = new Random(steeringSeed);
+        var config = new GameSessionConfig(
+            clock: TestHelpers.MakeClock(),
+            playerShadows: shadows,
+            steeringRng: rng,
+            startingInterest: startingInterest,
+            statDeliveryInstructions: instructions);
+
+        return new GameSession(
+            MakeProfile("Player"), MakeProfile("Datee"),
+            new NullLlmAdapter(), dice, new NullTrapRegistry(), config);
+    }
+
+    [Fact]
+    public async Task Overlay_Fires_PositiveInterest_FourWayAgreement()
+    {
+        var instructions = LoadDeliveryInstructions();
+        int startingInterest = 14;
+        var session = MakeSession(
+            startingInterest: startingInterest,
+            sessionHorniness: 15,
+            steeringSeed: OverlayFiredSeed,
+            instructions: instructions,
+            mainRoll: 18); // Ensuring success and positive interest delta
+
+        var turn = await session.StartTurnAsync();
+        var result = await session.ResolveTurnAsync(0);
+
+        Assert.True(result.HorninessCheck.OverlayApplied, "Expected horniness overlay to fire");
+
+        // preHorninessDelta
+        int preHorninessDelta = result.InterestDelta - result.HorninessInterestPenalty;
+        Assert.True(preHorninessDelta > 0, "Expected a positive pre-horniness delta for this test");
+
+        // Rule: Net interest applied is halved positive delta: floor(delta/2)
+        int expectedPenalty = (int)Math.Floor(preHorninessDelta / 2.0) - preHorninessDelta;
+        
+        // (c) result.HorninessInterestPenalty is negative and equals expectedPenalty
+        Assert.True(result.HorninessInterestPenalty < 0, "Penalty should be negative");
+        Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
+
+        // (a) result.InterestDelta == result.InterestBreakdown.Sum(x => x.Delta)
+        int breakdownSum = result.InterestBreakdown.Sum(x => x.Delta);
+        Assert.Equal(result.InterestDelta, breakdownSum);
+
+        // (b) result.StateAfter.Interest == interestBefore + result.InterestDelta
+        Assert.Equal(startingInterest + result.InterestDelta, result.StateAfter.Interest);
+
+        // (d) result.InterestBreakdown contains an item with Source == "horniness_trope_trap"
+        var horninessItem = result.InterestBreakdown.FirstOrDefault(x => x.Source == "horniness_trope_trap");
+        Assert.NotNull(horninessItem);
+        Assert.Equal(result.HorninessInterestPenalty, horninessItem.Delta);
+
+        // (e) positive pre-horniness components sum to preHorninessDelta
+        int preHorninessBreakdownSum = result.InterestBreakdown
+            .Where(x => x.Source != "horniness_trope_trap")
+            .Sum(x => x.Delta);
+        Assert.Equal(preHorninessDelta, preHorninessBreakdownSum);
+    }
+
+    [Fact]
+    public async Task Overlay_Fires_NonPositiveDelta_NoPenalty()
+    {
+        var instructions = LoadDeliveryInstructions();
+        int startingInterest = 14;
+        var session = MakeSession(
+            startingInterest: startingInterest,
+            sessionHorniness: 15,
+            steeringSeed: OverlayFiredSeed,
+            instructions: instructions,
+            mainRoll: 10); // Low roll ensures negative/zero interest delta
+
+        var turn = await session.StartTurnAsync();
+        var result = await session.ResolveTurnAsync(0);
+
+        Assert.True(result.HorninessCheck.OverlayApplied, "Expected overlay to fire");
+        
+        // Result shouldn't have positive preHorninessDelta
+        int preHorninessDelta = result.InterestDelta - result.HorninessInterestPenalty;
+        Assert.True(preHorninessDelta <= 0, "Expected a non-positive delta for this test");
+
+        Assert.Equal(0, result.HorninessInterestPenalty);
+        var horninessItem = result.InterestBreakdown.FirstOrDefault(x => x.Source == "horniness_trope_trap");
+        Assert.Null(horninessItem);
+
+        Assert.Equal(startingInterest + result.InterestDelta, result.StateAfter.Interest);
+        Assert.Equal(result.InterestDelta, result.InterestBreakdown.Sum(x => x.Delta));
+    }
+
+    [Fact]
+    public async Task Overlay_NotFired_ControlTurn_NoPenalty()
+    {
+        var instructions = LoadDeliveryInstructions();
+        int startingInterest = 14;
+        var session = MakeSession(
+            startingInterest: startingInterest,
+            sessionHorniness: 15,
+            steeringSeed: OverlayNotFiredSeed,
+            instructions: instructions,
+            mainRoll: 18);
+
+        var turn = await session.StartTurnAsync();
+        var result = await session.ResolveTurnAsync(0);
+
+        Assert.False(result.HorninessCheck.OverlayApplied, "Expected horniness overlay NOT to fire");
+
+        Assert.Equal(0, result.HorninessInterestPenalty);
+        var horninessItem = result.InterestBreakdown.FirstOrDefault(x => x.Source == "horniness_trope_trap");
+        Assert.Null(horninessItem);
+
+        Assert.Equal(startingInterest + result.InterestDelta, result.StateAfter.Interest);
+        Assert.Equal(result.InterestDelta, result.InterestBreakdown.Sum(x => x.Delta));
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -145,9 +145,10 @@ namespace Pinder.Core.Tests
             Assert.True(result.ShadowCheck.OverlayApplied,
                 "Shadow corruption overlay must apply on Honesty/Denial TropeTrap");
 
-            // #1209: shadow trap truncates the positive delta to 1, horniness has no penalty.
-            // Net final delta == 1.
-            Assert.Equal(1, result.InterestDelta);
+            // #1209: shadow trap truncates the positive delta to 1.
+            // #1247: horniness halves the post-shadow delta (floor(1/2) = 0).
+            // Net final delta == 0.
+            Assert.Equal(0, result.InterestDelta);
 
             // #1095: the turn is STILL a success — the FINAL verdict is NOT a miss.
             Assert.Equal(Pinder.Core.Rolls.RollVerdict.Success, result.Roll.Check.FinalVerdict);
@@ -233,9 +234,10 @@ namespace Pinder.Core.Tests
             Assert.False(result.ShadowCheck.CheckPerformed,
                 "Shadow check must not be performed when shadow value is 0");
 
-            int preDelta = result.InterestDelta;
+            int preDelta = result.InterestDelta - result.HorninessInterestPenalty;
             Assert.True(preDelta > 0, $"pre-§15 delta must be positive; got {preDelta}");
-            Assert.Equal(0, result.HorninessInterestPenalty);
+            int expectedPenalty = (int)Math.Floor(preDelta / 2.0) - preDelta;
+            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
 
             // Invariant: before + final delta == after.
             Assert.Equal(interestBefore + result.InterestDelta, interestAfter);

--- a/tests/Pinder.Core.Tests/Issue743_HorninessInterestPenaltyTests.cs
+++ b/tests/Pinder.Core.Tests/Issue743_HorninessInterestPenaltyTests.cs
@@ -15,6 +15,7 @@ namespace Pinder.Core.Tests
     /// <summary>
     /// Tests for issue #743: Horniness overlay fires → interest halved (floor).
     /// Rule §15.horniness-interest-penalty.
+    /// Halving was removed by #1209 but restored by #1247.
     /// </summary>
     [Trait("Category", "Core")]
     public class Issue743_HorninessInterestPenaltyTests
@@ -74,10 +75,10 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Horniness overlay fires + positive interest → no penalty (issue #1209).
+        /// Horniness overlay fires + positive interest → halving restored (#1247).
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_PositiveInterest_NoPenalty()
+        public async Task Overlay_Fires_PositiveInterest_HalvesInterest()
         {
             var instructions = LoadDeliveryInstructions();
             var session = MakeSession(
@@ -94,17 +95,20 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected horniness overlay to fire with seed=1, sessionHorniness=15");
 
-            // Penalty should be zero (removed in #1209)
-            Assert.Equal(0, result.HorninessInterestPenalty);
+            int pre = result.InterestDelta - result.HorninessInterestPenalty;
+            Assert.True(pre > 0, "Expected a positive pre-penalty interest delta");
 
-            Assert.True(result.InterestDelta > 0, "Expected a positive interest delta");
+            int expectedPenalty = (int)Math.Floor(pre / 2.0) - pre;
+            Assert.True(result.HorninessInterestPenalty < 0, "Expected a negative penalty");
+            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
+            Assert.Equal((int)Math.Floor(pre / 2.0), result.InterestDelta);
         }
 
         /// <summary>
-        /// Horniness overlay fires + odd interest (15) → no penalty.
+        /// Horniness overlay fires + odd interest (15) → applies floor halving.
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_OddInterest15_NoPenalty()
+        public async Task Overlay_Fires_OddInterest_FloorHalving()
         {
             var instructions = LoadDeliveryInstructions();
             // We want an odd delta so we can test the floor behavior.
@@ -131,8 +135,16 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected horniness overlay to fire");
 
-            Assert.True(result.InterestDelta > 0, "Test requires positive delta");
-            Assert.Equal(0, result.HorninessInterestPenalty);
+            int pre = result.InterestDelta - result.HorninessInterestPenalty;
+            Assert.True(pre > 0, "Test requires positive delta");
+            
+            int expectedPenalty = (int)Math.Floor(pre / 2.0) - pre;
+            Assert.Equal(expectedPenalty, result.HorninessInterestPenalty);
+            
+            if (pre % 2 != 0)
+            {
+                Assert.Equal((int)Math.Floor(pre / 2.0), result.InterestDelta);
+            }
         }
 
         /// <summary>
@@ -233,10 +245,10 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// InterestDelta on TurnResult is unmodified by horniness overlay.
+        /// InterestDelta on TurnResult includes penalty from horniness overlay.
         /// </summary>
         [Fact]
-        public async Task Overlay_Fires_InterestDeltaExcludesPenalty()
+        public async Task Overlay_Fires_InterestDeltaIncludesPenalty()
         {
             var instructions = LoadDeliveryInstructions();
             var session = MakeSession(
@@ -252,7 +264,9 @@ namespace Pinder.Core.Tests
             Assert.True(result.HorninessCheck.OverlayApplied,
                 "Expected overlay to fire");
 
-            Assert.Equal(0, result.HorninessInterestPenalty);
+            Assert.True(result.HorninessInterestPenalty < 0, "Expected penalty to be negative");
+            int pre = result.InterestDelta - result.HorninessInterestPenalty;
+            Assert.True(pre > result.InterestDelta, "Expected pre-penalty delta to be greater than InterestDelta");
         }
 
         /// <summary>

--- a/tests/Pinder.Core.Tests/Issue768_InterestBreakdownTests.cs
+++ b/tests/Pinder.Core.Tests/Issue768_InterestBreakdownTests.cs
@@ -156,22 +156,22 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Horniness penalty removed.
-        /// Sum invariant: 2 + 1 + 0 == 3.
+        /// Horniness penalty applied.
+        /// Sum invariant: 2 + 1 - 2 == 1.
         /// </summary>
         [Fact]
         public void Breakdown_WithHorninessTropeTrap_SumEqualsInterestDelta()
         {
             var result = MakeTurnResult(
-                interestDelta: 3,
+                interestDelta: 1,
                 baseInterestDelta: 2,
                 riskBonusDelta: 1,
-                horninessInterestPenalty: 0);
+                horninessInterestPenalty: -2);
 
-            Assert.Equal(3, result.InterestDelta);
-            Assert.Equal(3, result.InterestBreakdown.Sum(x => x.Delta));
-            Assert.Equal(2, result.InterestBreakdown.Count);
-            Assert.DoesNotContain(result.InterestBreakdown, x => x.Source == "horniness_trope_trap");
+            Assert.Equal(1, result.InterestDelta);
+            Assert.Equal(1, result.InterestBreakdown.Sum(x => x.Delta));
+            Assert.Equal(3, result.InterestBreakdown.Count);
+            Assert.Contains(result.InterestBreakdown, x => x.Source == "horniness_trope_trap");
         }
 
         /// <summary>
@@ -405,21 +405,22 @@ namespace Pinder.Core.Tests
         }
 
         /// <summary>
-        /// Variant: horniness TropeTrap fires on a success turn. No penalty.
-        /// Sum invariant: 2 + 0 == 2.
+        /// Variant: horniness TropeTrap fires on a success turn. Penalty applies.
+        /// Sum invariant: 2 - 1 == 1.
         /// </summary>
         [Fact]
-        public void LiveCase_HorninessOnPositiveInterest_NoPenalty_SumInvariantHolds()
+        public void LiveCase_HorninessOnPositiveInterest_HalvesInterest_SumInvariantHolds()
         {
             var result = MakeTurnResult(
-                interestDelta: 2,
-                baseInterestDelta: 2,                horninessInterestPenalty: 0);
+                interestDelta: 1,
+                baseInterestDelta: 2,
+                horninessInterestPenalty: -1);
 
-            Assert.Equal(2, result.InterestDelta);
-            Assert.Equal(2, result.InterestBreakdown.Sum(x => x.Delta));
-            Assert.Equal(1, result.InterestBreakdown.Count);
+            Assert.Equal(1, result.InterestDelta);
+            Assert.Equal(1, result.InterestBreakdown.Sum(x => x.Delta));
+            Assert.Equal(2, result.InterestBreakdown.Count);
             Assert.Contains(result.InterestBreakdown, x => x.Source == "base_roll" && x.Delta == 2);
-            Assert.DoesNotContain(result.InterestBreakdown, x => x.Source == "horniness_trope_trap");
+            Assert.Contains(result.InterestBreakdown, x => x.Source == "horniness_trope_trap" && x.Delta == -1);
         }
     }
 }


### PR DESCRIPTION
Closes #1247

## Problem
Commit #1209 (`1bb3752` "horniness appends a horny question; no rewrite/penalty") removed the horniness interest-halving from the engine. As a result, when the horniness overlay applied on a positive-interest success turn, the positive interest delta was no longer halved — `HorninessInterestPenalty` was always 0 and `StateAfter.Interest` reflected the full, unhalved gain. The owner reported the interest data no longer appears halved/capped as intended.

## Fix (engine-only, pinder-core)
Restore the halving in `src/Pinder.Core/Conversation/DeliveryStage.cs`, coexisting with #1209's horny-question append:

- When `horninessCheckResult.OverlayApplied && interestDelta > 0`:
  - `halvedDelta = floor(interestDelta / 2.0)`
  - `penalty = halvedDelta - interestDelta` (negative)
  - `interestDelta += penalty` (final delta becomes the halved value)
  - `horninessInterestBefore` snapshot recorded for display
- Non-positive / non-fired turns: penalty stays 0 (no regression).

`TurnOrchestrator.Resolve.cs` already applies `HorninessInterestPenalty` to state exactly once, and `TurnResult.BuildBreakdown` already itemizes the `horniness_trope_trap` line, so the four-way accounting agreement holds:
`TurnResult.InterestDelta == sum(InterestBreakdown.Delta)`, `StateAfter.Interest == interestBefore + InterestDelta`, `HorninessInterestPenalty == floor(pre/2) - pre`, and the breakdown carries the horniness line.

## Tests
- NEW `Issue1247_HorninessAccountingAgreementTests.cs`: deterministic full-turn regression pinning the four-way agreement on a positive overlay turn, the non-positive-no-penalty case, and the overlay-not-fired control.
- Reconciled #1209-era tests that asserted no-penalty back to asserting the restored halving: `Issue743`, `Issue768`, `Issue399`, `Issue1095`, `Issue1209` (chained shadow-trap→horniness now nets 0: truncate to 1, then floor(1/2)=0).

## Local verification (no GitHub Actions)
- `Pinder.Core.Tests`: 3092 passed / 0 failed / 18 skipped
- `Pinder.LlmAdapters.Tests`: 1069 passed / 0 failed
- `Pinder.Rules.Tests`: 11 failures are PRE-EXISTING (GameDefinitionYaml* content/path tests fail identically on the untouched `origin/main` baseline e4e0fda) — not caused by this change.