### PR TITLE
feat(session): persist complete resumable game state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.28] - 2026-08-02
+
+- Add a canonical `GameSession.CreateResimulateData()` export matching the
+  existing atomic `RestoreState` boundary for active-process continuation.
+- Preserve semantic Pi session snapshots, histories, combo/callback state,
+  progression events, psychological selection state, shadow state, and pending
+  one-turn mechanics without persisting uncommitted options or dice pools.
+- Validate restored state before adoption and retain the existing transactional
+  turn boundary on provider failure or cancellation.
+
 ## [0.2.27] - 2026-08-02
 
 - Run private DATEE emotional direction from a disposable `Pi.Agent.Core`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Preserve semantic Pi session snapshots, histories, combo/callback state,
   progression events, psychological selection state, shadow state, and pending
   one-turn mechanics without persisting uncommitted options or dice pools.
+- Restore each character's captured base and assembled system prompts as one
+  validated pair so a process restart cannot regenerate private setup context.
 - Validate restored state before adoption and retain the existing transactional
   turn boundary on provider failure or cancellation.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.27</Version>
+    <Version>0.2.28</Version>
   </PropertyGroup>
 </Project>

--- a/src/Pinder.Core/Characters/CharacterProfile.cs
+++ b/src/Pinder.Core/Characters/CharacterProfile.cs
@@ -138,6 +138,21 @@ namespace Pinder.Core.Characters
             BaseSystemPrompt = AssembledSystemPrompt;
         }
 
+        /// <summary>Restores the prompt pair captured for a resumable session.</summary>
+        public void RestoreSystemPrompts(string baseSystemPrompt, string assembledSystemPrompt)
+        {
+            if (baseSystemPrompt == null) throw new ArgumentNullException(nameof(baseSystemPrompt));
+            if (assembledSystemPrompt == null) throw new ArgumentNullException(nameof(assembledSystemPrompt));
+            if (!assembledSystemPrompt.StartsWith(baseSystemPrompt, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    "The assembled system prompt must preserve the captured base prompt prefix.",
+                    nameof(assembledSystemPrompt));
+            }
+            BaseSystemPrompt = baseSystemPrompt;
+            AssembledSystemPrompt = assembledSystemPrompt;
+        }
+
         public CharacterProfile(
             StatBlock stats,
             string assembledSystemPrompt,

--- a/src/Pinder.Core/Conversation/ComboTracker.cs
+++ b/src/Pinder.Core/Conversation/ComboTracker.cs
@@ -107,6 +107,15 @@ namespace Pinder.Core.Conversation
             _lastCombo = null;
         }
 
+        /// <summary>Returns the ordered history required to continue combo detection.</summary>
+        public IReadOnlyList<(string StatName, bool Succeeded)> CreateSnapshot()
+        {
+            var snapshot = new List<(string StatName, bool Succeeded)>(_history.Count);
+            foreach (var entry in _history)
+                snapshot.Add((entry.Stat.ToString(), entry.Succeeded));
+            return snapshot;
+        }
+
         /// <summary>
         /// Consumes the Triple bonus without recording a turn.
         /// Used when the player takes a non-Speak action (Read/Recover/Wait)

--- a/src/Pinder.Core/Conversation/GameSession.Helpers.cs
+++ b/src/Pinder.Core/Conversation/GameSession.Helpers.cs
@@ -170,6 +170,60 @@ namespace Pinder.Core.Conversation
         }
 
         /// <summary>
+        /// Captures all committed engine state required to continue an active
+        /// session in a fresh process. Prepared turn options and dice pools are
+        /// intentionally excluded because they are uncommitted work.
+        /// </summary>
+        public ResimulateData CreateResimulateData()
+        {
+            var data = new ResimulateData
+            {
+                TargetInterest = _interest.Current,
+                TurnNumber = _turnNumber,
+                MomentumStreak = _momentumStreak,
+                ConversationHistory = new List<(string Sender, string Text)>(_history),
+                ComboHistory = _comboTracker.CreateSnapshot().ToList(),
+                PendingTripleBonus = _comboTracker.HasTripleBonus,
+                RizzCumulativeFailureCount = _rizzCumulativeFailureCount,
+                Topics = new List<CallbackOpportunity>(_topics),
+                PendingMomentumBonus = _pendingMomentumBonus,
+                DateeHistory = _dateeHistory.Select(message => (message.Role, message.Content)).ToList(),
+                AvatarHistory = _avatarHistory.Select(message => (message.Role, message.Content)).ToList(),
+                DateeSessionSnapshot = _state.DateeSessionSnapshot,
+                AvatarSessionSnapshot = _state.AvatarSessionSnapshot,
+                DateeOutfitDescription = _state.DateeOutfitDescription,
+                SpentBackstoryIndices = new HashSet<int>(_state.SpentBackstoryIndices),
+                SpentStakeIndices = new HashSet<int>(_state.SpentStakeIndices),
+                PreviousPhase = _state.PreviousPhase,
+                PreviousResolvedIndex = _state.PreviousResolvedIndex,
+                CurrentResolvedTarget = _state.CurrentResolvedTarget,
+                CurrentCognitiveSubtext = _state.CurrentCognitiveSubtext,
+                XpEvents = _xpLedger.Events.Select(entry => (entry.Source, entry.Amount)).ToList(),
+                SessionHorniness = _sessionHorniness,
+                HorninessRoll = _horninessRoll,
+                HorninessTimeModifier = _horninessTimeModifier,
+                PendingCritAdvantage = _pendingCritAdvantage,
+                LastStatUsed = _lastStatUsed,
+                ActiveWeakness = _activeWeakness,
+                ActiveTell = _activeTell,
+            };
+
+            foreach (var trap in _traps.AllActive)
+                data.ActiveTraps.Add((trap.Definition.Stat.ToString(), trap.TurnsRemaining));
+            if (_playerShadows != null)
+            {
+                foreach (ShadowStatType shadow in System.Enum.GetValues(typeof(ShadowStatType)))
+                    data.ShadowValues[shadow.ToString()] = _playerShadows.GetEffectiveShadow(shadow);
+            }
+            if (_dateeShadows != null)
+            {
+                foreach (ShadowStatType shadow in System.Enum.GetValues(typeof(ShadowStatType)))
+                    data.DateeShadowValues[shadow.ToString()] = _dateeShadows.GetEffectiveShadow(shadow);
+            }
+            return data;
+        }
+
+        /// <summary>
         /// Get shadow threshold level, using rule resolver if available.
         /// </summary>
         private int ResolveThresholdLevel(int shadowValue)

--- a/src/Pinder.Core/Conversation/GameSessionState.cs
+++ b/src/Pinder.Core/Conversation/GameSessionState.cs
@@ -188,6 +188,14 @@ namespace Pinder.Core.Conversation
                 shadowValidationTracker.RestoreFromSnapshot(validatedShadowValues);
             }
 
+            Dictionary<string, int>? validatedDateeShadowValues = null;
+            if (DateeShadows != null && data.DateeShadowValues != null)
+            {
+                validatedDateeShadowValues = new Dictionary<string, int>(data.DateeShadowValues);
+                var shadowValidationTracker = DateeShadows.Clone();
+                shadowValidationTracker.RestoreFromSnapshot(validatedDateeShadowValues);
+            }
+
             var restoredTraps = new TrapState();
             if (data.ActiveTraps != null)
             {
@@ -224,6 +232,16 @@ namespace Pinder.Core.Conversation
                 // Keep the tracker identity shared by the session pipeline and host.
                 PlayerShadows!.RestoreFromSnapshot(validatedShadowValues);
             }
+            if (validatedDateeShadowValues != null)
+                DateeShadows!.RestoreFromSnapshot(validatedDateeShadowValues);
+
+            var restoredXpLedger = new XpLedger();
+            if (data.XpEvents != null)
+            {
+                foreach (var (source, amount) in data.XpEvents)
+                    restoredXpLedger.Record(source, amount);
+                restoredXpLedger.DrainTurnEvents();
+            }
 
             Interest = restoredInterest;
             MomentumStreak = data.MomentumStreak;
@@ -236,6 +254,29 @@ namespace Pinder.Core.Conversation
             TurnNumber = data.TurnNumber;
             ComboTracker = restoredComboTracker;
             RizzCumulativeFailureCount = data.RizzCumulativeFailureCount;
+            Topics = data.Topics != null
+                ? new List<CallbackOpportunity>(data.Topics)
+                : new List<CallbackOpportunity>();
+            PendingMomentumBonus = data.PendingMomentumBonus;
+            DateeOutfitDescription = data.DateeOutfitDescription ?? string.Empty;
+            SpentBackstoryIndices = data.SpentBackstoryIndices != null
+                ? new HashSet<int>(data.SpentBackstoryIndices)
+                : new HashSet<int>();
+            SpentStakeIndices = data.SpentStakeIndices != null
+                ? new HashSet<int>(data.SpentStakeIndices)
+                : new HashSet<int>();
+            PreviousPhase = data.PreviousPhase;
+            PreviousResolvedIndex = data.PreviousResolvedIndex;
+            CurrentResolvedTarget = data.CurrentResolvedTarget;
+            CurrentCognitiveSubtext = data.CurrentCognitiveSubtext;
+            XpLedger = restoredXpLedger;
+            SessionHorniness = data.SessionHorniness;
+            HorninessRoll = data.HorninessRoll;
+            HorninessTimeModifier = data.HorninessTimeModifier;
+            PendingCritAdvantage = data.PendingCritAdvantage;
+            LastStatUsed = data.LastStatUsed;
+            ActiveWeakness = data.ActiveWeakness;
+            ActiveTell = data.ActiveTell;
         }
 
         private static List<ConversationMessage> BuildConversationHistory(

--- a/src/Pinder.Core/Conversation/ResimulateData.cs
+++ b/src/Pinder.Core/Conversation/ResimulateData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Pinder.Core.Stats;
 
 namespace Pinder.Core.Conversation
 {
@@ -42,6 +43,8 @@ namespace Pinder.Core.Conversation
 
         /// <summary>Cumulative Rizz failure count for Despair shadow tracking.</summary>
         public int RizzCumulativeFailureCount { get; set; }
+        public List<CallbackOpportunity> Topics { get; set; } = new List<CallbackOpportunity>();
+        public int PendingMomentumBonus { get; set; }
 
         /// <summary>
         /// Engine-owned datee LLM conversation history (#788). Each entry is
@@ -73,5 +76,22 @@ namespace Pinder.Core.Conversation
         public LlmConversationSessionSnapshot? DateeSessionSnapshot { get; set; }
 
         public LlmConversationSessionSnapshot? AvatarSessionSnapshot { get; set; }
+
+        public string DateeOutfitDescription { get; set; } = string.Empty;
+        public HashSet<int> SpentBackstoryIndices { get; set; } = new HashSet<int>();
+        public HashSet<int> SpentStakeIndices { get; set; } = new HashSet<int>();
+        public string? PreviousPhase { get; set; }
+        public int PreviousResolvedIndex { get; set; }
+        public ResolvedRevelationTarget? CurrentResolvedTarget { get; set; }
+        public string? CurrentCognitiveSubtext { get; set; }
+        public List<(string Source, int Amount)> XpEvents { get; set; } = new List<(string, int)>();
+        public int SessionHorniness { get; set; }
+        public int HorninessRoll { get; set; }
+        public int HorninessTimeModifier { get; set; }
+        public bool PendingCritAdvantage { get; set; }
+        public StatType? LastStatUsed { get; set; }
+        public Dictionary<string, int> DateeShadowValues { get; set; } = new Dictionary<string, int>();
+        public WeaknessWindow? ActiveWeakness { get; set; }
+        public Tell? ActiveTell { get; set; }
     }
 }

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
@@ -403,5 +403,83 @@ namespace Pinder.Core.Tests.Conversation
             Assert.Equal(dateeBefore, session.DateeHistory.Select(m => (m.Role, m.Content)).ToList());
             Assert.Equal(avatarBefore, session.AvatarHistory.Select(m => (m.Role, m.Content)).ToList());
         }
+
+        [Fact]
+        public void ResumableState_RoundTripsContinuationSensitiveEngineFields()
+        {
+            var playerShadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2));
+            var dateeShadows = new SessionShadowTracker(TestHelpers.MakeStatBlock(2));
+            var session = new GameSession(
+                MakeProfile("P1"),
+                MakeProfile("P2"),
+                new NullLlmAdapter(),
+                new FixedDice(5),
+                new NullTrapRegistry(),
+                new GameSessionConfig(
+                    clock: TestHelpers.MakeClock(),
+                    playerShadows: playerShadows,
+                    dateeShadows: dateeShadows));
+            var target = new ResolvedRevelationTarget
+            {
+                Registry = "BACKSTORY",
+                Index = 3,
+                Field = "BIO_LIE",
+                Manner = "SINCERE",
+                StemText = "a remembered detail",
+                TransitionStyle = "gentle",
+            };
+
+            session.RestoreState(new ResimulateData
+            {
+                TargetInterest = 17,
+                TurnNumber = 4,
+                MomentumStreak = 2,
+                ConversationHistory = new List<(string, string)> { ("P1", "hello"), ("P2", "hi") },
+                ComboHistory = new List<(string, bool)> { ("Charm", true), ("Honesty", true) },
+                PendingTripleBonus = true,
+                RizzCumulativeFailureCount = 2,
+                Topics = new List<CallbackOpportunity> { new CallbackOpportunity("coffee", 2) },
+                PendingMomentumBonus = 1,
+                DateeOutfitDescription = "black coat",
+                SpentBackstoryIndices = new HashSet<int> { 1, 3 },
+                SpentStakeIndices = new HashSet<int> { 2 },
+                PreviousPhase = "BACKSTORY",
+                PreviousResolvedIndex = 3,
+                CurrentResolvedTarget = target,
+                CurrentCognitiveSubtext = "wants closeness but expects rejection",
+                XpEvents = new List<(string, int)> { ("StrongSuccess", 4), ("Callback", 2) },
+                SessionHorniness = 6,
+                HorninessRoll = 73,
+                HorninessTimeModifier = -1,
+                PendingCritAdvantage = true,
+                LastStatUsed = StatType.Honesty,
+                ShadowValues = new Dictionary<string, int> { [ShadowStatType.Dread.ToString()] = 5 },
+                DateeShadowValues = new Dictionary<string, int> { [ShadowStatType.Madness.ToString()] = 6 },
+                ActiveWeakness = new WeaknessWindow(StatType.Charm, 2),
+                ActiveTell = new Tell(StatType.Wit, "changes the subject when cornered"),
+            }, new NullTrapRegistry());
+
+            ResimulateData restored = session.CreateResimulateData();
+
+            Assert.Equal(17, restored.TargetInterest);
+            Assert.Equal(4, restored.TurnNumber);
+            Assert.Equal(2, restored.ComboHistory.Count);
+            Assert.True(restored.PendingTripleBonus);
+            Assert.Equal("black coat", restored.DateeOutfitDescription);
+            Assert.Equal("coffee", Assert.Single(restored.Topics).TopicKey);
+            Assert.Equal(1, restored.PendingMomentumBonus);
+            Assert.Equal(new[] { 1, 3 }, restored.SpentBackstoryIndices.OrderBy(x => x));
+            Assert.Equal("BACKSTORY", restored.PreviousPhase);
+            Assert.Equal("wants closeness but expects rejection", restored.CurrentCognitiveSubtext);
+            Assert.Equal(6, restored.XpEvents.Sum(entry => entry.Amount));
+            Assert.Equal(6, restored.SessionHorniness);
+            Assert.True(restored.PendingCritAdvantage);
+            Assert.Equal(StatType.Honesty, restored.LastStatUsed);
+            Assert.Equal(5, restored.ShadowValues[ShadowStatType.Dread.ToString()]);
+            Assert.Equal(6, restored.DateeShadowValues[ShadowStatType.Madness.ToString()]);
+            Assert.Equal(2, restored.ActiveWeakness!.DcReduction);
+            Assert.Equal(StatType.Wit, restored.ActiveTell!.Stat);
+            Assert.Equal(3, restored.CurrentResolvedTarget!.Value.Index);
+        }
     }
 }

--- a/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
+++ b/tests/Pinder.Core.Tests/Conversation/Issue788_SnapshotRoundTripTests.cs
@@ -481,5 +481,18 @@ namespace Pinder.Core.Tests.Conversation
             Assert.Equal(StatType.Wit, restored.ActiveTell!.Stat);
             Assert.Equal(3, restored.CurrentResolvedTarget!.Value.Index);
         }
+
+        [Fact]
+        public void CharacterPromptRestore_PreservesCapturedBaseAndPrivateAssembly()
+        {
+            CharacterProfile profile = MakeProfile("P2");
+
+            profile.RestoreSystemPrompts("captured base", "captured base\n\nprivate arc");
+
+            Assert.Equal("captured base", profile.BaseSystemPrompt);
+            Assert.Equal("captured base\n\nprivate arc", profile.AssembledSystemPrompt);
+            Assert.Throws<ArgumentException>(() =>
+                profile.RestoreSystemPrompts("different base", "unrelated assembled prompt"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- export and atomically restore the complete committed GameSession continuation state
- preserve ordered combo history, XP ledger, traps, private Pi session snapshots, typed histories, and continuation-sensitive turn fields
- restore captured base/assembled character prompt pairs without regenerating setup output

## Verification
- Pinder.Core.Tests: 3,399 passed, 1 known skip
- Pinder.LlmAdapters.Tests: 1,511 passed
- Pinder.RemoteAssets.Tests: 70 passed
- Pinder.Rules.Tests: 306 passed
- focused transaction/snapshot/cancellation: 25 passed
- focused Pi continuation/private-director/retry isolation: 9 passed

A strict global warnings-as-errors build remains blocked by the repository's existing nullable-warning baseline; the changed production code introduces no new compiler warnings.

Supports decay256/pi-csharp#56.