### PR TITLE
docs(#1296): fix stale deleted-adapter/MatchupAnalyzer refs + add doc-reference integrity test

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+File references in this doc are enforced by DocsArchitectureReferenceIntegrityTests.
+
 Developer guide to the Pinder codebase — systems, subsystems, interfaces, and constraints.
 
 ---
@@ -73,8 +75,6 @@ Prompt construction and LLM API integration. Depends on Pinder.Core and Pinder.R
 | | `GameDefinition.cs` — game-level creative direction loaded from YAML |
 | | `PromptTemplates.cs` — template strings for ENGINE injection blocks |
 | | `RollContextBuilder.cs` — YAML-sourced roll flavor text |
-| | `Anthropic/AnthropicLlmAdapter.cs` — deprecated Claude adapter |
-| | `OpenAi/OpenAiLlmAdapter.cs` — deprecated OpenAI adapter |
 
 ### Pinder.Core.TestCommon
 
@@ -115,21 +115,15 @@ Data-driven rule resolution. Loads YAML rule definitions and evaluates condition
 
 ### Pinder.SessionSetup
 
-Pre-session setup: narrative matchup analysis + stake generation. Isolated
-from the per-turn game loop so that the web tier (`Pinder.GameApi`) can run
-it eagerly in the background after session create, while the CLI harness
-skips it or runs a lighter version.
+Pre-session setup: stake generation. Isolated from the per-turn game loop so that the web tier (`Pinder.GameApi`) can run it eagerly in the background after session create.
 
 | Depends on | Pinder.Core, Pinder.LlmAdapters (via ILlmTransport) |
 |---|---|
-| **Purpose** | Matchup preview + stake copy at session boot time |
-| **Key files** | `IMatchupAnalyzer.cs` / `LlmMatchupAnalyzer.cs` — matchup narrative |
-| | `IStakeGenerator.cs` / `LlmStakeGenerator.cs` — player + datee stake strings |
+| **Purpose** | Pre-session stake generation at session boot time |
+| **Key files** | `IStakeGenerator.cs` / `LlmStakeGenerator.cs` — player + datee stake strings |
 | | `CharacterDefinitionLoader.cs` — shared character JSON loader |
 
-Ported into this library in #756 (`569b9f9`). Previously inlined in
-`session-runner/MatchupAnalyzer.cs`; still referenced there via the new
-interface for CLI use.
+Pre-session stake generation was ported into this library in #756 (`569b9f9`).
 
 ### session-runner
 
@@ -143,7 +137,6 @@ CLI executable that wires everything together and runs a full game session.
 | | `ScoringPlayerAgent.cs` — heuristic-based option scorer (default) |
 | | `LlmPlayerAgent.cs` — LLM-powered decision agent |
 | | `HumanPlayerAgent.cs` — interactive stdin agent |
-| | `MatchupAnalyzer.cs` — pre-session matchup analysis |
 
 ## 3. Core Game Loop
 
@@ -197,7 +190,6 @@ are:
 | `ITrapRegistry` | Pinder.Core | Supplies trap definitions by stat |
 | `IDiceRoller` | Pinder.Core | Deterministic roll injection for tests |
 | `IRuleResolver` | Pinder.Rules | YAML-driven constant lookup |
-| `IMatchupAnalyzer` | Pinder.SessionSetup | Pre-session matchup narrative |
 | `IStakeGenerator` | Pinder.SessionSetup | Pre-session stake generation |
 | `IPlayerAgent` | session-runner | Sim-agent decision-making |
 
@@ -225,7 +217,7 @@ Core abstraction for all LLM interactions. Stateless per-call.
 | `ApplyShadowCorruptionAsync(message, instruction, ...)` | Rewrite message with shadow corruption |
 | `ApplyTrapOverlayAsync(message, ...)` | Rewrite message with trap taint |
 
-**Implementations:** `AnthropicLlmAdapter`, `OpenAiLlmAdapter` (both in Pinder.LlmAdapters)
+**Implementations:** `PinderLlmAdapter` (in Pinder.LlmAdapters)
 
 ### IStatefulLlmAdapter : ILlmAdapter
 
@@ -236,7 +228,7 @@ Extends ILlmAdapter with persistent datee session for memory continuity across t
 | `StartDateeSession(systemPrompt)` | Initialize persistent datee conversation |
 | `GetSteeringQuestionAsync(SteeringContext)` | Generate steering question after successful roll |
 
-**Implementations:** `AnthropicLlmAdapter`, `OpenAiLlmAdapter`
+**Implementations:** `PinderLlmAdapter` (in Pinder.LlmAdapters)
 
 ### IPlayerAgent
 

--- a/tests/Pinder.Core.Tests/DocsArchitectureReferenceIntegrityTests.cs
+++ b/tests/Pinder.Core.Tests/DocsArchitectureReferenceIntegrityTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    [Trait("Category", "Core")]
+    public class DocsArchitectureReferenceIntegrityTests
+    {
+        private static string RepoRoot
+        {
+            get
+            {
+                string? dir = AppContext.BaseDirectory;
+                while (dir != null)
+                {
+                    if (Directory.Exists(Path.Combine(dir, "data")) &&
+                        Directory.Exists(Path.Combine(dir, "src")))
+                        return dir;
+                    dir = Directory.GetParent(dir)?.FullName;
+                }
+                throw new InvalidOperationException("Cannot find repo root from " + AppContext.BaseDirectory);
+            }
+        }
+
+        /// <summary>
+        /// Explicit allowlist for intentionally-historical references in ARCHITECTURE.md.
+        /// Each entry must have a comment/justification here.
+        /// MUST START EMPTY.
+        /// </summary>
+        private static readonly string[] HistoricalAllowlist = Array.Empty<string>();
+
+        [Fact]
+        public void Verify_DocsArchitecture_References_Exist()
+        {
+            // Arrange
+            string docPath = Path.Combine(RepoRoot, "docs", "ARCHITECTURE.md");
+            Assert.True(File.Exists(docPath), $"ARCHITECTURE.md does not exist at {docPath}");
+
+            string content = File.ReadAllText(docPath);
+
+            // Extract tokens ending with .cs
+            var matches = Regex.Matches(content, @"[A-Za-z0-9_./]+\.cs");
+            var tokens = matches
+                .Cast<Match>()
+                .Select(m => m.Value)
+                .Distinct()
+                .Where(t => !HistoricalAllowlist.Contains(t, StringComparer.OrdinalIgnoreCase))
+                .ToList();
+
+            // Find all C# files under src/, session-runner/, and tests/
+            var searchDirs = new[] { "src", "session-runner", "tests" };
+            var allCsFiles = searchDirs
+                .Select(sub => Path.Combine(RepoRoot, sub))
+                .Where(Directory.Exists)
+                .SelectMany(dir => Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+                .ToArray();
+
+            var relativeCsFiles = allCsFiles
+                .Select(f => Path.GetRelativePath(RepoRoot, f).Replace('\\', '/'))
+                .ToArray();
+
+            var missingFiles = new List<string>();
+
+            // Act
+            foreach (var token in tokens)
+            {
+                var normalizedToken = token.Replace('\\', '/');
+                var lastSegment = normalizedToken.Split('/').Last();
+
+                bool resolved = false;
+                foreach (var relPath in relativeCsFiles)
+                {
+                    // 1. Path ends with that token
+                    bool endsWithToken = relPath.EndsWith(normalizedToken, StringComparison.OrdinalIgnoreCase);
+                    if (endsWithToken)
+                    {
+                        // Ensure it's a boundary match (either exact match, or prefixed by a slash)
+                        if (relPath.Length == normalizedToken.Length || relPath[relPath.Length - normalizedToken.Length - 1] == '/')
+                        {
+                            resolved = true;
+                            break;
+                        }
+                    }
+
+                    // 2. Filename matches the last path segment
+                    var fileName = relPath.Split('/').Last();
+                    if (fileName.Equals(lastSegment, StringComparison.OrdinalIgnoreCase))
+                    {
+                        resolved = true;
+                        break;
+                    }
+                }
+
+                if (!resolved)
+                {
+                    missingFiles.Add(token);
+                }
+            }
+
+            // Assert
+            Assert.True(
+                missingFiles.Count == 0,
+                $"The following referenced .cs file(s) are missing from disk:\n{string.Join("\n", missingFiles)}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #1296.

## What
Docs+test only ticket (zero production code changes).

### docs/ARCHITECTURE.md
- Removed stale key-file rows for deleted adapters `Anthropic/AnthropicLlmAdapter.cs` and `OpenAi/OpenAiLlmAdapter.cs`.
- Corrected both `ILlmAdapter` / `IStatefulLlmAdapter` **Implementations:** lines to name the sole production impl `PinderLlmAdapter`.
- Removed the deleted `MatchupAnalyzer` family references (the whole class family was removed from the tree):
  - Pinder.SessionSetup key-file `IMatchupAnalyzer.cs` / `LlmMatchupAnalyzer.cs`
  - prose `session-runner/MatchupAnalyzer.cs` reference
  - session-runner key-file `MatchupAnalyzer.cs`
  - extension-points interface-table row `IMatchupAnalyzer`
  - Kept still-existing `IStakeGenerator.cs` / `LlmStakeGenerator.cs` / `CharacterDefinitionLoader.cs`.
- Added a note near the top pointing at the new guard test.

### tests/Pinder.Core.Tests/DocsArchitectureReferenceIntegrityTests.cs (new)
Extracts every `[A-Za-z0-9_./]+\.cs` token from ARCHITECTURE.md and asserts each referenced `.cs` file exists under `src/`, `session-runner/`, or `tests/`. Failure message names missing files. Explicit historical allowlist constant, starts EMPTY.

## Verification (local; no GitHub CI on these repos)
- Test authored RED first (failing against the stale refs), then made GREEN.
- `dotnet test tests/Pinder.Core.Tests/Pinder.Core.Tests.csproj` → Passed! Failed: 0, Passed: 3170, Skipped: 18.
- `git diff --stat origin/main -- src/ session-runner/` → empty (no production code touched).
- No NuGet/PackageReference changes.

Independent reviewer (claude-opus-4-8): Verdict APPROVE.