### PR TITLE
Add canonical character surface material contract

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.25</Version>
+    <Version>0.2.26</Version>
   </PropertyGroup>
 </Project>

--- a/data/anatomy/anatomy-parameters.json
+++ b/data/anatomy/anatomy-parameters.json
@@ -1123,62 +1123,6 @@
     ]
   },
   {
-    "id": "venicus",
-    "name": "Venicus (Vein Prominence - Age)",
-    "metadata": {
-      "group": "surface",
-      "section": "vascularity",
-      "label_key": "anatomy.venicus.label",
-      "control_type": "slider",
-      "normalized_min": 0,
-      "normalized_max": 1,
-      "normalized_default": 0.5,
-      "normalized_step": 0.01,
-      "display_order": 150
-    },
-    "bands": [
-      {
-        "lower": 0,
-        "upper": 0.05,
-        "personality_fragment": "quiet in this dimension; doesn't feel the need to signal history through appearance",
-        "summary_text": "Venicus (Vein Prominence - Age): minimum range (0-5%)."
-      },
-      {
-        "lower": 0.05,
-        "upper": 0.2,
-        "personality_fragment": "keep your emotions carefully tucked away behind a polite, calm facade, and never let them see you sweat or lose your cool",
-        "archetype_tendencies": [],
-        "summary_text": "Venicus (Vein Prominence - Age): low range (5-20%)."
-      },
-      {
-        "lower": 0.2,
-        "upper": 0.5,
-        "personality_fragment": "respond with a steady, moderate pulse, and express your interest clearly but avoid any sudden bursts of overwhelming enthusiasm",
-        "archetype_tendencies": [],
-        "summary_text": "Venicus (Vein Prominence - Age): moderate range (20-50%)."
-      },
-      {
-        "lower": 0.5,
-        "upper": 0.7,
-        "personality_fragment": "show your excitement with a bit more intensity, and let your sentences get slightly longer and more breathless when they talk about something you love",
-        "archetype_tendencies": [],
-        "summary_text": "Venicus (Vein Prominence - Age): balanced range (50-70%)."
-      },
-      {
-        "lower": 0.7,
-        "upper": 0.95,
-        "personality_fragment": "high-energy vein presence; enthusiasm visible and unfiltered; the vitality is a fact, not a performance",
-        "summary_text": "Venicus (Vein Prominence - Age): high range (70-95%)."
-      },
-      {
-        "lower": 0.95,
-        "upper": 1,
-        "personality_fragment": "very difficult to ignore; has calibrated everything around managing the reaction they produce; mostly successful; occasionally not",
-        "summary_text": "Venicus (Vein Prominence - Age): maximum range (95-100%)."
-      }
-    ]
-  },
-  {
     "id": "skinHue",
     "name": "Skin Hue",
     "metadata": {
@@ -1469,16 +1413,16 @@
     ]
   },
   {
-    "id": "blemishes",
-    "name": "Blemishes",
+    "id": "smoothness",
+    "name": "Smoothness",
     "metadata": {
       "group": "skin",
       "section": "details",
-      "label_key": "anatomy.blemishes.label",
+      "label_key": "anatomy.smoothness.label",
       "control_type": "slider",
       "normalized_min": 0,
       "normalized_max": 1,
-      "normalized_default": 0,
+      "normalized_default": 0.51,
       "normalized_step": 0.01,
       "display_order": 230
     },
@@ -1486,49 +1430,32 @@
       {
         "lower": 0,
         "upper": 0.05,
-        "personality_fragment": "smooth, clear; easy to approach; the surface presents no barriers; people sometimes mistake this for simplicity",
-        "stat_modifiers": {
-          "charm": 1
-        },
-        "summary_text": "Blemishes: minimum range (0-5%)."
+        "summary_text": "Smoothness: minimum gloss range (0-5%)."
       },
       {
         "lower": 0.05,
         "upper": 0.2,
-        "personality_fragment": "disclose your one tiny blemish as if it is a major structural defect, and ask if they can look past your ruined perfection",
-        "summary_text": "Blemishes: low range (5-20%)."
+        "summary_text": "Smoothness: low gloss range (5-20%)."
       },
       {
         "lower": 0.2,
         "upper": 0.5,
-        "personality_fragment": "describe your few blemishes as character marks that prove you have survived the harsh realities of the outside world, and demand some sympathy",
-        "summary_text": "Blemishes: moderate range (20-50%)."
+        "summary_text": "Smoothness: moderate gloss range (20-50%)."
       },
       {
         "lower": 0.5,
         "upper": 0.7,
-        "personality_fragment": "textured skin; the history is visible in the surface; doesn't sand it down for anyone's comfort",
-        "summary_text": "Blemishes: balanced range (50-70%)."
+        "summary_text": "Smoothness: balanced gloss range (50-70%)."
       },
       {
         "lower": 0.7,
         "upper": 0.95,
-        "personality_fragment": "significantly blemished; all the wear is visible; not going to pretend it isn't; the past happened and shows; this is a fact rather than a complaint",
-        "stat_modifiers": {
-          "honesty": 1,
-          "self_awareness": 1
-        },
-        "summary_text": "Blemishes: high range (70-95%)."
+        "summary_text": "Smoothness: high gloss range (70-95%)."
       },
       {
         "lower": 0.95,
         "upper": 1,
-        "personality_fragment": "heavily blemished; by thirty-two they had lived several lives; the surface shows all of it; people ask what happened; the accurate answer is 'a lot'",
-        "stat_modifiers": {
-          "honesty": 2,
-          "rizz": -1
-        },
-        "summary_text": "Blemishes: maximum range (95-100%)."
+        "summary_text": "Smoothness: maximum gloss range (95-100%)."
       }
     ]
   },

--- a/data/characters/brick.json
+++ b/data/characters/brick.json
@@ -29,14 +29,31 @@
     "prepucius": 0.92,
     "arrugatis": 0.91,
     "gravitatis": 0.9,
-    "venicus": 0.97,
     "skinHue": 0.06,
     "skinSat": 0.95,
     "skinVal": 0.97,
     "freckles": 0.92,
-    "blemishes": 0.04,
+    "smoothness": 0.51,
     "veins": 0.96,
     "isCircumcised": 1
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/data/characters/character-schema.json
+++ b/data/characters/character-schema.json
@@ -54,14 +54,88 @@
     },
     "items": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 },
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
       "description": "Equipped item ids; resolved against IItemRepository at load."
     },
     "anatomy": {
       "type": "object",
-      "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 },
-      "propertyNames": { "not": { "enum": ["sad", "happy", "serius"] } },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "propertyNames": {
+        "not": {
+          "enum": [
+            "sad",
+            "happy",
+            "serius",
+            "venicus",
+            "blemishes"
+          ]
+        }
+      },
       "description": "Anatomy scalars: parameter id (e.g. \"trunkLengthBase\") -> normalised float [0..1] value (issue #1175)."
+    },
+    "surface_material": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "smoothness",
+        "freckles_pattern_id",
+        "surface_layers"
+      ],
+      "description": "Typed material-surface controls with Unity-authored numeric ranges. Pattern ids are host-resolved strings, not scalar anatomy bands.",
+      "properties": {
+        "smoothness": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "freckles_pattern_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "surface_layers": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "strength",
+              "tiling",
+              "rotation",
+              "pattern_id"
+            ],
+            "properties": {
+              "strength": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 2
+              },
+              "tiling": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 50
+              },
+              "rotation": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 10
+              },
+              "pattern_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
     },
     "psychological_stake": {
       "type": "string",
@@ -79,7 +153,10 @@
       "type": "array",
       "minItems": 15,
       "maxItems": 15,
-      "items": { "type": "string", "minLength": 1 },
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
       "description": "Structured psychological stakes used by runtime prompts. Complete synthesized characters contain exactly 15 entries."
     },
     "psychiatric_diagnosis": {
@@ -100,17 +177,50 @@
       ],
       "description": "Therapist synthesis required by cognitive subtext when the character is used as the datee.",
       "properties": {
-        "derived_feeling": { "type": "string", "minLength": 1 },
-        "defense_reaction": { "type": "string", "minLength": 1 },
-        "safe_connection": { "type": "string", "minLength": 1 },
-        "hurt_protection": { "type": "string", "minLength": 1 },
-        "repair_requirement": { "type": "string", "minLength": 1 },
-        "charm_reaction": { "type": "string", "minLength": 1 },
-        "rizz_reaction": { "type": "string", "minLength": 1 },
-        "honesty_reaction": { "type": "string", "minLength": 1 },
-        "chaos_reaction": { "type": "string", "minLength": 1 },
-        "wit_reaction": { "type": "string", "minLength": 1 },
-        "self_awareness_reaction": { "type": "string", "minLength": 1 }
+        "derived_feeling": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defense_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safe_connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hurt_protection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repair_requirement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "charm_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rizz_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "honesty_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "chaos_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "wit_reaction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "self_awareness_reaction": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "backstory_categories": {
@@ -143,10 +253,17 @@
         "^[a-z_]+$": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["bio_lie", "tragic_reality"],
+          "required": [
+            "bio_lie",
+            "tragic_reality"
+          ],
           "properties": {
-            "bio_lie": { "type": "string" },
-            "tragic_reality": { "type": "string" }
+            "bio_lie": {
+              "type": "string"
+            },
+            "tragic_reality": {
+              "type": "string"
+            }
           }
         }
       }
@@ -154,20 +271,49 @@
     "allocation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["spent", "unspent_pool", "shadows"],
+      "required": [
+        "spent",
+        "unspent_pool",
+        "shadows"
+      ],
       "description": "Player-authored build-point allocation block. Bonuses NOT included here.",
       "properties": {
         "spent": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["charm", "rizz", "honesty", "chaos", "wit", "self_awareness"],
+          "required": [
+            "charm",
+            "rizz",
+            "honesty",
+            "chaos",
+            "wit",
+            "self_awareness"
+          ],
           "properties": {
-            "charm":          { "type": "integer", "minimum": 0 },
-            "rizz":           { "type": "integer", "minimum": 0 },
-            "honesty":        { "type": "integer", "minimum": 0 },
-            "chaos":          { "type": "integer", "minimum": 0 },
-            "wit":            { "type": "integer", "minimum": 0 },
-            "self_awareness": { "type": "integer", "minimum": 0 }
+            "charm": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "rizz": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "honesty": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "chaos": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "wit": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "self_awareness": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         },
         "unspent_pool": {
@@ -178,14 +324,39 @@
         "shadows": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["madness", "despair", "denial", "fixation", "dread", "overthinking"],
+          "required": [
+            "madness",
+            "despair",
+            "denial",
+            "fixation",
+            "dread",
+            "overthinking"
+          ],
           "properties": {
-            "madness":      { "type": "integer", "minimum": 0 },
-            "despair":      { "type": "integer", "minimum": 0 },
-            "denial":       { "type": "integer", "minimum": 0 },
-            "fixation":     { "type": "integer", "minimum": 0 },
-            "dread":        { "type": "integer", "minimum": 0 },
-            "overthinking": { "type": "integer", "minimum": 0 }
+            "madness": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "despair": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "denial": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "fixation": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "dread": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "overthinking": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       }

--- a/data/characters/gerald.json
+++ b/data/characters/gerald.json
@@ -29,14 +29,31 @@
     "prepucius": 0.5,
     "arrugatis": 0.5,
     "gravitatis": 0.5,
-    "venicus": 0.5,
     "skinHue": 0.5,
     "skinSat": 0.5,
     "skinVal": 0.5,
     "freckles": 0.5,
-    "blemishes": 0.5,
+    "smoothness": 0.51,
     "veins": 0.5,
     "isCircumcised": 1
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/data/characters/reuben.json
+++ b/data/characters/reuben.json
@@ -29,14 +29,31 @@
     "prepucius": 0,
     "arrugatis": 0,
     "gravitatis": 0,
-    "venicus": 0.96,
     "skinHue": 0.55,
     "skinSat": 0.6,
     "skinVal": 0.4,
     "freckles": 0.95,
-    "blemishes": 0.03,
+    "smoothness": 0.51,
     "veins": 0.04,
     "isCircumcised": 0
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/data/characters/sable.json
+++ b/data/characters/sable.json
@@ -26,14 +26,31 @@
     "prepucius": 0.53,
     "arrugatis": 0.47,
     "gravitatis": 0.5,
-    "venicus": 0.48,
     "skinHue": 0.48,
     "skinSat": 0.52,
     "skinVal": 0.5,
     "freckles": 0.49,
-    "blemishes": 0.51,
+    "smoothness": 0.51,
     "veins": 0.5,
     "isCircumcised": 0
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/data/characters/velvet.json
+++ b/data/characters/velvet.json
@@ -30,14 +30,31 @@
     "prepucius": 0.1,
     "arrugatis": 0.72,
     "gravitatis": 0.78,
-    "venicus": 0.18,
     "skinHue": 0.3,
     "skinSat": 0.15,
     "skinVal": 0.88,
     "freckles": 0.08,
-    "blemishes": 0.65,
+    "smoothness": 0.51,
     "veins": 0.7,
     "isCircumcised": 0
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/data/characters/zyx.json
+++ b/data/characters/zyx.json
@@ -28,14 +28,31 @@
     "prepucius": 0.1,
     "arrugatis": 0.05,
     "gravitatis": 0.05,
-    "venicus": 0.1,
     "skinHue": 0.06,
     "skinSat": 0.38,
     "skinVal": 0.8,
     "freckles": 0.3,
-    "blemishes": 0.6,
+    "smoothness": 0.51,
     "veins": 0.1,
     "isCircumcised": 0
+  },
+  "surface_material": {
+    "smoothness": 51,
+    "freckles_pattern_id": "Freckles_Dots",
+    "surface_layers": [
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Soft"
+      },
+      {
+        "strength": 0,
+        "tiling": 4,
+        "rotation": 0,
+        "pattern_id": "Wrinkles_Fine"
+      }
+    ]
   },
   "allocation": {
     "spent": {

--- a/docs/data-architecture.md
+++ b/docs/data-architecture.md
@@ -211,3 +211,7 @@ The **stats** (Charm, Rizz, Honesty, Chaos, Wit, Self-Awareness) and **shadows**
 |------|-------|---------|
 | 2026-04-07 | #655 | Initial creation — documented two-tier data model and extensibility approach |
 | 2026-04-30 | #812 | Filled in the full configuration map (delivery-instructions, characters, anatomy, timing). Added per-file loader table, quick-reference, and the anatomy parameter extensibility section. Cross-linked to [Unity Integration Guide](unity-integration.md) for engine-host integration. |
+
+### Material-surface character state
+
+surface_material is typed character state, not an extensible anatomy parameter collection. Core validates authored numeric ranges for smoothness and the two normal-detail layers while preserving host-resolved pattern ids as strings. This prevents freckles/surface pattern ids from being forced into scalar anatomy bands and keeps Unity/Web catalog resolution outside the pure engine boundary.

--- a/docs/modules/unity-core-sync-architecture.md
+++ b/docs/modules/unity-core-sync-architecture.md
@@ -232,4 +232,4 @@ When a Unity id has no core definition at assembly time:
 | pinder-core#836 | Texting style: slot→axis aggregation rule |
 | pinder-core#907 | Texting style: conflict matrix |
 
-Core now carries surface_material as typed material state: smoothness keeps Unity's 0-100 authored range, reckles_pattern_id is a host-resolved pattern id, and two surface_layers carry strength 0-2, tiling 1-50, rotation 0-10, and pattern ids. Legacy enicus migrates into canonical eins only when eins is absent; legacy lemishes is stripped and rejected on new writes.
+Core now carries surface_material as typed material state: smoothness keeps Unity's 0-100 authored range, freckles_pattern_id is a host-resolved pattern id, and two surface_layers carry strength 0-2, tiling 1-50, rotation 0-10, and pattern ids. Legacy venicus migrates into canonical veins only when veins is absent; legacy blemishes is stripped and rejected on new writes.

--- a/docs/modules/unity-core-sync-architecture.md
+++ b/docs/modules/unity-core-sync-architecture.md
@@ -183,7 +183,7 @@ Unity follow-up: remove the `PromptLookupTable` asset from `p-game` once the DLL
 | Age params | 0–100 float | `/100` |
 | Expression | 0–100 float | `/100` |
 | `skinColor` (RGB) | each channel [0..1] | RGB→HSV → `skinHue/skinSat/skinVal` |
-| `freckles`, `blemishes`, `veins` | 0–100 float | `/100` |
+| `freckles`, `smoothness`, `veins` | 0–100 float | `/100` |
 | `isCircumcised` | bool | `false→0.0`, `true→1.0` |
 
 All values are clamped to [0..1] after normalisation.
@@ -231,3 +231,5 @@ When a Unity id has no core definition at assembly time:
 | pinder-web#947 | Anatomy: admin editor + backend write path for anatomy band fragments |
 | pinder-core#836 | Texting style: slot→axis aggregation rule |
 | pinder-core#907 | Texting style: conflict matrix |
+
+Core now carries surface_material as typed material state: smoothness keeps Unity's 0-100 authored range, reckles_pattern_id is a host-resolved pattern id, and two surface_layers carry strength 0-2, tiling 1-50, rotation 0-10, and pattern ids. Legacy enicus migrates into canonical eins only when eins is absent; legacy lemishes is stripped and rejected on new writes.

--- a/docs/specs/character-file-format.md
+++ b/docs/specs/character-file-format.md
@@ -154,6 +154,6 @@ between runtime required fields, schema fields, and the diagnosis prompt.
 
 ## Surface Material
 
-surface_material is an optional typed visual-material block for browser/Unity-equivalent material controls that are not categorical anatomy bands. It carries smoothness in Unity's authored 0-100 range, reckles_pattern_id, and exactly two surface_layers with strength 0-2, tiling 1-50, rotation 0-10, and pattern_id. Pattern ids are host-resolved strings and are intentionally not stored in natomy.
+surface_material is an optional typed visual-material block for browser/Unity-equivalent material controls that are not categorical anatomy bands. It carries smoothness in Unity's authored 0-100 range, freckles_pattern_id, and exactly two surface_layers with strength 0-2, tiling 1-50, rotation 0-10, and pattern_id. Pattern ids are host-resolved strings and are intentionally not stored in anatomy.
 
-Legacy anatomy fields enicus and lemishes are not active fields. Reads migrate enicus to eins only when eins is missing; new writes containing either field are rejected.
+Legacy anatomy fields venicus and blemishes are not active fields. Reads migrate venicus to veins only when veins is missing; new writes containing either field are rejected.

--- a/docs/specs/character-file-format.md
+++ b/docs/specs/character-file-format.md
@@ -128,7 +128,7 @@ endings, UTF-8 without BOM, and a single trailing newline.
 Top-level writer order is:
 
 `schema_version`, `character_id`, `name`, `gender_identity`, `bio`, `level`,
-optional `timing_profile_id`, `items`, `anatomy`, `allocation`, optional
+optional `timing_profile_id`, `items`, `anatomy`, optional `surface_material`, `allocation`, optional
 `psychological_stake`, optional `consolidated_personality`, optional
 `consolidated_backstory`, optional `backstory_categories`, optional
 `stake_lines`, optional `psychiatric_diagnosis`.
@@ -151,3 +151,9 @@ between runtime required fields, schema fields, and the diagnosis prompt.
 - #815 - writer and format documentation.
 - #1175 - v2 scalar anatomy.
 - #1244/#1251 - bundled character synthesis and therapist formulation contract.
+
+## Surface Material
+
+surface_material is an optional typed visual-material block for browser/Unity-equivalent material controls that are not categorical anatomy bands. It carries smoothness in Unity's authored 0-100 range, reckles_pattern_id, and exactly two surface_layers with strength 0-2, tiling 1-50, rotation 0-10, and pattern_id. Pattern ids are host-resolved strings and are intentionally not stored in natomy.
+
+Legacy anatomy fields enicus and lemishes are not active fields. Reads migrate enicus to eins only when eins is missing; new writes containing either field are rejected.

--- a/docs/specs/unity-core-item-anatomy-contract.md
+++ b/docs/specs/unity-core-item-anatomy-contract.md
@@ -301,4 +301,4 @@ The following Unity fields/concepts are **excluded from pinder-core** and must n
 - **Dead `occupiedSlots` field on outfits:** Can be removed from Unity's `AccessoryData` struct.
 - **`vest6` gap:** `vest6` is absent from Unity's catalog. If intentional, no action needed. If a bug, re-add.
 
-Core canonicalization update: eins is the sole vascularity scalar and legacy enicus is read-migrated only as a missing-field fallback. lemishes is retired because the active shader has no blemish channel. Pattern-bearing material controls live in surface_material, outside scalar anatomy bands.
+Core canonicalization update: veins is the sole vascularity scalar and legacy venicus is read-migrated only as a missing-field fallback. blemishes is retired because the active shader has no blemish channel. Pattern-bearing material controls live in surface_material, outside scalar anatomy bands.

--- a/docs/specs/unity-core-item-anatomy-contract.md
+++ b/docs/specs/unity-core-item-anatomy-contract.md
@@ -198,9 +198,9 @@ All parameters mirror Unity's `CharacterData.cs` field names verbatim:
 | Trunk | `trunkLengthBase`, `trunkLengthMid`, `trunkLengthTip`, `trunkGirth`, `trunkCurvature` (bipolar) |
 | Glans | `glansScale`, `glansWidth` |
 | Scrotum | `scrotumScale`, `leftTesticleScale`, `rightTesticleScale`, `scrotumDrop` |
-| Age | `prepucius`, `arrugatis`, `gravitatis`, `venicus` |
+| Age | `prepucius`, `arrugatis`, `gravitatis` |
 | Expression | `sad`, `happy`, `serius` |
-| Skin | `skinHue`, `skinSat`, `skinVal`, `freckles`, `blemishes`, `veins`, `isCircumcised` |
+| Skin | `skinHue`, `skinSat`, `skinVal`, `freckles`, `smoothness`, `veins`, `isCircumcised` |
 
 Grooming fields (`hasHair`, `hairLength`, `hair`, `hairColor`) are **cosmetic-only** and excluded from anatomy parameters.
 
@@ -300,3 +300,5 @@ The following Unity fields/concepts are **excluded from pinder-core** and must n
 - **Empty `Waist` / `Body` slots:** No items currently use `Waist` (slot 3) or non-outfit `Body` items. Confirm intent.
 - **Dead `occupiedSlots` field on outfits:** Can be removed from Unity's `AccessoryData` struct.
 - **`vest6` gap:** `vest6` is absent from Unity's catalog. If intentional, no action needed. If a bug, re-add.
+
+Core canonicalization update: eins is the sole vascularity scalar and legacy enicus is read-migrated only as a missing-field fallback. lemishes is retired because the active shader has no blemish channel. Pattern-bearing material controls live in surface_material, outside scalar anatomy bands.

--- a/src/Pinder.Core/Characters/CharacterDataDto.cs
+++ b/src/Pinder.Core/Characters/CharacterDataDto.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Pinder.Core.Characters
@@ -41,7 +42,6 @@ namespace Pinder.Core.Characters
         public float Prepucius  { get; set; } = 0f;
         public float Arrugatis  { get; set; } = 0f;
         public float Gravitatis { get; set; } = 0f;
-        public float Venicus    { get; set; } = 0f;
 
         // ---- Skin ----
         /// <summary>Unity Color RGB, each channel [0..1].</summary>
@@ -49,11 +49,15 @@ namespace Pinder.Core.Characters
         public float SkinColorG { get; set; } = 0.72f;
         public float SkinColorB { get; set; } = 0.63f;
 
-        /// <summary>Freckles intensity 0–100.</summary>
+        /// <summary>Freckles intensity 0-100.</summary>
         public float Freckles  { get; set; } = 0f;
-        /// <summary>Blemishes intensity 0–100.</summary>
-        public float Blemishes { get; set; } = 0f;
-        /// <summary>Vein visibility 0–100.</summary>
+        /// <summary>Shader smoothness/gloss 0-100.</summary>
+        public float Smoothness { get; set; } = CharacterSurfaceMaterial.SmoothnessDefault;
+        /// <summary>Freckles texture pattern id; resolved by the host material catalog.</summary>
+        public string FrecklesPatternId { get; set; } = CharacterSurfaceMaterial.DefaultFrecklesPatternId;
+        /// <summary>Two authored normal-detail layers; resolved by the host material catalog.</summary>
+        public IReadOnlyList<CharacterSurfaceLayer> SurfaceLayers { get; set; } = CharacterSurfaceMaterial.Default.SurfaceLayers;
+        /// <summary>Canonical vascularity control 0-100.</summary>
         public float Veins     { get; set; } = 30f;
 
         /// <summary>Circumcision state.</summary>
@@ -108,7 +112,6 @@ namespace Pinder.Core.Characters
             map["prepucius"]  = Clamp01(dto.Prepucius  / 100f);
             map["arrugatis"]  = Clamp01(dto.Arrugatis  / 100f);
             map["gravitatis"] = Clamp01(dto.Gravitatis / 100f);
-            map["venicus"]    = Clamp01(dto.Venicus     / 100f);
 
             // Skin — RGB → HSV
             RgbToHsv(dto.SkinColorR, dto.SkinColorG, dto.SkinColorB,
@@ -118,13 +121,22 @@ namespace Pinder.Core.Characters
             map["skinVal"] = Clamp01(v);
 
             map["freckles"]  = Clamp01(dto.Freckles  / 100f);
-            map["blemishes"] = Clamp01(dto.Blemishes / 100f);
+            map["smoothness"] = Clamp01(dto.Smoothness / 100f);
             map["veins"]     = Clamp01(dto.Veins     / 100f);
 
             // Bool → 2-band at 0.5
             map["isCircumcised"] = dto.IsCircumcised ? 1.0f : 0.0f;
 
             return map;
+        }
+
+        public static CharacterSurfaceMaterial NormalizeSurfaceMaterial(CharacterDataDto dto)
+        {
+            if (dto == null) throw new ArgumentNullException(nameof(dto));
+            return new CharacterSurfaceMaterial(
+                dto.Smoothness,
+                dto.FrecklesPatternId,
+                dto.SurfaceLayers);
         }
 
         // -------------------------------------------------------------------

--- a/src/Pinder.Core/Characters/CharacterDefinition.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinition.cs
@@ -60,6 +60,9 @@ namespace Pinder.Core.Characters
         /// </summary>
         public IReadOnlyDictionary<string, float> Anatomy { get; }
 
+        /// <summary>Typed material-surface controls that are not categorical anatomy bands.</summary>
+        public CharacterSurfaceMaterial? SurfaceMaterial { get; }
+
         /// <summary>Player-authored build-point allocation block.</summary>
         public AllocationBlock Allocation { get; }
 
@@ -97,7 +100,8 @@ namespace Pinder.Core.Characters
             IReadOnlyDictionary<string, string>? psychiatricDiagnosis = null,
             string? consolidatedPersonality = null,
             string? consolidatedBackstory = null,
-            string? timingProfileId = null)
+            string? timingProfileId = null,
+            CharacterSurfaceMaterial? surfaceMaterial = null)
         {
             SchemaVersion = schemaVersion;
             CharacterId = characterId;
@@ -108,6 +112,7 @@ namespace Pinder.Core.Characters
             TimingProfileId = string.IsNullOrWhiteSpace(timingProfileId) ? null : timingProfileId;
             Items = items ?? throw new ArgumentNullException(nameof(items));
             Anatomy = anatomy ?? throw new ArgumentNullException(nameof(anatomy));
+            SurfaceMaterial = surfaceMaterial;
             Allocation = allocation ?? throw new ArgumentNullException(nameof(allocation));
             PsychologicalStake = psychologicalStake;
             Backstory = backstory;

--- a/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
+++ b/src/Pinder.Core/Characters/CharacterDefinitionWriter.cs
@@ -135,6 +135,9 @@ namespace Pinder.Core.Characters
                 writer.WriteNumber(kv.Key, kv.Value);
             writer.WriteEndObject();
 
+            if (def.SurfaceMaterial != null)
+                WriteSurfaceMaterial(writer, def.SurfaceMaterial);
+
             writer.WriteStartObject("allocation");
             WriteSpent(writer, def.Allocation);
             writer.WriteNumber("unspent_pool", def.Allocation.UnspentPool);
@@ -185,6 +188,25 @@ namespace Pinder.Core.Characters
             writer.WriteEndObject();
         }
 
+
+        private static void WriteSurfaceMaterial(Utf8JsonWriter writer, CharacterSurfaceMaterial surface)
+        {
+            writer.WriteStartObject("surface_material");
+            writer.WriteNumber("smoothness", surface.Smoothness);
+            writer.WriteString("freckles_pattern_id", surface.FrecklesPatternId);
+            writer.WriteStartArray("surface_layers");
+            foreach (var layer in surface.SurfaceLayers)
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("strength", layer.Strength);
+                writer.WriteNumber("tiling", layer.Tiling);
+                writer.WriteNumber("rotation", layer.Rotation);
+                writer.WriteString("pattern_id", layer.PatternId);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
         private static void WriteSpent(Utf8JsonWriter writer, AllocationBlock alloc)
         {
             writer.WriteStartObject("spent");

--- a/src/Pinder.Core/Characters/CharacterSurfaceMaterial.cs
+++ b/src/Pinder.Core/Characters/CharacterSurfaceMaterial.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pinder.Core.Characters
+{
+    /// <summary>
+    /// Typed material-surface state carried by character files and API DTOs.
+    /// Numeric ranges mirror the authored Unity controls; pattern ids are
+    /// carried as host-resolved strings and are not scalar anatomy bands.
+    /// </summary>
+    public sealed class CharacterSurfaceMaterial
+    {
+        public const float SmoothnessMin = 0f;
+        public const float SmoothnessMax = 100f;
+        public const float SmoothnessDefault = 51f;
+        public const string DefaultFrecklesPatternId = "Freckles_Dots";
+        public const int SurfaceLayerCount = 2;
+
+        public float Smoothness { get; }
+        public string FrecklesPatternId { get; }
+        public IReadOnlyList<CharacterSurfaceLayer> SurfaceLayers { get; }
+
+        public CharacterSurfaceMaterial(
+            float smoothness,
+            string frecklesPatternId,
+            IReadOnlyList<CharacterSurfaceLayer> surfaceLayers)
+        {
+            ValidateRange("surface_material.smoothness", smoothness, SmoothnessMin, SmoothnessMax);
+            if (string.IsNullOrWhiteSpace(frecklesPatternId))
+                throw new FormatException("Character definition field surface_material.freckles_pattern_id must be a non-empty string.");
+            if (surfaceLayers == null)
+                throw new ArgumentNullException(nameof(surfaceLayers));
+            if (surfaceLayers.Count != SurfaceLayerCount)
+                throw new FormatException($"Character definition field surface_material.surface_layers must contain exactly {SurfaceLayerCount} entries.");
+
+            Smoothness = smoothness;
+            FrecklesPatternId = frecklesPatternId;
+            SurfaceLayers = new List<CharacterSurfaceLayer>(surfaceLayers).AsReadOnly();
+        }
+
+        public static CharacterSurfaceMaterial Default => new CharacterSurfaceMaterial(
+            SmoothnessDefault,
+            DefaultFrecklesPatternId,
+            new[]
+            {
+                CharacterSurfaceLayer.Default("Wrinkles_Soft"),
+                CharacterSurfaceLayer.Default("Wrinkles_Fine"),
+            });
+
+        internal static void ValidateRange(string fieldPath, float value, float min, float max)
+        {
+            if (float.IsNaN(value) || float.IsInfinity(value) || value < min || value > max)
+                throw new FormatException($"Character definition field {fieldPath} must be within [{min}, {max}], got {value}.");
+        }
+    }
+
+    public sealed class CharacterSurfaceLayer
+    {
+        public const float StrengthMin = 0f;
+        public const float StrengthMax = 2f;
+        public const float TilingMin = 1f;
+        public const float TilingMax = 50f;
+        public const float RotationMin = 0f;
+        public const float RotationMax = 10f;
+
+        public float Strength { get; }
+        public float Tiling { get; }
+        public float Rotation { get; }
+        public string PatternId { get; }
+
+        public CharacterSurfaceLayer(float strength, float tiling, float rotation, string patternId)
+        {
+            CharacterSurfaceMaterial.ValidateRange("surface_material.surface_layers[].strength", strength, StrengthMin, StrengthMax);
+            CharacterSurfaceMaterial.ValidateRange("surface_material.surface_layers[].tiling", tiling, TilingMin, TilingMax);
+            CharacterSurfaceMaterial.ValidateRange("surface_material.surface_layers[].rotation", rotation, RotationMin, RotationMax);
+            if (string.IsNullOrWhiteSpace(patternId))
+                throw new FormatException("Character definition field surface_material.surface_layers[].pattern_id must be a non-empty string.");
+
+            Strength = strength;
+            Tiling = tiling;
+            Rotation = rotation;
+            PatternId = patternId;
+        }
+
+        public static CharacterSurfaceLayer Default(string patternId)
+            => new CharacterSurfaceLayer(0f, 4f, 0f, patternId);
+    }
+}

--- a/src/Pinder.Core/Characters/DeprecatedAnatomyFields.cs
+++ b/src/Pinder.Core/Characters/DeprecatedAnatomyFields.cs
@@ -17,21 +17,33 @@ namespace Pinder.Core.Characters
             "serius",
         };
 
-        private static readonly HashSet<string> DeprecatedExpressionTargetSet =
-            new HashSet<string>(DeprecatedExpressionTargetIds, StringComparer.Ordinal);
+        private static readonly string[] DeprecatedWriteOnlyIds =
+        {
+            "sad",
+            "happy",
+            "serius",
+            "venicus",
+            "blemishes",
+        };
+
+        private static readonly HashSet<string> DeprecatedWriteOnlySet =
+            new HashSet<string>(DeprecatedWriteOnlyIds, StringComparer.Ordinal);
 
         public static IReadOnlyList<string> ExpressionTargetIds => DeprecatedExpressionTargetIds;
 
         public static bool IsDeprecated(string fieldName)
         {
-            return DeprecatedExpressionTargetSet.Contains(fieldName);
+            return DeprecatedWriteOnlySet.Contains(fieldName);
         }
 
         public static void StripForLegacyRead(IDictionary<string, float> anatomy)
         {
             if (anatomy == null) throw new ArgumentNullException(nameof(anatomy));
 
-            foreach (string field in DeprecatedExpressionTargetIds)
+            if (anatomy.ContainsKey("venicus") && !anatomy.ContainsKey("veins"))
+                anatomy["veins"] = anatomy["venicus"];
+
+            foreach (string field in DeprecatedWriteOnlyIds)
                 anatomy.Remove(field);
         }
 
@@ -41,7 +53,7 @@ namespace Pinder.Core.Characters
         {
             if (anatomy == null) throw new ArgumentNullException(nameof(anatomy));
 
-            foreach (string field in DeprecatedExpressionTargetIds)
+            foreach (string field in DeprecatedWriteOnlyIds)
             {
                 if (anatomy.ContainsKey(field))
                     ThrowDeprecated(sourceDescription, field);

--- a/src/Pinder.Core/Prompts/TextingStyleAggregator.cs
+++ b/src/Pinder.Core/Prompts/TextingStyleAggregator.cs
@@ -99,7 +99,7 @@ namespace Pinder.Core.Prompts
 
         internal static readonly IReadOnlyList<string> RegisterGroup =
             new[] { "skinHue", "skinSat", "skinVal",
-                    "freckles", "blemishes", "veins" };
+                    "freckles", "smoothness", "veins" };
 
         internal static readonly IReadOnlyList<string> PacingGroup =
             new[] { "glansScale", "glansWidth",

--- a/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
+++ b/src/Pinder.SessionSetup/CharacterDefinitionLoader.cs
@@ -108,6 +108,7 @@ namespace Pinder.SessionSetup
 
                 var items = ParseItemIds(root);
                 var anatomy = ParseAnatomySelections(root);
+                var surfaceMaterial = ParseOptionalSurfaceMaterial(root);
                 var allocation = ParseAllocation(root);
 
                 // Issue #779: optional permanent psychological stake.
@@ -145,7 +146,8 @@ namespace Pinder.SessionSetup
                     psychiatricDiagnosis,
                     consolidatedPersonality,
                     consolidatedBackstory,
-                    timingProfileId);
+                    timingProfileId,
+                    surfaceMaterial);
             }
         }
 
@@ -389,9 +391,6 @@ namespace Pinder.SessionSetup
             var anatomy = new Dictionary<string, float>();
             foreach (var kv in prop.EnumerateObject())
             {
-                if (DeprecatedAnatomyFields.IsDeprecated(kv.Name))
-                    continue;
-
                 // v2: float values
                 if (kv.Value.ValueKind == JsonValueKind.Number)
                 {
@@ -415,6 +414,43 @@ namespace Pinder.SessionSetup
             return anatomy;
         }
 
+
+        private static CharacterSurfaceMaterial? ParseOptionalSurfaceMaterial(JsonElement root)
+        {
+            if (!root.TryGetProperty("surface_material", out var prop))
+                return null;
+            if (prop.ValueKind != JsonValueKind.Object)
+                throw new FormatException($"Character definition field surface_material must be an object, got {DescribeValueKind(prop)}.");
+
+            float smoothness = GetRequiredFloat(prop, "smoothness", "surface_material.smoothness");
+            string frecklesPatternId = GetRequiredString(prop, "freckles_pattern_id");
+
+            if (!prop.TryGetProperty("surface_layers", out var layersProp) || layersProp.ValueKind != JsonValueKind.Array)
+                throw new FormatException("Character definition missing required field: surface_material.surface_layers");
+
+            var layers = new List<CharacterSurfaceLayer>();
+            int index = 0;
+            foreach (var layerProp in layersProp.EnumerateArray())
+            {
+                if (layerProp.ValueKind != JsonValueKind.Object)
+                    throw new FormatException($"Character definition field surface_material.surface_layers[{index}] must be an object, got {DescribeValueKind(layerProp)}.");
+                float strength = GetRequiredFloat(layerProp, "strength", $"surface_material.surface_layers[{index}].strength");
+                float tiling = GetRequiredFloat(layerProp, "tiling", $"surface_material.surface_layers[{index}].tiling");
+                float rotation = GetRequiredFloat(layerProp, "rotation", $"surface_material.surface_layers[{index}].rotation");
+                string patternId = GetRequiredString(layerProp, "pattern_id");
+                layers.Add(new CharacterSurfaceLayer(strength, tiling, rotation, patternId));
+                index++;
+            }
+
+            return new CharacterSurfaceMaterial(smoothness, frecklesPatternId, layers);
+        }
+
+        private static float GetRequiredFloat(JsonElement root, string fieldName, string fieldPath)
+        {
+            if (!root.TryGetProperty(fieldName, out var prop) || prop.ValueKind != JsonValueKind.Number)
+                throw new FormatException($"Character definition missing required field: {fieldPath}");
+            return prop.GetSingle();
+        }
         private static AllocationBlock ParseAllocation(JsonElement root)
         {
             if (!root.TryGetProperty("allocation", out var alloc) ||

--- a/tests/Pinder.Core.Tests/AnatomyScaleTypeTests.cs
+++ b/tests/Pinder.Core.Tests/AnatomyScaleTypeTests.cs
@@ -301,8 +301,8 @@ namespace Pinder.Core.Tests
             var repo = new JsonAnatomyRepository(json);
             var all  = repo.GetAll().ToList();
 
-            Assert.True(all.Count >= 22,
-                $"Expected at least 22 anatomy params, got {all.Count}");
+            Assert.True(all.Count >= 21,
+                $"Expected at least 21 anatomy params, got {all.Count}");
 
             foreach (var param in all)
                 Assert.NotEmpty(param.Bands);

--- a/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionLoaderTests.cs
@@ -94,6 +94,91 @@ namespace Pinder.Core.Tests
             Assert.Equal(0.44f, def.Anatomy["trunkLengthBase"], precision: 5);
         }
 
+
+        [Fact]
+        public void ParseDefinition_MigratesLegacyVenicusToVeinsWhenVeinsIsMissing()
+        {
+            string json = ReplaceOrThrow(
+                ValidV1Json,
+                "\"anatomy\": {}",
+                "\"anatomy\": {\"venicus\": 0.73, \"trunkLengthBase\": 0.44}");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+            Assert.False(def.Anatomy.ContainsKey("venicus"));
+            Assert.Equal(0.73f, def.Anatomy["veins"], precision: 5);
+            Assert.Equal(0.44f, def.Anatomy["trunkLengthBase"], precision: 5);
+        }
+
+        [Fact]
+        public void ParseDefinition_UsesVeinsWhenBothLegacyVenicusAndCanonicalVeinsArePresent()
+        {
+            string json = ReplaceOrThrow(
+                ValidV1Json,
+                "\"anatomy\": {}",
+                "\"anatomy\": {\"venicus\": 0.11, \"veins\": 0.82}");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+            Assert.False(def.Anatomy.ContainsKey("venicus"));
+            Assert.Equal(0.82f, def.Anatomy["veins"], precision: 5);
+        }
+
+        [Fact]
+        public void ParseDefinition_RemovesLegacyBlemishesOnRead()
+        {
+            string json = ReplaceOrThrow(
+                ValidV1Json,
+                "\"anatomy\": {}",
+                "\"anatomy\": {\"blemishes\": 0.66, \"smoothness\": 0.51}");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+            Assert.False(def.Anatomy.ContainsKey("blemishes"));
+            Assert.Equal(0.51f, def.Anatomy["smoothness"], precision: 5);
+        }
+
+        [Fact]
+        public void ParseDefinition_ParsesTypedSurfaceMaterialContract()
+        {
+            string json = WithAdditionalRootProperty(@"""surface_material"": {
+                ""smoothness"": 51,
+                ""freckles_pattern_id"": ""Freckles_Dots"",
+                ""surface_layers"": [
+                    { ""strength"": 0.25, ""tiling"": 4, ""rotation"": 0.5, ""pattern_id"": ""Wrinkles_Soft"" },
+                    { ""strength"": 1.75, ""tiling"": 32, ""rotation"": 9.5, ""pattern_id"": ""Wrinkles_Fine"" }
+                ]
+            }");
+
+            var def = CharacterDefinitionLoader.ParseDefinition(json);
+
+            Assert.NotNull(def.SurfaceMaterial);
+            Assert.Equal(51f, def.SurfaceMaterial!.Smoothness, precision: 5);
+            Assert.Equal("Freckles_Dots", def.SurfaceMaterial.FrecklesPatternId);
+            Assert.Equal(2, def.SurfaceMaterial.SurfaceLayers.Count);
+            Assert.Equal(0.25f, def.SurfaceMaterial.SurfaceLayers[0].Strength, precision: 5);
+            Assert.Equal(4f, def.SurfaceMaterial.SurfaceLayers[0].Tiling, precision: 5);
+            Assert.Equal(0.5f, def.SurfaceMaterial.SurfaceLayers[0].Rotation, precision: 5);
+            Assert.Equal("Wrinkles_Soft", def.SurfaceMaterial.SurfaceLayers[0].PatternId);
+        }
+
+        [Fact]
+        public void ParseDefinition_RejectsSurfaceMaterialValuesOutsideAuthoredRanges()
+        {
+            string json = WithAdditionalRootProperty(@"""surface_material"": {
+                ""smoothness"": 101,
+                ""freckles_pattern_id"": ""Freckles_Dots"",
+                ""surface_layers"": [
+                    { ""strength"": 0, ""tiling"": 1, ""rotation"": 0, ""pattern_id"": ""Wrinkles_Soft"" },
+                    { ""strength"": 0, ""tiling"": 1, ""rotation"": 0, ""pattern_id"": ""Wrinkles_Fine"" }
+                ]
+            }");
+
+            var ex = Assert.Throws<FormatException>(() =>
+                CharacterDefinitionLoader.ParseDefinition(json));
+
+            Assert.Contains("surface_material.smoothness", ex.Message);
+        }
         [Fact]
         public void Load_GeraldDefinition_ProducesValidProfile()
         {

--- a/tests/Pinder.Core.Tests/CharacterDefinitionWriterTests.cs
+++ b/tests/Pinder.Core.Tests/CharacterDefinitionWriterTests.cs
@@ -224,6 +224,8 @@ namespace Pinder.Core.Tests
         [InlineData("sad")]
         [InlineData("happy")]
         [InlineData("serius")]
+        [InlineData("venicus")]
+        [InlineData("blemishes")]
         public void Write_RejectsDeprecatedExpressionTargets(string field)
         {
             var def = NewDefinitionWithAnatomy(new Dictionary<string, float>
@@ -239,13 +241,36 @@ namespace Pinder.Core.Tests
         }
 
         [Fact]
+        public void Write_SurfaceMaterial_RoundTripsTypedControls()
+        {
+            var def = NewDefinitionWithAnatomy(
+                new Dictionary<string, float> { ["smoothness"] = 0.51f },
+                new CharacterSurfaceMaterial(
+                    51f,
+                    "Freckles_Dots",
+                    new[]
+                    {
+                        new CharacterSurfaceLayer(0.2f, 4f, 0.5f, "Wrinkles_Soft"),
+                        new CharacterSurfaceLayer(1.8f, 32f, 9.5f, "Wrinkles_Fine"),
+                    }));
+
+            string json = CharacterDefinitionWriter.Write(def);
+            var roundTrip = CharacterDefinitionLoader.ParseDefinition(json);
+
+            Assert.NotNull(roundTrip.SurfaceMaterial);
+            Assert.Equal(51f, roundTrip.SurfaceMaterial!.Smoothness, precision: 5);
+            Assert.Equal("Freckles_Dots", roundTrip.SurfaceMaterial.FrecklesPatternId);
+            Assert.Equal("Wrinkles_Fine", roundTrip.SurfaceMaterial.SurfaceLayers[1].PatternId);
+        }
+        [Fact]
         public void Write_NullDef_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
                 CharacterDefinitionWriter.Write(null!));
         }
         private static CharacterDefinition NewDefinitionWithAnatomy(
-            IReadOnlyDictionary<string, float> anatomy)
+            IReadOnlyDictionary<string, float> anatomy,
+            CharacterSurfaceMaterial? surfaceMaterial = null)
         {
             var spent = new Dictionary<StatType, int>
             {
@@ -269,7 +294,8 @@ namespace Pinder.Core.Tests
                 1,
                 new List<string>(),
                 anatomy,
-                new AllocationBlock(spent, 0, shadows));
+                new AllocationBlock(spent, 0, shadows),
+                surfaceMaterial: surfaceMaterial);
         }
 
     }

--- a/tests/Pinder.Core.Tests/Issue1175_ScalarBandedAnatomyTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1175_ScalarBandedAnatomyTests.cs
@@ -79,12 +79,11 @@ namespace Pinder.Core.Tests
                 Prepucius       = 0f,
                 Arrugatis       = 0f,
                 Gravitatis      = 0f,
-                Venicus         = 0f,
                 SkinColorR      = 0.87f,
                 SkinColorG      = 0.72f,
                 SkinColorB      = 0.63f,
                 Freckles        = 0f,
-                Blemishes       = 0f,
+                Smoothness      = 51f,
                 Veins           = 30f,  // 30/100 = 0.30 → band 2 (0.20-0.50)
                 IsCircumcised   = false  // false → 0.0 → band 0 (uncircumcised)
             };
@@ -149,6 +148,67 @@ namespace Pinder.Core.Tests
             Assert.DoesNotContain(anatomyRepo.GetAll(), p => p.Id == field);
         }
 
+
+        [Fact]
+        public void CharacterDataNormalizer_EmitsCanonicalSurfaceScalarsOnly()
+        {
+            var dto = new CharacterDataDto
+            {
+                Freckles = 70f,
+                Smoothness = 51f,
+                Veins = 83f,
+                FrecklesPatternId = "Freckles_Patches",
+                SurfaceLayers = new[]
+                {
+                    new CharacterSurfaceLayer(0.25f, 4f, 0.5f, "Wrinkles_Soft"),
+                    new CharacterSurfaceLayer(1.75f, 32f, 9.5f, "Wrinkles_Fine"),
+                }
+            };
+
+            var anatomy = CharacterDataNormalizer.Normalize(dto);
+
+            Assert.Equal(0.70f, anatomy["freckles"], precision: 5);
+            Assert.Equal(0.51f, anatomy["smoothness"], precision: 5);
+            Assert.Equal(0.83f, anatomy["veins"], precision: 5);
+            Assert.False(anatomy.ContainsKey("venicus"));
+            Assert.False(anatomy.ContainsKey("blemishes"));
+            Assert.DoesNotContain(anatomy.Keys, key => key.Contains("Pattern"));
+            Assert.DoesNotContain(anatomy.Keys, key => key.StartsWith("surface", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void CharacterDataNormalizer_ExtractsTypedSurfaceMaterialWithAuthoredRanges()
+        {
+            var dto = new CharacterDataDto
+            {
+                Smoothness = 51f,
+                FrecklesPatternId = "Freckles_Fine",
+                SurfaceLayers = new[]
+                {
+                    new CharacterSurfaceLayer(0.25f, 4f, 0.5f, "Wrinkles_Soft"),
+                    new CharacterSurfaceLayer(1.75f, 32f, 9.5f, "Wrinkles_Fine"),
+                }
+            };
+
+            var surface = CharacterDataNormalizer.NormalizeSurfaceMaterial(dto);
+
+            Assert.Equal(51f, surface.Smoothness, precision: 5);
+            Assert.Equal("Freckles_Fine", surface.FrecklesPatternId);
+            Assert.Equal(2, surface.SurfaceLayers.Count);
+            Assert.Equal(32f, surface.SurfaceLayers[1].Tiling, precision: 5);
+            Assert.Equal(9.5f, surface.SurfaceLayers[1].Rotation, precision: 5);
+        }
+
+        [Fact]
+        public void ActiveAnatomyRepository_RetiresLegacyFieldsAndAddsSmoothness()
+        {
+            var anatomyRepo = LoadAnatomyRepo();
+
+            Assert.Null(anatomyRepo.GetParameter("venicus"));
+            Assert.Null(anatomyRepo.GetParameter("blemishes"));
+            Assert.NotNull(anatomyRepo.GetParameter("veins"));
+            Assert.NotNull(anatomyRepo.GetParameter("smoothness"));
+        }
         // ----------------------------------------------------------------
         // BIPOLAR: trunkCurvature normalisation
         // ----------------------------------------------------------------

--- a/tests/Pinder.Core.Tests/Issue1329_AnatomyMetadataTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1329_AnatomyMetadataTests.cs
@@ -12,12 +12,12 @@ namespace Pinder.Core.Tests
     public sealed class Issue1329_AnatomyMetadataTests
     {
         [Fact]
-        public void BundledFile_All22ParametersExposeMetadata()
+        public void BundledFile_All21ActiveParametersExposeMetadata()
         {
             var repo = new JsonAnatomyRepository(LoadBundledAnatomyJson());
             var all = repo.GetAll().ToList();
 
-            Assert.Equal(22, all.Count);
+            Assert.Equal(21, all.Count);
 
             foreach (var parameter in all)
             {

--- a/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.cs
+++ b/tests/Pinder.Core.Tests/Issue836_TextingStyleAggregationRuleTests.cs
@@ -90,7 +90,7 @@ namespace Pinder.Core.Tests
         // so each of the three tone axes has a contributing source.
         // #1175: now uses Unity param ids with float values [0..1].
         // Stance group: trunkLengthBase, trunkLengthMid, trunkLengthTip, trunkGirth, trunkCurvature
-        // Register group: skinHue, skinSat, skinVal, freckles, blemishes, veins
+        // Register group: skinHue, skinSat, skinVal, freckles, smoothness, veins
         // Pacing group: glansScale, glansWidth, scrotumScale, leftTesticleScale, rightTesticleScale, scrotumDrop, isCircumcised
         private static readonly Dictionary<string, float> AnatomyStack =
             new Dictionary<string, float>
@@ -98,7 +98,7 @@ namespace Pinder.Core.Tests
                 { "trunkLengthBase",  0.18f },  // stance group (band 1 – compact)
                 { "trunkGirth",       0.08f },  // stance group (band 0 – slim)
                 { "veins",            0.08f },  // register group (band 0 – subtle)
-                { "blemishes",        0.05f },  // register group (band 0 – smooth)
+                { "smoothness",        0.51f },  // register group (band 0 – smooth)
                 { "glansScale",       0.50f },  // pacing group (mid band)
                 { "isCircumcised",    0.0f  },  // pacing group (uncircumcised band)
             };


### PR DESCRIPTION
Core dependency for pinder-web #1234/#1224/#1225. Canonicalizes veins over venicus, retires blemishes, and adds typed smoothness/freckles-pattern/two-layer surface material persistence. Focused 177 tests and serialized full solution passed; independent review in progress.