### PR TITLE
feat(llm): route shadow corruptions to Groq overlay + unhinged prompt (#1287)

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -88,3 +88,11 @@ Phase 5. Tests pin this byte-equality so a Phase-N PR that
 accidentally tunes a string in the yaml without touching the const —
 or vice versa — fails loudly. After Phase 5 the const is gone and
 the test is rewritten to lock the yaml render alone.
+
+## Groq Overlay Routing for Shadow Corruptions
+
+Shadow corruptions now support routing to the Groq overlay applier. This behavior is gated on the presence of both `OverlayGroqModel` and `OverlayGroqApiKey` in the LLM adapter options (mirroring the routing logic for horniness and trap overlays).
+
+If both parameters are provided, shadow corruptions bypass the primary LLM transport entirely and run through `GroqOverlayApplier.ApplyShadowCorruptionAsync` using a highly unhinged and comedic system rewrite prompt that includes the target shadow stat name.
+
+If either parameter is missing, the adapter falls back to the primary LLM transport, using the same unhinged rewrite system prompt.

--- a/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
+++ b/src/Pinder.LlmAdapters/Groq/GroqOverlayApplier.cs
@@ -264,5 +264,122 @@ namespace Pinder.LlmAdapters.Groq
                 return message;
             }
         }
+
+        public static async Task<string> ApplyShadowCorruptionAsync(
+            string groqApiKey,
+            string model,
+            string message,
+            string instruction,
+            Pinder.Core.Stats.ShadowStatType shadow,
+            string? archetypeDirective,
+            System.Threading.CancellationToken ct,
+            Action<OverlayDegradedEvent>? onDegraded)
+        {
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
+            {
+                if (string.IsNullOrWhiteSpace(instruction))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "groq",
+                        model: model,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped
+                    ));
+                }
+                return message;
+            }
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                $"The character's {shadow} shadow corruption is flaring up, turning them into an absolute lunatic! " +
+                "Rewrite the message to make it EXTREMELY unhinged, distinct, and hilariously comedic, " +
+                "dramatically applying the requested shadow corruption instruction while staying in the character's voice. " +
+                "Be wildly creative, ridiculous, and funny, but return ONLY the rewritten message text. " +
+                "No commentary, no meta-text, no preamble, and no refusals. Absolute silence except for the unhinged rewrite.";
+
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nSHADOW CORRUPTION ({shadow}) INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (preserving the archetype voice above, but making it hilariously unhinged/comedic) and return the modified message."
+                : $"SHADOW CORRUPTION ({shadow}) INSTRUCTION:\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the corruption (making it hilariously unhinged/comedic) and return the modified message.";
+
+            var payload = new
+            {
+                model = model,
+                max_tokens = 400,
+                messages = new[]
+                {
+                    new { role = "system", content = systemPrompt },
+                    new { role = "user", content = userContent }
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.groq.com/openai/v1/chat/completions");
+            request.Headers.Add("Authorization", $"Bearer {groqApiKey}");
+            request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "groq",
+                        model: model,
+                        reason: "http_error",
+                        outcome: OverlayOutcome.Degraded,
+                        errorCode: ((int)response.StatusCode).ToString()
+                    ));
+                    return message;
+                }
+
+                var json = JObject.Parse(body);
+                var text = json["choices"]?[0]?["message"]?["content"]?.Value<string>()?.Trim();
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "groq",
+                        model: model,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
+
+                if (text!.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    text.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    text.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    onDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "shadow_corruption",
+                        provider: "groq",
+                        model: model,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
+
+                return text;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
+            }
+            catch (Exception ex)
+            {
+                onDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "shadow_corruption",
+                    provider: "groq",
+                    model: model,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
+                return message;
+            }
+        }
     }
 }

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -522,11 +522,17 @@ namespace Pinder.LlmAdapters
                 return message;
             }
 
-            string systemPrompt = "You are editing a text message for Pinder, a satirical comedy dating app. " +
-                "Apply the shadow corruption instruction to rewrite the delivered message. " +
-                "The message has already been through its normal delivery transformation. " +
-                "Now the character's shadow stat is corrupting it further. " +
-                "Return ONLY the corrupted message text. No commentary, no preamble, no refusals.";
+            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
+            {
+                return await GroqOverlayApplier.ApplyShadowCorruptionAsync(_options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, shadow, archetypeDirective, ct, _options.OnOverlayDegraded).ConfigureAwait(false);
+            }
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                $"The character's {shadow} shadow corruption is flaring up, turning them into an absolute lunatic! " +
+                "Rewrite the message to make it EXTREMELY unhinged, distinct, and hilariously comedic, " +
+                "dramatically applying the requested shadow corruption instruction while staying in the character's voice. " +
+                "Be wildly creative, ridiculous, and funny, but return ONLY the rewritten message text. " +
+                "No commentary, no meta-text, no preamble, and no refusals. Absolute silence except for the unhinged rewrite.";
 
             // Inject the speaker's active archetype directive (#372) so the
             // shadow-corrupted rewrite still sounds like the character.

--- a/tests/Pinder.LlmAdapters.Tests/Issue1287_ShadowCorruptionGroqRoutingTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1287_ShadowCorruptionGroqRoutingTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1287_ShadowCorruptionGroqRoutingTests
+    {
+        private sealed class FixedResponseTransport : ILlmTransport
+        {
+            private readonly string _response;
+            public FixedResponseTransport(string response) => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(_response);
+        }
+
+        private sealed class CountingTransport : ILlmTransport
+        {
+            public int Calls { get; set; }
+            private readonly string _response;
+            public CountingTransport(string response = "primary-was-called") => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+            {
+                Calls++;
+                return Task.FromResult(_response);
+            }
+        }
+
+        // (a) [Fact] NoGroqConfigured_UsesPrimaryTransport_ReturnsRewrite
+        [Fact]
+        public async Task NoGroqConfigured_UsesPrimaryTransport_ReturnsRewrite()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("shadow-rewritten");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyShadowCorruptionAsync("orig", "corrupt it", ShadowStatType.Madness);
+
+            // Assert
+            Assert.Equal("shadow-rewritten", result.Trim());
+        }
+
+        // (b) [Fact] EmptyInstruction_ReturnsOriginalUnchanged
+        [Fact]
+        public async Task EmptyInstruction_ReturnsOriginalUnchanged()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("some-rewrite");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyShadowCorruptionAsync("orig", "", ShadowStatType.Madness);
+
+            // Assert
+            Assert.Equal("orig", result);
+        }
+
+        // (c) [Fact] PrimaryReturnsEmpty_ReturnsOriginalMessage
+        [Fact]
+        public async Task PrimaryReturnsEmpty_ReturnsOriginalMessage()
+        {
+            // Arrange
+            var transport = new FixedResponseTransport("");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            var result = await adapter.ApplyShadowCorruptionAsync("orig msg", "corrupt it", ShadowStatType.Madness);
+
+            // Assert
+            Assert.Equal("orig msg", result);
+        }
+
+        // (d) [Fact] GroqOverlayApplier_HasPublicShadowCorruptionMethodWithShadowParam
+        [Fact]
+        public void GroqOverlayApplier_HasPublicShadowCorruptionMethodWithShadowParam()
+        {
+            // Arrange & Act
+            var method = typeof(Pinder.LlmAdapters.Groq.GroqOverlayApplier)
+                .GetMethod("ApplyShadowCorruptionAsync", BindingFlags.Public | BindingFlags.Static);
+
+            // Assert
+            Assert.NotNull(method);
+            var parameters = method!.GetParameters();
+            var hasShadowParam = parameters.Any(p => p.ParameterType == typeof(Pinder.Core.Stats.ShadowStatType));
+            Assert.True(hasShadowParam, "Method should have a parameter of type ShadowStatType.");
+        }
+
+        // (e) [Fact] WhenGroqConfigured_PrimaryTransportIsBypassed
+        [Fact]
+        public async Task WhenGroqConfigured_PrimaryTransportIsBypassed()
+        {
+            // Arrange
+            var transport = new CountingTransport();
+            var options = new PinderLlmAdapterOptions
+            {
+                GameDefinition = GameDefinition.PinderDefaults,
+                OverlayGroqModel = "llama-3.3-70b-versatile",
+                OverlayGroqApiKey = "gsk_test_dummy"
+            };
+            var adapter = new PinderLlmAdapter(transport, options);
+
+            // Act
+            // Dummy network call with invalid API key fails fast.
+            // Using a safe CancellationToken to absolutely prevent hanging.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var result = await adapter.ApplyShadowCorruptionAsync("orig", "corrupt it", ShadowStatType.Madness, ct: cts.Token);
+
+            // Assert
+            Assert.Equal(0, transport.Calls);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1287. Adds GroqOverlayApplier.ApplyShadowCorruptionAsync and routes PinderLlmAdapter.ApplyShadowCorruptionAsync to Groq when OverlayGroqModel+OverlayGroqApiKey are set (mirroring horniness/trap overlays), with a more unhinged/comedic system prompt on both the Groq and primary-fallback paths. Docs updated. Focused verify: dotnet test tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj --filter FullyQualifiedName~Issue1287 -> 5/5 green; full adapter suite green.