### PR TITLE
feat(#1248): DATEE horniness reaction gated on absolute Interest threshold

### DIFF
--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -152,6 +152,12 @@ prompts:
   interest-narrative-5-9:
     system_prompt: >-
       Skeptical. Still testing.
+  datee-horniness-reaction-below-threshold:
+    system_prompt: >-
+      The player's last message came across as overtly horny / too eager / too forward — but this is NOT charming at your current interest. You are not won over by raw thirst this early. React guarded, a little cooler, or mildly awkward; the horniness does not land as flirtation and it does NOT raise your interest by itself. Do NOT reward it with warmth you haven't decided to give. Resistance is still real; Date Secured remains gated at Interest 25 and this message does not move you toward it. Do NOT explain the mechanic — just let your reaction show it.
+  datee-horniness-reaction-high-interest:
+    system_prompt: >-
+      The player's last message came across as overtly horny / too eager — and at your current high interest you MAY receive it warmly, as mutual flirtation, if it fits your character. You can lean in or flirt back, still in your own voice, without gushing. This is allowed because you are already genuinely into them — not because horniness is automatically charming. It still does NOT secure the date: Date Secured remains gated at Interest 25, and warmth here cannot shortcut that terminal state.
   datee-reaction-catastrophe:
     system_prompt: >-
       Their last message was a disaster. Something in it was genuinely confusing or uncomfortable. Your response reflects real discomfort — shorter, cooler, possibly questioning. The vibe has taken a visible hit. Do NOT explain what went wrong. Just let your reaction show it.

--- a/src/Pinder.Core/Conversation/DateeContext.cs
+++ b/src/Pinder.Core/Conversation/DateeContext.cs
@@ -68,6 +68,12 @@ namespace Pinder.Core.Conversation
         /// <summary>Active archetype directive for the datee character, or null if none.</summary>
         public string ActiveArchetypeDirective { get; }
 
+        /// <summary>True when the horniness overlay made the player's delivered message overtly horny/eager this turn.</summary>
+        public bool HorninessOverlayApplied { get; }
+
+        /// <summary>Miss tier of the horniness overlay this turn; only meaningful when HorninessOverlayApplied is true.</summary>
+        public FailureTier HorninessTier { get; }
+
         public DateeContext(
             string dateePrompt,
             IReadOnlyList<(string Sender, string Text)> conversationHistory,
@@ -85,7 +91,9 @@ namespace Pinder.Core.Conversation
             int currentTurn = 0,
             FailureTier deliveryTier = FailureTier.Success,
             string activeArchetypeDirective = null,
-            PublicProfileCard? playerAvatarCard = null)
+            PublicProfileCard? playerAvatarCard = null,
+            bool horninessOverlayApplied = false,
+            FailureTier horninessTier = FailureTier.Success)
         {
             PlayerAvatarCard = playerAvatarCard ?? PublicProfileCard.Empty;
             DateePrompt = dateePrompt ?? throw new System.ArgumentNullException(nameof(dateePrompt));
@@ -104,6 +112,8 @@ namespace Pinder.Core.Conversation
             CurrentTurn = currentTurn;
             DeliveryTier = deliveryTier;
             ActiveArchetypeDirective = activeArchetypeDirective;
+            HorninessOverlayApplied = horninessOverlayApplied;
+            HorninessTier = horninessTier;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/DateeResponseStage.cs
+++ b/src/Pinder.Core/Conversation/DateeResponseStage.cs
@@ -80,7 +80,9 @@ namespace Pinder.Core.Conversation
                 // #1123 strict bleed isolation: the datee session sees ONLY the
                 // avatar's public dating-app card, never the avatar's full
                 // private system prompt.
-                playerAvatarCard: GameSessionHelpers.BuildPublicProfileCard(player));
+                playerAvatarCard: GameSessionHelpers.BuildPublicProfileCard(player),
+                horninessOverlayApplied: deliveryStage.HorninessCheckResult.OverlayApplied,
+                horninessTier: deliveryStage.HorninessCheckResult.Tier);
 
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DateeResponseStarted));
 

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -104,6 +104,10 @@ namespace Pinder.LlmAdapters
 
         internal static string DateeReactionLegendary => GetCatalogString("datee-reaction-legendary");
 
+        internal static string DateeHorninessReactionBelowThreshold => GetCatalogString("datee-horniness-reaction-below-threshold");
+
+        internal static string DateeHorninessReactionHighInterest => GetCatalogString("datee-horniness-reaction-high-interest");
+
         // ── Interest narrative bands ────────────────────────────────────────
 
         internal static string InterestNarrative_1_4 => GetCatalogString("interest-narrative-1-4");

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
@@ -9,6 +9,8 @@ namespace Pinder.LlmAdapters
 {
     public static partial class SessionDocumentBuilder
     {
+        public const int HorninessWarmthThreshold = 18;
+
         /// <summary>
         /// Computes the datee response length ceiling from the player's message length.
         /// Formula: ceiling = min(600, max(playerLen × 2, 80)).
@@ -161,6 +163,20 @@ namespace Pinder.LlmAdapters
                 case FailureTier.Catastrophe: return PromptTemplates.DateeReactionCatastrophe;
                 case FailureTier.Legendary: return PromptTemplates.DateeReactionLegendary;
                 default: return string.Empty;
+            }
+        }
+
+        internal static string GetHorninessReactionGuidance(int interest, bool overlayApplied, Pinder.Core.Rolls.FailureTier tier)
+        {
+            if (!overlayApplied) return string.Empty;
+
+            if (interest < HorninessWarmthThreshold)
+            {
+                return $"Current interest: {interest}/25. {PromptTemplates.DateeHorninessReactionBelowThreshold}";
+            }
+            else
+            {
+                return $"Current interest: {interest}/25. {PromptTemplates.DateeHorninessReactionHighInterest}";
             }
         }
     }

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -252,6 +252,17 @@ namespace Pinder.LlmAdapters
 
             sb.AppendLine();
 
+            if (context.HorninessOverlayApplied)
+            {
+                string horninessGuidance = GetHorninessReactionGuidance(context.InterestAfter, context.HorninessOverlayApplied, context.HorninessTier);
+                string templateKey = context.InterestAfter < HorninessWarmthThreshold 
+                    ? "datee-horniness-reaction-below-threshold" 
+                    : "datee-horniness-reaction-high-interest";
+                sb.AppendLine("HORNINESS REACTION GUIDANCE");
+                sb.AppendLine(horninessGuidance, GetTemplateSource(templateKey), "datee-horniness-reaction");
+                sb.AppendLine();
+            }
+
             // [ENGINE — DATEE] injection block with interest narrative
             string interestNarrative = PromptTemplates.GetInterestNarrative(context.InterestAfter);
             string dateeBlock = PromptTemplates.EngineDateeBlock

--- a/tests/Pinder.LlmAdapters.Tests/Issue1248_DateeHorninessThresholdTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1248_DateeHorninessThresholdTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests;
+
+public class Issue1248_DateeHorninessThresholdTests
+{
+    private static DateeContext MakeDateeContext(
+        int interestAfter, 
+        bool horninessOverlayApplied = false, 
+        FailureTier horninessTier = FailureTier.Success)
+    {
+        return new DateeContext(
+            dateePrompt: "datee prompt",
+            conversationHistory: new List<(string, string)> { ("P", "hey"), ("O", "hi") },
+            dateeLastMessage: "hi",
+            activeTraps: Array.Empty<string>(),
+            currentInterest: interestAfter,
+            playerDeliveredMessage: "wow, you look hot",
+            interestBefore: interestAfter,
+            interestAfter: interestAfter,
+            responseDelayMinutes: 2.0,
+            playerName: "P",
+            dateeName: "O",
+            horninessOverlayApplied: horninessOverlayApplied,
+            horninessTier: horninessTier);
+    }
+
+    private bool ContainsAny(string text, params string[] options)
+    {
+        foreach (var opt in options)
+        {
+            if (text.Contains(opt, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void Threshold_Constant_Is18()
+    {
+        Assert.Equal(18, SessionDocumentBuilder.HorninessWarmthThreshold);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(12)]
+    [InlineData(17)]
+    public void HorninessOverlayApplied_BelowThreshold_GuidanceIsGuardedNegative(int interest)
+    {
+        var ctx = MakeDateeContext(interest, horninessOverlayApplied: true, horninessTier: FailureTier.Misfire);
+        var result = SessionDocumentBuilder.BuildDateePrompt(ctx);
+
+        // The implementer must include "horny" or "too eager"/"too forward" in the prompt text.
+        Assert.True(ContainsAny(result, "horny", "too eager", "too forward"), 
+            "Should contain a recognizable horniness-reaction header/marker.");
+
+        // The below-threshold block must contain one of these guarded-direction cues.
+        Assert.True(ContainsAny(result, "guarded", "cooler", "awkward", "does not land", "not charming"),
+            "Should contain guarded/negative direction language.");
+
+        // Must still reaffirm the 25 gate
+        Assert.Contains("25", result);
+    }
+
+    [Theory]
+    [InlineData(18)]
+    [InlineData(20)]
+    [InlineData(24)]
+    public void HorninessOverlayApplied_AtOrAboveThreshold_GuidanceAllowsWarmth(int interest)
+    {
+        var ctx = MakeDateeContext(interest, horninessOverlayApplied: true, horninessTier: FailureTier.Success);
+        var result = SessionDocumentBuilder.BuildDateePrompt(ctx);
+
+        Assert.True(ContainsAny(result, "horny", "too eager", "too forward"),
+            "Should contain a recognizable horniness-reaction header/marker.");
+
+        // The at/above threshold block must contain one of these warmth-permitting cues.
+        Assert.True(ContainsAny(result, "may", "can", "mutual", "warmly", "flirt"),
+            "Should contain warmth-permitting direction.");
+
+        // Must still reaffirm the 25 gate
+        Assert.Contains("25", result);
+    }
+
+    [Fact]
+    public void HorninessOverlayApplied_HighInterest_StillGatedAt25()
+    {
+        var ctx = MakeDateeContext(24, horninessOverlayApplied: true, horninessTier: FailureTier.Success);
+        var result = SessionDocumentBuilder.BuildDateePrompt(ctx);
+
+        // The existing prompt already includes "Below Interest 25" rule.
+        Assert.Contains("Below Interest 25", result);
+        
+        // Assert it does NOT say the date is secured
+        Assert.DoesNotContain("date is secured", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secured at " + 24, result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("25", result);
+    }
+
+    [Fact]
+    public void HorninessOverlayApplied_BoundaryAt17vs18()
+    {
+        var block17 = SessionDocumentBuilder.GetHorninessReactionGuidance(17, true, FailureTier.Success);
+        Assert.True(ContainsAny(block17, "guarded", "cooler", "awkward", "does not land", "not charming"));
+        Assert.False(ContainsAny(block17, "mutual", "warmly", "flirt back"));
+
+        var block18 = SessionDocumentBuilder.GetHorninessReactionGuidance(18, true, FailureTier.Success);
+        Assert.True(ContainsAny(block18, "may", "can", "mutual", "warmly", "flirt"));
+    }
+
+    [Fact]
+    public void NoHorninessOverlay_NoHorninessBlock()
+    {
+        var ctx = MakeDateeContext(20, horninessOverlayApplied: false);
+        var result = SessionDocumentBuilder.BuildDateePrompt(ctx);
+
+        // The rest of the prompt (resistance block etc.) is unchanged, and horniness reaction is absent
+        Assert.False(ContainsAny(result, "horny", "too eager", "too forward"));
+    }
+}


### PR DESCRIPTION
Closes #1248

## Problem
When the horniness overlay made the player's delivered message overtly horny/too-eager, the DATEE's response did not depend on the DATEE's absolute current Interest. Horniness could land as positive flirtation at low/mid interest, which it should not — it should only have a chance to land warmly at a high interest threshold.

## Fix (engine + prompt, pinder-core)
Plumb the horniness-overlay signal into the DATEE-response context and gate the reaction guidance on absolute current Interest:

- `DateeContext` gains `HorninessOverlayApplied` (bool) and `HorninessTier` (FailureTier), both optional/back-compat.
- `DateeResponseStage` passes `deliveryStage.HorninessCheckResult.OverlayApplied` / `.Tier` into the context.
- `SessionDocumentBuilder`:
  - New public const `HorninessWarmthThreshold = 18`.
  - New `GetHorninessReactionGuidance(int interest, bool overlayApplied, FailureTier tier)` — empty when not applied; **below 18** → guarded/cooler/awkward, horniness does NOT land as flirtation; **>= 18** → DATEE MAY receive it warmly / as mutual flirtation, still in character.
  - `BuildDateePromptEx` injects the block ONLY when the overlay applied this turn (absent otherwise).
- Two new data-driven `data/prompts/templates.yaml` keys (`datee-horniness-reaction-below-threshold`, `datee-horniness-reaction-high-interest`) so threshold/tone changes are testable rather than hidden in prose.

**Date Secured stays gated at Interest 25:** both bands explicitly reaffirm that high-interest warmth cannot shortcut the terminal state, and the base prompt's "Below Interest 25" FUNDAMENTAL RULE is unchanged. The guidance directs the DATEE to react to the situation, not narrate the mechanic.

## Tests
- NEW `Issue1248_DateeHorninessThresholdTests.cs`: below-threshold guarded, at/above-threshold warmth-permitting, the exact 17-vs-18 boundary (scoped to the guidance block), high-interest-still-gated-at-25, no-overlay-no-block, and the threshold constant.

## Local verification (no GitHub Actions)
- `Issue1248_DateeHorninessThresholdTests`: 11 passed / 0 failed
- `Pinder.LlmAdapters.Tests`: 1080 passed / 0 failed
- `Pinder.Core.Tests`: 3092 passed / 0 failed / 18 skipped
- (Pinder.Rules.Tests has 11 pre-existing failures on the untouched baseline, unrelated to this change.)