### PR TITLE
Fix diagnosis structured-output recovery

### DIFF
--- a/data/prompts/diagnosis.yaml
+++ b/data/prompts/diagnosis.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 prompts:
   diagnosis:
     temperature: 0.45
-    max_tokens: 900
+    max_tokens: 1400
     system_prompt: |-
       You are a clinical therapist diagnosing a dating-app character based only on their generated backstory and 15 psychological stake lines.
       Output exactly one JSON object and nothing else.
@@ -34,3 +34,11 @@ prompts:
 
       Psychological stake lines JSON:
       {stakes}
+  diagnosis-repair-json:
+    system_prompt: |-
+      The previous answer could not be read as one complete JSON object.
+      Generate the diagnosis again from the original inputs. Return only one complete JSON object with every required key and a nonblank string value for each key. Do not add markdown or commentary.
+  diagnosis-repair-field:
+    system_prompt: |-
+      The previous answer did not provide a usable nonblank value for the required field "{field}".
+      Generate the complete diagnosis again from the original inputs, including that field and every other required key. Return only one JSON object. Do not add markdown or commentary.

--- a/src/Pinder.LlmAdapters/PromptCatalog.cs
+++ b/src/Pinder.LlmAdapters/PromptCatalog.cs
@@ -120,6 +120,8 @@ namespace Pinder.LlmAdapters
             "resistance-date-secured",
             "engine-options-block",
             "engine-datee-block",
+            "diagnosis-repair-json",
+            "diagnosis-repair-field",
         };
 
         private static readonly string[] RuntimeCompletePromptKeys =
@@ -159,6 +161,7 @@ namespace Pinder.LlmAdapters
                 "cognitive_subtext_line", "transition_target_line", "transition_style_line", "options_count", "options_format_list"),
             SystemTokens("engine-datee-block", "datee_name", "interest", "interest_narrative",
                 "cognitive_subtext_line", "transition_target_line", "transition_style_line"),
+            SystemTokens("diagnosis-repair-field", "field"),
             UserTokens("backstory", "characterName", "genderIdentity", "bio", "consolidated_backstory", "consolidated_personality"),
             UserTokens("dramatic_arc", "playerName", "playerStake", "playerBio", "dateeName", "dateeStake", "dateeBio"),
             UserTokens("outfit", "playerName", "playerItems", "dateeName", "dateeItems"),

--- a/src/Pinder.LlmAdapters/TherapistDiagnosisStructuredContract.cs
+++ b/src/Pinder.LlmAdapters/TherapistDiagnosisStructuredContract.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Pinder.Core.Characters;
+using Pinder.Core.Interfaces;
+
+namespace Pinder.LlmAdapters
+{
+    public static class TherapistDiagnosisStructuredContract
+    {
+        public const string SchemaName = "therapist_diagnosis";
+        public const string SchemaVersion = "therapist_diagnosis.v1";
+
+        public static StructuredLlmRequest CreateRequest(
+            string systemPrompt,
+            string userMessage,
+            double temperature,
+            int maxTokens)
+        {
+            return new StructuredLlmRequest(
+                SchemaName,
+                SchemaVersion,
+                BuildJsonSchema(),
+                systemPrompt,
+                userMessage,
+                temperature,
+                maxTokens,
+                LlmPhase.Synthesis);
+        }
+
+        private static string BuildJsonSchema()
+        {
+            var properties = new Dictionary<string, object>();
+            foreach (string field in TherapistDiagnosisContract.RequiredFields)
+            {
+                properties[field] = new Dictionary<string, object>
+                {
+                    ["type"] = "string",
+                };
+            }
+
+            return JsonConvert.SerializeObject(new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = properties,
+                ["required"] = TherapistDiagnosisContract.RequiredFields,
+                ["additionalProperties"] = false,
+            });
+        }
+    }
+}

--- a/src/Pinder.SessionSetup/Synthesis/LlmTherapistDiagnosisGenerator.cs
+++ b/src/Pinder.SessionSetup/Synthesis/LlmTherapistDiagnosisGenerator.cs
@@ -41,6 +41,7 @@ namespace Pinder.SessionSetup
         {
             var entry = _catalog.Get("diagnosis");
             var systemPrompt = entry.SystemPrompt!;
+            var attemptSystemPrompt = systemPrompt;
 
             var userPromptTemplate = entry.UserTemplate!;
             var userPrompt = PromptCatalog.Substitute(userPromptTemplate, new Dictionary<string, string>
@@ -53,16 +54,32 @@ namespace Pinder.SessionSetup
                 MaxAttempts,
                 async (attempt, attemptCancellationToken) =>
                 {
-                    string llmResponse = await LlmOptionalTextGeneration.SendRequiredAsync(
-                        "diagnosis",
-                        _transport,
-                        systemPrompt,
-                        userPrompt,
-                        entry.Temperature!.Value,
-                        entry.MaxTokens!.Value,
-                        LlmPhase.Synthesis,
-                        _onDiagnostic,
-                        attemptCancellationToken).ConfigureAwait(false);
+                    string llmResponse;
+                    StructuredLlmResponse? structuredResponse = null;
+                    if (_transport is IStructuredLlmTransport structuredTransport)
+                    {
+                        structuredResponse = await structuredTransport.SendStructuredAsync(
+                            TherapistDiagnosisStructuredContract.CreateRequest(
+                                attemptSystemPrompt,
+                                userPrompt,
+                                entry.Temperature!.Value,
+                                entry.MaxTokens!.Value),
+                            attemptCancellationToken).ConfigureAwait(false);
+                        llmResponse = structuredResponse.JsonText;
+                    }
+                    else
+                    {
+                        llmResponse = await LlmOptionalTextGeneration.SendRequiredAsync(
+                            "diagnosis",
+                            _transport,
+                            attemptSystemPrompt,
+                            userPrompt,
+                            entry.Temperature!.Value,
+                            entry.MaxTokens!.Value,
+                            LlmPhase.Synthesis,
+                            _onDiagnostic,
+                            attemptCancellationToken).ConfigureAwait(false);
+                    }
 
                     try
                     {
@@ -73,18 +90,31 @@ namespace Pinder.SessionSetup
                             // deserializes to it) rather than an object. That is not the
                             // same as a diagnosis object satisfying the two required
                             // cognitive-subtext fields, so fail loudly.
-                            throw new JsonException("Deserialized diagnosis was null.");
+                            throw new DiagnosisContractException(
+                                "root_nonobject",
+                                null,
+                                "Deserialized diagnosis was null.");
                         }
 
-                        return SemanticOutputRecoveryAttemptResult<Dictionary<string, string>, DiagnosisRejection>.Accepted(
-                            ValidateDiagnosis(dict));
+                        var accepted = ValidateDiagnosis(dict);
+                        structuredResponse?.ReportValidation("accepted");
+                        return SemanticOutputRecoveryAttemptResult<Dictionary<string, string>, DiagnosisRejection>
+                            .Accepted(accepted);
                     }
-                    catch (JsonException ex)
+                    catch (Exception ex) when (ex is JsonException || ex is DiagnosisContractException)
                     {
-                        return SemanticOutputRecoveryAttemptResult<Dictionary<string, string>, DiagnosisRejection>.Rejected(
-                            new DiagnosisRejection(llmResponse, ex));
+                        var rejection = DiagnosisRejection.From(ex);
+                        structuredResponse?.ReportValidation("rejected", rejection.Reason);
+                        if (attempt < MaxAttempts)
+                        {
+                            attemptSystemPrompt = BuildRetrySystemPrompt(systemPrompt, rejection);
+                        }
+
+                        return SemanticOutputRecoveryAttemptResult<Dictionary<string, string>, DiagnosisRejection>
+                            .Rejected(rejection);
                     }
                 },
+                onRejected: EmitRejectedDiagnostic,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (recovery.IsAccepted)
@@ -93,27 +123,36 @@ namespace Pinder.SessionSetup
             }
 
             var finalRejection = recovery.Exhaustion.FinalRejection;
-            // Fail-loud by propagating the failure with structural context,
-            // mirroring LlmSequentialStakeGenerator: a malformed/unparseable
-            // diagnosis response is a genuine generation failure, not a
-            // valid empty diagnosis, and must not be silently swallowed.
             throw new InvalidOperationException(
-                LlmDiagnosticFormatter.GeneratedTextFailure(
-                    "Failed to parse diagnosis JSON from LLM response.",
-                    LlmPhase.Synthesis,
-                    finalRejection.GeneratedText),
-                finalRejection.Failure);
+                $"Failed to parse diagnosis JSON from LLM response. " +
+                $"Reason={finalRejection.Reason}; Field={finalRejection.Field ?? "none"}.",
+                new JsonException(
+                    finalRejection.Failure.Message,
+                    finalRejection.Failure));
         }
 
         internal static Dictionary<string, string>? ParseDiagnosisJson(string llmResponse)
         {
             var extraction = GeneratedJsonObjectExtractor.TryExtractFirstValidObject(llmResponse);
             if (!extraction.Success)
-                throw new JsonException(
+                throw new DiagnosisContractException(
+                    "invalid_json",
+                    null,
                     $"Diagnosis response did not contain a valid JSON object. FailureCode={extraction.FailureCode}.");
 
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(extraction.Json!, options);
+            try
+            {
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(extraction.Json!, options);
+            }
+            catch (JsonException ex)
+            {
+                throw new DiagnosisContractException(
+                    "invalid_json",
+                    null,
+                    "Diagnosis JSON could not be deserialized into string fields.",
+                    ex);
+            }
         }
 
         private static Dictionary<string, string> ValidateDiagnosis(
@@ -124,7 +163,9 @@ namespace Pinder.SessionSetup
             if (!validation.IsValid)
             {
                 var violation = validation.Violation!;
-                throw new JsonException(
+                throw new DiagnosisContractException(
+                    violation.Code,
+                    violation.Field,
                     $"Diagnosis response violates contract: code={violation.Code}; field='{violation.Field}'. {violation.Message}");
             }
 
@@ -151,17 +192,106 @@ namespace Pinder.SessionSetup
             return selected;
         }
 
+        private string BuildRetrySystemPrompt(string basePrompt, DiagnosisRejection rejection)
+        {
+            string key = rejection.Field == null
+                ? "diagnosis-repair-json"
+                : "diagnosis-repair-field";
+            var repairEntry = _catalog.TryGet(key);
+            string? repairTemplate = repairEntry?.SystemPrompt;
+            if (string.IsNullOrWhiteSpace(repairTemplate))
+            {
+                return basePrompt;
+            }
+
+            string repairPrompt = PromptCatalog.Substitute(
+                repairTemplate!,
+                new Dictionary<string, string>
+                {
+                    ["field"] = rejection.Field ?? string.Empty,
+                });
+            return basePrompt + Environment.NewLine + Environment.NewLine + repairPrompt;
+        }
+
+        private void EmitRejectedDiagnostic(
+            SemanticOutputRecoveryRejection<DiagnosisRejection> rejection)
+        {
+            var hints = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["generator"] = "diagnosis",
+                ["reason"] = rejection.Rejection.Reason,
+                ["attempt"] = rejection.Attempt.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["total_attempts"] = rejection.TotalAttempts.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            };
+            if (rejection.Rejection.Field != null)
+            {
+                hints["field"] = rejection.Rejection.Field;
+            }
+
+            OperationalDiagnostics.Emit(
+                _onDiagnostic,
+                new OperationalDiagnosticEvent(
+                    "LlmTherapistDiagnosisGenerator",
+                    "DiagnosisContractRejected",
+                    rejection.IsFinalAttempt
+                        ? OperationalDiagnosticSeverity.Error
+                        : OperationalDiagnosticSeverity.Warning,
+                    "Therapist diagnosis output failed structured validation.",
+                    operationKind: OperationalDiagnosticOperationKind.SetupSynthesis,
+                    phaseCode: LlmPhase.Synthesis,
+                    lifecycle: rejection.IsFinalAttempt
+                        ? OperationalDiagnosticLifecycle.Terminal
+                        : OperationalDiagnosticLifecycle.Phase,
+                    outcome: rejection.IsFinalAttempt
+                        ? OperationalDiagnosticOutcome.Failed
+                        : OperationalDiagnosticOutcome.Degraded,
+                    failureClassification: OperationalDiagnosticFailureClassification.Permanent,
+                    callId: OperationalDiagnostics.CreateCallId(),
+                    correlationHints: hints));
+        }
+
         private sealed class DiagnosisRejection
         {
-            public DiagnosisRejection(string generatedText, JsonException failure)
+            private DiagnosisRejection(string reason, string? field, Exception failure)
             {
-                GeneratedText = generatedText;
+                Reason = reason;
+                Field = field;
                 Failure = failure;
             }
 
-            public string GeneratedText { get; }
+            public string Reason { get; }
 
-            public JsonException Failure { get; }
+            public string? Field { get; }
+
+            public Exception Failure { get; }
+
+            public static DiagnosisRejection From(Exception failure)
+            {
+                if (failure is DiagnosisContractException contract)
+                {
+                    return new DiagnosisRejection(contract.Reason, contract.Field, contract);
+                }
+
+                return new DiagnosisRejection("invalid_json", null, failure);
+            }
+        }
+
+        private sealed class DiagnosisContractException : JsonException
+        {
+            public DiagnosisContractException(
+                string reason,
+                string? field,
+                string message,
+                Exception? innerException = null)
+                : base(message, innerException)
+            {
+                Reason = reason;
+                Field = field;
+            }
+
+            public string Reason { get; }
+
+            public string? Field { get; }
         }
     }
 }

--- a/tests/Pinder.Core.Tests/Issue1253_SequentialSynthesisTests.cs
+++ b/tests/Pinder.Core.Tests/Issue1253_SequentialSynthesisTests.cs
@@ -72,6 +72,7 @@ namespace Pinder.Core.Tests
             public int? LastMaxTokens { get; private set; }
             public string? LastPhase { get; private set; }
             public int CallCount { get; private set; }
+            public List<string> SystemPrompts { get; } = new List<string>();
             public string ResponseToReturn { get; set; } = "{}";
             public Queue<string>? ResponsesToReturn { get; set; }
 
@@ -79,6 +80,7 @@ namespace Pinder.Core.Tests
             {
                 CallCount++;
                 LastSystemPrompt = systemPrompt;
+                SystemPrompts.Add(systemPrompt);
                 LastUserMessage = userMessage;
                 LastTemperature = temperature;
                 LastMaxTokens = maxTokens;
@@ -157,7 +159,16 @@ namespace Pinder.Core.Tests
         {
             var testDir = Path.Combine(Directory.GetCurrentDirectory(), "TestData_Prompts_" + Guid.NewGuid());
             Directory.CreateDirectory(testDir);
-            File.WriteAllText(Path.Combine(testDir, "diagnosis.yaml"), "schema_version: 1\nprompts:\n  diagnosis:\n    temperature: 0.62\n    max_tokens: 888\n    system_prompt: \"SYSTEM PROMPT\"\n    user_template: \"USER {backstory} - {stakes}\"");
+            File.WriteAllText(
+                Path.Combine(testDir, "diagnosis.yaml"),
+                "schema_version: 1\nprompts:\n" +
+                "  diagnosis:\n" +
+                "    temperature: 0.62\n" +
+                "    max_tokens: 888\n" +
+                "    system_prompt: \"SYSTEM PROMPT\"\n" +
+                "    user_template: \"USER {backstory} - {stakes}\"\n" +
+                "  diagnosis-repair-json:\n" +
+                "    system_prompt: \"The previous answer was not a usable JSON object. Return the complete object again with every required key.\"\n");
 
             var transport = new FakeLlmTransport
             {
@@ -196,7 +207,16 @@ namespace Pinder.Core.Tests
         {
             var testDir = Path.Combine(Directory.GetCurrentDirectory(), "TestData_Prompts_" + Guid.NewGuid());
             Directory.CreateDirectory(testDir);
-            File.WriteAllText(Path.Combine(testDir, "diagnosis.yaml"), "schema_version: 1\nprompts:\n  diagnosis:\n    temperature: 0.62\n    max_tokens: 888\n    system_prompt: \"SYSTEM PROMPT\"\n    user_template: \"USER {backstory} - {stakes}\"");
+            File.WriteAllText(
+                Path.Combine(testDir, "diagnosis.yaml"),
+                "schema_version: 1\nprompts:\n" +
+                "  diagnosis:\n" +
+                "    temperature: 0.62\n" +
+                "    max_tokens: 888\n" +
+                "    system_prompt: \"SYSTEM PROMPT\"\n" +
+                "    user_template: \"USER {backstory} - {stakes}\"\n" +
+                "  diagnosis-repair-json:\n" +
+                "    system_prompt: \"The previous answer was not a usable JSON object. Return the complete object again with every required key.\"\n");
 
             var transport = new FakeLlmTransport
             {
@@ -225,6 +245,11 @@ namespace Pinder.Core.Tests
                 Assert.Equal("preemptive irony", result["defense_reaction"]);
                 Assert.Equal(TherapistDiagnosisContract.RequiredFields, result.Keys.ToArray());
                 Assert.Equal(2, transport.CallCount);
+                Assert.Equal("SYSTEM PROMPT", transport.SystemPrompts[0]);
+                Assert.Contains("not a usable JSON object", transport.SystemPrompts[1]);
+                Assert.DoesNotContain(
+                    "I would diagnose this as anxious clowning.",
+                    transport.SystemPrompts[1]);
             }
             finally
             {

--- a/tests/Pinder.Core.Tests/Issue843_PromptCatalogPhase1Tests.cs
+++ b/tests/Pinder.Core.Tests/Issue843_PromptCatalogPhase1Tests.cs
@@ -73,7 +73,7 @@ namespace Pinder.Core.Tests
             Assert.Contains("{backstory}", diagnosis.UserTemplate);
             Assert.Contains("{stakes}", diagnosis.UserTemplate);
             Assert.Equal(0.45, diagnosis.Temperature);
-            Assert.Equal(900, diagnosis.MaxTokens);
+            Assert.Equal(1400, diagnosis.MaxTokens);
 
             Assert.Contains("{character_profile}", stake.UserTemplate);
             Assert.Equal(0.9, stake.Temperature);


### PR DESCRIPTION
Adds provider-neutral structured output for therapist diagnosis, configurable repair prompts for malformed or missing fields, privacy-safe rejection diagnostics, and regression coverage. Core suite: 3394 passed, 1 skipped.