### PR TITLE
feat(#1255,#1256): dynamic prompt compiler with safe {token} replacement + tests

### DIFF
--- a/src/Pinder.LlmAdapters/PromptCompilationException.cs
+++ b/src/Pinder.LlmAdapters/PromptCompilationException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Pinder.LlmAdapters
+{
+    public sealed class PromptCompilationException : Exception
+    {
+        public PromptCompilationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/PromptCompilationInput.cs
+++ b/src/Pinder.LlmAdapters/PromptCompilationInput.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.LlmAdapters
+{
+    public sealed class PromptCompilationInput
+    {
+        public string CharacterProfile { get; }
+        public IReadOnlyList<string> BackstoryFacts { get; }
+        public IReadOnlyList<string> PsychologicalStakes { get; }
+
+        public PromptCompilationInput(
+            string characterProfile,
+            IReadOnlyList<string> backstoryFacts,
+            IReadOnlyList<string> psychologicalStakes)
+        {
+            CharacterProfile = characterProfile ?? throw new ArgumentNullException(nameof(characterProfile));
+            BackstoryFacts = backstoryFacts ?? throw new ArgumentNullException(nameof(backstoryFacts));
+            PsychologicalStakes = psychologicalStakes ?? throw new ArgumentNullException(nameof(psychologicalStakes));
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
+++ b/src/Pinder.LlmAdapters/SessionSystemPromptBuilder.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Pinder.Core.Text;
 
 namespace Pinder.LlmAdapters
@@ -25,6 +28,87 @@ namespace Pinder.LlmAdapters
     /// </summary>
     public static class SessionSystemPromptBuilder
     {
+        public const int RequiredBackstoryFactCount = 20;
+        public const int RequiredPsychologicalStakeCount = 15;
+
+        public const string CharacterProfileToken = "{character_profile}";
+        public const string BackstoryFactsToken = "{backstory_facts}";
+        public const string PsychologicalStakesToken = "{psychological_stakes}";
+
+        public static string CompilePrompt(string template, PromptCompilationInput input)
+        {
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            // Validate character profile
+            if (string.IsNullOrWhiteSpace(input.CharacterProfile))
+            {
+                throw new PromptCompilationException("Character profile (anatomy) cannot be empty or whitespace.");
+            }
+
+            // Validate backstory facts
+            if (input.BackstoryFacts == null)
+            {
+                throw new PromptCompilationException("Backstory facts cannot be null.");
+            }
+            if (input.BackstoryFacts.Count != RequiredBackstoryFactCount)
+            {
+                throw new PromptCompilationException($"Backstory facts count expected {RequiredBackstoryFactCount}, actual count {input.BackstoryFacts.Count}.");
+            }
+            foreach (var fact in input.BackstoryFacts)
+            {
+                if (string.IsNullOrWhiteSpace(fact))
+                {
+                    throw new PromptCompilationException("Backstory fact cannot be null or whitespace.");
+                }
+            }
+
+            // Validate psychological stakes
+            if (input.PsychologicalStakes == null)
+            {
+                throw new PromptCompilationException("Psychological stakes cannot be null.");
+            }
+            if (input.PsychologicalStakes.Count != RequiredPsychologicalStakeCount)
+            {
+                throw new PromptCompilationException($"Psychological stakes count expected {RequiredPsychologicalStakeCount}, actual count {input.PsychologicalStakes.Count}.");
+            }
+            foreach (var stake in input.PsychologicalStakes)
+            {
+                if (string.IsNullOrWhiteSpace(stake))
+                {
+                    throw new PromptCompilationException("Psychological stake cannot be null or whitespace.");
+                }
+            }
+
+            // Single-pass replacement over template
+            return Regex.Replace(template, @"\{[A-Za-z0-9_]+\}", match =>
+            {
+                string token = match.Value;
+                if (token == CharacterProfileToken)
+                {
+                    return input.CharacterProfile;
+                }
+                else if (token == BackstoryFactsToken)
+                {
+                    return string.Join("\n", input.BackstoryFacts.Select((f, i) => (i + 1) + ". " + f));
+                }
+                else if (token == PsychologicalStakesToken)
+                {
+                    return string.Join("\n", input.PsychologicalStakes.Select((s, i) => (i + 1) + ". " + s));
+                }
+                else
+                {
+                    throw new PromptCompilationException("unknown token '" + token + "'");
+                }
+            });
+        }
+
         /// <summary>
         /// Header that marks the start of the per-session character-spec block.
         /// Everything BEFORE this marker is the shared, identical GM base.

--- a/tests/Pinder.LlmAdapters.Tests/Issue1004_PromptCompilationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1004_PromptCompilationTests.cs
@@ -284,10 +284,7 @@ STAKES:
             string actual = SessionSystemPromptBuilder.CompilePrompt(template, input);
 
             // Assert
-            string expectedNormalized = ExpectedGoldenCompiled.Replace("\r\n", "\n").Trim();
-            string actualNormalized = actual.Replace("\r\n", "\n").Trim();
-
-            Assert.Equal(expectedNormalized, actualNormalized);
+            Assert.Equal(ExpectedGoldenCompiled, actual);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue1004_PromptCompilationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1004_PromptCompilationTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class Issue1004_PromptCompilationTests
+    {
+        private const string ValidProfile = "anatomy: tier-3 / asset: leather";
+
+        private static List<string> CreateValidBackstoryFacts()
+        {
+            return Enumerable.Range(1, SessionSystemPromptBuilder.RequiredBackstoryFactCount)
+                .Select(i => $"fact-{i}")
+                .ToList();
+        }
+
+        private static List<string> CreateValidPsychologicalStakes()
+        {
+            return Enumerable.Range(1, SessionSystemPromptBuilder.RequiredPsychologicalStakeCount)
+                .Select(i => $"stake-{i}")
+                .ToList();
+        }
+
+        private static PromptCompilationInput CreateValidInput()
+        {
+            return new PromptCompilationInput(
+                ValidProfile,
+                CreateValidBackstoryFacts(),
+                CreateValidPsychologicalStakes()
+            );
+        }
+
+        [Fact]
+        public void CompilePrompt_AllThreeTokensReplaced_OutputContainsNoneOfTokensAndContainsExpandedValues()
+        {
+            // Arrange
+            string template = "Profile:\n{character_profile}\n\nFacts:\n{backstory_facts}\n\nStakes:\n{psychological_stakes}";
+            var input = CreateValidInput();
+
+            // Act
+            string result = SessionSystemPromptBuilder.CompilePrompt(template, input);
+
+            // Assert
+            Assert.DoesNotContain(SessionSystemPromptBuilder.CharacterProfileToken, result);
+            Assert.DoesNotContain(SessionSystemPromptBuilder.BackstoryFactsToken, result);
+            Assert.DoesNotContain(SessionSystemPromptBuilder.PsychologicalStakesToken, result);
+
+            Assert.Contains(ValidProfile, result);
+            Assert.Contains("1. fact-1", result);
+            Assert.Contains("20. fact-20", result);
+            Assert.Contains("1. stake-1", result);
+            Assert.Contains("15. stake-15", result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\n")]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenCharacterProfileIsEmptyOrWhitespace(string invalidProfile)
+        {
+            // Arrange
+            string template = "Profile:\n{character_profile}";
+            var input = new PromptCompilationInput(
+                invalidProfile,
+                CreateValidBackstoryFacts(),
+                CreateValidPsychologicalStakes()
+            );
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenBackstoryFactsCountIs19()
+        {
+            // Arrange
+            string template = "Facts:\n{backstory_facts}";
+            var facts = Enumerable.Range(1, 19).Select(i => $"fact-{i}").ToList();
+            var input = new PromptCompilationInput(ValidProfile, facts, CreateValidPsychologicalStakes());
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenBackstoryFactsCountIs21()
+        {
+            // Arrange
+            string template = "Facts:\n{backstory_facts}";
+            var facts = Enumerable.Range(1, 21).Select(i => $"fact-{i}").ToList();
+            var input = new PromptCompilationInput(ValidProfile, facts, CreateValidPsychologicalStakes());
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenBackstoryFactIsBlankOrWhitespaceOrNull(string invalidFact)
+        {
+            // Arrange
+            string template = "Facts:\n{backstory_facts}";
+            var facts = CreateValidBackstoryFacts();
+            facts[5] = invalidFact!; // Replace one fact with invalid value
+            var input = new PromptCompilationInput(ValidProfile, facts, CreateValidPsychologicalStakes());
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenPsychologicalStakesCountIs14()
+        {
+            // Arrange
+            string template = "Stakes:\n{psychological_stakes}";
+            var stakes = Enumerable.Range(1, 14).Select(i => $"stake-{i}").ToList();
+            var input = new PromptCompilationInput(ValidProfile, CreateValidBackstoryFacts(), stakes);
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenPsychologicalStakesCountIs16()
+        {
+            // Arrange
+            string template = "Stakes:\n{psychological_stakes}";
+            var stakes = Enumerable.Range(1, 16).Select(i => $"stake-{i}").ToList();
+            var input = new PromptCompilationInput(ValidProfile, CreateValidBackstoryFacts(), stakes);
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenPsychologicalStakeIsBlankOrWhitespaceOrNull(string invalidStake)
+        {
+            // Arrange
+            string template = "Stakes:\n{psychological_stakes}";
+            var stakes = CreateValidPsychologicalStakes();
+            stakes[5] = invalidStake!; // Replace one stake with invalid value
+            var input = new PromptCompilationInput(ValidProfile, CreateValidBackstoryFacts(), stakes);
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsPromptCompilationException_WhenTemplateContainsUnknownToken()
+        {
+            // Arrange
+            string template = "Profile: {character_profile} and mystery: {mystery_token}";
+            var input = CreateValidInput();
+
+            // Act & Assert
+            Assert.Throws<PromptCompilationException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_Determinism_CompilingIdenticalInputTwiceYieldsByteIdenticalOutput()
+        {
+            // Arrange
+            string template = "Profile:\n{character_profile}\n\nFacts:\n{backstory_facts}\n\nStakes:\n{psychological_stakes}";
+            var input1 = CreateValidInput();
+            var input2 = CreateValidInput();
+
+            // Act
+            string result1 = SessionSystemPromptBuilder.CompilePrompt(template, input1);
+            string result2 = SessionSystemPromptBuilder.CompilePrompt(template, input2);
+
+            // Assert
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsArgumentNullException_OnNullTemplate()
+        {
+            // Arrange
+            var input = CreateValidInput();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(null!, input));
+        }
+
+        [Fact]
+        public void CompilePrompt_ThrowsArgumentNullException_OnNullInput()
+        {
+            // Arrange
+            string template = "Profile:\n{character_profile}";
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                SessionSystemPromptBuilder.CompilePrompt(template, null!));
+        }
+
+        [Fact]
+        public void PromptCompilationInput_Ctor_ThrowsArgumentNullException_WhenNullArgsPassed()
+        {
+            // Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new PromptCompilationInput(null!, CreateValidBackstoryFacts(), CreateValidPsychologicalStakes()));
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new PromptCompilationInput(ValidProfile, null!, CreateValidPsychologicalStakes()));
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new PromptCompilationInput(ValidProfile, CreateValidBackstoryFacts(), null!));
+        }
+
+        private const string ExpectedGoldenCompiled = @"PROFILE:
+anatomy: tier-3 / asset: leather
+
+FACTS:
+1. fact-1
+2. fact-2
+3. fact-3
+4. fact-4
+5. fact-5
+6. fact-6
+7. fact-7
+8. fact-8
+9. fact-9
+10. fact-10
+11. fact-11
+12. fact-12
+13. fact-13
+14. fact-14
+15. fact-15
+16. fact-16
+17. fact-17
+18. fact-18
+19. fact-19
+20. fact-20
+
+STAKES:
+1. stake-1
+2. stake-2
+3. stake-3
+4. stake-4
+5. stake-5
+6. stake-6
+7. stake-7
+8. stake-8
+9. stake-9
+10. stake-10
+11. stake-11
+12. stake-12
+13. stake-13
+14. stake-14
+15. stake-15";
+
+        [Fact]
+        public void CompilePrompt_ByteEqualityGolden_AssertsMatchExactly()
+        {
+            // Arrange
+            string template = @"PROFILE:
+{character_profile}
+
+FACTS:
+{backstory_facts}
+
+STAKES:
+{psychological_stakes}";
+
+            var input = CreateValidInput();
+
+            // Act
+            string actual = SessionSystemPromptBuilder.CompilePrompt(template, input);
+
+            // Assert
+            string expectedNormalized = ExpectedGoldenCompiled.Replace("\r\n", "\n").Trim();
+            string actualNormalized = actual.Replace("\r\n", "\n").Trim();
+
+            Assert.Equal(expectedNormalized, actualNormalized);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the dynamic prompt compiler refactor (#1255) and its unit/integration tests (#1256).

Adds a safe, single-pass token-replacement compiler in `SessionSystemPromptBuilder` that expands `{character_profile}`, `{backstory_facts}` (20 facts), and `{psychological_stakes}` (15 stems) from DB-loaded character data.

### Changes
- `SessionSystemPromptBuilder.CompilePrompt(template, PromptCompilationInput)` — single-pass `Regex.Replace` over the **template** via a MatchEvaluator, so substituted data is never re-scanned (safe; braces inside data are inert).
- New `PromptCompilationInput` POCO (CharacterProfile + 20 BackstoryFacts + 15 PsychologicalStakes; null-arg guarded).
- New `PromptCompilationException` for **loud** failures (no silent fallback-padding).
- New token/count consts (`RequiredBackstoryFactCount=20`, `RequiredPsychologicalStakeCount=15`, the three `{token}` strings).

### Loud-failure semantics (#1255/#1256)
Throws `PromptCompilationException` on: empty/whitespace character profile (incomplete anatomy), backstory count != 20, blank fact, stakes count != 15, blank stake, and any unknown `{token}` left in the template. Throws `ArgumentNullException` on null template/input.

### Caching compatibility
Output is deterministic (ordered list rendering + `string.Join`, no DateTime/Guid/hash/dict-order), so the compiled prefix stays stable and Anthropic/OpenRouter prompt-cache-compatible.

### Tests (#1256 — `Issue1004_PromptCompilationTests`, 20 tests)
- All three `{tokens}` replaced; expanded values present, literal tokens absent.
- Loud failure on every incomplete-data case + unknown token.
- **Strict byte-equality** golden fixture (`Assert.Equal(ExpectedGoldenCompiled, actual)`, no normalization/trim) to lock regression.
- Determinism + null-arg guards.

### Verification (local only — no CI)
`dotnet test tests/Pinder.LlmAdapters.Tests` → **1108 passed / 0 failed** (incl. 20 new Issue1004 tests). Independently re-run by orchestrator and two independent reviewers.

Existing GM-puppeteer methods (`BuildPlayerAvatar`/`BuildDatee`) are untouched.

Closes #1255
Closes #1256