### PR TITLE
Fix emotional director drafted-reply recovery

### DIFF
--- a/data/prompts/emotional-reactions.yaml
+++ b/data/prompts/emotional-reactions.yaml
@@ -101,7 +101,7 @@ prompts:
 
       The schema_version field must be exactly "emotional_director.v1".
 
-      The seven director fields must be concise, concrete, actionable natural-language prose, each 180 characters or fewer. Use intensity to describe the emotion's strength and movement, and underlying_feeling for the feeling beneath the primary emotion. Interpret the recipient's private reaction; do not draft chat text, mention prompts, mention this director step, or expose game mechanics.
+      The seven director fields must be concise, concrete, actionable natural-language prose, each 180 characters or fewer. Every field is private direction about the DATEE, never wording the DATEE could send. Use intensity to describe the emotion's strength and movement, and underlying_feeling for the feeling beneath the primary emotion. Write impulse as a behavioral urge in third-person or infinitive form, such as "pull back and test their sincerity", never as first-person speech or a quoted reply. Interpret the recipient's private reaction; do not draft chat text, mention prompts, mention this director step, or expose game mechanics.
     user_template: |-
       Private emotional director source packet:
 
@@ -116,6 +116,10 @@ prompts:
   emotional-reaction-director-repair-field-too-long:
     system_prompt: >-
       A previous emotional direction exceeded the permitted field length. Return a fresh complete object with every direction field 180 characters or fewer. Preserve the emotional meaning, but compress each field to one direct, actionable sentence or phrase.
+
+  emotional-reaction-director-repair-drafted-chat-reply:
+    system_prompt: >-
+      The previous object drafted words the DATEE could send instead of private emotional direction. Return a fresh complete object whose fields only describe the DATEE's internal reaction and performance direction. In particular, write impulse as a behavioral urge in third-person or infinitive form, such as "pull back and test their sincerity". Do not use first-person speech, quotations, or any sendable chat sentence in any field.
 
   emotional-reaction-event-charm-clean:
     system_prompt: >-

--- a/src/Pinder.LlmAdapters/EmotionalPromptCompiler.cs
+++ b/src/Pinder.LlmAdapters/EmotionalPromptCompiler.cs
@@ -97,6 +97,8 @@ namespace Pinder.LlmAdapters
             "emotional-reaction-director-repair-contract";
         public const string DirectorFieldTooLongRepairPromptKey =
             "emotional-reaction-director-repair-field-too-long";
+        public const string DirectorDraftedChatReplyRepairPromptKey =
+            "emotional-reaction-director-repair-drafted-chat-reply";
         private const string CompiledInputPlaceholder = "{compiled_reaction_input}";
 
         private readonly PromptCatalog _catalog;
@@ -149,12 +151,12 @@ namespace Pinder.LlmAdapters
             PromptTraceResult baseSystemPrompt,
             string rejectionReason)
         {
-            string repairKey = string.Equals(
-                rejectionReason,
-                "field_too_long",
-                StringComparison.Ordinal)
-                ? DirectorFieldTooLongRepairPromptKey
-                : DirectorContractRepairPromptKey;
+            string repairKey = rejectionReason switch
+            {
+                "field_too_long" => DirectorFieldTooLongRepairPromptKey,
+                "drafted_chat_reply" => DirectorDraftedChatReplyRepairPromptKey,
+                _ => DirectorContractRepairPromptKey,
+            };
             PromptEntry repair = _catalog.TryGet(repairKey)
                 ?? throw new InvalidOperationException(
                     $"prompt-catalog: missing required runtime prompt key '{repairKey}'. The yaml file is incomplete or missing.");

--- a/src/Pinder.LlmAdapters/EmotionalReactionPromptCatalog.cs
+++ b/src/Pinder.LlmAdapters/EmotionalReactionPromptCatalog.cs
@@ -187,6 +187,9 @@ namespace Pinder.LlmAdapters
             RequireSystemPrompt(
                 catalog,
                 EmotionalPromptCompiler.DirectorFieldTooLongRepairPromptKey);
+            RequireSystemPrompt(
+                catalog,
+                EmotionalPromptCompiler.DirectorDraftedChatReplyRepairPromptKey);
         }
 
         private static string RequireSystemPrompt(PromptCatalog catalog, string key)

--- a/tests/Pinder.LlmAdapters.Tests/Issue1339_EmotionalReactionPromptCatalogTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1339_EmotionalReactionPromptCatalogTests.cs
@@ -212,7 +212,7 @@ namespace Pinder.LlmAdapters.Tests
                 .Select(key => (Key: key, Prompt: catalog.Get(key).SystemPrompt!))
                 .ToArray();
 
-            Assert.Equal(80, entries.Length);
+            Assert.Equal(81, entries.Length);
 
             foreach (var entry in entries)
             {

--- a/tests/Pinder.LlmAdapters.Tests/Issue1341_EmotionalDirectorContractTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1341_EmotionalDirectorContractTests.cs
@@ -396,6 +396,75 @@ namespace Pinder.LlmAdapters.Tests
             Assert.DoesNotContain(privateRejectedText, plainTransport.SystemPrompts[1], StringComparison.Ordinal);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Retry_DraftedChatReplyAddsActionableCatalogRepairWithoutEchoingRejectedOutput(
+            bool structured)
+        {
+            const string privateRejectedText =
+                "That actually means a lot, but I need to know you mean it.";
+            string invalid = ValidJson(impulse: privateRejectedText);
+            var context = MakeContext();
+
+            if (structured)
+            {
+                var transport = new StructuredQueueTransport(
+                    new StructuredLlmResponse(
+                        invalid,
+                        provider: "test",
+                        model: "structured",
+                        usedNativeStructuredOutput: true),
+                    new StructuredLlmResponse(
+                        ValidJson(),
+                        provider: "test",
+                        model: "structured",
+                        usedNativeStructuredOutput: true));
+                var adapter = CreateAdapter(transport, retries: 1);
+
+                var direction = await adapter.GenerateEmotionalDirectionAsync(context);
+
+                Assert.Equal("relieved but cautious", direction.PrimaryEmotion);
+                Assert.Equal(2, transport.StructuredCalls);
+                Assert.Contains(
+                    "write impulse as a behavioral urge",
+                    transport.StructuredRequests[1].SystemPrompt,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "Do not use first-person speech",
+                    transport.StructuredRequests[1].SystemPrompt,
+                    StringComparison.Ordinal);
+                Assert.DoesNotContain(
+                    privateRejectedText,
+                    transport.StructuredRequests[1].SystemPrompt,
+                    StringComparison.Ordinal);
+                Assert.Equal(
+                    transport.StructuredRequests[0].JsonSchema,
+                    transport.StructuredRequests[1].JsonSchema);
+                return;
+            }
+
+            var plainTransport = new PlainQueueTransport(invalid, ValidJson());
+            var plainAdapter = CreateAdapter(plainTransport, retries: 1);
+
+            var plainDirection = await plainAdapter.GenerateEmotionalDirectionAsync(context);
+
+            Assert.Equal("relieved but cautious", plainDirection.PrimaryEmotion);
+            Assert.Equal(2, plainTransport.PlainCalls);
+            Assert.Contains(
+                "write impulse as a behavioral urge",
+                plainTransport.SystemPrompts[1],
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Do not use first-person speech",
+                plainTransport.SystemPrompts[1],
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                privateRejectedText,
+                plainTransport.SystemPrompts[1],
+                StringComparison.Ordinal);
+        }
+
         [Fact]
         public void FieldTooLongRepairPreservesYamlSpanInCompiledSystemPrompt()
         {
@@ -434,6 +503,28 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal("data/prompts/emotional-reactions.yaml", repairSpan.SourceFile);
             Assert.Equal(
                 catalog.Get(EmotionalPromptCompiler.DirectorContractRepairPromptKey).SystemPrompt!.Trim(),
+                repaired.Text.Substring(repairSpan.Start, repairSpan.End - repairSpan.Start));
+            Assert.Contains(
+                repaired.Spans,
+                span => span.Key == EmotionalPromptCompiler.DirectorPromptKey);
+        }
+
+        [Fact]
+        public void DraftedChatReplyRepairPreservesYamlSpanInCompiledSystemPrompt()
+        {
+            PromptCatalog catalog = BuiltInCatalog();
+            var compiler = new EmotionalPromptCompiler(catalog);
+            CompiledEmotionalDirectorPrompt initial = compiler.CompileDirector(MakeContext());
+
+            var repaired = compiler.CompileDirectorRetrySystemPrompt(
+                initial.SystemPrompt,
+                "drafted_chat_reply");
+
+            var repairSpan = Assert.Single(repaired.Spans.Where(
+                span => span.Key == EmotionalPromptCompiler.DirectorDraftedChatReplyRepairPromptKey));
+            Assert.Equal("data/prompts/emotional-reactions.yaml", repairSpan.SourceFile);
+            Assert.Equal(
+                catalog.Get(EmotionalPromptCompiler.DirectorDraftedChatReplyRepairPromptKey).SystemPrompt!.Trim(),
                 repaired.Text.Substring(repairSpan.Start, repairSpan.End - repairSpan.Start));
             Assert.Contains(
                 repaired.Spans,


### PR DESCRIPTION
## Summary`n- make the configured director prompt define private behavioral direction explicitly`n- add a reason-specific repair prompt for drafted chat replies`n- preserve prompt-catalog validation and provenance`n`n## Regression coverage`n- structured and plain transports repair drafted replies without echoing private output`n- prompt span remains attributable to the editable YAML catalog`n- focused LLM adapter suite: 51 passed