### PR TITLE
refactor(#1292): unify overlay LLM calls onto ILlmTransport — add optional overlayTransport to PinderLlmAdapter

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -89,6 +89,6 @@ accidentally tunes a string in the yaml without touching the const —
 or vice versa — fails loudly. After Phase 5 the const is gone and
 the test is rewritten to lock the yaml render alone.
 
-## Groq Overlay Routing for Shadow Corruptions
+## Overlay Transport Routing
 
 Overlay calls (horniness/trap/shadow-corruption) use a second, optional ILlmTransport passed to PinderLlmAdapter's constructor. When omitted, overlays use the same transport as primary game-turn calls. There is no vendor-specific overlay routing inside the adapter — the host application controls which model/vendor handles overlays purely by which transport instance it constructs and passes in. (GameApi wiring for this is tracked in a separate follow-up ticket.)

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -91,8 +91,4 @@ the test is rewritten to lock the yaml render alone.
 
 ## Groq Overlay Routing for Shadow Corruptions
 
-Shadow corruptions now support routing to the Groq overlay applier. This behavior is gated on the presence of both `OverlayGroqModel` and `OverlayGroqApiKey` in the LLM adapter options (mirroring the routing logic for horniness and trap overlays).
-
-If both parameters are provided, shadow corruptions bypass the primary LLM transport entirely and run through `GroqOverlayApplier.ApplyShadowCorruptionAsync` using a highly unhinged and comedic system rewrite prompt that includes the target shadow stat name.
-
-If either parameter is missing, the adapter falls back to the primary LLM transport, using the same unhinged rewrite system prompt.
+Overlay calls (horniness/trap/shadow-corruption) use a second, optional ILlmTransport passed to PinderLlmAdapter's constructor. When omitted, overlays use the same transport as primary game-turn calls. There is no vendor-specific overlay routing inside the adapter — the host application controls which model/vendor handles overlays purely by which transport instance it constructs and passes in. (GameApi wiring for this is tracked in a separate follow-up ticket.)

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -26,15 +26,26 @@ namespace Pinder.LlmAdapters
         private const double DefaultDateeResponseTemperature = 0.85;
 
         private readonly ILlmTransport _transport;
+        private readonly ILlmTransport _overlayTransport;
         private readonly PinderLlmAdapterOptions _options;
 
         // #788: datee conversation state lives on GameSession, not here.
         // The adapter is pure-stateless and safe for concurrent reuse across sessions.
 
-        public PinderLlmAdapter(ILlmTransport transport, PinderLlmAdapterOptions options)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PinderLlmAdapter"/> class.
+        /// </summary>
+        /// <param name="transport">The primary LLM transport.</param>
+        /// <param name="options">The adapter configuration options.</param>
+        /// <param name="overlayTransport">The optional secondary transport for overlay rewriting.</param>
+        /// <remarks>
+        /// When null, overlay calls (ApplyHorninessOverlayAsync/ApplyTrapOverlayAsync/ApplyShadowCorruptionAsync) use the same transport as primary game-turn calls. Pass a distinct transport (built the same way as the primary transport, via whatever factory the host application uses to resolve provider-qualified model specs) to route overlay rewrites to a different/cheaper model. Overlay routing must never be selected by vendor-specific fields on PinderLlmAdapterOptions — the transport instance is the only routing mechanism.
+        /// </remarks>
+        public PinderLlmAdapter(ILlmTransport transport, PinderLlmAdapterOptions options, ILlmTransport? overlayTransport = null)
         {
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _overlayTransport = overlayTransport ?? transport;
         }
 
         // ── ILlmAdapter ────────────────────────────────────────────────────
@@ -318,14 +329,6 @@ namespace Pinder.LlmAdapters
                 return message;
             }
 
-            // Route to Groq if configured
-            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
-            {
-                return await GroqOverlayApplier.ApplyHorninessOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, dateeContext, archetypeDirective, ct, _options.OnOverlayDegraded)
-                    .ConfigureAwait(false);
-            }
-
             // Use primary transport
             string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
                 "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
@@ -345,7 +348,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
+                var result = await _overlayTransport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.HorninessOverlay, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result))
@@ -421,14 +424,6 @@ namespace Pinder.LlmAdapters
                 return message;
             }
 
-            // Route to Groq when configured — same path as horniness/shadow overlays.
-            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
-            {
-                return await GroqOverlayApplier.ApplyTrapOverlayAsync(
-                    _options.OverlayGroqApiKey, _options.OverlayGroqModel, message, trapInstruction, trapName, dateeContext, archetypeDirective, ct, _options.OnOverlayDegraded)
-                    .ConfigureAwait(false);
-            }
-
             string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
                 "The humour is absurdist and satirical — characters are oblivious to double-entendre, not explicit. " +
                 "A trap is currently corrupting the character's voice. " +
@@ -447,7 +442,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay, ct: ct)
+                var result = await _overlayTransport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.TrapOverlay, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result))
@@ -522,11 +517,6 @@ namespace Pinder.LlmAdapters
                 return message;
             }
 
-            if (!string.IsNullOrWhiteSpace(_options.OverlayGroqModel) && !string.IsNullOrWhiteSpace(_options.OverlayGroqApiKey))
-            {
-                return await GroqOverlayApplier.ApplyShadowCorruptionAsync(_options.OverlayGroqApiKey, _options.OverlayGroqModel, message, instruction, shadow, archetypeDirective, ct, _options.OnOverlayDegraded).ConfigureAwait(false);
-            }
-
             string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
                 $"The character's {shadow} shadow corruption is flaring up, turning them into an absolute lunatic! " +
                 "Rewrite the message to make it EXTREMELY unhinged, distinct, and hilariously comedic, " +
@@ -543,7 +533,7 @@ namespace Pinder.LlmAdapters
             try
             {
                 double temperature = _options.DeliveryTemperature ?? 0.7;
-                var result = await _transport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption, ct: ct)
+                var result = await _overlayTransport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.ShadowCorruption, ct: ct)
                     .ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(result))

--- a/tests/Pinder.LlmAdapters.Tests/Issue1292_UnifiedOverlayTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1292_UnifiedOverlayTransportTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Stats;
+using Pinder.LlmAdapters;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    [Collection("PromptTraceSingleton")]
+    public class Issue1292_UnifiedOverlayTransportTests
+    {
+        private sealed class CountingTransport : ILlmTransport
+        {
+            public int Calls { get; set; }
+            private readonly string _response;
+            public CountingTransport(string response = "primary-was-called") => _response = response;
+
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+            {
+                Calls++;
+                return Task.FromResult(_response);
+            }
+        }
+
+        [Fact]
+        public async Task ApplyHorninessOverlayAsync_NoOverlayTransportProvided_UsesPrimaryTransport()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-horniness");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor with overlayTransport: null
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: null);
+
+            // Act
+            var result = await adapter.ApplyHorninessOverlayAsync("some message", "some instruction");
+
+            // Assert
+            Assert.Equal(1, primary.Calls);
+            Assert.Equal("primary-horniness", result);
+        }
+
+        [Fact]
+        public async Task ApplyHorninessOverlayAsync_OverlayTransportProvided_RoutesToOverlayTransportNotPrimary()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-horniness");
+            var overlay = new CountingTransport("overlay-horniness");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: overlay);
+
+            // Act
+            var result = await adapter.ApplyHorninessOverlayAsync("some message", "some instruction");
+
+            // Assert
+            Assert.Equal(1, overlay.Calls);
+            Assert.Equal(0, primary.Calls);
+            Assert.Equal("overlay-horniness", result);
+        }
+
+        [Fact]
+        public async Task ApplyTrapOverlayAsync_NoOverlayTransportProvided_UsesPrimaryTransport()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-trap");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor with overlayTransport: null
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: null);
+
+            // Act
+            var result = await adapter.ApplyTrapOverlayAsync("some message", "some instruction", "clown-trap");
+
+            // Assert
+            Assert.Equal(1, primary.Calls);
+            Assert.Equal("primary-trap", result);
+        }
+
+        [Fact]
+        public async Task ApplyTrapOverlayAsync_OverlayTransportProvided_RoutesToOverlayTransportNotPrimary()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-trap");
+            var overlay = new CountingTransport("overlay-trap");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: overlay);
+
+            // Act
+            var result = await adapter.ApplyTrapOverlayAsync("some message", "some instruction", "clown-trap");
+
+            // Assert
+            Assert.Equal(1, overlay.Calls);
+            Assert.Equal(0, primary.Calls);
+            Assert.Equal("overlay-trap", result);
+        }
+
+        [Fact]
+        public async Task ApplyShadowCorruptionAsync_NoOverlayTransportProvided_UsesPrimaryTransport()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-shadow");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor with overlayTransport: null
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: null);
+
+            // Act
+            var result = await adapter.ApplyShadowCorruptionAsync("some message", "some instruction", ShadowStatType.Madness);
+
+            // Assert
+            Assert.Equal(1, primary.Calls);
+            Assert.Equal("primary-shadow", result);
+        }
+
+        [Fact]
+        public async Task ApplyShadowCorruptionAsync_OverlayTransportProvided_RoutesToOverlayTransportNotPrimary()
+        {
+            // Arrange
+            var primary = new CountingTransport("primary-shadow");
+            var overlay = new CountingTransport("overlay-shadow");
+            var options = new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults };
+            // Using the 3-arg constructor
+            var adapter = new PinderLlmAdapter(primary, options, overlayTransport: overlay);
+
+            // Act
+            var result = await adapter.ApplyShadowCorruptionAsync("some message", "some instruction", ShadowStatType.Madness);
+
+            // Assert
+            Assert.Equal(1, overlay.Calls);
+            Assert.Equal(0, primary.Calls);
+            Assert.Equal("overlay-shadow", result);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1292

## Summary
Gives `PinderLlmAdapter` an optional second `ILlmTransport` for overlay calls and collapses the vendor-specific Groq branch out of the three overlay methods.

- New optional 3rd constructor param: `PinderLlmAdapter(ILlmTransport transport, PinderLlmAdapterOptions options, ILlmTransport? overlayTransport = null)`; stores `_overlayTransport = overlayTransport ?? transport;` (100% backwards-compatible for existing 2-arg callers).
- `ApplyHorninessOverlayAsync` / `ApplyTrapOverlayAsync` / `ApplyShadowCorruptionAsync` now route their LLM call through `_overlayTransport.SendAsync(...)`; the `if (OverlayGroqModel && OverlayGroqApiKey) return GroqOverlayApplier...` branch is removed from all three.
- Non-overlay methods (dialogue/datee/delivery/steering) still use `_transport` unchanged.
- Per ticket scope: `GroqOverlayApplier.cs`, `AnthropicOverlayApplier.cs`, and the `OverlayGroqModel`/`OverlayGroqApiKey` option fields are intentionally left in place (removed in follow-up #1293).
- `docs/prompts.md`: replaced the Groq-specific overlay routing section with the unified transport model.

## Tests
- New `Issue1292_UnifiedOverlayTransportTests.cs`: 6 tests (2 per overlay method) proving overlay calls route to `overlayTransport` when supplied (overlay=1, primary=0) and to the primary transport when omitted (primary=1). All 6 pass.
- Full suite: 1126 passed / 1 failed. The single failure — `Issue1287_ShadowCorruptionGroqRoutingTests.WhenGroqConfigured_PrimaryTransportIsBypassed` — is EXPECTED and documented in the ticket: it asserts the now-deleted Groq-routing branch and is removed by follow-up #1293.

## Verification
- Contract-test leaf (RED), implementer leaf (GREEN), independent reviewer (APPROVE after docs-heading fix). Local `dotnet test` gate only — no GitHub CI.