### PR TITLE
test(#1297): options-field consumption guard — every public option property must be read by production code

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,12 @@ Prompt construction and LLM API integration. Depends on Pinder.Core and Pinder.R
 | | `PromptTemplates.cs` — template strings for ENGINE injection blocks |
 | | `RollContextBuilder.cs` — YAML-sourced roll flavor text |
 
+#### Guard tests
+
+Options classes (`PinderLlmAdapterOptions` and `AnthropicOptions`) are consumption-guarded by `OptionsConsumptionGuardTests`. This test ensures that every public instance option property is textually consumed in production code under `src/` to prevent dead-code or orphan configurations.
+
+If an options property is intentionally not referenced by name in `src/` but must be retained as a legitimate exception, it can be added to the test's `Allowlist` dictionary using the key format `"ClassName.PropertyName"` mapped to a clear justification string. However, prefer wiring the property in production or removing the field entirely over adding it to the allowlist.
+
 ### Pinder.Core.TestCommon
 
 Shared testing library. Consolidates stubs and mock setups to deduplicate unit test boilerplate.

--- a/tests/Pinder.LlmAdapters.Tests/OptionsConsumptionGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OptionsConsumptionGuardTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+using Pinder.LlmAdapters;
+using Pinder.LlmAdapters.Anthropic;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public class OptionsConsumptionGuardTests
+    {
+        private static readonly Dictionary<string, string> Allowlist = new();
+
+        private static string FindRepoRoot()
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null)
+            {
+                string dataDir = Path.Combine(dir, "data");
+                string srcDir = Path.Combine(dir, "src");
+                if (Directory.Exists(dataDir) && Directory.Exists(srcDir))
+                {
+                    return Path.GetFullPath(dir);
+                }
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            throw new DirectoryNotFoundException("Could not locate repository root in any ancestor of the test binary.");
+        }
+
+        [Fact]
+        public void VerifyNoOrphanOptionFields()
+        {
+            string repoRoot = FindRepoRoot();
+            string srcPath = Path.Combine(repoRoot, "src");
+
+            var assembly = typeof(PinderLlmAdapterOptions).Assembly;
+            var typesToGuard = new[]
+            {
+                assembly.GetType("Pinder.LlmAdapters.PinderLlmAdapterOptions")
+                    ?? throw new Exception("Could not find PinderLlmAdapterOptions"),
+                assembly.GetType("Pinder.LlmAdapters.Anthropic.AnthropicOptions")
+                    ?? throw new Exception("Could not find AnthropicOptions")
+            };
+
+            // Recursively get all *.cs files under src/
+            var csFiles = Directory.GetFiles(srcPath, "*.cs", SearchOption.AllDirectories)
+                .Select(Path.GetFullPath)
+                .ToList();
+
+            var orphans = new List<string>();
+
+            foreach (var type in typesToGuard)
+            {
+                // Find declaring file of the options class under src/
+                string declaringFile = Path.GetFullPath(
+                    Directory.GetFiles(srcPath, $"{type.Name}.cs", SearchOption.AllDirectories)
+                    .FirstOrDefault() ?? throw new FileNotFoundException($"Declaring file for {type.Name} not found under src/"));
+
+                // Enumerate all public instance properties
+                var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+                foreach (var prop in properties)
+                {
+                    // Skip if allowlisted (by property name or ClassName.PropertyName)
+                    if (Allowlist.ContainsKey(prop.Name) || Allowlist.ContainsKey($"{type.Name}.{prop.Name}"))
+                    {
+                        continue;
+                    }
+
+                    // Scan ALL *.cs files under src/ EXCLUDING that property's own declaring file
+                    bool hasReference = false;
+                    string pattern = $@"\b{Regex.Escape(prop.Name)}\b";
+
+                    foreach (var file in csFiles)
+                    {
+                        if (file.Equals(declaringFile, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        // Read the content of the file
+                        string content = File.ReadAllText(file);
+                        if (Regex.IsMatch(content, pattern))
+                        {
+                            hasReference = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasReference)
+                    {
+                        orphans.Add($"{type.Name}.{prop.Name}");
+                    }
+                }
+            }
+
+            if (orphans.Count > 0)
+            {
+                var errorMessages = orphans.Select(orphan =>
+                    $"{orphan}: public option field with no production consumer — this is the #1287 dead-code pattern; wire it or remove it.");
+                
+                Assert.Fail(string.Join(Environment.NewLine, errorMessages));
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/OptionsConsumptionGuardTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/OptionsConsumptionGuardTests.cs
@@ -12,7 +12,12 @@ namespace Pinder.LlmAdapters.Tests
 {
     public class OptionsConsumptionGuardTests
     {
-        private static readonly Dictionary<string, string> Allowlist = new();
+        private static readonly Dictionary<string, string> Allowlist = new()
+        {
+            // TODO(orphan-candidate): the entries below are option fields with no current production consumer; see #1297 PR — file follow-up removal tickets, do NOT silently keep forever.
+            { "AnthropicOptions.ApiKey", "the Anthropic API key is consumed by the transport/client credential path, not referenced by name in adapter src; orphan-candidate pending confirmation (see #1287 pattern). Follow-up removal ticket to be filed." },
+            { "AnthropicOptions.InterestChangeBeatTemperature", "per-method temperature override with no current production consumer; orphan-candidate. Follow-up removal ticket to be filed." }
+        };
 
         private static string FindRepoRoot()
         {


### PR DESCRIPTION
Closes #1297.

## What
Test-only ticket (plus one docs note). Adds a permanent guard that fails the build if a public option property has no production (`src/`) consumer — the #1287 dead-code pattern.

### tests/Pinder.LlmAdapters.Tests/OptionsConsumptionGuardTests.cs (new)
Reflects over the `Pinder.LlmAdapters` assembly and enumerates all public instance properties of `PinderLlmAdapterOptions` and `AnthropicOptions`. For each property, scans all `*.cs` under `src/` (recursively) EXCLUDING the property's own declaring file for a word-boundary reference to the property name; asserts at least one hit. `session-runner/` consumption does NOT count (that was exactly the #1287 trap). Explicit name→justification allowlist; failure message names the orphan and states the #1287-pattern guidance.

### Orphan-candidates found & allowlisted (NOT fixed here, per ticket scope)
Two genuine orphans were flagged and allowlisted with justification + `// TODO(orphan-candidate)` marker. Production code was NOT touched — follow-up removal tickets should be filed:
- `AnthropicOptions.ApiKey` — no production consumer by name in adapter src (key flows via transport/client credential path).
- `AnthropicOptions.InterestChangeBeatTemperature` — per-method temperature override with no current production consumer.

### docs/ARCHITECTURE.md
Added a short "Guard tests" subsection (Pinder.LlmAdapters section) documenting the consumption guard and how to use the allowlist.

## Verification (local; no GitHub CI on these repos)
- Test authored RED first (flagged the two orphans), then made GREEN via justified allowlisting.
- `dotnet test tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj` → Passed! Failed: 0, Passed: 1127.
- `DocsArchitectureReferenceIntegrityTests` still passes (docs edit added no bad .cs ref).
- `git diff --stat origin/main -- src/ session-runner/` → empty (no production code touched). No NuGet changes.

Independent reviewer (claude-opus-4-8): Verdict APPROVE — allowlist decisions independently validated (both fields confirmed to lack any src consumer; non-allowlisted fields confirmed to have real consumers).