### PR TITLE
Adopt provider-neutral Pi conversation sessions

### DIFF
--- a/src/Pinder.Core/Conversation/DateeResponseStage.cs
+++ b/src/Pinder.Core/Conversation/DateeResponseStage.cs
@@ -121,9 +121,30 @@ namespace Pinder.Core.Conversation
                     }));
 
             DateeResponse dateeResponse;
+            StatefulDateeResult? sessionResult = null;
             try
             {
-                if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter statefulLlm)
+                if (_llm is Pinder.Core.Interfaces.ISessionStatefulLlmAdapter sessionLlm
+                    && sessionLlm.SupportsConversationSessions)
+                {
+                    sessionResult = await sessionLlm.GetDateeResponseAsync(
+                        dateeContext,
+                        new List<ConversationMessage>(state.DateeHistory),
+                        new List<ConversationMessage>(state.AvatarHistory),
+                        state.DateeSessionSnapshot,
+                        state.AvatarSessionSnapshot,
+                        ct).ConfigureAwait(false);
+                    if (sessionResult == null)
+                        throw new InvalidOperationException("LLM adapter returned null session datee result");
+                    dateeResponse = sessionResult.Response;
+                    if (dateeResponse == null)
+                        throw new InvalidOperationException("LLM adapter returned null datee response");
+                    if (sessionResult.DateeSessionSnapshot == null)
+                        throw new InvalidOperationException("Session adapter omitted the DATEE session snapshot.");
+                    if (sessionResult.AvatarSessionSnapshot == null)
+                        throw new InvalidOperationException("Session adapter omitted the avatar session snapshot.");
+                }
+                else if (_llm is Pinder.Core.Interfaces.IStatefulLlmAdapter statefulLlm)
                 {
                     var statefulResult = await statefulLlm.GetDateeResponseAsync(
                         dateeContext,
@@ -183,6 +204,13 @@ namespace Pinder.Core.Conversation
 
             state.DateeHistory.Add(ConversationMessage.User(deliveryStage.DeliveredMessage));
             state.DateeHistory.Add(ConversationMessage.Assistant(dateeResponse.MessageText));
+            if (sessionResult != null)
+            {
+                state.AvatarHistory.Add(ConversationMessage.Assistant(deliveryStage.DeliveredMessage));
+                state.AvatarHistory.Add(ConversationMessage.User(dateeResponse.MessageText));
+                state.DateeSessionSnapshot = sessionResult.DateeSessionSnapshot;
+                state.AvatarSessionSnapshot = sessionResult.AvatarSessionSnapshot;
+            }
 
             string dateeMessage = dateeResponse.MessageText;
             progress?.Report(new TurnProgressEvent(TurnProgressStage.DateeResponseCompleted, dateeMessage));

--- a/src/Pinder.Core/Conversation/GameSession.Helpers.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Helpers.cs
@@ -199,7 +199,9 @@ namespace Pinder.Core.Conversation
                 _comboTracker.HasTripleBonus,
                 _dateeHistory,
                 _avatarHistory,
-                _playerShadows);
+                _playerShadows,
+                _state.DateeSessionSnapshot,
+                _state.AvatarSessionSnapshot);
         }
     }
 }

--- a/src/Pinder.Core/Conversation/GameSession.cs
+++ b/src/Pinder.Core/Conversation/GameSession.cs
@@ -40,17 +40,13 @@ namespace Pinder.Core.Conversation
         // profile is now derived from the character's equipped items instead.
         private string _dateeOutfitDescription { get => _state.DateeOutfitDescription; set => _state.DateeOutfitDescription = value; }
 
-        // #788: datee LLM conversation history lives here, not in the adapter.
-        // The adapter is pure-stateless across calls; the engine passes this list
-        // in on every datee call and appends the new entries returned by the
-        // adapter. Survives snapshot/restore via ResimulateData.DateeHistory.
+        // Engine-owned datee-perspective semantic history. During migration it is
+        // dual-written with the provider-neutral Pi session snapshot.
         private List<ConversationMessage> _dateeHistory { get => _state.DateeHistory; set => _state.DateeHistory = value; }
 
-        // #1123: avatar LLM conversation history lives here, symmetric to
-        // _dateeHistory. The avatar (delivery) session is now stateful — the
-        // engine passes this list in on every avatar call and appends the new
-        // entries returned by the adapter. Survives snapshot/restore via
-        // ResimulateData.AvatarHistory.
+        // Engine-owned avatar-perspective semantic history. There is no separate
+        // delivery-model call; session-capable adapters use this state for option
+        // generation and future private reasoning.
         private List<ConversationMessage> _avatarHistory { get => _state.AvatarHistory; set => _state.AvatarHistory = value; }
 
         // Sprint 8 Wave 0: optional config fields

--- a/src/Pinder.Core/Conversation/GameSessionHelpers.cs
+++ b/src/Pinder.Core/Conversation/GameSessionHelpers.cs
@@ -147,7 +147,9 @@ namespace Pinder.Core.Conversation
             bool tripleBonusActive,
             System.Collections.Generic.IReadOnlyList<ConversationMessage> dateeHistory = null,
             System.Collections.Generic.IReadOnlyList<ConversationMessage> avatarHistory = null,
-            SessionShadowTracker? playerShadows = null)
+            SessionShadowTracker? playerShadows = null,
+            LlmConversationSessionSnapshot? dateeSessionSnapshot = null,
+            LlmConversationSessionSnapshot? avatarSessionSnapshot = null)
         {
             var trapNames = traps.AllActive
                 .Select(t => t.Definition.Id)
@@ -198,7 +200,9 @@ namespace Pinder.Core.Conversation
                 dateeHistory: historySnapshot,
                 ghostProbabilityPerTurn: ghostProbabilityPerTurn,
                 avatarHistory: avatarHistorySnapshot,
-                shadowValues: shadowValues);
+                shadowValues: shadowValues,
+                dateeSessionSnapshot: dateeSessionSnapshot,
+                avatarSessionSnapshot: avatarSessionSnapshot);
         }
 
         /// <summary>

--- a/src/Pinder.Core/Conversation/GameSessionState.cs
+++ b/src/Pinder.Core/Conversation/GameSessionState.cs
@@ -18,11 +18,12 @@ namespace Pinder.Core.Conversation
         public List<(string Sender, string Text)> History { get; internal set; } = new List<(string Sender, string Text)>();
         public string DateeOutfitDescription { get; internal set; } = string.Empty;
         public List<ConversationMessage> DateeHistory { get; internal set; } = new List<ConversationMessage>();
-        // #1123: avatar-session LLM conversation history, the symmetric sibling
-        // of DateeHistory. The avatar (delivery) session is now stateful and
-        // cached just like the datee session — the engine owns this list and
-        // threads it through the stateful avatar adapter overload on each turn.
+        // Avatar-perspective semantic history: what the player character knows.
+        // There is no separate delivery-model call; session-capable adapters use
+        // this mirror for option generation and future private reasoning.
         public List<ConversationMessage> AvatarHistory { get; internal set; } = new List<ConversationMessage>();
+        public LlmConversationSessionSnapshot? DateeSessionSnapshot { get; internal set; }
+        public LlmConversationSessionSnapshot? AvatarSessionSnapshot { get; internal set; }
         public HashSet<int> SpentBackstoryIndices { get; internal set; } = new HashSet<int>();
         public HashSet<int> SpentStakeIndices { get; internal set; } = new HashSet<int>();
         public string? PreviousPhase { get; set; }
@@ -69,6 +70,8 @@ namespace Pinder.Core.Conversation
             clone.DateeOutfitDescription = DateeOutfitDescription;
             clone.DateeHistory = new List<ConversationMessage>(DateeHistory);
             clone.AvatarHistory = new List<ConversationMessage>(AvatarHistory);
+            clone.DateeSessionSnapshot = DateeSessionSnapshot;
+            clone.AvatarSessionSnapshot = AvatarSessionSnapshot;
             foreach (var idx in SpentBackstoryIndices) clone.SpentBackstoryIndices.Add(idx);
             foreach (var idx in SpentStakeIndices) clone.SpentStakeIndices.Add(idx);
             clone.PreviousPhase = PreviousPhase;
@@ -128,6 +131,8 @@ namespace Pinder.Core.Conversation
             DateeOutfitDescription = prepared.DateeOutfitDescription;
             DateeHistory = prepared.DateeHistory;
             AvatarHistory = prepared.AvatarHistory;
+            DateeSessionSnapshot = prepared.DateeSessionSnapshot;
+            AvatarSessionSnapshot = prepared.AvatarSessionSnapshot;
             SpentBackstoryIndices = prepared.SpentBackstoryIndices;
             SpentStakeIndices = prepared.SpentStakeIndices;
             PreviousPhase = prepared.PreviousPhase;
@@ -226,6 +231,8 @@ namespace Pinder.Core.Conversation
             History = restoredHistory;
             DateeHistory = restoredDateeHistory;
             AvatarHistory = restoredAvatarHistory;
+            DateeSessionSnapshot = data.DateeSessionSnapshot;
+            AvatarSessionSnapshot = data.AvatarSessionSnapshot;
             TurnNumber = data.TurnNumber;
             ComboTracker = restoredComboTracker;
             RizzCumulativeFailureCount = data.RizzCumulativeFailureCount;

--- a/src/Pinder.Core/Conversation/GameStateSnapshot.cs
+++ b/src/Pinder.Core/Conversation/GameStateSnapshot.cs
@@ -52,6 +52,10 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public IReadOnlyList<ConversationMessage> AvatarHistory { get; }
 
+        public LlmConversationSessionSnapshot? DateeSessionSnapshot { get; }
+
+        public LlmConversationSessionSnapshot? AvatarSessionSnapshot { get; }
+
         public IReadOnlyDictionary<string, int> ShadowValues { get; }
 
         public GameStateSnapshot(
@@ -65,7 +69,9 @@ namespace Pinder.Core.Conversation
             IReadOnlyList<ConversationMessage> dateeHistory = null,
             double ghostProbabilityPerTurn = 0.0,
             IReadOnlyList<ConversationMessage> avatarHistory = null,
-            IReadOnlyDictionary<string, int> shadowValues = null)
+            IReadOnlyDictionary<string, int> shadowValues = null,
+            LlmConversationSessionSnapshot? dateeSessionSnapshot = null,
+            LlmConversationSessionSnapshot? avatarSessionSnapshot = null)
         {
             Interest = interest;
             State = state;
@@ -78,6 +84,8 @@ namespace Pinder.Core.Conversation
             AvatarHistory = avatarHistory ?? System.Array.Empty<ConversationMessage>();
             GhostProbabilityPerTurn = ghostProbabilityPerTurn;
             ShadowValues = shadowValues ?? new Dictionary<string, int>();
+            DateeSessionSnapshot = dateeSessionSnapshot;
+            AvatarSessionSnapshot = avatarSessionSnapshot;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/LlmConversationSessionSnapshot.cs
+++ b/src/Pinder.Core/Conversation/LlmConversationSessionSnapshot.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Pinder.Core.Conversation
+{
+    /// <summary>
+    /// Versioned serialized state for one provider-neutral LLM conversation.
+    /// The engine treats the payload as immutable; Pi.Agent.Core owns its schema
+    /// and reconstruction semantics.
+    /// </summary>
+    public sealed class LlmConversationSessionSnapshot
+    {
+        public const string PiAgentSessionV1 = "pi-agent-session.v1";
+
+        public string Format { get; }
+        public string Payload { get; }
+
+        public LlmConversationSessionSnapshot(string format, string payload)
+        {
+            if (string.IsNullOrWhiteSpace(format))
+                throw new ArgumentException("Session snapshot format is required.", nameof(format));
+            if (string.IsNullOrWhiteSpace(payload))
+                throw new ArgumentException("Session snapshot payload is required.", nameof(payload));
+            Format = format;
+            Payload = payload;
+        }
+    }
+}

--- a/src/Pinder.Core/Conversation/ResimulateData.cs
+++ b/src/Pinder.Core/Conversation/ResimulateData.cs
@@ -69,5 +69,9 @@ namespace Pinder.Core.Conversation
         /// </para>
         /// </summary>
         public List<(string Role, string Content)> AvatarHistory { get; set; } = new List<(string, string)>();
+
+        public LlmConversationSessionSnapshot? DateeSessionSnapshot { get; set; }
+
+        public LlmConversationSessionSnapshot? AvatarSessionSnapshot { get; set; }
     }
 }

--- a/src/Pinder.Core/Conversation/StatefulDateeResult.cs
+++ b/src/Pinder.Core/Conversation/StatefulDateeResult.cs
@@ -31,12 +31,20 @@ namespace Pinder.Core.Conversation
         /// </summary>
         public IReadOnlyList<ConversationMessage> NewHistoryEntries { get; }
 
+        public LlmConversationSessionSnapshot? DateeSessionSnapshot { get; }
+
+        public LlmConversationSessionSnapshot? AvatarSessionSnapshot { get; }
+
         public StatefulDateeResult(
             DateeResponse response,
-            IReadOnlyList<ConversationMessage> newHistoryEntries)
+            IReadOnlyList<ConversationMessage> newHistoryEntries,
+            LlmConversationSessionSnapshot? dateeSessionSnapshot = null,
+            LlmConversationSessionSnapshot? avatarSessionSnapshot = null)
         {
             Response = response ?? throw new System.ArgumentNullException(nameof(response));
             NewHistoryEntries = newHistoryEntries ?? throw new System.ArgumentNullException(nameof(newHistoryEntries));
+            DateeSessionSnapshot = dateeSessionSnapshot;
+            AvatarSessionSnapshot = avatarSessionSnapshot;
         }
     }
 }

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.Helpers.cs
@@ -128,7 +128,9 @@ namespace Pinder.Core.Conversation
                 state.ComboTracker.HasTripleBonus,
                 state.DateeHistory,
                 state.AvatarHistory,
-                state.PlayerShadows);
+                state.PlayerShadows,
+                state.DateeSessionSnapshot,
+                state.AvatarSessionSnapshot);
         }
 
         internal static System.Collections.Generic.IReadOnlyList<(string Sender, string Text)> BuildHistoryForLlmContext(GameSessionState state)

--- a/src/Pinder.Core/Conversation/TurnOrchestrator.cs
+++ b/src/Pinder.Core/Conversation/TurnOrchestrator.cs
@@ -265,7 +265,19 @@ namespace Pinder.Core.Conversation
             DialogueOption[] rawOptions;
             try
             {
-                rawOptions = await _llm.GetDialogueOptionsAsync(context, ct).ConfigureAwait(false);
+                if (_llm is ISessionStatefulLlmAdapter sessionLlm
+                    && sessionLlm.SupportsConversationSessions)
+                {
+                    rawOptions = await sessionLlm.GetDialogueOptionsAsync(
+                        context,
+                        new List<ConversationMessage>(state.AvatarHistory),
+                        state.AvatarSessionSnapshot,
+                        ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    rawOptions = await _llm.GetDialogueOptionsAsync(context, ct).ConfigureAwait(false);
+                }
                 OperationalDiagnostics.EmitSucceededTerminal(
                     _onDiagnostic,
                     "TurnOrchestrator",

--- a/src/Pinder.Core/Interfaces/IConversationLlmTransport.cs
+++ b/src/Pinder.Core/Interfaces/IConversationLlmTransport.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+
+namespace Pinder.Core.Interfaces
+{
+    /// <summary>
+    /// Provider-neutral ordered-message transport. Prior semantic messages stay
+    /// typed and the current engine instruction remains a transient user turn.
+    /// </summary>
+    public interface IConversationLlmTransport : ILlmTransport
+    {
+        /// <summary>
+        /// True only when ordered typed messages can traverse the complete
+        /// transport/decorator chain without flattening or rejection.
+        /// </summary>
+        bool SupportsConversationMessages { get; }
+
+        Task<string> SendConversationAsync(
+            string systemPrompt,
+            IReadOnlyList<ConversationMessage> priorMessages,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.Core/Interfaces/ISessionStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/ISessionStatefulLlmAdapter.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+
+namespace Pinder.Core.Interfaces
+{
+    /// <summary>
+    /// Pi-session-aware extension used during the dual-write migration window.
+    /// Existing adapters remain valid through <see cref="IStatefulLlmAdapter"/>.
+    /// </summary>
+    public interface ISessionStatefulLlmAdapter : IStatefulLlmAdapter
+    {
+        bool SupportsConversationSessions { get; }
+
+        Task<DialogueOption[]> GetDialogueOptionsAsync(
+            DialogueContext context,
+            IReadOnlyList<ConversationMessage> avatarHistory,
+            LlmConversationSessionSnapshot? avatarSession,
+            CancellationToken cancellationToken = default);
+
+        Task<StatefulDateeResult> GetDateeResponseAsync(
+            DateeContext context,
+            IReadOnlyList<ConversationMessage> dateeHistory,
+            IReadOnlyList<ConversationMessage> avatarHistory,
+            LlmConversationSessionSnapshot? dateeSession,
+            LlmConversationSessionSnapshot? avatarSession,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
+++ b/src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs
@@ -6,8 +6,10 @@ using Pinder.Core.Conversation;
 namespace Pinder.Core.Interfaces
 {
     /// <summary>
-    /// LLM adapter interface that supports a multi-turn datee conversation by
-    /// accepting the conversation history as a parameter on each call.
+    /// Legacy LLM adapter interface that supports a multi-turn datee conversation
+    /// by accepting semantic conversation history on each call. Adapters that can
+    /// restore provider-neutral Pi sessions also implement
+    /// <see cref="ISessionStatefulLlmAdapter"/>.
     ///
     /// <para>
     /// As of #788 (Phase 1 of the #393 fast-gameplay refactor) the adapter is
@@ -21,16 +23,17 @@ namespace Pinder.Core.Interfaces
     /// <para>
     /// The base <see cref="ILlmAdapter.GetDateeResponseAsync(DateeContext)"/>
     /// remains as the single-turn fallback (used by callers that don't carry an
-    /// datee history yet). Stateful callers MUST go through the
+    /// datee history yet). Legacy stateful callers MUST go through the
     /// history-passing overload below.
     /// </para>
     /// </summary>
     public interface IStatefulLlmAdapter : ILlmAdapter
     {
         /// <summary>
-        /// Generate the datee's next response. The complete prompt transcript is
-        /// supplied by <paramref name="context"/>; <paramref name="history"/> is
-        /// engine-owned semantic dialogue retained for snapshots and diagnostics.
+        /// Generate the datee's next response through the legacy prompt-document
+        /// path. The complete transcript is supplied by <paramref name="context"/>;
+        /// <paramref name="history"/> is engine-owned semantic dialogue retained
+        /// for snapshots and diagnostics.
         /// Stateless: implementations MUST NOT retain any datee-session field
         /// across calls.
         /// </summary>

--- a/src/Pinder.Core/Interfaces/IStructuredConversationLlmTransport.cs
+++ b/src/Pinder.Core/Interfaces/IStructuredConversationLlmTransport.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+
+namespace Pinder.Core.Interfaces
+{
+    /// <summary>Structured-output counterpart to <see cref="IConversationLlmTransport"/>.</summary>
+    public interface IStructuredConversationLlmTransport : IStructuredLlmTransport
+    {
+        /// <summary>
+        /// True only when structured output and ordered typed messages can both
+        /// traverse the complete transport/decorator chain.
+        /// </summary>
+        bool SupportsStructuredConversationMessages { get; }
+
+        Task<StructuredLlmResponse> SendStructuredConversationAsync(
+            StructuredLlmRequest request,
+            IReadOnlyList<ConversationMessage> priorMessages,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Pinder.LlmAdapters/EmotionalPromptCompiler.cs
+++ b/src/Pinder.LlmAdapters/EmotionalPromptCompiler.cs
@@ -131,11 +131,16 @@ namespace Pinder.LlmAdapters
 
         public PromptTraceResult CompilePerformance(
             DateeContext context,
-            EmotionalPrivateDirection direction)
+            EmotionalPrivateDirection direction,
+            bool includeConversationHistory = true)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (direction == null) throw new ArgumentNullException(nameof(direction));
-            return SessionDocumentBuilder.BuildDateePerformancePromptEx(context, direction, _catalog);
+            return SessionDocumentBuilder.BuildDateePerformancePromptEx(
+                context,
+                direction,
+                _catalog,
+                includeConversationHistory);
         }
 
         public CompiledEmotionalPrompts CompileScenario(

--- a/src/Pinder.LlmAdapters/PiConversationSession.cs
+++ b/src/Pinder.LlmAdapters/PiConversationSession.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pi.AI;
+using Pi.Agent.Core;
+using Pinder.Core.Conversation;
+
+namespace Pinder.LlmAdapters
+{
+    /// <summary>
+    /// Short-lived adapter over Pi.Agent.Core's store/session API. Pinder owns
+    /// when semantic messages commit; Pi owns ordering, parentage, snapshots,
+    /// reconstruction, and later branch mechanics.
+    /// </summary>
+    internal sealed class PiConversationSession : IAsyncDisposable
+    {
+        private readonly InMemorySessionStore _store;
+
+        private PiConversationSession(InMemorySessionStore store, ISession<SessionMetadata> session)
+        {
+            _store = store;
+            Session = session;
+        }
+
+        public ISession<SessionMetadata> Session { get; }
+
+        public static async Task<PiConversationSession> RestoreOrImportAsync(
+            LlmConversationSessionSnapshot? snapshot,
+            IReadOnlyList<ConversationMessage> legacyHistory,
+            string sessionKind)
+        {
+            if (legacyHistory == null) throw new ArgumentNullException(nameof(legacyHistory));
+            var store = new InMemorySessionStore();
+            var repository = Repository(store);
+            try
+            {
+                ISession<SessionMetadata> session;
+                if (snapshot != null)
+                {
+                    if (!string.Equals(
+                        snapshot.Format,
+                        LlmConversationSessionSnapshot.PiAgentSessionV1,
+                        StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Unsupported {sessionKind} session snapshot format '{snapshot.Format}'.");
+                    }
+
+                    SessionSnapshot decoded = SessionJsonCodec.DeserializeSnapshot(snapshot.Payload);
+                    await store.RestoreSnapshotAsync(decoded).ConfigureAwait(false);
+                    session = await repository.OpenAsync(decoded.Metadata).ConfigureAwait(false);
+                }
+                else
+                {
+                    session = await repository.CreateAsync(new InMemorySessionCreateOptions
+                    {
+                        Id = $"pinder-{sessionKind}-{SessionUtilities.CreateSessionId()}",
+                    }).ConfigureAwait(false);
+                    foreach (ConversationMessage message in legacyHistory)
+                        await session.AppendMessageAsync(ToAgentMessage(message)).ConfigureAwait(false);
+                }
+
+                return new PiConversationSession(store, session);
+            }
+            catch
+            {
+                await store.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        public async Task<IReadOnlyList<ConversationMessage>> BuildSemanticHistoryAsync()
+        {
+            SessionContext context = await Session.BuildContextAsync().ConfigureAwait(false);
+            var result = new List<ConversationMessage>(context.Messages.Count);
+            foreach (AgentMessage message in context.Messages)
+            {
+                if (message.Message is UserMessage user)
+                    result.Add(ConversationMessage.User(TextUtilities.ContentText(user.Content)));
+                else if (message.Message is AssistantMessage assistant)
+                    result.Add(ConversationMessage.Assistant(TextUtilities.ContentText(assistant.Content)));
+                else
+                    throw new InvalidOperationException(
+                        $"Pinder semantic session contains unsupported role '{message.Role}'.");
+            }
+            return result;
+        }
+
+        public Task AppendUserAsync(string text)
+            => Session.AppendMessageAsync(AgentMessage.FromMessage(
+                new UserMessage(text ?? string.Empty, Timestamp())));
+
+        public Task AppendAssistantAsync(string text)
+            => Session.AppendMessageAsync(AgentMessage.FromMessage(new AssistantMessage(
+                new IAssistantMessageContent[] { new TextContent(text ?? string.Empty) },
+                new Api("pinder-semantic"),
+                new ProviderId("pinder"),
+                "semantic-history",
+                Usage.Zero,
+                StopReason.Stop,
+                Timestamp())));
+
+        public async Task<LlmConversationSessionSnapshot> SnapshotAsync()
+        {
+            var snapshot = new SessionSnapshot
+            {
+                Metadata = await Session.GetMetadataAsync().ConfigureAwait(false),
+                Entries = await Session.GetEntriesAsync().ConfigureAwait(false),
+            };
+            return new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                SessionJsonCodec.SerializeSnapshot(snapshot));
+        }
+
+        public async ValueTask DisposeAsync()
+            => await _store.DisposeAsync().ConfigureAwait(false);
+
+        private static SessionRepository<SessionMetadata, InMemorySessionCreateOptions, object> Repository(
+            InMemorySessionStore store)
+            => new SessionRepository<SessionMetadata, InMemorySessionCreateOptions, object>(
+                new SessionRepositoryOptions<SessionMetadata, InMemorySessionCreateOptions, object>
+                {
+                    Store = store,
+                });
+
+        private static AgentMessage ToAgentMessage(ConversationMessage message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            if (message.Role == ConversationMessage.UserRole)
+                return AgentMessage.FromMessage(new UserMessage(message.Content, Timestamp()));
+            if (message.Role == ConversationMessage.AssistantRole)
+            {
+                return AgentMessage.FromMessage(new AssistantMessage(
+                    new IAssistantMessageContent[] { new TextContent(message.Content) },
+                    new Api("pinder-semantic"),
+                    new ProviderId("pinder"),
+                    "semantic-history",
+                    Usage.Zero,
+                    StopReason.Stop,
+                    Timestamp()));
+            }
+            throw new InvalidOperationException($"Unsupported Pinder conversation role '{message.Role}'.");
+        }
+
+        private static long Timestamp() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    }
+}

--- a/src/Pinder.LlmAdapters/PiLlmTransport.cs
+++ b/src/Pinder.LlmAdapters/PiLlmTransport.cs
@@ -15,8 +15,8 @@ namespace Pinder.LlmAdapters.Pi
     /// Adapts Pinder's prompt transport contracts to Pi's provider-neutral model API.
     /// Pinder retains prompt construction and response parsing; Pi owns provider execution.
     /// </summary>
-    public sealed class PiLlmTransport : ILlmTransport, IStreamingLlmTransport,
-        IStructuredLlmTransport, ITokenUsageProvider
+    public sealed class PiLlmTransport : ILlmTransport, IConversationLlmTransport, IStreamingLlmTransport,
+        IStructuredLlmTransport, IStructuredConversationLlmTransport, ITokenUsageProvider
     {
         private readonly Model _model;
         private readonly Func<Model, Context, ModelsSimpleStreamOptions, Task<AssistantMessage>> _completeAsync;
@@ -30,6 +30,10 @@ namespace Pinder.LlmAdapters.Pi
         private long _cacheReadTokens;
         private long _cacheWriteTokens;
         private long _callCount;
+
+        public bool SupportsConversationMessages => true;
+
+        public bool SupportsStructuredConversationMessages => true;
 
         public PiLlmTransport(
             ModelsCollection models,
@@ -83,12 +87,32 @@ namespace Pinder.LlmAdapters.Pi
             string? phase = null,
             CancellationToken ct = default)
         {
-            Context context = CreateContext(systemPrompt, userMessage);
+            return await SendConversationAsync(
+                systemPrompt,
+                Array.Empty<Pinder.Core.Conversation.ConversationMessage>(),
+                userMessage,
+                temperature,
+                maxTokens,
+                phase,
+                ct).ConfigureAwait(false);
+        }
+
+        public async Task<string> SendConversationAsync(
+            string systemPrompt,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken cancellationToken = default)
+        {
+            Context context = CreateContext(systemPrompt, priorMessages, userMessage);
             var responseStatus = new ResponseStatusCapture();
-            ModelsSimpleStreamOptions options = CreateOptions(phase, temperature, maxTokens, ct, responseStatus);
+            ModelsSimpleStreamOptions options = CreateOptions(
+                phase, temperature, maxTokens, cancellationToken, responseStatus);
             AssistantMessage response = await _completeAsync(_model, context, options).ConfigureAwait(false);
             Observe(response, phase);
-            EnsureSuccess(response, ct, false, responseStatus);
+            EnsureSuccess(response, cancellationToken, false, responseStatus);
 
             string text = TextUtilities.ContentText(response.Content);
             if (string.IsNullOrWhiteSpace(text))
@@ -126,9 +150,18 @@ namespace Pinder.LlmAdapters.Pi
         public async Task<StructuredLlmResponse> SendStructuredAsync(
             StructuredLlmRequest request,
             CancellationToken ct = default)
+            => await SendStructuredConversationAsync(
+                request,
+                Array.Empty<Pinder.Core.Conversation.ConversationMessage>(),
+                ct).ConfigureAwait(false);
+
+        public async Task<StructuredLlmResponse> SendStructuredConversationAsync(
+            StructuredLlmRequest request,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            CancellationToken cancellationToken = default)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
-            Context context = CreateContext(request.SystemPrompt, request.UserMessage);
+            Context context = CreateContext(request.SystemPrompt, priorMessages, request.UserMessage);
             string toolName = NormalizeToolName(request.SchemaName);
             context.Tools = new List<Tool>
             {
@@ -143,7 +176,7 @@ namespace Pinder.LlmAdapters.Pi
 
             var responseStatus = new ResponseStatusCapture();
             ModelsSimpleStreamOptions options = CreateOptions(
-                request.Phase, request.Temperature, request.MaxTokens, ct, responseStatus);
+                request.Phase, request.Temperature, request.MaxTokens, cancellationToken, responseStatus);
             options.Extra["toolChoice"] = "required";
             var metadata = new Dictionary<string, object?>(StringComparer.Ordinal);
             foreach (KeyValuePair<string, string> item in request.Metadata) metadata[item.Key] = item.Value;
@@ -153,7 +186,7 @@ namespace Pinder.LlmAdapters.Pi
 
             AssistantMessage response = await _completeAsync(_model, context, options).ConfigureAwait(false);
             Observe(response, request.Phase);
-            EnsureSuccess(response, ct, false, responseStatus);
+            EnsureSuccess(response, cancellationToken, false, responseStatus);
 
             ToolCall? toolCall = response.Content.OfType<ToolCall>()
                 .FirstOrDefault(call => string.Equals(call.Name, toolName, StringComparison.Ordinal));
@@ -196,13 +229,49 @@ namespace Pinder.LlmAdapters.Pi
         }
 
         private Context CreateContext(string systemPrompt, string userMessage)
+            => CreateContext(
+                systemPrompt,
+                Array.Empty<Pinder.Core.Conversation.ConversationMessage>(),
+                userMessage);
+
+        private Context CreateContext(
+            string systemPrompt,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            string userMessage)
         {
             if (systemPrompt == null) throw new ArgumentNullException(nameof(systemPrompt));
+            if (priorMessages == null) throw new ArgumentNullException(nameof(priorMessages));
             if (userMessage == null) throw new ArgumentNullException(nameof(userMessage));
+            var messages = new List<Message>(priorMessages.Count + 1);
+            foreach (Pinder.Core.Conversation.ConversationMessage message in priorMessages)
+            {
+                if (message.Role == Pinder.Core.Conversation.ConversationMessage.UserRole)
+                {
+                    messages.Add(new UserMessage(message.Content, _timestampMilliseconds()));
+                }
+                else if (message.Role == Pinder.Core.Conversation.ConversationMessage.AssistantRole)
+                {
+                    messages.Add(new AssistantMessage(
+                        new IAssistantMessageContent[] { new TextContent(message.Content) },
+                        _model.Api,
+                        _model.Provider,
+                        _model.Id,
+                        Usage.Zero,
+                        StopReason.Stop,
+                        _timestampMilliseconds()));
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"Unsupported conversation role '{message.Role}'.",
+                        nameof(priorMessages));
+                }
+            }
+            messages.Add(new UserMessage(userMessage, _timestampMilliseconds()));
             return new Context
             {
                 SystemPrompt = systemPrompt,
-                Messages = new List<Message> { new UserMessage(userMessage, _timestampMilliseconds()) }
+                Messages = messages
             };
         }
 

--- a/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
+++ b/src/Pinder.LlmAdapters/PinderLlmAdapter.cs
@@ -14,14 +14,16 @@ using Pinder.LlmAdapters.Anthropic;
 namespace Pinder.LlmAdapters
 {
     /// <summary>
-    /// Provider-agnostic implementation of ILlmAdapter and IStatefulLlmAdapter.
+    /// Provider-agnostic implementation of ILlmAdapter and its stateful session extensions.
     /// All game-level prompt building and response parsing lives here — single source of truth.
     /// Delegates raw LLM I/O to an ILlmTransport (AnthropicTransport, OpenAiTransport, etc.).
     ///
     /// This replaces the need for every transport to duplicate game logic.
-    /// The transport does ONE thing: (systemPrompt, userMessage) → rawText.
+    /// Plain transports accept a single user message; conversation transports
+    /// additionally accept ordered typed prior messages. Provider wire formats
+    /// remain below the transport boundary.
     /// </summary>
-    public sealed partial class PinderLlmAdapter : IStatefulLlmAdapter, IDisposable
+    public sealed partial class PinderLlmAdapter : ISessionStatefulLlmAdapter, IDisposable
     {
         private const string HorninessOverlayPrompt = "horniness_overlay";
         private const string TrapOverlayPrompt = "trap_overlay";
@@ -41,6 +43,13 @@ namespace Pinder.LlmAdapters
         private readonly ILlmTransport _overlayTransport;
         private readonly PinderLlmAdapterOptions _options;
         private readonly PinderLlmAdapterTemperatureSource _temperatures;
+
+        public bool SupportsConversationSessions
+            => _transport is IConversationLlmTransport contextual
+                && contextual.SupportsConversationMessages
+                && (!(_transport is IStructuredLlmTransport)
+                    || (_transport is IStructuredConversationLlmTransport structuredContextual
+                        && structuredContextual.SupportsStructuredConversationMessages));
 
         // #788: datee conversation state lives on GameSession, not here.
         // The adapter is pure-stateless and safe for concurrent reuse across sessions.
@@ -65,14 +74,36 @@ namespace Pinder.LlmAdapters
         // ── ILlmAdapter ────────────────────────────────────────────────────
 
         /// <inheritdoc />
-        public async Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+        public Task<DialogueOption[]> GetDialogueOptionsAsync(DialogueContext context, CancellationToken ct = default)
+            => GetDialogueOptionsCoreAsync(context, priorMessages: null, ct);
+
+        public async Task<DialogueOption[]> GetDialogueOptionsAsync(
+            DialogueContext context,
+            IReadOnlyList<ConversationMessage> avatarHistory,
+            LlmConversationSessionSnapshot? avatarSession,
+            CancellationToken cancellationToken = default)
+        {
+            await using PiConversationSession session = await PiConversationSession.RestoreOrImportAsync(
+                avatarSession,
+                avatarHistory,
+                "avatar").ConfigureAwait(false);
+            IReadOnlyList<ConversationMessage> priorMessages = await session.BuildSemanticHistoryAsync()
+                .ConfigureAwait(false);
+            return await GetDialogueOptionsCoreAsync(context, priorMessages, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        private async Task<DialogueOption[]> GetDialogueOptionsCoreAsync(
+            DialogueContext context,
+            IReadOnlyList<ConversationMessage>? priorMessages,
+            CancellationToken ct)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             var gameDef = RequireGameDefinition();
-            var userContent = SessionDocumentBuilder.BuildDialogueOptionsPrompt(
-                context,
-                _options.PromptCatalog);
+            string userContent = priorMessages == null
+                ? SessionDocumentBuilder.BuildDialogueOptionsPrompt(context, _options.PromptCatalog)
+                : SessionDocumentBuilder.BuildDialogueOptionsSessionPromptEx(context, _options.PromptCatalog).Text;
             var systemPrompt = SessionSystemPromptBuilder.BuildPlayerAvatar(context.PlayerAvatarPrompt, gameDef);
             double temperature = _temperatures.For(PinderLlmAdapterPhase.DialogueOptions);
 
@@ -98,7 +129,8 @@ namespace Pinder.LlmAdapters
                                     request,
                                     LlmPhase.DialogueOptions,
                                     context.CurrentTurn,
-                                    attemptCancellationToken)
+                                    attemptCancellationToken,
+                                    priorMessages: priorMessages)
                                 .ConfigureAwait(false);
                             try
                             {
@@ -157,7 +189,8 @@ namespace Pinder.LlmAdapters
                                     _options.MaxTokens,
                                     LlmPhase.DialogueOptions,
                                     context.CurrentTurn,
-                                    attemptCancellationToken)
+                                    attemptCancellationToken,
+                                    priorMessages: priorMessages)
                                 .ConfigureAwait(false);
 
                             parsedOptions = ParseDialogueOptionsFromTextOrJson(
@@ -206,10 +239,47 @@ namespace Pinder.LlmAdapters
         }
 
         /// <inheritdoc />
-        public async Task<StatefulDateeResult> GetDateeResponseAsync(
+        public Task<StatefulDateeResult> GetDateeResponseAsync(
             DateeContext context,
             IReadOnlyList<ConversationMessage> history,
             CancellationToken cancellationToken = default)
+            => GetDateeResponseCoreAsync(context, history, priorMessages: null, cancellationToken);
+
+        public async Task<StatefulDateeResult> GetDateeResponseAsync(
+            DateeContext context,
+            IReadOnlyList<ConversationMessage> dateeHistory,
+            IReadOnlyList<ConversationMessage> avatarHistory,
+            LlmConversationSessionSnapshot? dateeSession,
+            LlmConversationSessionSnapshot? avatarSession,
+            CancellationToken cancellationToken = default)
+        {
+            await using PiConversationSession datee = await PiConversationSession.RestoreOrImportAsync(
+                dateeSession, dateeHistory, "datee").ConfigureAwait(false);
+            await using PiConversationSession avatar = await PiConversationSession.RestoreOrImportAsync(
+                avatarSession, avatarHistory, "avatar").ConfigureAwait(false);
+
+            IReadOnlyList<ConversationMessage> priorMessages = await datee.BuildSemanticHistoryAsync()
+                .ConfigureAwait(false);
+            StatefulDateeResult accepted = await GetDateeResponseCoreAsync(
+                context, dateeHistory, priorMessages, cancellationToken).ConfigureAwait(false);
+
+            await datee.AppendUserAsync(context.PlayerDeliveredMessage).ConfigureAwait(false);
+            await datee.AppendAssistantAsync(accepted.Response.MessageText).ConfigureAwait(false);
+            await avatar.AppendAssistantAsync(context.PlayerDeliveredMessage).ConfigureAwait(false);
+            await avatar.AppendUserAsync(accepted.Response.MessageText).ConfigureAwait(false);
+
+            return new StatefulDateeResult(
+                accepted.Response,
+                accepted.NewHistoryEntries,
+                await datee.SnapshotAsync().ConfigureAwait(false),
+                await avatar.SnapshotAsync().ConfigureAwait(false));
+        }
+
+        private async Task<StatefulDateeResult> GetDateeResponseCoreAsync(
+            DateeContext context,
+            IReadOnlyList<ConversationMessage> history,
+            IReadOnlyList<ConversationMessage>? priorMessages,
+            CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (history == null) throw new ArgumentNullException(nameof(history));
@@ -228,8 +298,10 @@ namespace Pinder.LlmAdapters
                     emotionalPromptCompiler,
                     cancellationToken)
                 .ConfigureAwait(false);
-            PromptTraceResult dateePrompt =
-                emotionalPromptCompiler.CompilePerformance(context, emotionalDirection);
+            PromptTraceResult dateePrompt = emotionalPromptCompiler.CompilePerformance(
+                context,
+                emotionalDirection,
+                includeConversationHistory: priorMessages == null);
             InMemoryPromptTraceService.Instance.RecordTrace("datee", dateePrompt);
             var userContent = dateePrompt.Text;
             var systemPrompt = SessionSystemPromptBuilder.BuildDatee(context.DateePrompt, gameDef);
@@ -243,10 +315,10 @@ namespace Pinder.LlmAdapters
                 {
                     try
                     {
-                        // DateeContext.ConversationHistory is the authoritative transcript
-                        // and BuildDateePrompt renders it into userContent. Prefixing the
-                        // separate engine-owned DateeHistory here would include each prior
-                        // full prompt again and cause nested, quadratic prompt growth.
+                        // Legacy calls render DateeContext.ConversationHistory into
+                        // userContent. Session calls omit that block and supply ordered
+                        // semantic priorMessages instead. Never combine both forms: doing
+                        // so duplicates context and produces quadratic prompt growth.
                         string responseText = await SendWithDiagnosticsAsync(
                                 _transport,
                                 systemPrompt,
@@ -259,7 +331,8 @@ namespace Pinder.LlmAdapters
                                 attempt,
                                 maxAttempts,
                                 DateePrivatePhasePerformance,
-                                performanceMetadata)
+                                performanceMetadata,
+                                priorMessages)
                             .ConfigureAwait(false);
 
                         if (string.IsNullOrWhiteSpace(responseText))
@@ -1225,7 +1298,8 @@ namespace Pinder.LlmAdapters
             int? attempt = null,
             int? totalAttempts = null,
             string? dateePrivatePhase = null,
-            IReadOnlyDictionary<string, string>? metadata = null)
+            IReadOnlyDictionary<string, string>? metadata = null,
+            IReadOnlyList<ConversationMessage>? priorMessages = null)
         {
             var sink = GetDiagnosticSink();
             string callId = OperationalDiagnostics.CreateCallId();
@@ -1256,7 +1330,19 @@ namespace Pinder.LlmAdapters
             var tokenUsageBefore = CaptureTokenUsageSnapshot(transport);
             try
             {
-                var result = await transport.SendStructuredAsync(request, ct).ConfigureAwait(false);
+                StructuredLlmResponse result;
+                if (priorMessages != null)
+                {
+                    if (!(transport is IStructuredConversationLlmTransport contextual))
+                        throw new InvalidOperationException(
+                            "The configured transport does not support structured ordered conversation messages.");
+                    result = await contextual.SendStructuredConversationAsync(request, priorMessages, ct)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    result = await transport.SendStructuredAsync(request, ct).ConfigureAwait(false);
+                }
                 var tokenUsageAfter = CaptureTokenUsageSnapshot(transport);
                 var hints = CloneHints(baseHints);
                 AddElapsedHint(hints, stopwatch);
@@ -1339,7 +1425,8 @@ namespace Pinder.LlmAdapters
             int? attempt = null,
             int? totalAttempts = null,
             string? dateePrivatePhase = null,
-            IReadOnlyDictionary<string, string>? metadata = null)
+            IReadOnlyDictionary<string, string>? metadata = null,
+            IReadOnlyList<ConversationMessage>? priorMessages = null)
         {
             var sink = GetDiagnosticSink();
             string callId = OperationalDiagnostics.CreateCallId();
@@ -1368,9 +1455,27 @@ namespace Pinder.LlmAdapters
             var tokenUsageBefore = CaptureTokenUsageSnapshot(transport);
             try
             {
-                string result = await transport
-                    .SendAsync(systemPrompt, userContent, temperature, maxTokens, phase: phase, ct: ct)
-                    .ConfigureAwait(false);
+                string result;
+                if (priorMessages != null)
+                {
+                    if (!(transport is IConversationLlmTransport contextual))
+                        throw new InvalidOperationException(
+                            "The configured transport does not support ordered conversation messages.");
+                    result = await contextual.SendConversationAsync(
+                        systemPrompt,
+                        priorMessages,
+                        userContent,
+                        temperature,
+                        maxTokens,
+                        phase,
+                        ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = await transport
+                        .SendAsync(systemPrompt, userContent, temperature, maxTokens, phase: phase, ct: ct)
+                        .ConfigureAwait(false);
+                }
 
                 var tokenUsageAfter = CaptureTokenUsageSnapshot(transport);
                 var hints = CloneHints(baseHints);

--- a/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
+++ b/src/Pinder.LlmAdapters/PunctuationNormalizingTransport.cs
@@ -45,7 +45,7 @@ namespace Pinder.LlmAdapters
     /// buffering — to avoid changing streaming latency characteristics.
     /// </para>
     /// </remarks>
-    public sealed class PunctuationNormalizingTransport : ILlmTransport, IStreamingLlmTransport, IStructuredLlmTransport, ITokenUsageProvider, System.IDisposable
+    public sealed class PunctuationNormalizingTransport : ILlmTransport, IConversationLlmTransport, IStreamingLlmTransport, IStructuredLlmTransport, IStructuredConversationLlmTransport, ITokenUsageProvider, System.IDisposable
     {
         // U+2014 = em-dash, U+2009 = thin-space.
         private const char EmDash    = '\u2014';
@@ -76,6 +76,14 @@ namespace Pinder.LlmAdapters
         /// constructed without one. Same purpose as <see cref="Inner"/>.
         /// </summary>
         public IStreamingLlmTransport? InnerStreaming => _innerStreaming;
+
+        public bool SupportsConversationMessages
+            => _inner is IConversationLlmTransport contextual
+                && contextual.SupportsConversationMessages;
+
+        public bool SupportsStructuredConversationMessages
+            => _inner is IStructuredConversationLlmTransport contextual
+                && contextual.SupportsStructuredConversationMessages;
 
         /// <inheritdoc />
         public SessionTokenUsage GetSessionUsage()
@@ -115,6 +123,24 @@ namespace Pinder.LlmAdapters
             return Normalize(raw);
         }
 
+        public async Task<string> SendConversationAsync(
+            string systemPrompt,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(_inner is IConversationLlmTransport contextual))
+                throw new System.InvalidOperationException(
+                    "The wrapped LLM transport does not support ordered conversation messages.");
+            string raw = await contextual.SendConversationAsync(
+                systemPrompt, priorMessages, userMessage, temperature, maxTokens, phase, cancellationToken)
+                .ConfigureAwait(false);
+            return Normalize(raw);
+        }
+
         public async Task<StructuredLlmResponse> SendStructuredAsync(
             StructuredLlmRequest request,
             CancellationToken ct = default)
@@ -131,6 +157,19 @@ namespace Pinder.LlmAdapters
             return new StructuredLlmResponse(
                 Normalize(raw),
                 usedNativeStructuredOutput: false);
+        }
+
+        public async Task<StructuredLlmResponse> SendStructuredConversationAsync(
+            StructuredLlmRequest request,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(_inner is IStructuredConversationLlmTransport contextual))
+                throw new System.InvalidOperationException(
+                    "The wrapped LLM transport does not support structured ordered conversation messages.");
+            StructuredLlmResponse response = await contextual.SendStructuredConversationAsync(
+                request, priorMessages, cancellationToken).ConfigureAwait(false);
+            return response.WithJsonText(Normalize(response.JsonText));
         }
 
         public async IAsyncEnumerable<string> SendStreamAsync(

--- a/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
+++ b/src/Pinder.LlmAdapters/SessionDocumentBuilder.Trace.cs
@@ -125,6 +125,17 @@ namespace Pinder.LlmAdapters
         public static PromptTraceResult BuildDialogueOptionsPromptEx(
             DialogueContext context,
             PromptCatalog? promptCatalog = null)
+            => BuildDialogueOptionsPromptCore(context, promptCatalog, includeConversationHistory: true);
+
+        internal static PromptTraceResult BuildDialogueOptionsSessionPromptEx(
+            DialogueContext context,
+            PromptCatalog? promptCatalog = null)
+            => BuildDialogueOptionsPromptCore(context, promptCatalog, includeConversationHistory: false);
+
+        private static PromptTraceResult BuildDialogueOptionsPromptCore(
+            DialogueContext context,
+            PromptCatalog? promptCatalog,
+            bool includeConversationHistory)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (string.IsNullOrEmpty(context.PlayerName)) throw new ArgumentException("PlayerName cannot be null or empty.");
@@ -143,11 +154,13 @@ namespace Pinder.LlmAdapters
                 sb.AppendLine();
             }
 
-            // Conversation history
-            var historySb = new StringBuilder();
-            HistoryFormatter.Format(historySb, context.ConversationHistory, playerName);
-            sb.Append(historySb.ToString(), "conversation-history", "conversation-history");
-            sb.AppendLine();
+            if (includeConversationHistory)
+            {
+                var historySb = new StringBuilder();
+                HistoryFormatter.Format(historySb, context.ConversationHistory, playerName);
+                sb.Append(historySb.ToString(), "conversation-history", "conversation-history");
+                sb.AppendLine();
+            }
 
             // Game state summary
             var gameState = new StringBuilder();
@@ -417,16 +430,18 @@ namespace Pinder.LlmAdapters
         internal static PromptTraceResult BuildDateePerformancePromptEx(
             DateeContext context,
             EmotionalPrivateDirection emotionalDirection,
-            PromptCatalog? promptCatalog = null)
+            PromptCatalog? promptCatalog = null,
+            bool includeConversationHistory = true)
         {
             if (emotionalDirection == null) throw new ArgumentNullException(nameof(emotionalDirection));
-            return BuildDateePromptCore(context, emotionalDirection, promptCatalog);
+            return BuildDateePromptCore(context, emotionalDirection, promptCatalog, includeConversationHistory);
         }
 
         private static PromptTraceResult BuildDateePromptCore(
             DateeContext context,
             EmotionalPrivateDirection? emotionalDirection,
-            PromptCatalog? promptCatalog)
+            PromptCatalog? promptCatalog,
+            bool includeConversationHistory = true)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (string.IsNullOrEmpty(context.PlayerName)) throw new ArgumentException("PlayerName cannot be null or empty.");
@@ -437,11 +452,13 @@ namespace Pinder.LlmAdapters
 
             var sb = new AnnotatedStringBuilder();
 
-            // Conversation history
-            var historySb = new StringBuilder();
-            HistoryFormatter.Format(historySb, context.ConversationHistory, playerName);
-            sb.Append(historySb.ToString(), "conversation-history", "conversation-history");
-            sb.AppendLine();
+            if (includeConversationHistory)
+            {
+                var historySb = new StringBuilder();
+                HistoryFormatter.Format(historySb, context.ConversationHistory, playerName);
+                sb.Append(historySb.ToString(), "conversation-history", "conversation-history");
+                sb.AppendLine();
+            }
 
             // Player's last message with failure context
             if (context.DeliveryTier != FailureTier.Success)

--- a/src/Pinder.LlmAdapters/ThinkingStrippingLlmTransport.cs
+++ b/src/Pinder.LlmAdapters/ThinkingStrippingLlmTransport.cs
@@ -68,7 +68,7 @@ namespace Pinder.LlmAdapters
     /// fragment whose content rules out a leading tag.
     /// </para>
     /// </remarks>
-    public sealed class ThinkingStrippingLlmTransport : ILlmTransport, IStreamingLlmTransport, IStructuredLlmTransport, ITokenUsageProvider, System.IDisposable
+    public sealed class ThinkingStrippingLlmTransport : ILlmTransport, IConversationLlmTransport, IStreamingLlmTransport, IStructuredLlmTransport, IStructuredConversationLlmTransport, ITokenUsageProvider, System.IDisposable
     {
         /// <summary>
         /// Maximum characters to buffer in the streaming code path while
@@ -108,6 +108,14 @@ namespace Pinder.LlmAdapters
         /// </summary>
         public IStreamingLlmTransport? InnerStreaming => _innerStreaming;
 
+        public bool SupportsConversationMessages
+            => _inner is IConversationLlmTransport contextual
+                && contextual.SupportsConversationMessages;
+
+        public bool SupportsStructuredConversationMessages
+            => _inner is IStructuredConversationLlmTransport contextual
+                && contextual.SupportsStructuredConversationMessages;
+
         /// <inheritdoc />
         public SessionTokenUsage GetSessionUsage()
         {
@@ -146,6 +154,24 @@ namespace Pinder.LlmAdapters
             return InlineThinkingStripper.Strip(raw);
         }
 
+        public async Task<string> SendConversationAsync(
+            string systemPrompt,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            string userMessage,
+            double temperature = 0.9,
+            int maxTokens = 1024,
+            string? phase = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(_inner is IConversationLlmTransport contextual))
+                throw new System.InvalidOperationException(
+                    "The wrapped LLM transport does not support ordered conversation messages.");
+            string raw = await contextual.SendConversationAsync(
+                systemPrompt, priorMessages, userMessage, temperature, maxTokens, phase, cancellationToken)
+                .ConfigureAwait(false);
+            return InlineThinkingStripper.Strip(raw);
+        }
+
         public async Task<StructuredLlmResponse> SendStructuredAsync(
             StructuredLlmRequest request,
             CancellationToken ct = default)
@@ -162,6 +188,19 @@ namespace Pinder.LlmAdapters
             return new StructuredLlmResponse(
                 InlineThinkingStripper.Strip(raw),
                 usedNativeStructuredOutput: false);
+        }
+
+        public async Task<StructuredLlmResponse> SendStructuredConversationAsync(
+            StructuredLlmRequest request,
+            IReadOnlyList<Pinder.Core.Conversation.ConversationMessage> priorMessages,
+            CancellationToken cancellationToken = default)
+        {
+            if (!(_inner is IStructuredConversationLlmTransport contextual))
+                throw new System.InvalidOperationException(
+                    "The wrapped LLM transport does not support structured ordered conversation messages.");
+            StructuredLlmResponse response = await contextual.SendStructuredConversationAsync(
+                request, priorMessages, cancellationToken).ConfigureAwait(false);
+            return response.WithJsonText(InlineThinkingStripper.Strip(response.JsonText));
         }
 
         public async IAsyncEnumerable<string> SendStreamAsync(

--- a/tests/Pinder.Core.Tests/Conversation/DateeResponseStageTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/DateeResponseStageTests.cs
@@ -108,6 +108,54 @@ namespace Pinder.Core.Tests.Conversation
             }
         }
 
+        private sealed class SessionStatefulLlm : NullLlmAdapter, ISessionStatefulLlmAdapter
+        {
+            private readonly StatefulDateeResult _result;
+
+            public SessionStatefulLlm(StatefulDateeResult result)
+            {
+                _result = result;
+            }
+
+            public bool SupportsConversationSessions => true;
+            public int LegacyDateeCallCount { get; private set; }
+            public IReadOnlyList<ConversationMessage>? DateeHistorySeen { get; private set; }
+            public IReadOnlyList<ConversationMessage>? AvatarHistorySeen { get; private set; }
+            public LlmConversationSessionSnapshot? DateeSnapshotSeen { get; private set; }
+            public LlmConversationSessionSnapshot? AvatarSnapshotSeen { get; private set; }
+
+            public override Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context,
+                IReadOnlyList<ConversationMessage> history,
+                CancellationToken cancellationToken = default)
+            {
+                LegacyDateeCallCount++;
+                return base.GetDateeResponseAsync(context, history, cancellationToken);
+            }
+
+            public Task<DialogueOption[]> GetDialogueOptionsAsync(
+                DialogueContext context,
+                IReadOnlyList<ConversationMessage> avatarHistory,
+                LlmConversationSessionSnapshot? avatarSession,
+                CancellationToken cancellationToken = default)
+                => Task.FromResult(Array.Empty<DialogueOption>());
+
+            public Task<StatefulDateeResult> GetDateeResponseAsync(
+                DateeContext context,
+                IReadOnlyList<ConversationMessage> dateeHistory,
+                IReadOnlyList<ConversationMessage> avatarHistory,
+                LlmConversationSessionSnapshot? dateeSession,
+                LlmConversationSessionSnapshot? avatarSession,
+                CancellationToken cancellationToken = default)
+            {
+                DateeHistorySeen = dateeHistory;
+                AvatarHistorySeen = avatarHistory;
+                DateeSnapshotSeen = dateeSession;
+                AvatarSnapshotSeen = avatarSession;
+                return Task.FromResult(_result);
+            }
+        }
+
         private static CharacterProfile MakeProfile(string name)
         {
             return TestHelpers.MakeCharacterProfile(
@@ -358,6 +406,112 @@ namespace Pinder.Core.Tests.Conversation
             Assert.DoesNotContain(
                 state.DateeHistory,
                 entry => entry.Content.Contains("PRIVATE MUTATION", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SessionAdapter_AtomicallyAdoptsSnapshotsAndDualWritesSemanticHistory()
+        {
+            var oldDateeSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"old\":\"datee\"}");
+            var oldAvatarSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"old\":\"avatar\"}");
+            var newDateeSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"new\":\"datee\"}");
+            var newAvatarSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"new\":\"avatar\"}");
+            var llm = new SessionStatefulLlm(new StatefulDateeResult(
+                new DateeResponse("Accepted visible reply"),
+                Array.Empty<ConversationMessage>(),
+                newDateeSnapshot,
+                newAvatarSnapshot));
+            var stage = new DateeResponseStage(llm);
+            var state = new GameSessionState { Interest = new InterestMeter(10) };
+            state.DateeHistory.Add(ConversationMessage.User("Older player line"));
+            state.DateeHistory.Add(ConversationMessage.Assistant("Older DATEE reply"));
+            state.AvatarHistory.Add(ConversationMessage.Assistant("Older player line"));
+            state.AvatarHistory.Add(ConversationMessage.User("Older DATEE reply"));
+            state.DateeSessionSnapshot = oldDateeSnapshot;
+            state.AvatarSessionSnapshot = oldAvatarSnapshot;
+
+            await stage.ExecuteAsync(
+                state,
+                MakeRollStageResult(),
+                new DeliveryStageResult
+                {
+                    DeliveredMessage = "Current delivered line",
+                    HorninessCheckResult = HorninessCheckResult.NotPerformed
+                },
+                MakeProfile("Player"),
+                MakeProfile("Datee"),
+                null,
+                CancellationToken.None);
+
+            Assert.Equal(0, llm.LegacyDateeCallCount);
+            Assert.Same(oldDateeSnapshot, llm.DateeSnapshotSeen);
+            Assert.Same(oldAvatarSnapshot, llm.AvatarSnapshotSeen);
+            Assert.Equal(2, llm.DateeHistorySeen!.Count);
+            Assert.Equal(2, llm.AvatarHistorySeen!.Count);
+            Assert.Equal(4, state.DateeHistory.Count);
+            Assert.Equal(ConversationMessage.UserRole, state.DateeHistory[2].Role);
+            Assert.Equal("Current delivered line", state.DateeHistory[2].Content);
+            Assert.Equal(ConversationMessage.AssistantRole, state.DateeHistory[3].Role);
+            Assert.Equal("Accepted visible reply", state.DateeHistory[3].Content);
+            Assert.Equal(4, state.AvatarHistory.Count);
+            Assert.Equal(ConversationMessage.AssistantRole, state.AvatarHistory[2].Role);
+            Assert.Equal("Current delivered line", state.AvatarHistory[2].Content);
+            Assert.Equal(ConversationMessage.UserRole, state.AvatarHistory[3].Role);
+            Assert.Equal("Accepted visible reply", state.AvatarHistory[3].Content);
+            Assert.Same(newDateeSnapshot, state.DateeSessionSnapshot);
+            Assert.Same(newAvatarSnapshot, state.AvatarSessionSnapshot);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_SessionAdapterWithIncompleteSnapshot_DoesNotMutateState()
+        {
+            var oldDateeSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"old\":\"datee\"}");
+            var oldAvatarSnapshot = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"old\":\"avatar\"}");
+            var llm = new SessionStatefulLlm(new StatefulDateeResult(
+                new DateeResponse("Must not commit"),
+                Array.Empty<ConversationMessage>(),
+                oldDateeSnapshot,
+                avatarSessionSnapshot: null));
+            var diagnostics = new List<OperationalDiagnosticEvent>();
+            var stage = new DateeResponseStage(llm, diagnostics.Add);
+            var state = new GameSessionState { Interest = new InterestMeter(10) };
+            state.DateeHistory.Add(ConversationMessage.Assistant("Existing DATEE history"));
+            state.AvatarHistory.Add(ConversationMessage.User("Existing avatar history"));
+            state.DateeSessionSnapshot = oldDateeSnapshot;
+            state.AvatarSessionSnapshot = oldAvatarSnapshot;
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() => stage.ExecuteAsync(
+                state,
+                MakeRollStageResult(),
+                new DeliveryStageResult
+                {
+                    DeliveredMessage = "Must not append",
+                    HorninessCheckResult = HorninessCheckResult.NotPerformed
+                },
+                MakeProfile("Player"),
+                MakeProfile("Datee"),
+                null,
+                CancellationToken.None));
+
+            Assert.Contains("avatar session snapshot", error.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(state.DateeHistory);
+            Assert.Single(state.AvatarHistory);
+            Assert.Same(oldDateeSnapshot, state.DateeSessionSnapshot);
+            Assert.Same(oldAvatarSnapshot, state.AvatarSessionSnapshot);
+            var terminal = Assert.Single(diagnostics.FindAll(
+                d => d.Lifecycle == OperationalDiagnosticLifecycle.Terminal));
+            Assert.Equal(OperationalDiagnosticOutcome.Failed, terminal.Outcome);
         }
 
         private static RollStageResult MakeRollStageResult()

--- a/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue1123_SymmetricTwoSessionGmTests.cs
@@ -16,17 +16,16 @@ namespace Pinder.Core.Tests.Conversation
     /// Issue #1123 — Symmetric two-session GM acceptance tests.
     ///
     /// <para>
-    /// #1125 supersedes the avatar (delivery) <em>session</em>: the delivery LLM
-    /// call was collapsed into the deterministic, non-LLM DeliveryOverlay commit
-    /// step, so there is no longer an avatar GM session, no avatar LLM call, and
-    /// no avatar history accumulation. The clean-history rule the avatar session
-    /// once upheld is now trivially satisfied — only the committed line is
-    /// persisted. These tests are updated to lock the post-#1125 contract:
+    /// #1125 removed the avatar delivery-model call in favor of the deterministic
+    /// DeliveryOverlay commit step. Session-capable adapters may still maintain an
+    /// avatar-perspective semantic session for option generation; these legacy
+    /// adapter tests lock the compatibility contract:
     /// </para>
     /// <list type="number">
     ///   <item><description>
-    ///     <b>No avatar session</b>: <see cref="GameSession.AvatarHistory"/> stays
-    ///     EMPTY across turns and no stateful avatar (delivery) LLM call fires.
+    ///     <b>No delivery-model call</b>: with a legacy stateful adapter,
+    ///     <see cref="GameSession.AvatarHistory"/> stays empty and no avatar
+    ///     delivery LLM call fires.
     ///   </description></item>
     ///   <item><description>
     ///     <b>Datee bleed isolation (unchanged)</b>: the datee session's context
@@ -146,11 +145,10 @@ namespace Pinder.Core.Tests.Conversation
                 new NullTrapRegistry(),
                 new GameSessionConfig(clock: TestHelpers.MakeClock()));
 
-        // AC-1 (post-#1125): there is no avatar (delivery) session anymore, so the
-        // engine accumulates NO avatar history across turns and never fires a
-        // stateful avatar call. (Was: avatar history accumulation.)
+        // AC-1 (post-#1125): a legacy adapter gets no avatar delivery call and
+        // does not opt into the new avatar-perspective session mirror.
         [Fact]
-        public async Task AvatarSession_IsGone_NoHistoryAccumulated_NoAvatarCall()
+        public async Task LegacyAdapter_HasNoAvatarHistoryAndNoDeliveryModelCall()
         {
             var adapter = new RecordingStatefulAdapter();
             // ctor d10 + per-turn (d20 main + d100 timing) for 3 turns.
@@ -164,7 +162,7 @@ namespace Pinder.Core.Tests.Conversation
                 await session.ResolveTurnAsync(0);
             }
 
-            // No avatar GM session: history stays empty and no avatar call fired.
+            // Legacy behavior remains unchanged: no mirrored session and no call.
             Assert.Empty(session.AvatarHistory);
             Assert.Empty(adapter.AvatarHistoriesSeen);
             Assert.False(adapter.AvatarCallFired);
@@ -183,7 +181,7 @@ namespace Pinder.Core.Tests.Conversation
             await session.ResolveTurnAsync(0);
 
             Assert.NotEmpty(adapter.DateePromptsSeen);
-            // No avatar session fired, so no avatar prompt was ever built.
+            // No avatar delivery call fired, so no avatar prompt was built.
             Assert.Empty(adapter.AvatarPromptsSeen);
 
             // --- Datee session ---

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
@@ -281,6 +281,38 @@ namespace Pinder.Core.Tests.Conversation
         }
 
         [Fact]
+        public void RestoreState_RoundTripsProviderNeutralSessionSnapshots()
+        {
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(clock: TestHelpers.MakeClock()));
+            var datee = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"session\":\"datee\"}");
+            var avatar = new LlmConversationSessionSnapshot(
+                LlmConversationSessionSnapshot.PiAgentSessionV1,
+                "{\"session\":\"avatar\"}");
+
+            session.RestoreState(new ResimulateData
+            {
+                TargetInterest = session.CreateSnapshot().Interest,
+                TurnNumber = 2,
+                DateeSessionSnapshot = datee,
+                AvatarSessionSnapshot = avatar,
+            }, new NullTrapRegistry());
+
+            GameStateSnapshot snapshot = session.CreateSnapshot();
+            Assert.Same(datee, snapshot.DateeSessionSnapshot);
+            Assert.Same(avatar, snapshot.AvatarSessionSnapshot);
+            Assert.Equal("{\"session\":\"datee\"}", snapshot.DateeSessionSnapshot!.Payload);
+            Assert.Equal("{\"session\":\"avatar\"}", snapshot.AvatarSessionSnapshot!.Payload);
+        }
+
+        [Fact]
         public void RestoreState_WithMalformedPersistedRole_IsAtomic()
         {
             var tracker = new SessionShadowTracker(TestHelpers.MakeStatBlock());

--- a/tests/Pinder.LlmAdapters.Tests/Issue1344_RetryHistoryIsolationTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue1344_RetryHistoryIsolationTests.cs
@@ -54,6 +54,84 @@ namespace Pinder.LlmAdapters.Tests
             Assert.DoesNotContain("TELL:", result.NewHistoryEntries[1].Content, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public async Task SessionPath_UsesTypedCanonicalHistoryAndCommitsBothCharacterPerspectives()
+        {
+            var transport = new RecordingTransport(ValidDirectionJson(), "A visible accepted reply.");
+            var adapter = new PinderLlmAdapter(
+                transport,
+                new PinderLlmAdapterOptions
+                {
+                    GameDefinition = GameDefinition.PinderDefaults,
+                    PromptCatalog = BuiltInCatalog(),
+                    MaxContractViolationRetries = 0,
+                });
+            var dateeHistory = new[]
+            {
+                ConversationMessage.User("canonical older player line"),
+                ConversationMessage.Assistant("canonical older datee reply"),
+            };
+
+            StatefulDateeResult result = await adapter.GetDateeResponseAsync(
+                MakeContext("visible delivered line"),
+                dateeHistory,
+                Array.Empty<ConversationMessage>(),
+                dateeSession: null,
+                avatarSession: null);
+
+            Assert.True(adapter.SupportsConversationSessions);
+            IReadOnlyList<ConversationMessage> sentHistory = Assert.Single(transport.PriorMessages);
+            Assert.Equal(dateeHistory.Select(message => message.Role), sentHistory.Select(message => message.Role));
+            Assert.Equal(dateeHistory.Select(message => message.Content), sentHistory.Select(message => message.Content));
+            Assert.DoesNotContain("older visible player line", transport.ContextualUserMessages.Single(), StringComparison.Ordinal);
+            Assert.DoesNotContain("older visible datee line", transport.ContextualUserMessages.Single(), StringComparison.Ordinal);
+            Assert.NotNull(result.DateeSessionSnapshot);
+            Assert.NotNull(result.AvatarSessionSnapshot);
+
+            await using PiConversationSession datee = await PiConversationSession.RestoreOrImportAsync(
+                result.DateeSessionSnapshot,
+                Array.Empty<ConversationMessage>(),
+                "datee");
+            Assert.Equal(
+                new[]
+                {
+                    "canonical older player line",
+                    "canonical older datee reply",
+                    "visible delivered line",
+                    "A visible accepted reply.",
+                },
+                (await datee.BuildSemanticHistoryAsync()).Select(message => message.Content).ToArray());
+
+            await using PiConversationSession avatar = await PiConversationSession.RestoreOrImportAsync(
+                result.AvatarSessionSnapshot,
+                Array.Empty<ConversationMessage>(),
+                "avatar");
+            var avatarMessages = await avatar.BuildSemanticHistoryAsync();
+            Assert.Equal(
+                new[] { ConversationMessage.AssistantRole, ConversationMessage.UserRole },
+                avatarMessages.Select(message => message.Role).ToArray());
+            Assert.Equal(
+                new[] { "visible delivered line", "A visible accepted reply." },
+                avatarMessages.Select(message => message.Content).ToArray());
+        }
+
+        [Fact]
+        public void WrappedLegacyTransport_DoesNotAdvertiseSessionSupport()
+        {
+            ILlmTransport legacy = new LegacyTransport();
+            var punctuation = new PunctuationNormalizingTransport(legacy);
+            var thinking = new ThinkingStrippingLlmTransport(punctuation);
+            var adapter = new PinderLlmAdapter(
+                thinking,
+                new PinderLlmAdapterOptions { GameDefinition = GameDefinition.PinderDefaults });
+
+            Assert.False(punctuation.SupportsConversationMessages);
+            Assert.False(punctuation.SupportsStructuredConversationMessages);
+            Assert.False(thinking.SupportsConversationMessages);
+            Assert.False(thinking.SupportsStructuredConversationMessages);
+            Assert.False(adapter.SupportsConversationSessions);
+        }
+
         private static DateeContext MakeContext(string deliveredMessage)
         {
             return new DateeContext(
@@ -114,7 +192,7 @@ namespace Pinder.LlmAdapters.Tests
             throw new DirectoryNotFoundException("Could not locate bundled data/prompts.");
         }
 
-        private sealed class RecordingTransport : ILlmTransport
+        private sealed class RecordingTransport : IConversationLlmTransport
         {
             private readonly Queue<string> _responses;
 
@@ -124,6 +202,9 @@ namespace Pinder.LlmAdapters.Tests
             }
 
             public List<string?> Phases { get; } = new List<string?>();
+            public List<IReadOnlyList<ConversationMessage>> PriorMessages { get; } = new();
+            public List<string> ContextualUserMessages { get; } = new();
+            public bool SupportsConversationMessages => true;
 
             public Task<string> SendAsync(
                 string systemPrompt,
@@ -137,6 +218,34 @@ namespace Pinder.LlmAdapters.Tests
                 Phases.Add(phase);
                 return Task.FromResult(_responses.Dequeue());
             }
+
+            public Task<string> SendConversationAsync(
+                string systemPrompt,
+                IReadOnlyList<ConversationMessage> priorMessages,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Phases.Add(phase);
+                PriorMessages.Add(priorMessages.ToArray());
+                ContextualUserMessages.Add(userMessage);
+                return Task.FromResult(_responses.Dequeue());
+            }
+        }
+
+        private sealed class LegacyTransport : ILlmTransport
+        {
+            public Task<string> SendAsync(
+                string systemPrompt,
+                string userMessage,
+                double temperature = 0.9,
+                int maxTokens = 1024,
+                string? phase = null,
+                CancellationToken ct = default)
+                => Task.FromResult(string.Empty);
         }
     }
 }

--- a/tests/Pinder.LlmAdapters.Tests/Issue52_PiLlmTransportTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue52_PiLlmTransportTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Pi.AI;
+using Pinder.Core.Conversation;
 using Pinder.LlmAdapters;
 using Pinder.LlmAdapters.Pi;
 using Xunit;
@@ -200,6 +201,40 @@ namespace Pinder.LlmAdapters.Tests
             Assert.Equal(321, capturedOptions.MaxTokens);
             Assert.Equal(0, capturedOptions.MaxRetries);
             Assert.Equal("datee", capturedPhase);
+        }
+
+        [Fact]
+        public async Task SendConversationAsync_PreservesTypedHistoryBeforeTransientInstruction()
+        {
+            Context? captured = null;
+            var transport = new PiLlmTransport(
+                Model("model-1"),
+                (_, context, __) =>
+                {
+                    captured = context;
+                    return Task.FromResult(Response("answer"));
+                },
+                timestampMilliseconds: () => 1234L);
+            var history = new[]
+            {
+                ConversationMessage.User("older player line"),
+                ConversationMessage.Assistant("older datee reply"),
+            };
+
+            string result = await transport.SendConversationAsync(
+                "complete character system prompt",
+                history,
+                "current engine instruction");
+
+            Assert.Equal("answer", result);
+            Assert.Equal("complete character system prompt", captured!.SystemPrompt);
+            Assert.Collection(
+                captured.Messages,
+                message => Assert.Equal("older player line", Assert.IsType<UserMessage>(message).Content.Text),
+                message => Assert.Equal(
+                    "older datee reply",
+                    TextUtilities.ContentText(Assert.IsType<AssistantMessage>(message).Content)),
+                message => Assert.Equal("current engine instruction", Assert.IsType<UserMessage>(message).Content.Text));
         }
 
         [Fact]

--- a/tests/Pinder.LlmAdapters.Tests/Issue54_PiConversationSessionTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/Issue54_PiConversationSessionTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests
+{
+    public sealed class Issue54_PiConversationSessionTests
+    {
+        [Fact]
+        public async Task LegacyImport_SnapshotRestoreAndContinuationUseCanonicalTypedMessages()
+        {
+            LlmConversationSessionSnapshot snapshot;
+            await using (PiConversationSession imported = await PiConversationSession.RestoreOrImportAsync(
+                snapshot: null,
+                new[]
+                {
+                    ConversationMessage.User("older player line"),
+                    ConversationMessage.Assistant("older datee reply"),
+                },
+                "datee"))
+            {
+                await imported.AppendUserAsync("new player line");
+                await imported.AppendAssistantAsync("new datee reply");
+                snapshot = await imported.SnapshotAsync();
+            }
+
+            Assert.Equal(LlmConversationSessionSnapshot.PiAgentSessionV1, snapshot.Format);
+            await using PiConversationSession restored = await PiConversationSession.RestoreOrImportAsync(
+                snapshot,
+                new[] { ConversationMessage.User("legacy fallback must be ignored") },
+                "datee");
+            var messages = await restored.BuildSemanticHistoryAsync();
+
+            Assert.Equal(
+                new[] { "older player line", "older datee reply", "new player line", "new datee reply" },
+                messages.Select(message => message.Content).ToArray());
+            Assert.Equal(
+                new[]
+                {
+                    ConversationMessage.UserRole,
+                    ConversationMessage.AssistantRole,
+                    ConversationMessage.UserRole,
+                    ConversationMessage.AssistantRole,
+                },
+                messages.Select(message => message.Role).ToArray());
+        }
+
+        [Fact]
+        public async Task UnsupportedSnapshotFormatFailsClosedWithoutLegacyFallback()
+        {
+            var snapshot = new LlmConversationSessionSnapshot("unknown.v9", "{}");
+
+            InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await PiConversationSession.RestoreOrImportAsync(
+                    snapshot,
+                    new[] { ConversationMessage.User("must not silently import") },
+                    "datee"));
+
+            Assert.Contains("Unsupported datee session snapshot format", error.Message, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add versioned Pi.Agent.Core session snapshots and session-aware adapter/transport contracts
- preserve typed DATEE and avatar-perspective history without embedding prior transcript documents
- dual-write legacy semantic histories and atomically adopt accepted Pi snapshots
- route option generation through the avatar session while keeping current engine instructions transient
- preserve legacy adapter behavior through explicit delegated capability checks

This is the Pinder Core half of decay256/pi-csharp#54. Web persistence and production wrapper wiring follow against the merged Core SHA.

## Local verification
- Core focused session/persistence slice: 23 passed
- Pinder.Core.Tests (deterministic local run): 3397 passed, 1 skipped
- Pinder.LlmAdapters.Tests (deterministic local run): 1507 passed
- isolated parallel-race test: passed
- git diff --check: passed

No GitHub Actions or hosted CI used.