### PR TITLE
fix(engine): restore config-driven LLM failure corruption prompts (#1311)

### DIFF
--- a/src/Pinder.Core/Conversation/DeliveryStage.cs
+++ b/src/Pinder.Core/Conversation/DeliveryStage.cs
@@ -95,7 +95,40 @@ namespace Pinder.Core.Conversation
             // and this commit overlay are ephemeral; only the committed line is
             // persisted (by TurnOrchestrator), preserving the clean-history rule.
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryStarted));
-            string deliveredMessage = DeliveryOverlay.Apply(originalIntendedText, rollResult.Tier, rollResult.MissMargin, chosenOption.Stat);
+            string? deliveredMessage = null;
+
+            if (!rollResult.IsSuccess)
+            {
+                string? failureInstruction = HorninessEngine.GetStatFailureInstruction(_statDeliveryInstructions, chosenOption.Stat, rollResult.Tier);
+                if (!string.IsNullOrWhiteSpace(failureInstruction) && _llm != null)
+                {
+                    try
+                    {
+                        deliveredMessage = await _llm.ApplyFailureCorruptionAsync(
+                            originalIntendedText,
+                            failureInstruction,
+                            chosenOption.Stat,
+                            rollResult.Tier,
+                            playerArchetypeDirectiveForDelivery,
+                            ct).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception)
+                    {
+                        // Fall back to deterministic DeliveryOverlay
+                        deliveredMessage = null;
+                    }
+                }
+            }
+
+            if (deliveredMessage == null || deliveredMessage == originalIntendedText)
+            {
+                deliveredMessage = DeliveryOverlay.Apply(originalIntendedText, rollResult.Tier, rollResult.MissMargin, chosenOption.Stat);
+            }
+
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DeliveryCompleted, deliveredMessage));
 
             // #902 / SANITIZATION-INVARIANTS-MUST-RUN-AFTER-EACH-STAGE: meta-prefix

--- a/src/Pinder.Core/Conversation/NullLlmAdapter.cs
+++ b/src/Pinder.Core/Conversation/NullLlmAdapter.cs
@@ -115,5 +115,12 @@ namespace Pinder.Core.Conversation
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(message);
         }
+
+        /// <inheritdoc />
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(message);
+        }
     }
 }

--- a/src/Pinder.Core/Interfaces/ILlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ILlmAdapter.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Pinder.Core.Conversation;
+using Pinder.Core.Rolls;
 using Pinder.Core.Stats;
 
 namespace Pinder.Core.Interfaces
@@ -83,5 +84,12 @@ namespace Pinder.Core.Interfaces
         /// the trap-overlay rewrite still sounds like the character (#372 + #371 union).
         /// </param>
         Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Apply a stat-specific failure corruption instruction to a delivered message.
+        /// Called when a standard option roll fails and a config prompt is available.
+        /// Returns the corrupted message text.
+        /// </summary>
+        Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default);
     }
 }

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -499,6 +499,13 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(message);
+        }
+
+        /// <inheritdoc />
         public async Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -499,10 +499,87 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default)
+        public async Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default)
         {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(message);
+            if (string.IsNullOrWhiteSpace(message) || string.IsNullOrWhiteSpace(instruction))
+            {
+                if (string.IsNullOrWhiteSpace(instruction))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "failure_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "skipped_no_instruction",
+                        outcome: OverlayOutcome.Skipped
+                    ));
+                }
+                return message;
+            }
+
+            string systemPrompt = "You are editing dialogue for Pinder, a comedy RPG where sentient penises date each other on a fictional app. " +
+                $"The character completely failed a {stat} check (failure tier: {tier}), causing their message to be corrupted or botched! " +
+                "Rewrite the message to dramatically apply the failure instruction while staying in the character's voice. " +
+                "Be wildly creative, ridiculous, and funny, but return ONLY the rewritten message text. " +
+                "No commentary, no meta-text, no preamble, and no refusals. Absolute silence except for the rewritten message.";
+
+            string userContent = !string.IsNullOrWhiteSpace(archetypeDirective)
+                ? $"{archetypeDirective}\n\nFAILURE CORRUPTION INSTRUCTION ({stat}, {tier}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the failure corruption (preserving the archetype voice above) and return the modified message."
+                : $"FAILURE CORRUPTION INSTRUCTION ({stat}, {tier}):\n{instruction}\n\nORIGINAL MESSAGE:\n{message}\n\nApply the failure corruption and return the modified message.";
+
+            try
+            {
+                double temperature = _options.DeliveryTemperature ?? DefaultDeliveryTemperature;
+                var result = await _overlayTransport.SendAsync(systemPrompt, userContent, temperature, _options.MaxTokens, phase: LlmPhase.Delivery, ct: ct)
+                    .ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "failure_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "empty_output",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
+
+                string trimmed = result.Trim();
+
+                // Detect refusal — fall back to original message silently
+                if (trimmed.StartsWith("I can't", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith("I cannot", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.IndexOf("inappropriate", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    trimmed.IndexOf("I'd be happy to help", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                        overlayType: "failure_corruption",
+                        provider: "primary",
+                        model: null,
+                        reason: "refusal",
+                        outcome: OverlayOutcome.Degraded
+                    ));
+                    return message;
+                }
+
+                return trimmed;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // #794: cancellation must propagate.
+            }
+            catch (Exception ex)
+            {
+                _options.OnOverlayDegraded?.Invoke(new OverlayDegradedEvent(
+                    overlayType: "failure_corruption",
+                    provider: "primary",
+                    model: null,
+                    reason: "error",
+                    outcome: OverlayOutcome.Degraded,
+                    errorCode: ex.GetType().Name
+                ));
+                return message;
+            }
         }
 
         /// <inheritdoc />

--- a/tests/Pinder.Core.TestCommon/StubLlmAdapter.cs
+++ b/tests/Pinder.Core.TestCommon/StubLlmAdapter.cs
@@ -69,6 +69,9 @@ namespace Pinder.Core.TestCommon
         public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
             => Task.FromResult(message);
 
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, CancellationToken ct = default)
+            => Task.FromResult(message);
+
         public static StatBlock MakeStatBlock(int allStats = 2, int allShadow = 0)
         {
             var stats = new Dictionary<StatType, int>

--- a/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/CallbackGameSessionTests.cs
@@ -57,7 +57,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 [Fact]
         public async Task ResolveTurn_WithCallbackOption_AppliesCallbackBonus()

--- a/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
+++ b/tests/Pinder.Core.Tests/ComboGameSessionTests.cs
@@ -50,7 +50,12 @@ namespace Pinder.Core.Tests
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
-    }
+    
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
+        }
+}
 
     [Trait("Category", "Core")]
     public class ComboGameSessionTests

--- a/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
@@ -130,7 +130,12 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private static GameSession MakeSession(RecordingStatefulAdapter adapter, IDiceRoller dice) =>
             new GameSession(

--- a/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue293_MarkEndedTests.cs
@@ -24,7 +24,12 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedDice : IDiceRoller
         {

--- a/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue536_RevertStatefulAdapterTests.cs
@@ -31,7 +31,12 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class StatefulDummyLlmAdapter : IStatefulLlmAdapter
         {
@@ -66,6 +71,7 @@ namespace Pinder.Core.Tests.Conversation
             public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+            public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
         }
 
         private sealed class DummyDice : IDiceRoller

--- a/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue593_WeaknessDcReductionOnTurnStartTests.cs
@@ -213,6 +213,11 @@ namespace Pinder.Core.Tests.Conversation
                 ct.ThrowIfCancellationRequested();
                 return Task.FromResult(message);
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_StatelessAdapterConcurrencyTests.cs
@@ -92,7 +92,12 @@ namespace Pinder.Core.Tests.Conversation
                     Interlocked.Decrement(ref _inFlight);
                 }
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private static DateeContext MakeContext(string playerLabel) =>
             new DateeContext(

--- a/tests/Pinder.Core.Tests/Conversation/Issue957_WaitTransactionalTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue957_WaitTransactionalTests.cs
@@ -357,7 +357,12 @@ namespace Pinder.Core.Tests.Conversation
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class NullTrapRegistry : ITrapRegistry
         {

--- a/tests/Pinder.Core.Tests/Conversation/LlmDispatcherTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/LlmDispatcherTests.cs
@@ -37,7 +37,12 @@ namespace Pinder.Core.Tests.Conversation
                 TrapCalls++;
                 return Task.FromResult(TrapResponse == "ECHO" ? message : TrapResponse);
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         [Fact]
         public async Task Dispatcher_ReturnsOriginalMessage_WhenNoOverlaysEnabled()

--- a/tests/Pinder.Core.Tests/CritAdvantageTests.cs
+++ b/tests/Pinder.Core.Tests/CritAdvantageTests.cs
@@ -234,6 +234,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
+++ b/tests/Pinder.Core.Tests/FixationHighestPctProbabilityTests.cs
@@ -214,6 +214,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
+++ b/tests/Pinder.Core.Tests/GameSessionWaitTests.cs
@@ -284,7 +284,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 private sealed class StubTrapRegistry : ITrapRegistry
         {

--- a/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessAlwaysRolledTests.cs
@@ -163,7 +163,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 private sealed class TestClock : IGameClock
         {

--- a/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
+++ b/tests/Pinder.Core.Tests/HorninessOverlayTests.cs
@@ -258,6 +258,11 @@ namespace Pinder.Core.Tests
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
+++ b/tests/Pinder.Core.Tests/Integration/FullConversationIntegrationTest.cs
@@ -154,6 +154,11 @@ namespace Pinder.Core.Tests.Integration
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1095_ShadowTrapTruncateTests.cs
@@ -280,7 +280,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : System.Random
         {

--- a/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1125_CollapseDeliveryTests.cs
@@ -114,7 +114,12 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
                 => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private static GameSession NewSession(ILlmAdapter llm, IDiceRoller dice)
             => new GameSession(

--- a/tests/Pinder.Core.Tests/Issue1168_DcBiasTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1168_DcBiasTests.cs
@@ -57,7 +57,12 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult(message);
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         // 1. RollEngine.ApplyDcBias
         [Fact]

--- a/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1207_Nat20ImprovementTests.cs
@@ -70,7 +70,12 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult(context.DeliveredMessage + $" [IMPROVED:{context.TierKey}]");
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private static GameSession NewSession(ILlmAdapter llm, IDiceRoller dice, int playerStats = 2, int dateeStats = 2)
             => new GameSession(

--- a/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1209_HorninessAppendQuestionTests.cs
@@ -73,7 +73,12 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
                 => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         // Shared RNGs for predictable checks
         private sealed class AlwaysMinRandom : Random

--- a/tests/Pinder.Core.Tests/Issue1210_SuccessImprovementTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1210_SuccessImprovementTests.cs
@@ -73,7 +73,12 @@ namespace Pinder.Core.Tests
                 // Appends a marker for assertion
                 return Task.FromResult(context.DeliveredMessage + $" [IMPROVED:{context.TierKey}]");
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private static GameSession NewSession(ILlmAdapter llm, IDiceRoller dice, int playerStats = 2, int dateeStats = 2)
             => new GameSession(

--- a/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1218_DenialThresholdSsotTests.cs
@@ -259,6 +259,11 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1243_SuccessImprovementFailClosedTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1243_SuccessImprovementFailClosedTests.cs
@@ -76,7 +76,12 @@ namespace Pinder.Core.Tests
             {
                 return Task.FromResult(_improvementResponse);
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class AlwaysMinRandom : Random
         {

--- a/tests/Pinder.Core.Tests/Issue1311_RestoreLlmDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1311_RestoreLlmDeliveryTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Characters;
+using Pinder.Core.Conversation;
+using Pinder.Core.Interfaces;
+using Pinder.Core.Rolls;
+using Pinder.Core.Stats;
+using Xunit;
+
+namespace Pinder.Core.Tests
+{
+    /// <summary>
+    /// Contract and unit tests for issue #1311: restoring config-driven LLM failure corruption prompts.
+    /// </summary>
+    [Trait("Category", "Core")]
+    public class Issue1311_RestoreLlmDeliveryTests
+    {
+        [Fact]
+        public async Task ApplyFailureCorruption_InvokedWhenFailedAndInstructionConfigured()
+        {
+            // 1. Setup GameSession with a mock LLM adapter
+            var llm = new MockLlmAdapter1311();
+            
+            // Dice: 1 (horniness roll), 1 (Nat 1 d20 for turn, guaranteed failure), 50 (timing)
+            var dice = new FixedDice(1, 1, 50);
+
+            var statInstructions = new MockStatDeliveryInstructions("REWRITE WITH DISASTER STYLE");
+            var activeArchetype = new ActiveArchetype("The Peacock", "Speak boastfully.", 10);
+
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                statDeliveryInstructions: statInstructions
+            );
+
+            var player = MakeProfile("Sable", activeArchetype: activeArchetype);
+            var datee = MakeProfile("Brick");
+
+            var session = new GameSession(player, datee, llm, dice, new NullTrapRegistry(), config);
+
+            // 2. Start turn and resolve picking the first option
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // 3. Verify it's a failed roll
+            Assert.False(result.Roll.IsSuccess);
+
+            // 4. Verify that ApplyFailureCorruptionAsync was invoked with the correct arguments
+            Assert.True(llm.ApplyFailureCorruptionCalled, "ApplyFailureCorruptionAsync should have been called on the LLM adapter.");
+            Assert.Equal("REWRITE WITH DISASTER STYLE", llm.CapturedInstruction);
+            Assert.Equal(StatType.Charm, llm.CapturedStat);
+            Assert.Equal(result.Roll.Tier, llm.CapturedTier);
+            Assert.Equal(activeArchetype.Directive, llm.CapturedArchetypeDirective);
+
+            // 5. Verify that the LLM returned value is used as the delivered message
+            Assert.Equal("Corrupted by LLM!", result.DeliveredMessage);
+        }
+
+        [Fact]
+        public async Task ApplyFailureCorruption_FallsBackToDeliveryOverlay_WhenLlmThrows()
+        {
+            // 1. Setup GameSession with a mock LLM adapter configured to throw
+            var llm = new MockLlmAdapter1311 { ShouldThrow = true };
+            
+            // Dice: 1 (horniness), 1 (Nat 1 d20), 50 (timing)
+            var dice = new FixedDice(1, 1, 50);
+
+            var statInstructions = new MockStatDeliveryInstructions("REWRITE WITH DISASTER STYLE");
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                statDeliveryInstructions: statInstructions
+            );
+
+            var player = MakeProfile("Sable");
+            var datee = MakeProfile("Brick");
+
+            var session = new GameSession(player, datee, llm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // 2. Verify that it's a failed roll and falls back to deterministic overlay
+            Assert.False(result.Roll.IsSuccess);
+            Assert.True(llm.ApplyFailureCorruptionCalled, "ApplyFailureCorruptionAsync should be called and throw.");
+            
+            // Should fall back to DeliveryOverlay.Apply (meaning it does not throw an exception out of the session,
+            // and instead delivers a deterministically degraded string).
+            string expectedDeterministic = DeliveryOverlay.Apply("Test Option", result.Roll.Tier, result.Roll.MissMargin, StatType.Charm);
+            expectedDeterministic = Pinder.Core.Text.MarkdownSanitizer.Strip(expectedDeterministic);
+            Assert.Equal(expectedDeterministic, result.DeliveredMessage);
+        }
+
+        [Fact]
+        public async Task ApplyFailureCorruption_FallsBackToDeliveryOverlay_WhenNoInstructionConfigured()
+        {
+            // 1. Setup GameSession with a mock LLM adapter but no failure instructions configured (returns null)
+            var llm = new MockLlmAdapter1311();
+            
+            // Dice: 1 (horniness), 1 (Nat 1 d20), 50 (timing)
+            var dice = new FixedDice(1, 1, 50);
+
+            // Stat delivery instructions return null
+            var statInstructions = new MockStatDeliveryInstructions(null);
+            var config = new GameSessionConfig(
+                clock: TestHelpers.MakeClock(),
+                statDeliveryInstructions: statInstructions
+            );
+
+            var player = MakeProfile("Sable");
+            var datee = MakeProfile("Brick");
+
+            var session = new GameSession(player, datee, llm, dice, new NullTrapRegistry(), config);
+
+            await session.StartTurnAsync();
+            var result = await session.ResolveTurnAsync(0);
+
+            // 2. Verify that ApplyFailureCorruptionAsync is NOT called and falls back to deterministic overlay
+            Assert.False(result.Roll.IsSuccess);
+            Assert.False(llm.ApplyFailureCorruptionCalled, "ApplyFailureCorruptionAsync should not be called when instruction is null.");
+
+            string expectedDeterministic = DeliveryOverlay.Apply("Test Option", result.Roll.Tier, result.Roll.MissMargin, StatType.Charm);
+            expectedDeterministic = Pinder.Core.Text.MarkdownSanitizer.Strip(expectedDeterministic);
+            Assert.Equal(expectedDeterministic, result.DeliveredMessage);
+        }
+
+        // ======================== Helpers & Mocks ========================
+
+        private static CharacterProfile MakeProfile(string name, int allStats = 2, ActiveArchetype? activeArchetype = null)
+        {
+            return new CharacterProfile(
+                stats: TestHelpers.MakeStatBlock(allStats),
+                assembledSystemPrompt: $"You are {name}.",
+                displayName: name,
+                timing: new TimingProfile(5, 0.0f, 0.0f, "neutral"),
+                level: 1,
+                activeArchetype: activeArchetype
+            );
+        }
+
+        private class MockStatDeliveryInstructions
+        {
+            private readonly string? _instruction;
+
+            public MockStatDeliveryInstructions(string? instruction)
+            {
+                _instruction = instruction;
+            }
+
+            public string? GetStatFailureInstruction(StatType stat, FailureTier tier)
+            {
+                return _instruction;
+            }
+        }
+
+        private class MockLlmAdapter1311 : ILlmAdapter
+        {
+            public bool ApplyFailureCorruptionCalled { get; set; }
+            public string? CapturedMessage { get; set; }
+            public string? CapturedInstruction { get; set; }
+            public StatType? CapturedStat { get; set; }
+            public FailureTier? CapturedTier { get; set; }
+            public string? CapturedArchetypeDirective { get; set; }
+            
+            public string ReturnValue { get; set; } = "Corrupted by LLM!";
+            public bool ShouldThrow { get; set; }
+
+            public Task<string> ApplyFailureCorruptionAsync(
+                string message, 
+                string instruction, 
+                StatType stat, 
+                FailureTier tier, 
+                string? archetypeDirective = null, 
+                CancellationToken ct = default)
+            {
+                ApplyFailureCorruptionCalled = true;
+                CapturedMessage = message;
+                CapturedInstruction = instruction;
+                CapturedStat = stat;
+                CapturedTier = tier;
+                CapturedArchetypeDirective = archetypeDirective;
+
+                if (ShouldThrow)
+                {
+                    throw new Exception("LLM failure!");
+                }
+
+                return Task.FromResult(ReturnValue);
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+            {
+                return Task.FromResult(new[] { new DialogueOption(StatType.Charm, "Test Option") });
+            }
+
+            public Task<DateeResponse> GetDateeResponseAsync(DateeContext context, CancellationToken ct = default)
+            {
+                return Task.FromResult(new DateeResponse("..."));
+            }
+
+            public Task<string?> GetInterestChangeBeatAsync(InterestChangeContext context, CancellationToken ct = default)
+            {
+                return Task.FromResult<string?>(null);
+            }
+
+            public Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+
+            public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, CancellationToken ct = default)
+            {
+                return Task.FromResult(message);
+            }
+        }
+    }
+}

--- a/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
+++ b/tests/Pinder.Core.Tests/Issue241_GameSessionDeliveryContextTests.cs
@@ -118,7 +118,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 private sealed class FixedDice : IDiceRoller
         {

--- a/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
+++ b/tests/Pinder.Core.Tests/Issue307_ShadowTaintRawValueTests.cs
@@ -279,7 +279,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
         {
@@ -301,6 +306,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_DeliveryDateeShadowThresholdsTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_DeliveryDateeShadowThresholdsTests.cs
@@ -216,6 +216,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
+++ b/tests/Pinder.Core.Tests/Issue308_ShadowThresholdWiringSpecTests.cs
@@ -341,6 +341,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
+++ b/tests/Pinder.Core.Tests/Issue314_TextLayerNoopCallbackTests.cs
@@ -193,7 +193,12 @@ namespace Pinder.Core.Tests
 
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedDice : IDiceRoller
         {

--- a/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
+++ b/tests/Pinder.Core.Tests/Issue333_TurnZeroSceneEntriesTests.cs
@@ -169,6 +169,11 @@ namespace Pinder.Core.Tests
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
+++ b/tests/Pinder.Core.Tests/Issue364_SteeringBeforeDeliveryTests.cs
@@ -282,7 +282,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("so when are we doing this?");
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : Random
         {

--- a/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
+++ b/tests/Pinder.Core.Tests/Issue365_ShadowOnFailedRollTests.cs
@@ -278,7 +278,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : System.Random
         {

--- a/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
+++ b/tests/Pinder.Core.Tests/Issue399_HorninessShadowOrderingTests.cs
@@ -357,7 +357,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult("steering question");
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : System.Random
         {

--- a/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
+++ b/tests/Pinder.Core.Tests/Issue493_FailureDegradationCoreTests.cs
@@ -62,7 +62,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 #endregion
 

--- a/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
+++ b/tests/Pinder.Core.Tests/Issue695_StatFailureCorruptionTests.cs
@@ -192,7 +192,12 @@ namespace Pinder.Core.Tests
             public Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(message);
             public Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => Task.FromResult(message);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedDice : IDiceRoller
         {

--- a/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
+++ b/tests/Pinder.Core.Tests/Issue840_NoLengthClampTests.cs
@@ -171,7 +171,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, System.Threading.CancellationToken ct = default)
                 => Task.FromResult(_steeringQuestion);
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : Random
         {

--- a/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
+++ b/tests/Pinder.Core.Tests/MadnessT3UnhingedSpecTests.cs
@@ -434,7 +434,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 /// <summary>Null trap registry for tests.</summary>
         private sealed class NullTrapRegistry : ITrapRegistry

--- a/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
+++ b/tests/Pinder.Core.Tests/Rolls/Issue927_FinalVerdictTierTests.cs
@@ -400,7 +400,12 @@ namespace Pinder.Core.Tests
             public Task<string> GetHorninessQuestionAsync(HorninessQuestionContext context, CancellationToken ct = default) => Task.FromResult("question?");
         public Task<string> GetSteeringQuestionAsync(SteeringContext context, CancellationToken ct = default)
                 => Task.FromResult("steering question");
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         private sealed class FixedRandom : System.Random
         {

--- a/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthEventTests.cs
@@ -170,6 +170,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.Helpers.cs
+++ b/tests/Pinder.Core.Tests/ShadowGrowthSpecTests.Helpers.cs
@@ -137,7 +137,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
         /// <summary>LLM adapter that rotates through different option sets per turn.</summary>
         private sealed class RotatingLlmAdapter : ILlmAdapter
@@ -159,6 +164,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.Helpers.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdGameSessionTests.Helpers.cs
@@ -125,7 +125,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
         /// <summary>LLM adapter that captures DialogueContext for inspection.</summary>
         private sealed class CapturingLlmAdapter : ILlmAdapter
@@ -149,6 +154,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
+++ b/tests/Pinder.Core.Tests/ShadowThresholdSpecTests.cs
@@ -292,7 +292,12 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
 
                 private sealed class CapturingLlmAdapter : ILlmAdapter
         {
@@ -315,6 +320,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusSpecTests.cs
@@ -331,6 +331,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/TellBonusTests.cs
+++ b/tests/Pinder.Core.Tests/TellBonusTests.cs
@@ -208,6 +208,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
+++ b/tests/Pinder.Core.Tests/TrapPipelineW2aTests.cs
@@ -88,7 +88,12 @@ namespace Pinder.Core.Tests
                 // Mark the message so a Trap (X) text-diff is emitted.
                 return Task.FromResult($"[Trap:{trapName}] {message}");
             }
+        
+        public Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return Task.FromResult(message);
         }
+}
 
         /// <summary>
         /// Trap registry that exposes one trap per stat. Stat → trap-name map matches

--- a/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
+++ b/tests/Pinder.Core.Tests/TrapTaintInjectionTests.cs
@@ -48,7 +48,12 @@ namespace Pinder.Core.Tests
         public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
         public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
-    }
+    
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
+        }
+}
 
     // ---------------------------------------------------------------
     // Trap registry that returns a specific trap with LLM instruction

--- a/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowSpecTests.cs
@@ -423,6 +423,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }

--- a/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
+++ b/tests/Pinder.Core.Tests/WeaknessWindowTests.cs
@@ -440,6 +440,11 @@ namespace Pinder.Core.Tests
             public System.Threading.Tasks.Task<string> ApplyHorninessOverlayAsync(string message, string instruction, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyShadowCorruptionAsync(string message, string instruction, Pinder.Core.Stats.ShadowStatType shadow, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
             public System.Threading.Tasks.Task<string> ApplyTrapOverlayAsync(string message, string trapInstruction, string trapName, string? dateeContext = null, string? archetypeDirective = null, System.Threading.CancellationToken ct = default) => System.Threading.Tasks.Task.FromResult(message);
+        
+        public System.Threading.Tasks.Task<string> ApplyFailureCorruptionAsync(string message, string instruction, Pinder.Core.Stats.StatType stat, Pinder.Core.Rolls.FailureTier tier, string? archetypeDirective = null, System.Threading.CancellationToken ct = default)
+        {
+            return System.Threading.Tasks.Task.FromResult(message);
         }
+}
     }
 }


### PR DESCRIPTION
Restores the config-driven failure corruption prompts using ILlmAdapter.ApplyFailureCorruptionAsync and integrates them into DeliveryStage.ExecuteAsync with fallback to DeliveryOverlay.Apply.