### PR TITLE
test(arch): architecture dependency-rule tests — kernel purity and single-adapter invariant

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,8 @@ API. `Pinder.RemoteAssets` is NOT used by the engine or the CLI harness directly
 
 ## 2. Assembly Map
 
+These assembly-map invariants — Pinder.Core kernel purity (zero non-BCL dependencies) and a single production ILlmAdapter implementation (PinderLlmAdapter), with vendor transports under vendor namespaces — are enforced by ArchitectureRuleTests.
+
 ### Pinder.Core
 
 The domain kernel. Zero external dependencies — no NuGet packages, no I/O.

--- a/tests/Pinder.Core.Tests/ArchitectureRuleTests.cs
+++ b/tests/Pinder.Core.Tests/ArchitectureRuleTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.LlmAdapters;
+
+namespace Pinder.Core.Tests
+{
+    public class ArchitectureRuleTests
+    {
+        // ── Test A ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void KernelPurity()
+        {
+            var assembly = typeof(GameSession).Assembly;
+            var referencedAssemblies = assembly.GetReferencedAssemblies();
+            var offending = new List<string>();
+
+            foreach (var refAsm in referencedAssemblies)
+            {
+                var name = refAsm.Name;
+                if (name == null) continue;
+
+                bool isPermitted = name.Equals("netstandard", StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("mscorlib", StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("System", StringComparison.OrdinalIgnoreCase)
+                    || name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                    || name.StartsWith("Microsoft.Bcl.", StringComparison.OrdinalIgnoreCase);
+
+                if (!isPermitted)
+                {
+                    offending.Add(name);
+                }
+            }
+
+            if (offending.Count > 0)
+            {
+                Assert.Fail($"Pinder.Core must remain a zero-dependency domain kernel. Offending assemblies: {string.Join(", ", offending)}");
+            }
+        }
+
+        // ── Test B ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SingleProductionAdapter()
+        {
+            var assembly = typeof(PinderLlmAdapter).Assembly;
+            var adapterTypes = assembly.GetTypes()
+                .Where(t => !t.IsAbstract && !t.IsInterface &&
+                            (typeof(ILlmAdapter).IsAssignableFrom(t) ||
+                             typeof(IStatefulLlmAdapter).IsAssignableFrom(t)))
+                .ToList();
+
+            var expectedFullName = "Pinder.LlmAdapters.PinderLlmAdapter";
+            var extraTypes = adapterTypes
+                .Where(t => t.FullName != expectedFullName)
+                .Select(t => t.FullName ?? t.Name)
+                .ToList();
+
+            if (adapterTypes.Count != 1 || adapterTypes[0].FullName != expectedFullName)
+            {
+                Assert.Fail("second production ILlmAdapter implementation detected — parallel adapter paths are how the OverlayApplier dead-end happened; extend PinderLlmAdapter/ILlmTransport instead. Extra types found: " + string.Join(", ", extraTypes));
+            }
+        }
+
+        // ── Test C ────────────────────────────────────────────────────────────
+
+        private static readonly HashSet<string> DecoratorAllowlist = new HashSet<string>
+        {
+            // #340 cosmetic punctuation decorator, wraps inner ILlmTransport
+            "Pinder.LlmAdapters.PunctuationNormalizingTransport",
+
+            // #831 thinking-block strip decorator, wraps inner ILlmTransport
+            "Pinder.LlmAdapters.ThinkingStrippingLlmTransport"
+        };
+
+        [Fact]
+        public void TransportNamespaceShape()
+        {
+            var assembly = typeof(PinderLlmAdapter).Assembly;
+            var transportTypes = assembly.GetTypes()
+                .Where(t => !t.IsAbstract && !t.IsInterface && typeof(ILlmTransport).IsAssignableFrom(t))
+                .ToList();
+
+            foreach (var type in transportTypes)
+            {
+                var ns = type.Namespace;
+                var fullName = type.FullName;
+
+                bool isVendorNamespace = ns == "Pinder.LlmAdapters.Anthropic" || ns == "Pinder.LlmAdapters.OpenAi";
+                bool isAllowlisted = fullName != null && DecoratorAllowlist.Contains(fullName);
+
+                if (!isVendorNamespace && !isAllowlisted)
+                {
+                    Assert.Fail($"Offending transport type '{fullName}' with namespace '{ns}'. New VENDOR transports must live under a vendor namespace (Pinder.LlmAdapters.<Vendor>) and new cross-cutting decorators must be added to the allowlist with justification.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1298.

## What
Test-only ticket (plus one docs note). Adds reflection-based guards for the two load-bearing architecture invariants, so a regression fails the build instead of silently accumulating dead parallel machinery.

### tests/Pinder.Core.Tests/ArchitectureRuleTests.cs (new, plain reflection — no NuGet)
- Test A — KernelPurity: `typeof(GameSession).Assembly.GetReferencedAssemblies()` must contain only BCL/System/netstandard refs (permitted: `netstandard`, `mscorlib`, `System`, `System.*`, `Microsoft.Bcl.*`); any `Pinder.*` or third-party ref fails with "Pinder.Core must remain a zero-dependency domain kernel."
- Test B — SingleProductionAdapter: in the `Pinder.LlmAdapters` assembly, the set of non-abstract `ILlmAdapter`/`IStatefulLlmAdapter` implementations must be exactly `{ PinderLlmAdapter }`. (`NullLlmAdapter` lives in `Pinder.Core`, naturally excluded.)
- Test C — TransportNamespaceShape: every non-abstract `ILlmTransport` in `Pinder.LlmAdapters` must be under a vendor namespace (`.Anthropic`/`.OpenAi`) OR in an explicit, per-entry-justified decorator allowlist. The two legitimate cross-cutting decorators — `PunctuationNormalizingTransport` (#340) and `ThinkingStrippingLlmTransport` (#831), both wrapping an inner `ILlmTransport` — are allowlisted; new vendor transports must use a vendor namespace.

### docs/ARCHITECTURE.md
One-line note in section 2 (Assembly Map) that these invariants are enforced by `ArchitectureRuleTests`.

## Verification (local; no GitHub CI on these repos)
- `dotnet test ...Pinder.Core.Tests --filter ArchitectureRuleTests` → 3 passed.
- Full `Pinder.Core.Tests` → Passed: 3173, Failed: 0, Skipped: 18. `Pinder.LlmAdapters.Tests` → 1127 passed. `DocsArchitectureReferenceIntegrityTests` still green.
- `git diff --stat origin/main -- src/ session-runner/` → empty. No NuGet/project changes.
- Guards independently confirmed non-vacuous (each goes RED under a genuine violation) and the two Test-C decorators confirmed genuine decorators, not vendor transports.

Independent reviewer (claude-opus-4-8): Verdict APPROVE.