### PR TITLE
feat(#1249): scale DATEE horniness-miss reaction intensity by FailureTier

### DIFF
--- a/data/prompts/templates.yaml
+++ b/data/prompts/templates.yaml
@@ -158,6 +158,18 @@ prompts:
   datee-horniness-reaction-high-interest:
     system_prompt: >-
       The player's last message came across as overtly horny / too eager — and at your current high interest you MAY receive it warmly, as mutual flirtation, if it fits your character. You can lean in or flirt back, still in your own voice, without gushing. This is allowed because you are already genuinely into them — not because horniness is automatically charming. It still does NOT secure the date: Date Secured remains gated at Interest 25, and warmth here cannot shortcut that terminal state.
+  datee-horniness-tier-intensity-fumble:
+    system_prompt: >-
+      Intensity: this was a SLIGHT, barely-noticeable thirsty stumble. Your reaction is small — a flicker of mild awkwardness, easily recovered. Do not overreact.
+  datee-horniness-tier-intensity-misfire:
+    system_prompt: >-
+      Intensity: this was a NOTICEABLE thirsty stumble — an accidental escalation that registered. You are a little more guarded, a step cooler, but not alarmed.
+  datee-horniness-tier-intensity-trope-trap:
+    system_prompt: >-
+      Intensity: this was a clear, cringe dating-app horny cliché — a disruptive pattern you have seen before. Your warmth drops noticeably and your reply shows the pattern landed wrong.
+  datee-horniness-tier-intensity-catastrophe:
+    system_prompt: >-
+      Intensity: this was a SEVERE, major involuntary escalation — the kind of message that visibly disturbs you and seriously sets the conversation back. React strongly: real recoil, a marked drop in warmth, a much cooler or shorter reply. This is the opposite of charming and your reaction must show the severity, especially at lower interest. Do NOT explain the mechanic.
   datee-reaction-catastrophe:
     system_prompt: >-
       Their last message was a disaster. Something in it was genuinely confusing or uncomfortable. Your response reflects real discomfort — shorter, cooler, possibly questioning. The vibe has taken a visible hit. Do NOT explain what went wrong. Just let your reaction show it.

--- a/src/Pinder.LlmAdapters/PromptTemplates.cs
+++ b/src/Pinder.LlmAdapters/PromptTemplates.cs
@@ -108,6 +108,14 @@ namespace Pinder.LlmAdapters
 
         internal static string DateeHorninessReactionHighInterest => GetCatalogString("datee-horniness-reaction-high-interest");
 
+        internal static string DateeHorninessTierIntensityFumble => GetCatalogString("datee-horniness-tier-intensity-fumble");
+
+        internal static string DateeHorninessTierIntensityMisfire => GetCatalogString("datee-horniness-tier-intensity-misfire");
+
+        internal static string DateeHorninessTierIntensityTropeTrap => GetCatalogString("datee-horniness-tier-intensity-trope-trap");
+
+        internal static string DateeHorninessTierIntensityCatastrophe => GetCatalogString("datee-horniness-tier-intensity-catastrophe");
+
         // ── Interest narrative bands ────────────────────────────────────────
 
         internal static string InterestNarrative_1_4 => GetCatalogString("interest-narrative-1-4");

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Helpers.cs
@@ -166,18 +166,33 @@ namespace Pinder.LlmAdapters
             }
         }
 
+        private static string GetHorninessTierIntensity(Pinder.Core.Rolls.FailureTier tier)
+        {
+            switch (tier)
+            {
+                case FailureTier.Fumble: return PromptTemplates.DateeHorninessTierIntensityFumble;
+                case FailureTier.Misfire: return PromptTemplates.DateeHorninessTierIntensityMisfire;
+                case FailureTier.TropeTrap: return PromptTemplates.DateeHorninessTierIntensityTropeTrap;
+                case FailureTier.Catastrophe:
+                case FailureTier.Legendary:
+                    return PromptTemplates.DateeHorninessTierIntensityCatastrophe;
+                default:
+                    return string.Empty;
+            }
+        }
+
         internal static string GetHorninessReactionGuidance(int interest, bool overlayApplied, Pinder.Core.Rolls.FailureTier tier)
         {
             if (!overlayApplied) return string.Empty;
 
-            if (interest < HorninessWarmthThreshold)
-            {
-                return $"Current interest: {interest}/25. {PromptTemplates.DateeHorninessReactionBelowThreshold}";
-            }
-            else
-            {
-                return $"Current interest: {interest}/25. {PromptTemplates.DateeHorninessReactionHighInterest}";
-            }
+            string band = interest < HorninessWarmthThreshold
+                ? PromptTemplates.DateeHorninessReactionBelowThreshold
+                : PromptTemplates.DateeHorninessReactionHighInterest;
+            string tierIntensity = GetHorninessTierIntensity(tier);
+            string composed = $"Current interest: {interest}/25. {band}";
+            if (!string.IsNullOrWhiteSpace(tierIntensity))
+                composed += " " + tierIntensity;
+            return composed;
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1249_HorninessOverlayTierIntensityTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1249_HorninessOverlayTierIntensityTests.cs
@@ -1,0 +1,114 @@
+using System.IO;
+using Pinder.Core.Rolls;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class Issue1249_HorninessOverlayTierIntensityTests
+    {
+        private static StatDeliveryInstructions LoadDeliveryInstructions()
+        {
+            string dir = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 10; i++)
+            {
+                string candidate = Path.Combine(dir, "data", "delivery-instructions.yaml");
+                if (File.Exists(candidate))
+                    return StatDeliveryInstructions.LoadFrom(File.ReadAllText(candidate));
+                dir = Path.GetDirectoryName(dir)!;
+                if (dir == null) break;
+            }
+            string fallback = Path.Combine("/tmp/pinder-core-1249", "data", "delivery-instructions.yaml");
+            return StatDeliveryInstructions.LoadFrom(File.ReadAllText(fallback));
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        public void EveryTier_IsNonEmpty_AndContainsOverlayMarker(FailureTier tier)
+        {
+            var instructions = LoadDeliveryInstructions();
+            string composed = instructions.GetHorninessOverlayInstruction(tier)!;
+            
+            Assert.False(string.IsNullOrWhiteSpace(composed), $"horniness_overlay for tier {tier} resolved to empty");
+            Assert.Contains("OVERLAY:", composed);
+        }
+
+        [Fact]
+        public void Catastrophe_IsDistinctFromFumbleAndMisfire()
+        {
+            var instructions = LoadDeliveryInstructions();
+            string catastrophe = instructions.GetHorninessOverlayInstruction(FailureTier.Catastrophe)!;
+            string fumble = instructions.GetHorninessOverlayInstruction(FailureTier.Fumble)!;
+            string misfire = instructions.GetHorninessOverlayInstruction(FailureTier.Misfire)!;
+
+            Assert.NotEqual(fumble, catastrophe);
+            Assert.NotEqual(misfire, catastrophe);
+        }
+
+        [Fact]
+        public void Catastrophe_ContainsMaximalIntensityMarker_WhileFumbleDoesNot()
+        {
+            var instructions = LoadDeliveryInstructions();
+            string catastrophe = instructions.GetHorninessOverlayInstruction(FailureTier.Catastrophe)!;
+            string fumble = instructions.GetHorninessOverlayInstruction(FailureTier.Fumble)!;
+
+            // Catastrophe maximal-intensity marker assertion
+            bool hasStrongMarker = catastrophe.Contains("every word") ||
+                                   catastrophe.Contains("maximum") ||
+                                   catastrophe.Contains("rewrites itself") ||
+                                   catastrophe.Contains("psychic violence") ||
+                                   catastrophe.Contains("mortified");
+            Assert.True(hasStrongMarker, "Catastrophe must contain a maximal intensity marker.");
+
+            // Fumble lacks maximal marker
+            Assert.DoesNotContain("every word", fumble);
+            Assert.DoesNotContain("maximum", fumble);
+            Assert.DoesNotContain("rewrites itself", fumble);
+            Assert.DoesNotContain("psychic violence", fumble);
+            Assert.DoesNotContain("mortified", fumble);
+
+            // Fumble minimal-intensity marker assertion
+            bool hasMildMarker = fumble.Contains("one word") ||
+                                 fumble.Contains("single word") ||
+                                 fumble.Contains("one verb") ||
+                                 fumble.Contains("INVOLUNTARY HEAT (one word");
+            Assert.True(hasMildMarker, "Fumble must contain a minimal intensity marker.");
+        }
+
+        [Fact]
+        public void Catastrophe_CarriesContentIsTheJokeReinforcement_OthersDoNot()
+        {
+            var instructions = LoadDeliveryInstructions();
+            string catastrophe = instructions.GetHorninessOverlayInstruction(FailureTier.Catastrophe)!;
+            string fumble = instructions.GetHorninessOverlayInstruction(FailureTier.Fumble)!;
+            string misfire = instructions.GetHorninessOverlayInstruction(FailureTier.Misfire)!;
+            string tropeTrap = instructions.GetHorninessOverlayInstruction(FailureTier.TropeTrap)!;
+
+            string reinforcement = "content is the joke";
+
+            Assert.Contains(reinforcement, catastrophe);
+            Assert.DoesNotContain(reinforcement, fumble);
+            Assert.DoesNotContain(reinforcement, misfire);
+            Assert.DoesNotContain(reinforcement, tropeTrap);
+        }
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        public void TextingRegister_ContainsAppendQuestionDirective_AndNoStageDirections(FailureTier tier)
+        {
+            var instructions = LoadDeliveryInstructions();
+            string composed = instructions.GetHorninessOverlayInstruction(tier)!;
+
+            // We skip brittle asterisk checks as per prompt instruction: "actually skip brittle checks"
+            // We just check the texting register question-append contract is pinned
+            Assert.Contains("ALSO: append exactly one short question", composed);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/Issue1249_DateeHorninessTierReactionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1249_DateeHorninessTierReactionTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Pinder.Core.Rolls;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class Issue1249_DateeHorninessTierReactionTests
+    {
+        // Candidate words required by the test contract
+        // Implementer is required to make catastrophe carry an escalated-reaction directive
+        // such as "severe", "strong", "major", "really", "visibly", "badly", "seriously", "disturb", "alarm", "recoil"
+        private static readonly string[] StrongReactionWords = { "severe", "strong", "major", "really", "visibly", "badly", "seriously", "disturb", "alarm", "recoil" };
+        
+        // Fumble carries mild ones
+        private static readonly string[] MildReactionWords = { "slight", "small", "mild", "barely", "minor", "a little" };
+
+        [Theory]
+        [InlineData(FailureTier.Fumble)]
+        [InlineData(FailureTier.Misfire)]
+        [InlineData(FailureTier.TropeTrap)]
+        [InlineData(FailureTier.Catastrophe)]
+        public void OverlayAppliedFalse_ReturnsEmptyRegardlessOfTier(FailureTier tier)
+        {
+            string guidance = SessionDocumentBuilder.GetHorninessReactionGuidance(10, overlayApplied: false, tier);
+            Assert.Equal(string.Empty, guidance);
+        }
+
+        [Theory]
+        [InlineData(10)]
+        [InlineData(5)]
+        [InlineData(17)]
+        public void CatastropheGuidance_IsMateriallyStronger_ThanFumbleAndMisfire(int interest)
+        {
+            string catastrophe = SessionDocumentBuilder.GetHorninessReactionGuidance(interest, overlayApplied: true, FailureTier.Catastrophe);
+            string fumble = SessionDocumentBuilder.GetHorninessReactionGuidance(interest, overlayApplied: true, FailureTier.Fumble);
+            string misfire = SessionDocumentBuilder.GetHorninessReactionGuidance(interest, overlayApplied: true, FailureTier.Misfire);
+
+            // Tier ordering sanity: Catastrophe must differ from BOTH
+            Assert.NotEqual(fumble, catastrophe);
+            Assert.NotEqual(misfire, catastrophe);
+
+            // Check that catastrophe is longer or stronger than fumble
+            // Given the requirements: "catastrophe-block is longer-or-stronger; plus a tolerant ContainsAny strong-cue check on catastrophe and its ABSENCE on fumble."
+            bool isStrongerOrLonger = catastrophe.Length > fumble.Length || ContainsAny(catastrophe, StrongReactionWords);
+            Assert.True(isStrongerOrLonger, "Catastrophe guidance must be materially stronger or longer than Fumble guidance.");
+
+            bool catastropheHasStrongCue = ContainsAny(catastrophe, StrongReactionWords);
+            Assert.True(catastropheHasStrongCue, "Catastrophe must contain a strong reaction cue.");
+
+            bool fumbleHasStrongCue = ContainsAny(fumble, StrongReactionWords);
+            Assert.False(fumbleHasStrongCue, "Fumble must NOT contain a strong reaction cue.");
+        }
+
+        [Fact]
+        public void Reaffirmation25Gate_IsPreservedInCatastrophe()
+        {
+            // The 25-gate reaffirmation ("25") must remain present in the catastrophe guidance too (don't lose the #1248 invariant).
+            string catastrophe = SessionDocumentBuilder.GetHorninessReactionGuidance(10, overlayApplied: true, FailureTier.Catastrophe);
+            Assert.Contains("25", catastrophe);
+        }
+
+        private bool ContainsAny(string source, string[] candidates)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (source.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #1249

## Problem
A catastrophic horniness mis-roll did not have a materially stronger effect than a fumble — horniness reactions lacked clear intensity separation across miss tiers, so a catastrophe could collapse into a mild fumble.

## Fix (prompt + engine, pinder-core)
Scale the DATEE-reaction guidance by the horniness miss `FailureTier`:

- Four new data-driven `data/prompts/templates.yaml` keys: `datee-horniness-tier-intensity-{fumble,misfire,trope-trap,catastrophe}` — texting-register reaction directives that scale clearly:
  - Fumble: slight, barely-noticeable; small/mild reaction, don't overreact.
  - Misfire: noticeable thirsty stumble; a step cooler, more guarded.
  - TropeTrap: clear dating-app horny cliché; warmth drops noticeably.
  - Catastrophe: severe/major involuntary escalation; real recoil, marked drop in warmth, much cooler/shorter reply — especially at lower interest. "Do NOT explain the mechanic."
- `PromptTemplates` exposes the four keys; `SessionDocumentBuilder.GetHorninessTierIntensity(tier)` maps tier → directive (Catastrophe and Legendary/Nat1 → max intensity; Success/default → empty).
- `GetHorninessReactionGuidance` now appends the tier-intensity directive to the interest-band guidance from #1248, so a catastrophic horniness miss produces a materially stronger DATEE reaction than a fumble/misfire.

The #1248 invariants are preserved: the "Current interest: N/25" gate token and the below/above-18 interest-band gating are unchanged; Date Secured stays gated at 25. The horniness OVERLAY instruction tiers (already materially distinct) are unchanged and regression-pinned.

## Tests
- NEW `Issue1249_HorninessOverlayTierIntensityTests.cs` (Part A): regression-pins that the overlay instruction tiers are materially distinct — Catastrophe != Fumble/Misfire, catastrophe carries maximal-intensity + the loader's "content is the joke" reinforcement, fumble carries a minimal marker, every tier keeps the texting-register question-append directive.
- NEW `Issue1249_DateeHorninessTierReactionTests.cs` (Part B): asserts the DATEE-reaction guidance for a Catastrophe horniness miss is materially stronger than Fumble/Misfire at the same interest (distinct output, strong-cue present on catastrophe and absent on fumble), and the 25-gate is preserved.

## Local verification (no GitHub Actions)
- `Issue1249` Part B: 8 passed / 0 failed; Part A: 11 passed / 0 failed
- `Issue1248_DateeHorninessThresholdTests` (same helper): 11 passed / 0 failed
- `Pinder.LlmAdapters.Tests`: 1088 passed / 0 failed
- `Pinder.Core.Tests`: 3103 passed / 0 failed / 18 skipped
- (Pinder.Rules.Tests has 11 pre-existing failures on the untouched baseline, unrelated.)