### PR TITLE
docs: define agent journal invocation ownership

### DIFF
--- a/contracts/agent-journal-invocation-ownership.v1.json
+++ b/contracts/agent-journal-invocation-ownership.v1.json
@@ -1,0 +1,958 @@
+{
+  "schema_version": "agent-journal-invocation-ownership.v1",
+  "ticket_id": "CORE-1373",
+  "depends_on": "Core #1370 agent-journal contract vocabulary",
+  "closed_inventory": true,
+  "inventory_size": 16,
+  "status_values": [
+    "live_production",
+    "provider_capable_dormant",
+    "dead_with_proof"
+  ],
+  "dead_rows_approved": false,
+  "rows": [
+    {
+      "id": "game.datee.performance",
+      "status": "live_production",
+      "status_evidence": [
+        "DateeResponseStage calls the session-aware DATEE response path when conversation sessions are supported.",
+        "PinderLlmAdapter restores the DATEE Pi session, generates the DATEE performance prompt, and snapshots the accepted branch."
+      ],
+      "activation_rule": "Already live. Wiring must attach invocation records to the Game Run Bundle DATEE journal using this row.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / DATEE journal",
+      "pi_agent_session": "yes",
+      "journal_destination": "datee_agent_journal",
+      "context_membership": "datee_agent_session_provider_context",
+      "player_delivery": "player_visible_datee_reply_after_validation",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.datee.live",
+      "required_owner_ids": [
+        "game_run_id",
+        "agent_session_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "SessionSystemPromptBuilder.BuildDatee",
+        "EmotionalPromptCompiler.CompilePerformance",
+        "InMemoryPromptTraceService.RecordTrace:datee"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/ISessionStatefulLlmAdapter.cs",
+          "pattern": "GetDateeResponseAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "GetDateeResponseAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/DateeResponseStage.cs",
+          "pattern": "GetDateeResponseAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live"
+    },
+    {
+      "id": "game.avatar.reply",
+      "status": "live_production",
+      "status_evidence": [
+        "TurnOrchestrator calls the session-aware dialogue option overload when conversation sessions are supported.",
+        "PinderLlmAdapter restores the avatar Pi session before compiling avatar dialogue output."
+      ],
+      "activation_rule": "Already live. Wiring must attach invocation records to the Game Run Bundle avatar journal using this row.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / avatar journal",
+      "pi_agent_session": "yes",
+      "journal_destination": "avatar_agent_journal",
+      "context_membership": "avatar_agent_session_provider_context",
+      "player_delivery": "player_candidate_avatar_lines_before_player_choice",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.avatar.live",
+      "required_owner_ids": [
+        "game_run_id",
+        "agent_session_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "SessionSystemPromptBuilder.BuildPlayerAvatar",
+        "SessionDocumentBuilder.BuildDialogueOptionsSessionPromptEx",
+        "DialogueOptionsStructuredContract.CreateRequest"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/ISessionStatefulLlmAdapter.cs",
+          "pattern": "Task<DialogueOption\\[]> GetDialogueOptionsAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "public async Task<DialogueOption\\[]> GetDialogueOptionsAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/TurnOrchestrator.cs",
+          "pattern": "sessionLlm\\.GetDialogueOptionsAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live"
+    },
+    {
+      "id": "game.emotional-director",
+      "status": "live_production",
+      "status_evidence": [
+        "The DATEE response path forks a datee-private-analysis branch when a DATEE Pi session is present.",
+        "The emotional director invocation uses a private phase and may append diagnostics to the disposable branch."
+      ],
+      "activation_rule": "Already live. Wiring must keep this as a disposable private DATEE branch and must not deliver it to the player timeline.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / private DATEE branch",
+      "pi_agent_session": "yes_disposable_branch",
+      "journal_destination": "private_datee_branch_record",
+      "context_membership": "private_datee_director_branch_context",
+      "player_delivery": "not_player_delivered",
+      "visibility": "authorized_private_branch_debugger_only",
+      "retention_policy_key": "game_run.agent_journal.datee.private_branch",
+      "required_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "branch_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "branch_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "EmotionalPromptCompiler.CompileDirector",
+        "EmotionalDirectorContract.CreateRequest",
+        "PinderLlmAdapter.DateePrivatePhaseDirector"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.EmotionalDirector.cs",
+          "pattern": "GenerateEmotionalDirectionAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "GenerateEmotionalDirectionAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.EmotionalDirector.cs",
+          "pattern": "PiConversationBranch\\? privateBranch"
+        }
+      ],
+      "verifier_group": "core_game_run_live_private"
+    },
+    {
+      "id": "game.dialogue-options",
+      "status": "live_production",
+      "status_evidence": [
+        "TurnOrchestrator still has the stateless dialogue options fallback call.",
+        "The stateless adapter method builds dialogue options without restoring a Pi Agent Session."
+      ],
+      "activation_rule": "Already live. Wiring must create a Game Run Bundle one-shot record and must not mint a Pi Agent Session ID for this row.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / one-shot record",
+      "pi_agent_session": "no",
+      "journal_destination": "game_run_one_shot_record",
+      "context_membership": "compiled_prompt_only_no_agent_session_context",
+      "player_delivery": "player_candidate_dialogue_options",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.one_shot.dialogue_options",
+      "required_owner_ids": [
+        "game_run_id",
+        "operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "operation_id",
+        "invocation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "SessionSystemPromptBuilder.BuildPlayerAvatar",
+        "SessionDocumentBuilder.BuildDialogueOptionsPrompt",
+        "DialogueOptionsStructuredContract.CreateRequest"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/ILlmAdapter.cs",
+          "pattern": "GetDialogueOptionsAsync\\(DialogueContext"
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "public Task<DialogueOption\\[]> GetDialogueOptionsAsync\\(DialogueContext context"
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/TurnOrchestrator.cs",
+          "pattern": "_llm\\.GetDialogueOptionsAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live"
+    },
+    {
+      "id": "game.setup.dramatic-arc",
+      "status": "live_production",
+      "status_evidence": [
+        "LlmDramaticArcGenerator is the setup generator for the dramatic_arc prompt.",
+        "It records dramatic-arc prompt traces and calls LlmOptionalTextGeneration with LlmPhase.DramaticArc."
+      ],
+      "activation_rule": "Already live. Wiring must create a Game Run setup one-shot record and must not reuse character-synthesis owner IDs.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / setup one-shot",
+      "pi_agent_session": "no",
+      "journal_destination": "game_run_setup_one_shot_record",
+      "context_membership": "setup_prompt_only_no_agent_session_context",
+      "player_delivery": "not_directly_player_delivered_setup_diagnostic",
+      "visibility": "authorized_game_run_setup_debugger",
+      "retention_policy_key": "game_run.agent_journal.one_shot.setup.dramatic_arc",
+      "required_owner_ids": [
+        "game_run_id",
+        "setup_operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "setup_operation_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "LlmDramaticArcGenerator.GenerateAsync",
+        "InMemoryPromptTraceService.RecordTrace:dramatic-arc-system",
+        "InMemoryPromptTraceService.RecordTrace:dramatic-arc-user"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs",
+          "pattern": "public async Task<string> GenerateAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs",
+          "pattern": "LlmOptionalTextGeneration\\.RunAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/LlmDramaticArcGenerator.cs",
+          "pattern": "LlmPhase\\.DramaticArc"
+        }
+      ],
+      "verifier_group": "core_game_run_setup_live"
+    },
+    {
+      "id": "game.prefetch.option-branch",
+      "status": "live_production",
+      "status_evidence": [
+        "GameSession.Clone documents branch-scoped transport replacement for speculative option work.",
+        "ResimulateData carries DATEE and avatar session snapshots for cloned Game State restoration."
+      ],
+      "activation_rule": "Already live as a branch operation. Wiring must restore DATEE/avatar branch journals from cloned Game State snapshots and keep branch correlations branch-local.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / branch-local DATEE/avatar journals",
+      "pi_agent_session": "yes_restored_from_cloned_game_state_snapshots",
+      "journal_destination": "game_run_prefetch_branch_journals",
+      "context_membership": "branch_local_datee_avatar_agent_contexts",
+      "player_delivery": "not_player_delivered_until_branch_adopted",
+      "visibility": "authorized_game_run_branch_debugger",
+      "retention_policy_key": "game_run.agent_journal.branch.prefetch",
+      "required_owner_ids": [
+        "game_run_id",
+        "branch_id",
+        "agent_session_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "branch_id",
+        "agent_session_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "GameSession.Clone",
+        "GameStateSnapshot.DateeSessionSnapshot",
+        "GameStateSnapshot.AvatarSessionSnapshot"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/GameSession.Clone.cs",
+          "pattern": "public GameSession Clone\\(ILlmAdapter llm\\)"
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/ResimulateData.cs",
+          "pattern": "DateeSessionSnapshot"
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/ResimulateData.cs",
+          "pattern": "AvatarSessionSnapshot"
+        }
+      ],
+      "verifier_group": "core_game_run_branch_live"
+    },
+    {
+      "id": "game.speculation.option-branch",
+      "status": "live_production",
+      "status_evidence": [
+        "GameSession.Clone supports speculative replay against cloned Game State and replacement LLM adapters.",
+        "LlmConversationSessionSnapshot is the provider-neutral state artifact used by branch-local DATEE/avatar journals."
+      ],
+      "activation_rule": "Already live as speculative gameplay. Wiring must restore branch-local DATEE/avatar journals from cloned Game State snapshots and must not persist branch records as mainline journals unless adopted.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / branch-local DATEE/avatar journals",
+      "pi_agent_session": "yes_restored_from_cloned_game_state_snapshots",
+      "journal_destination": "game_run_speculation_branch_journals",
+      "context_membership": "branch_local_datee_avatar_agent_contexts",
+      "player_delivery": "not_player_delivered_unless_branch_adopted",
+      "visibility": "authorized_game_run_branch_debugger",
+      "retention_policy_key": "game_run.agent_journal.branch.speculation",
+      "required_owner_ids": [
+        "game_run_id",
+        "branch_id",
+        "agent_session_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "branch_id",
+        "agent_session_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "GameSession.Clone",
+        "LlmConversationSessionSnapshot.PiAgentSessionV1",
+        "GameStateSnapshot.AvatarSessionSnapshot"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/GameSession.Clone.cs",
+          "pattern": "SnapshotRecordingLlmTransport"
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/LlmConversationSessionSnapshot.cs",
+          "pattern": "PiAgentSessionV1"
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Conversation/GameStateSnapshot.cs",
+          "pattern": "AvatarSessionSnapshot"
+        }
+      ],
+      "verifier_group": "core_game_run_branch_live"
+    },
+    {
+      "id": "character.synthesis",
+      "status": "live_production",
+      "status_evidence": [
+        "SequentialSynthesisPipeline coordinates character-creation provider calls.",
+        "Current LLM-backed synthesis generators live under Pinder.SessionSetup and are not Game Run journal entries."
+      ],
+      "activation_rule": "Already live. Wiring must use a character-creation operation journal and must not invent a Game Run ID.",
+      "owner": "character_creation_operation",
+      "owner_description": "character-creation operation journal",
+      "pi_agent_session": "no_game_run_journal",
+      "journal_destination": "character_creation_operation_journal",
+      "context_membership": "character_creation_context_only",
+      "player_delivery": "not_game_run_player_delivery",
+      "visibility": "authorized_character_authoring_debugger",
+      "retention_policy_key": "character_creation.operation_journal",
+      "required_owner_ids": [
+        "character_operation_id"
+      ],
+      "required_correlation_ids": [
+        "character_operation_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "SequentialSynthesisPipeline.SynthesizeAsync",
+        "LlmOptionalTextGeneration.RunAsync",
+        "TherapistDiagnosisContract"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/SequentialSynthesisPipeline.cs",
+          "pattern": "SynthesizeAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/LlmBackstoryConsolidator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/LlmPersonalityConsolidator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/LlmBioGenerator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/LlmSequentialStakeGenerator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/Synthesis/LlmTherapistDiagnosisGenerator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/LlmBackstoryGenerator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/LlmStakeGenerator.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.SessionSetup/LlmStakeGenerator.cs",
+          "pattern": "LlmOptionalTextGeneration\\.RunAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.SessionSetup/LlmOutfitDescriber.cs",
+          "pattern": "GenerateAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.SessionSetup/LlmOutfitDescriber.cs",
+          "pattern": "LlmOptionalTextGeneration\\.RunAsync\\("
+        }
+      ],
+      "verifier_group": "core_character_operation_live"
+    },
+    {
+      "id": "admin.temporary-chat",
+      "status": "live_production",
+      "status_evidence": [
+        "Web-owned admin temporary chat path is confirmed by checked-in review notes.",
+        "No Pinder Core implementation is introduced by this contract."
+      ],
+      "activation_rule": "Already live in the host. Wiring must use the separate temporary-chat owner and must not reclassify the path inside Web implementation.",
+      "owner": "admin_temporary_chat_execution",
+      "owner_description": "admin authoring execution / separate temporary-chat owner",
+      "pi_agent_session": "separate_temporary_chat_owner",
+      "journal_destination": "admin_temporary_chat_journal",
+      "context_membership": "admin_authoring_context_only",
+      "player_delivery": "not_player_delivered",
+      "visibility": "authorized_admin_authoring_debugger",
+      "retention_policy_key": "admin.temporary_chat.execution_journal",
+      "required_owner_ids": [
+        "temporary_chat_id",
+        "admin_execution_id"
+      ],
+      "required_correlation_ids": [
+        "temporary_chat_id",
+        "admin_execution_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "character_operation_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "pinder-web.admin.temporary-chat.prompt-provenance"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "web_review_anchor",
+          "file": "docs/agent-journal-invocation-ownership.md",
+          "anchor": "web-review:admin.temporary-chat"
+        }
+      ],
+      "verifier_group": "web_reviewed_external_live"
+    },
+    {
+      "id": "admin.prompt-speculation",
+      "status": "live_production",
+      "status_evidence": [
+        "Web-owned admin prompt speculation path is confirmed by checked-in review notes.",
+        "No Pinder Core implementation is introduced by this contract."
+      ],
+      "activation_rule": "Already live in the host. Wiring must use the separate authoring owner and must not reclassify the path inside Web implementation.",
+      "owner": "admin_prompt_authoring_execution",
+      "owner_description": "admin authoring execution / separate authoring owner",
+      "pi_agent_session": "separate_authoring_owner",
+      "journal_destination": "admin_prompt_speculation_journal",
+      "context_membership": "admin_authoring_context_only",
+      "player_delivery": "not_player_delivered",
+      "visibility": "authorized_admin_authoring_debugger",
+      "retention_policy_key": "admin.prompt_speculation.execution_journal",
+      "required_owner_ids": [
+        "authoring_execution_id",
+        "admin_execution_id"
+      ],
+      "required_correlation_ids": [
+        "authoring_execution_id",
+        "admin_execution_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "character_operation_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "pinder-web.admin.prompt-speculation.prompt-provenance"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "web_review_anchor",
+          "file": "docs/agent-journal-invocation-ownership.md",
+          "anchor": "web-review:admin.prompt-speculation"
+        }
+      ],
+      "verifier_group": "web_reviewed_external_live"
+    },
+    {
+      "id": "narrative.harness",
+      "status": "live_production",
+      "status_evidence": [
+        "HarnessRunner drives the Narrative Harness through ILlmTransport.",
+        "PursuerActor may also drive a second harness-side LLM participant."
+      ],
+      "activation_rule": "Already live. Wiring must use Narrative Harness run ownership and must not attach records to a Game Run Bundle.",
+      "owner": "narrative_harness_run",
+      "owner_description": "Narrative Harness run",
+      "pi_agent_session": "harness_owned",
+      "journal_destination": "narrative_harness_run_journal",
+      "context_membership": "harness_context_only",
+      "player_delivery": "not_game_run_player_delivery",
+      "visibility": "authorized_harness_debugger",
+      "retention_policy_key": "narrative_harness.run_journal",
+      "required_owner_ids": [
+        "harness_run_id"
+      ],
+      "required_correlation_ids": [
+        "harness_run_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "HarnessRunner.BuildCharacterUserMessage",
+        "SessionSystemPromptBuilder.BuildDatee",
+        "RawLlmSession.ParsePhase"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.NarrativeHarness/HarnessRunner.cs",
+          "pattern": "public async Task<HarnessRunResult> RunAsync\\(|_transport\\.SendAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.NarrativeHarness/PursuerActor.cs",
+          "pattern": "CharacterPursuerActor|GenericLlmPursuerActor|_transport\\.SendAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.NarrativeHarness/RecordingLlmTransport.cs",
+          "pattern": "RawLlmSession"
+        }
+      ],
+      "verifier_group": "core_harness_live"
+    },
+    {
+      "id": "session.simulation",
+      "status": "live_production",
+      "status_evidence": [
+        "session-runner LlmPlayerAgent creates a Pi structured transport and sends strategic player choices.",
+        "The path is a simulation run, not a Game Run Agent Journal Bundle member."
+      ],
+      "activation_rule": "Already live. Wiring must use simulation-run ownership and must not attach records to a Game Run Bundle.",
+      "owner": "session_simulation_run",
+      "owner_description": "simulation run",
+      "pi_agent_session": "simulation_owned",
+      "journal_destination": "session_simulation_run_journal",
+      "context_membership": "simulation_agent_context_only",
+      "player_delivery": "simulation_decision_only_not_game_run_player_delivery",
+      "visibility": "authorized_simulation_debugger",
+      "retention_policy_key": "session_simulation.run_journal",
+      "required_owner_ids": [
+        "simulation_run_id"
+      ],
+      "required_correlation_ids": [
+        "simulation_run_id",
+        "invocation_id",
+        "operation_id",
+        "attempt_ordinal"
+      ],
+      "forbidden_owner_ids": [
+        "game_run_id",
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id"
+      ],
+      "provenance_builder_ids": [
+        "LlmPlayerAgent.BuildSystemMessage",
+        "LlmPlayerAgent.BuildPrompt",
+        "StructuredLlmRequest:llm-player-pick"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "session-runner/LlmPlayerAgent.cs",
+          "pattern": "public sealed class LlmPlayerAgent|PiProviderTransportFactory\\.Create|SendStructuredAsync\\("
+        }
+      ],
+      "verifier_group": "core_simulation_live"
+    },
+    {
+      "id": "game.delivery.success-improvement",
+      "status": "live_production",
+      "status_evidence": [
+        "DeliveryStage calls GetSuccessImprovementAsync after strong, critical, exceptional, or nat20 success tiers.",
+        "PinderLlmAdapter builds the success improvement envelope and sends it through the primary transport."
+      ],
+      "activation_rule": "Already live. Wiring must create a Game Run Bundle one-shot record and must not mint a Pi Agent Session ID.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / one-shot record",
+      "pi_agent_session": "no",
+      "journal_destination": "game_run_delivery_one_shot_record",
+      "context_membership": "delivery_prompt_only_no_agent_session_context",
+      "player_delivery": "replaces_delivered_player_message_before_datee_response",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.one_shot.delivery.success_improvement",
+      "required_owner_ids": [
+        "game_run_id",
+        "operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "operation_id",
+        "invocation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "PinderLlmAdapter.GetSuccessImprovementAsync",
+        "StatDeliveryInstructions.GetSuccessImprovementPromptTemplate",
+        "SessionSystemPromptBuilder.BuildPlayerAvatar"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs",
+          "pattern": "GetSuccessImprovementAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "GetSuccessImprovementAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/DeliveryStage.cs",
+          "pattern": "GetSuccessImprovementAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live_delivery"
+    },
+    {
+      "id": "game.delivery.horniness-question",
+      "status": "live_production",
+      "status_evidence": [
+        "DeliveryStage calls GetHorninessQuestionAsync on horniness miss appends.",
+        "PinderLlmAdapter builds the horniness question prompt and sends it through the primary transport."
+      ],
+      "activation_rule": "Already live. Wiring must create a Game Run Bundle one-shot append record and must not mint a Pi Agent Session ID.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / one-shot append record",
+      "pi_agent_session": "no",
+      "journal_destination": "game_run_delivery_append_one_shot_record",
+      "context_membership": "delivery_append_prompt_only_no_agent_session_context",
+      "player_delivery": "appends_to_delivered_player_message_before_datee_response",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.one_shot.delivery.horniness_question",
+      "required_owner_ids": [
+        "game_run_id",
+        "operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "operation_id",
+        "invocation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "PinderLlmAdapter.GetHorninessQuestionAsync",
+        "GameDefinition.HorninessPrompt",
+        "SessionSystemPromptBuilder.BuildPlayerAvatar"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs",
+          "pattern": "GetHorninessQuestionAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "GetHorninessQuestionAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/DeliveryStage.cs",
+          "pattern": "GetHorninessQuestionAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live_delivery"
+    },
+    {
+      "id": "game.delivery.steering-question",
+      "status": "live_production",
+      "status_evidence": [
+        "SteeringEngine calls GetSteeringQuestionAsync when steering succeeds.",
+        "PinderLlmAdapter builds the steering prompt and sends it through the primary transport."
+      ],
+      "activation_rule": "Already live. Wiring must create a Game Run Bundle one-shot append record and must not mint a Pi Agent Session ID.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / one-shot append record",
+      "pi_agent_session": "no",
+      "journal_destination": "game_run_delivery_append_one_shot_record",
+      "context_membership": "delivery_append_prompt_only_no_agent_session_context",
+      "player_delivery": "appends_to_delivered_player_message_before_datee_response",
+      "visibility": "authorized_game_run_agent_journal_debugger",
+      "retention_policy_key": "game_run.agent_journal.one_shot.delivery.steering_question",
+      "required_owner_ids": [
+        "game_run_id",
+        "operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "operation_id",
+        "invocation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "PinderLlmAdapter.GetSteeringQuestionAsync",
+        "GameDefinition.SteeringPrompt",
+        "SessionSystemPromptBuilder.BuildPlayerAvatar"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/IStatefulLlmAdapter.cs",
+          "pattern": "GetSteeringQuestionAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "GetSteeringQuestionAsync\\("
+        },
+        {
+          "kind": "production_call",
+          "file": "src/Pinder.Core/Conversation/SteeringEngine.cs",
+          "pattern": "GetSteeringQuestionAsync\\("
+        }
+      ],
+      "verifier_group": "core_game_run_live_delivery"
+    },
+    {
+      "id": "game.datee.interest-change-beat",
+      "status": "provider_capable_dormant",
+      "status_evidence": [
+        "ILlmAdapter and PinderLlmAdapter still expose GetInterestChangeBeatAsync.",
+        "The static verifier proves there is no production caller outside declarations, NullLlmAdapter, and the provider implementation."
+      ],
+      "activation_rule": "Dormant guard: if any production caller of GetInterestChangeBeatAsync appears, verification fails and the path must return to planning before runtime journal wiring is added.",
+      "owner": "game_run_bundle",
+      "owner_description": "Game Run Bundle / dormant DATEE interest-change one-shot",
+      "pi_agent_session": "no_runtime_journal_until_replanned",
+      "journal_destination": "none_until_replanned",
+      "context_membership": "provider_capable_no_runtime_context_membership",
+      "player_delivery": "none_until_reactivated",
+      "visibility": "not_visible_until_replanned",
+      "retention_policy_key": "game_run.agent_journal.dormant.datee.interest_change_beat",
+      "required_owner_ids": [
+        "game_run_id",
+        "operation_id"
+      ],
+      "required_correlation_ids": [
+        "game_run_id",
+        "operation_id",
+        "invocation_id",
+        "attempt_ordinal",
+        "turn_id"
+      ],
+      "forbidden_owner_ids": [
+        "agent_session_id",
+        "character_operation_id",
+        "admin_execution_id",
+        "harness_run_id",
+        "simulation_run_id"
+      ],
+      "provenance_builder_ids": [
+        "SessionDocumentBuilder.BuildInterestChangeBeatPrompt",
+        "SessionSystemPromptBuilder.BuildDatee",
+        "PinderLlmAdapter.GetInterestChangeBeatAsync"
+      ],
+      "implementation_matchers": [
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.Core/Interfaces/ILlmAdapter.cs",
+          "pattern": "GetInterestChangeBeatAsync\\("
+        },
+        {
+          "kind": "symbol",
+          "file": "src/Pinder.LlmAdapters/PinderLlmAdapter.cs",
+          "pattern": "public async Task<string\\?> GetInterestChangeBeatAsync\\("
+        },
+        {
+          "kind": "no_production_caller",
+          "search_roots": [
+            "src",
+            "session-runner",
+            "tools"
+          ],
+          "pattern": "GetInterestChangeBeatAsync\\(",
+          "allowed_files": [
+            "src/Pinder.Core/Interfaces/ILlmAdapter.cs",
+            "src/Pinder.Core/Conversation/NullLlmAdapter.cs",
+            "src/Pinder.LlmAdapters/PinderLlmAdapter.cs"
+          ]
+        }
+      ],
+      "verifier_group": "core_game_run_dormant_guard"
+    }
+  ]
+}

--- a/docs/agent-journal-invocation-ownership.md
+++ b/docs/agent-journal-invocation-ownership.md
@@ -1,0 +1,104 @@
+# Agent Journal Invocation Ownership
+
+This document is the checked-in review note for
+`contracts/agent-journal-invocation-ownership.v1.json`. It uses the terminology
+from `docs/agent-journals.md` and the merged Core #1370 contracts. The manifest
+is deliberately closed: wiring work must consume these rows and must not choose
+new ownership, visibility, or retention classifications while coding.
+
+## Contract Shape
+
+Each row fixes:
+
+- lifecycle owner and journal destination;
+- whether a Pi Agent Session exists for the invocation;
+- provider-context membership and player-delivery visibility;
+- required owner and correlation identifiers;
+- retention-policy key;
+- provenance builder identifiers;
+- implementation matchers for the static verifier; and
+- status, status evidence, activation rule, and verifier group.
+
+The accepted status values are `live_production`,
+`provider_capable_dormant`, and `dead_with_proof`. This v1 approves no dead
+rows. `game.datee.interest-change-beat` is provider-capable dormant, not dead.
+
+## Closed V1 Inventory
+
+| ID | Status | Owner / destination | Pi Agent Session |
+|---|---|---|---|
+| `game.datee.performance` | `live_production` | Game Run Bundle / DATEE journal | yes |
+| `game.avatar.reply` | `live_production` | Game Run Bundle / avatar journal | yes |
+| `game.emotional-director` | `live_production` | Game Run Bundle / private DATEE branch | yes, disposable branch |
+| `game.dialogue-options` | `live_production` | Game Run Bundle / one-shot record | no |
+| `game.setup.dramatic-arc` | `live_production` | Game Run Bundle / setup one-shot | no |
+| `game.prefetch.option-branch` | `live_production` | Game Run Bundle / branch-local DATEE/avatar journals | yes, restored from cloned Game State snapshots |
+| `game.speculation.option-branch` | `live_production` | Game Run Bundle / branch-local DATEE/avatar journals | yes, restored from cloned Game State snapshots |
+| `character.synthesis` | `live_production` | character-creation operation journal | no Game Run journal |
+| `admin.temporary-chat` | `live_production` | admin authoring execution / temporary-chat owner | separate temporary-chat owner |
+| `admin.prompt-speculation` | `live_production` | admin authoring execution / authoring owner | separate authoring owner |
+| `narrative.harness` | `live_production` | Narrative Harness run | harness-owned |
+| `session.simulation` | `live_production` | simulation run | simulation-owned |
+| `game.delivery.success-improvement` | `live_production` | Game Run Bundle / one-shot record | no |
+| `game.delivery.horniness-question` | `live_production` | Game Run Bundle / one-shot append record | no |
+| `game.delivery.steering-question` | `live_production` | Game Run Bundle / one-shot append record | no |
+| `game.datee.interest-change-beat` | `provider_capable_dormant` | no runtime journal wiring until re-planned | no runtime journal |
+
+## Dormant Activation Guard
+
+`game.datee.interest-change-beat` remains implemented by
+`PinderLlmAdapter.GetInterestChangeBeatAsync`, but the current production code
+has no caller. The verifier searches `src`, `session-runner`, and `tools` for
+`GetInterestChangeBeatAsync(` and permits only:
+
+- `src/Pinder.Core/Interfaces/ILlmAdapter.cs`;
+- `src/Pinder.Core/Conversation/NullLlmAdapter.cs`; and
+- `src/Pinder.LlmAdapters/PinderLlmAdapter.cs`.
+
+Any new production caller fails verification. Reactivation requires planning
+before journal wiring; wiring workers must not silently turn the dormant row
+into a live row.
+
+## Web-Owned Review
+
+web-review:admin.temporary-chat
+
+`admin.temporary-chat` is host-owned by Pinder Web/admin authoring. Core records
+the ownership row because wiring consumers need the closed matrix, but Core does
+not implement, reclassify, or assign Game Run identifiers to this path. The row
+requires a `temporary_chat_id` and `admin_execution_id`; `game_run_id` and
+`agent_session_id` are explicitly forbidden.
+
+web-review:admin.prompt-speculation
+
+`admin.prompt-speculation` is host-owned by Pinder Web/admin authoring. Core
+records the row for the closed matrix only. The row requires an
+`authoring_execution_id` and `admin_execution_id`; `game_run_id` and
+`agent_session_id` are explicitly forbidden.
+
+## Boundary Notes
+
+Game Run rows may require `game_run_id`; non-Game-Run rows must not. Provider
+calls are not automatically Agent Sessions. One-shot delivery/setup/dialogue
+rows must not mint `agent_session_id`; DATEE/avatar rows must use the relevant
+Agent Session or branch identifiers; branch rows must keep branch-local
+correlations.
+
+`character.synthesis` groups current character creation and synthesis provider
+paths under the character-creation operation journal. It is not a Game Run
+Agent Journal Bundle member.
+
+`narrative.harness` and `session.simulation` are live provider-capable paths,
+but they are owned by their run types rather than by a Game Run Bundle.
+
+## Verification
+
+Run:
+
+```powershell
+pwsh ./scripts/verify-agent-journal-ownership.ps1
+```
+
+The verifier checks the exact 16-ID inventory, row field completeness, live /
+dormant / dead counts, implementation matcher counts, the dormant no-caller
+proof, static scan coverage, focused xUnit tests, and `git diff --check`.

--- a/scripts/verify-agent-journal-ownership.ps1
+++ b/scripts/verify-agent-journal-ownership.ps1
@@ -1,0 +1,378 @@
+param(
+    [string]$EvidenceDir = $env:EIGENTAKT_KEEP_DIR
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$manifestPath = Join-Path $repo "contracts/agent-journal-invocation-ownership.v1.json"
+$docsPath = Join-Path $repo "docs/agent-journal-invocation-ownership.md"
+$testProject = Join-Path $repo "tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj"
+$resultsDir = Join-Path $repo "TestResults/agent-journal-ownership"
+
+$requiredIds = @(
+    "game.datee.performance",
+    "game.avatar.reply",
+    "game.emotional-director",
+    "game.dialogue-options",
+    "game.setup.dramatic-arc",
+    "game.prefetch.option-branch",
+    "game.speculation.option-branch",
+    "character.synthesis",
+    "admin.temporary-chat",
+    "admin.prompt-speculation",
+    "narrative.harness",
+    "session.simulation",
+    "game.delivery.success-improvement",
+    "game.delivery.horniness-question",
+    "game.delivery.steering-question",
+    "game.datee.interest-change-beat"
+)
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function As-Array {
+    param($Value)
+    if ($null -eq $Value) {
+        return @()
+    }
+    if ($Value -is [System.Array]) {
+        return @($Value)
+    }
+    return @($Value)
+}
+
+function Normalize-PathText {
+    param([string]$Path)
+    return ($Path -replace "\\", "/")
+}
+
+function Read-Text {
+    param([string]$Path)
+    Assert-True (Test-Path -LiteralPath $Path) "Missing file: $Path"
+    return Get-Content -LiteralPath $Path -Raw
+}
+
+function Get-SourceLines {
+    param(
+        [string]$RelativePath,
+        [string]$Pattern
+    )
+    $path = Join-Path $repo $RelativePath
+    $text = Read-Text $path
+    $matches = New-Object System.Collections.Generic.List[string]
+    $lines = $text -split "`r?`n"
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        if ($lines[$i] -match $Pattern) {
+            $matches.Add(("{0}:{1}" -f (Normalize-PathText $RelativePath), ($i + 1)))
+        }
+    }
+    return @($matches)
+}
+
+function Test-Matcher {
+    param($Row, $Matcher)
+
+    $kind = [string]$Matcher.kind
+    switch ($kind) {
+        { $_ -in @("symbol", "production_call") } {
+            $file = [string]$Matcher.file
+            $pattern = [string]$Matcher.pattern
+            Assert-True ($file.Length -gt 0) "Matcher for $($Row.id) is missing file"
+            Assert-True ($pattern.Length -gt 0) "Matcher for $($Row.id) is missing pattern"
+            Assert-True ($pattern -ne ".*") "Catch-all matcher is forbidden for $($Row.id)"
+            return Get-SourceLines $file $pattern
+        }
+        "web_review_anchor" {
+            $file = [string]$Matcher.file
+            $anchor = [string]$Matcher.anchor
+            Assert-True ($anchor.Length -gt 0) "Web review matcher for $($Row.id) is missing anchor"
+            $text = Read-Text (Join-Path $repo $file)
+            Assert-True ($text.Contains($anchor)) "Missing web review anchor '$anchor' for $($Row.id)"
+            return @(("{0}:anchor:{1}" -f (Normalize-PathText $file), $anchor))
+        }
+        "no_production_caller" {
+            $pattern = [string]$Matcher.pattern
+            $allowed = As-Array $Matcher.allowed_files | ForEach-Object { Normalize-PathText ([string]$_) }
+            $roots = As-Array $Matcher.search_roots | ForEach-Object { Join-Path $repo ([string]$_) }
+            $violations = New-Object System.Collections.Generic.List[string]
+            foreach ($rootPath in $roots) {
+                if (-not (Test-Path -LiteralPath $rootPath)) {
+                    continue
+                }
+                $files = Get-ChildItem -LiteralPath $rootPath -Recurse -File -Filter "*.cs" |
+                    Where-Object {
+                        $rel = Normalize-PathText ($_.FullName.Substring($repo.Path.Length + 1))
+                        $rel -notmatch "/bin/" -and
+                        $rel -notmatch "/obj/" -and
+                        $rel -notmatch "^tests/" -and
+                        $rel -notmatch "^docs/" -and
+                        $rel -notmatch "^contracts/"
+                    }
+                foreach ($file in $files) {
+                    $rel = Normalize-PathText ($file.FullName.Substring($repo.Path.Length + 1))
+                    $lines = Get-Content -LiteralPath $file.FullName
+                    for ($i = 0; $i -lt $lines.Count; $i++) {
+                        if ($lines[$i] -match $pattern -and $allowed -notcontains $rel) {
+                            $violations.Add(("{0}:{1}" -f $rel, ($i + 1)))
+                        }
+                    }
+                }
+            }
+            Assert-True ($violations.Count -eq 0) ("Dormant caller guard failed for {0}: {1}" -f $Row.id, ($violations -join ", "))
+            return @("dormant-no-caller-proof:$($Row.id)")
+        }
+        default {
+            throw "Unknown matcher kind '$kind' for $($Row.id)"
+        }
+    }
+}
+
+function Add-Candidate {
+    param(
+        [System.Collections.Generic.List[object]]$Candidates,
+        [string]$RelativePath,
+        [int]$LineNumber,
+        [string]$Text,
+        [string]$Reason
+    )
+    $Candidates.Add([pscustomobject]@{
+        Key = "{0}:{1}" -f (Normalize-PathText $RelativePath), $LineNumber
+        File = Normalize-PathText $RelativePath
+        Line = $LineNumber
+        Text = $Text.Trim()
+        Reason = $Reason
+    })
+}
+
+function Get-StaticScanCandidates {
+    $candidates = New-Object System.Collections.Generic.List[object]
+    $roots = @("src", "session-runner", "tools")
+    foreach ($root in $roots) {
+        $rootPath = Join-Path $repo $root
+        if (-not (Test-Path -LiteralPath $rootPath)) {
+            continue
+        }
+        $files = Get-ChildItem -LiteralPath $rootPath -Recurse -File -Filter "*.cs" |
+            Where-Object {
+                $rel = Normalize-PathText ($_.FullName.Substring($repo.Path.Length + 1))
+                $rel -notmatch "/bin/" -and
+                $rel -notmatch "/obj/" -and
+                $rel -notmatch "^src/Pinder.RemoteAssets/" -and
+                $rel -notmatch "^src/Pinder.LlmAdapters/(PiLlmTransport|ThinkingStrippingLlmTransport|PunctuationNormalizingTransport|PiProviderTransportFactory)\.cs$" -and
+                $rel -notmatch "^src/Pinder.Core/Interfaces/" -and
+                $rel -notmatch "^src/Pinder.Core/Conversation/NullLlmAdapter\.cs$" -and
+                $rel -notmatch "^src/Pinder.SessionSetup/(I|Synthesis/I)" -and
+                $rel -notmatch "^src/Pinder.SessionSetup/LlmOptionalTextGeneration\.cs$"
+            }
+        foreach ($file in $files) {
+            $rel = Normalize-PathText ($file.FullName.Substring($repo.Path.Length + 1))
+            $lines = Get-Content -LiteralPath $file.FullName
+            for ($i = 0; $i -lt $lines.Count; $i++) {
+                $line = $lines[$i]
+                if ($line.TrimStart().StartsWith("//")) {
+                    continue
+                }
+                $lineNo = $i + 1
+                if ($rel -match "^src/Pinder.Core/Conversation/" -and
+                    $line -match "Get(DialogueOptions|DateeResponse|SuccessImprovement|SteeringQuestion|HorninessQuestion)Async\(") {
+                    Add-Candidate $candidates $rel $lineNo $line "core-conversation-call"
+                }
+                elseif ($rel -match "^src/Pinder.LlmAdapters/PinderLlmAdapter(\.EmotionalDirector)?\.cs$" -and
+                    $line -match "Get(DialogueOptions|DateeResponse|InterestChangeBeat|SuccessImprovement|SteeringQuestion|HorninessQuestion)Async\(|GenerateEmotionalDirectionAsync\(") {
+                    Add-Candidate $candidates $rel $lineNo $line "adapter-provider-path"
+                }
+                elseif ($rel -match "^src/Pinder.SessionSetup/" -and
+                    $line -match "public async Task<.*GenerateAsync\(|SynthesizeAsync\(|LlmOptionalTextGeneration\.RunAsync\(") {
+                    Add-Candidate $candidates $rel $lineNo $line "setup-synthesis-provider-path"
+                }
+                elseif ($rel -match "^src/Pinder.NarrativeHarness/" -and
+                    $line -match "public async Task<HarnessRunResult> RunAsync\(|CharacterPursuerActor|GenericLlmPursuerActor|_transport\.SendAsync\(") {
+                    Add-Candidate $candidates $rel $lineNo $line "harness-provider-path"
+                }
+                elseif ($rel -eq "session-runner/LlmPlayerAgent.cs" -and
+                    $line -match "public sealed class LlmPlayerAgent|PiProviderTransportFactory\.Create|SendStructuredAsync\(") {
+                    Add-Candidate $candidates $rel $lineNo $line "simulation-provider-path"
+                }
+            }
+        }
+    }
+    return @($candidates)
+}
+
+function Get-TrxTestCount {
+    param([string]$TrxPath)
+    [xml]$trx = Get-Content -LiteralPath $TrxPath -Raw
+    $ns = New-Object System.Xml.XmlNamespaceManager($trx.NameTable)
+    $ns.AddNamespace("t", "http://microsoft.com/schemas/VisualStudio/TeamTest/2010")
+    $counters = $trx.SelectSingleNode("//t:Counters", $ns)
+    Assert-True ($null -ne $counters) "TRX counters missing: $TrxPath"
+    return [int]$counters.total
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+Assert-True ($manifest.schema_version -eq "agent-journal-invocation-ownership.v1") "Unexpected manifest schema_version"
+Assert-True ($manifest.closed_inventory -eq $true) "Manifest must be closed_inventory=true"
+Assert-True ([int]$manifest.inventory_size -eq 16) "Manifest inventory_size must be 16"
+
+$rows = As-Array $manifest.rows
+Assert-True ($rows.Count -eq 16) "Manifest must contain exactly 16 rows; found $($rows.Count)"
+$ids = @($rows | ForEach-Object { [string]$_.id })
+$missing = @($requiredIds | Where-Object { $ids -notcontains $_ })
+$extra = @($ids | Where-Object { $requiredIds -notcontains $_ })
+Assert-True ($missing.Count -eq 0) "Missing manifest IDs: $($missing -join ', ')"
+Assert-True ($extra.Count -eq 0) "Unexpected manifest IDs: $($extra -join ', ')"
+Assert-True (($ids | Select-Object -Unique).Count -eq $ids.Count) "Duplicate manifest IDs are forbidden"
+
+$requiredFields = @(
+    "id",
+    "status",
+    "status_evidence",
+    "activation_rule",
+    "owner",
+    "owner_description",
+    "pi_agent_session",
+    "journal_destination",
+    "context_membership",
+    "player_delivery",
+    "visibility",
+    "retention_policy_key",
+    "required_owner_ids",
+    "required_correlation_ids",
+    "forbidden_owner_ids",
+    "provenance_builder_ids",
+    "implementation_matchers",
+    "verifier_group"
+)
+
+$symbolMatchMap = @{}
+$allMatcherResults = New-Object System.Collections.Generic.List[string]
+$webReviewMatches = 0
+$dormantProofs = 0
+
+foreach ($row in $rows) {
+    foreach ($field in $requiredFields) {
+        Assert-True ($row.PSObject.Properties.Name -contains $field) "Row $($row.id) is missing $field"
+    }
+    foreach ($arrayField in @("status_evidence", "required_owner_ids", "required_correlation_ids", "forbidden_owner_ids", "provenance_builder_ids", "implementation_matchers")) {
+        Assert-True ((As-Array $row.$arrayField).Count -gt 0) "Row $($row.id) has empty $arrayField"
+    }
+    Assert-True (([string]$row.activation_rule).Trim().Length -gt 0) "Row $($row.id) has empty activation_rule"
+    Assert-True (([string]$row.retention_policy_key).Trim().Length -gt 0) "Row $($row.id) has empty retention_policy_key"
+
+    $ownerIds = As-Array $row.required_owner_ids | ForEach-Object { [string]$_ }
+    $correlationIds = As-Array $row.required_correlation_ids | ForEach-Object { [string]$_ }
+    if ([string]$row.id -like "game.*") {
+        Assert-True ($ownerIds -contains "game_run_id") "Game row $($row.id) must require game_run_id"
+        Assert-True ($correlationIds -contains "game_run_id") "Game row $($row.id) must correlate game_run_id"
+    }
+    else {
+        Assert-True ($ownerIds -notcontains "game_run_id") "Non-Game row $($row.id) must not require game_run_id"
+        Assert-True ($correlationIds -notcontains "game_run_id") "Non-Game row $($row.id) must not correlate game_run_id"
+    }
+
+    foreach ($matcher in (As-Array $row.implementation_matchers)) {
+        $matches = @(Test-Matcher $row $matcher)
+        Assert-True ($matches.Count -gt 0) "Matcher for $($row.id) produced zero matches"
+        foreach ($match in $matches) {
+            $allMatcherResults.Add("$($row.id) -> $match")
+            if ([string]$matcher.kind -in @("symbol", "production_call")) {
+                if (-not $symbolMatchMap.ContainsKey($match)) {
+                    $symbolMatchMap[$match] = New-Object System.Collections.Generic.HashSet[string]
+                }
+                [void]$symbolMatchMap[$match].Add([string]$row.id)
+            }
+            elseif ([string]$matcher.kind -eq "web_review_anchor") {
+                $webReviewMatches++
+            }
+            elseif ([string]$matcher.kind -eq "no_production_caller") {
+                $dormantProofs++
+            }
+        }
+    }
+}
+
+$interestRow = $rows | Where-Object { $_.id -eq "game.datee.interest-change-beat" } | Select-Object -First 1
+Assert-True ($interestRow.status -eq "provider_capable_dormant") "Interest-change beat must be provider_capable_dormant"
+Assert-True ([string]$interestRow.activation_rule -match "fails" -and [string]$interestRow.activation_rule -match "planning") "Interest-change activation rule must fail back to planning"
+Assert-True ($dormantProofs -gt 0) "Dormant no-caller proof did not run"
+
+$liveCount = @($rows | Where-Object { $_.status -eq "live_production" }).Count
+$dormantCount = @($rows | Where-Object { $_.status -eq "provider_capable_dormant" }).Count
+$deadCount = @($rows | Where-Object { $_.status -eq "dead_with_proof" }).Count
+Assert-True ($liveCount -eq 15) "Expected 15 live rows; found $liveCount"
+Assert-True ($dormantCount -eq 1) "Expected 1 dormant row; found $dormantCount"
+Assert-True ($deadCount -eq 0) "No dead rows are approved; found $deadCount"
+
+$candidates = @(Get-StaticScanCandidates)
+Assert-True ($candidates.Count -gt 0) "Static production scan produced zero candidates"
+$unmatched = New-Object System.Collections.Generic.List[object]
+$duplicates = New-Object System.Collections.Generic.List[string]
+foreach ($candidate in $candidates) {
+    if (-not $symbolMatchMap.ContainsKey($candidate.Key)) {
+        $unmatched.Add($candidate)
+        continue
+    }
+    if ($symbolMatchMap[$candidate.Key].Count -ne 1) {
+        $duplicates.Add(("{0} -> {1}" -f $candidate.Key, ([string]::Join(",", $symbolMatchMap[$candidate.Key]))))
+    }
+}
+Assert-True ($unmatched.Count -eq 0) ("Unclassified production LLM paths: " + (($unmatched | ForEach-Object { "$($_.Key) [$($_.Reason)] $($_.Text)" }) -join "; "))
+Assert-True ($duplicates.Count -eq 0) ("Duplicate production LLM path ownership: " + ($duplicates -join "; "))
+
+New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+$trxName = "agent-journal-ownership.trx"
+dotnet test $testProject `
+    --filter "FullyQualifiedName~OwnershipManifestTests" `
+    --results-directory $resultsDir `
+    --logger "trx;LogFileName=$trxName"
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+$trxPath = Join-Path $resultsDir $trxName
+Assert-True (Test-Path -LiteralPath $trxPath) "Test TRX was not produced: $trxPath"
+$testCount = Get-TrxTestCount $trxPath
+Assert-True ($testCount -gt 0) "OwnershipManifestTests matched zero tests"
+
+git -C $repo diff --check
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$symbolMatchCount = $symbolMatchMap.Keys.Count
+Assert-True ($symbolMatchCount -gt 0) "Production symbol-match count is zero"
+Assert-True ($webReviewMatches -gt 0) "Web review match count is zero"
+
+$summary = @(
+    "agent-journal ownership verifier completed",
+    "manifest_count=16",
+    "live_count=$liveCount",
+    "dormant_count=$dormantCount",
+    "dead_count=$deadCount",
+    "production_symbol_match_count=$symbolMatchCount",
+    "static_scan_candidate_count=$($candidates.Count)",
+    "web_review_match_count=$webReviewMatches",
+    "dormant_interest_change_no_caller_proof=passed",
+    "ownership_test_count=$testCount"
+)
+
+$summary | ForEach-Object { Write-Host $_ }
+
+if (-not [string]::IsNullOrWhiteSpace($EvidenceDir)) {
+    New-Item -ItemType Directory -Force -Path $EvidenceDir | Out-Null
+    $summaryPath = Join-Path $EvidenceDir "CORE-1373-agent-journal-ownership-verifier.txt"
+    $matchesPath = Join-Path $EvidenceDir "CORE-1373-agent-journal-ownership-matches.txt"
+    $manifestCopy = Join-Path $EvidenceDir "CORE-1373-agent-journal-invocation-ownership.v1.json"
+    Set-Content -LiteralPath $summaryPath -Value ($summary -join [Environment]::NewLine)
+    Set-Content -LiteralPath $matchesPath -Value ($allMatcherResults -join [Environment]::NewLine)
+    Copy-Item -LiteralPath $manifestPath -Destination $manifestCopy -Force
+}

--- a/scripts/verify-agent-journal-ownership.py
+++ b/scripts/verify-agent-journal-ownership.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+REQUIRED_IDS = [
+    "game.datee.performance",
+    "game.avatar.reply",
+    "game.emotional-director",
+    "game.dialogue-options",
+    "game.setup.dramatic-arc",
+    "game.prefetch.option-branch",
+    "game.speculation.option-branch",
+    "character.synthesis",
+    "admin.temporary-chat",
+    "admin.prompt-speculation",
+    "narrative.harness",
+    "session.simulation",
+    "game.delivery.success-improvement",
+    "game.delivery.horniness-question",
+    "game.delivery.steering-question",
+    "game.datee.interest-change-beat",
+]
+
+REQUIRED_FIELDS = [
+    "id",
+    "status",
+    "status_evidence",
+    "activation_rule",
+    "owner",
+    "owner_description",
+    "pi_agent_session",
+    "journal_destination",
+    "context_membership",
+    "player_delivery",
+    "visibility",
+    "retention_policy_key",
+    "required_owner_ids",
+    "required_correlation_ids",
+    "forbidden_owner_ids",
+    "provenance_builder_ids",
+    "implementation_matchers",
+    "verifier_group",
+]
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        raise AssertionError(f"Missing file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def rel(repo: Path, path: Path) -> str:
+    return path.relative_to(repo).as_posix()
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def source_lines(repo: Path, file_name: str, pattern: str) -> list[str]:
+    path = repo / file_name
+    text = read_text(path)
+    regex = re.compile(pattern)
+    return [
+        f"{file_name}:{idx}"
+        for idx, line in enumerate(text.splitlines(), start=1)
+        if regex.search(line)
+    ]
+
+
+def no_production_caller(repo: Path, row: dict, matcher: dict) -> list[str]:
+    regex = re.compile(matcher["pattern"])
+    allowed_files = set(matcher["allowed_files"])
+    violations: list[str] = []
+    for root in matcher["search_roots"]:
+        root_path = repo / root
+        if not root_path.exists():
+            continue
+        for path in root_path.rglob("*.cs"):
+            name = rel(repo, path)
+            if any(part in {"bin", "obj"} for part in path.parts):
+                continue
+            if name.startswith(("tests/", "docs/", "contracts/")):
+                continue
+            for idx, line in enumerate(read_text(path).splitlines(), start=1):
+                if regex.search(line) and name not in allowed_files:
+                    violations.append(f"{name}:{idx}")
+    if violations:
+        raise AssertionError(
+            f"Dormant caller guard failed for {row['id']}: {', '.join(violations)}"
+        )
+    return [f"dormant-no-caller-proof:{row['id']}"]
+
+
+def matcher_results(repo: Path, row: dict, matcher: dict) -> list[str]:
+    kind = matcher["kind"]
+    if kind in {"symbol", "production_call"}:
+        pattern = matcher.get("pattern", "")
+        if pattern == ".*":
+            raise AssertionError(f"Catch-all matcher forbidden for {row['id']}")
+        return source_lines(repo, matcher["file"], pattern)
+    if kind == "web_review_anchor":
+        text = read_text(repo / matcher["file"])
+        anchor = matcher["anchor"]
+        if anchor not in text:
+            raise AssertionError(f"Missing web review anchor {anchor} for {row['id']}")
+        return [f"{matcher['file']}:anchor:{anchor}"]
+    if kind == "no_production_caller":
+        return no_production_caller(repo, row, matcher)
+    raise AssertionError(f"Unknown matcher kind {kind} for {row['id']}")
+
+
+def add_candidate(
+    candidates: list[dict],
+    file_name: str,
+    line_no: int,
+    line: str,
+    reason: str,
+) -> None:
+    candidates.append(
+        {
+            "key": f"{file_name}:{line_no}",
+            "file": file_name,
+            "line": line_no,
+            "text": line.strip(),
+            "reason": reason,
+        }
+    )
+
+
+def static_scan_candidates(repo: Path) -> list[dict]:
+    candidates: list[dict] = []
+    for root in ("src", "session-runner", "tools"):
+        root_path = repo / root
+        if not root_path.exists():
+            continue
+        for path in root_path.rglob("*.cs"):
+            name = rel(repo, path)
+            if any(part in {"bin", "obj"} for part in path.parts):
+                continue
+            if name.startswith("src/Pinder.RemoteAssets/"):
+                continue
+            if re.match(
+                r"^src/Pinder.LlmAdapters/(PiLlmTransport|ThinkingStrippingLlmTransport|PunctuationNormalizingTransport|PiProviderTransportFactory)\.cs$",
+                name,
+            ):
+                continue
+            if name.startswith("src/Pinder.Core/Interfaces/"):
+                continue
+            if name == "src/Pinder.Core/Conversation/NullLlmAdapter.cs":
+                continue
+            if re.match(r"^src/Pinder.SessionSetup/(I|Synthesis/I)", name):
+                continue
+            if name == "src/Pinder.SessionSetup/LlmOptionalTextGeneration.cs":
+                continue
+
+            for idx, line in enumerate(read_text(path).splitlines(), start=1):
+                if line.lstrip().startswith("//"):
+                    continue
+                if name.startswith("src/Pinder.Core/Conversation/") and re.search(
+                    r"Get(DialogueOptions|DateeResponse|SuccessImprovement|SteeringQuestion|HorninessQuestion)Async\(",
+                    line,
+                ):
+                    add_candidate(candidates, name, idx, line, "core-conversation-call")
+                elif re.match(
+                    r"^src/Pinder.LlmAdapters/PinderLlmAdapter(\.EmotionalDirector)?\.cs$",
+                    name,
+                ) and re.search(
+                    r"Get(DialogueOptions|DateeResponse|InterestChangeBeat|SuccessImprovement|SteeringQuestion|HorninessQuestion)Async\(|GenerateEmotionalDirectionAsync\(",
+                    line,
+                ):
+                    add_candidate(candidates, name, idx, line, "adapter-provider-path")
+                elif name.startswith("src/Pinder.SessionSetup/") and re.search(
+                    r"public async Task<.*GenerateAsync\(|SynthesizeAsync\(|LlmOptionalTextGeneration\.RunAsync\(",
+                    line,
+                ):
+                    add_candidate(candidates, name, idx, line, "setup-synthesis-provider-path")
+                elif name.startswith("src/Pinder.NarrativeHarness/") and re.search(
+                    r"public async Task<HarnessRunResult> RunAsync\(|CharacterPursuerActor|GenericLlmPursuerActor|_transport\.SendAsync\(",
+                    line,
+                ):
+                    add_candidate(candidates, name, idx, line, "harness-provider-path")
+                elif name == "session-runner/LlmPlayerAgent.cs" and re.search(
+                    r"public sealed class LlmPlayerAgent|PiProviderTransportFactory\.Create|SendStructuredAsync\(",
+                    line,
+                ):
+                    add_candidate(candidates, name, idx, line, "simulation-provider-path")
+    return candidates
+
+
+def run_dotnet_ownership_tests(repo: Path, results_dir: Path) -> Path:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    trx_name = "agent-journal-ownership-host.trx"
+    project = repo / "tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj"
+    subprocess.run(
+        [
+            "dotnet",
+            "test",
+            str(project),
+            "--filter",
+            "FullyQualifiedName~OwnershipManifestTests",
+            "--results-directory",
+            str(results_dir),
+            "--logger",
+            f"trx;LogFileName={trx_name}",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    trx_path = results_dir / trx_name
+    if not trx_path.exists():
+        raise AssertionError(f"Test TRX was not produced: {trx_path}")
+    return trx_path
+
+
+def trx_test_count(path: Path) -> int:
+    root = ET.parse(path).getroot()
+    ns = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+    counters = root.find(".//t:Counters", ns)
+    if counters is None:
+        raise AssertionError(f"TRX counters missing: {path}")
+    return int(counters.attrib["total"])
+
+
+def verify_manifest(repo: Path) -> tuple[list[str], dict[str, int]]:
+    manifest_path = repo / "contracts/agent-journal-invocation-ownership.v1.json"
+    manifest = json.loads(read_text(manifest_path))
+    if manifest["schema_version"] != "agent-journal-invocation-ownership.v1":
+        raise AssertionError("Unexpected manifest schema_version")
+    if manifest["closed_inventory"] is not True:
+        raise AssertionError("Manifest must be closed_inventory=true")
+    if manifest["inventory_size"] != 16:
+        raise AssertionError("Manifest inventory_size must be 16")
+
+    rows = manifest["rows"]
+    ids = [row["id"] for row in rows]
+    if ids != REQUIRED_IDS:
+        raise AssertionError(f"Manifest ID inventory changed: {ids}")
+    if len(set(ids)) != len(ids):
+        raise AssertionError("Duplicate manifest IDs are forbidden")
+
+    symbol_map: dict[str, set[str]] = {}
+    all_matches: list[str] = []
+    web_review_count = 0
+    dormant_proofs = 0
+
+    for row in rows:
+        for field in REQUIRED_FIELDS:
+            if field not in row:
+                raise AssertionError(f"Row {row['id']} is missing {field}")
+        for field in (
+            "status_evidence",
+            "required_owner_ids",
+            "required_correlation_ids",
+            "forbidden_owner_ids",
+            "provenance_builder_ids",
+            "implementation_matchers",
+        ):
+            if not as_list(row[field]):
+                raise AssertionError(f"Row {row['id']} has empty {field}")
+
+        owner_ids = set(row["required_owner_ids"])
+        correlation_ids = set(row["required_correlation_ids"])
+        if row["id"].startswith("game."):
+            if "game_run_id" not in owner_ids or "game_run_id" not in correlation_ids:
+                raise AssertionError(f"Game row {row['id']} must require/correlate game_run_id")
+        else:
+            if "game_run_id" in owner_ids or "game_run_id" in correlation_ids:
+                raise AssertionError(f"Non-Game row {row['id']} must not require/correlate game_run_id")
+
+        for matcher in row["implementation_matchers"]:
+            matches = matcher_results(repo, row, matcher)
+            if not matches:
+                raise AssertionError(f"Matcher for {row['id']} produced zero matches")
+            for match in matches:
+                all_matches.append(f"{row['id']} -> {match}")
+                if matcher["kind"] in {"symbol", "production_call"}:
+                    symbol_map.setdefault(match, set()).add(row["id"])
+                elif matcher["kind"] == "web_review_anchor":
+                    web_review_count += 1
+                elif matcher["kind"] == "no_production_caller":
+                    dormant_proofs += 1
+
+    live_count = sum(1 for row in rows if row["status"] == "live_production")
+    dormant_count = sum(1 for row in rows if row["status"] == "provider_capable_dormant")
+    dead_count = sum(1 for row in rows if row["status"] == "dead_with_proof")
+    if live_count != 15 or dormant_count != 1 or dead_count != 0:
+        raise AssertionError(
+            f"Unexpected status counts: live={live_count}, dormant={dormant_count}, dead={dead_count}"
+        )
+    if dormant_proofs == 0:
+        raise AssertionError("Dormant no-caller proof did not run")
+    if web_review_count == 0:
+        raise AssertionError("Web review match count is zero")
+
+    candidates = static_scan_candidates(repo)
+    if not candidates:
+        raise AssertionError("Static production scan produced zero candidates")
+    unmatched = [candidate for candidate in candidates if candidate["key"] not in symbol_map]
+    duplicates = [
+        f"{candidate['key']} -> {','.join(sorted(symbol_map[candidate['key']]))}"
+        for candidate in candidates
+        if candidate["key"] in symbol_map and len(symbol_map[candidate["key"]]) != 1
+    ]
+    if unmatched:
+        raise AssertionError(
+            "Unclassified production LLM paths: "
+            + "; ".join(f"{item['key']} [{item['reason']}] {item['text']}" for item in unmatched)
+        )
+    if duplicates:
+        raise AssertionError("Duplicate production LLM path ownership: " + "; ".join(duplicates))
+
+    counts = {
+        "manifest_count": len(rows),
+        "live_count": live_count,
+        "dormant_count": dormant_count,
+        "dead_count": dead_count,
+        "production_symbol_match_count": len(symbol_map),
+        "static_scan_candidate_count": len(candidates),
+        "web_review_match_count": web_review_count,
+    }
+    return all_matches, counts
+
+
+def write_evidence(repo: Path, evidence_dir: Path | None, summary: list[str], matches: list[str]) -> None:
+    if evidence_dir is None:
+        return
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    (evidence_dir / "CORE-1373-host-compatible-local-verifier.txt").write_text(
+        "\n".join(summary) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "CORE-1373-agent-journal-ownership-matches.txt").write_text(
+        "\n".join(matches) + "\n",
+        encoding="utf-8",
+    )
+    shutil.copyfile(
+        repo / "contracts/agent-journal-invocation-ownership.v1.json",
+        evidence_dir / "CORE-1373-agent-journal-invocation-ownership.v1.json",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify the closed Agent Journal invocation ownership manifest.")
+    parser.add_argument(
+        "--evidence-dir",
+        default=os.environ.get("EIGENTAKT_KEEP_DIR"),
+        help="Optional directory for CORE-1373 evidence files.",
+    )
+    args = parser.parse_args()
+
+    repo = repo_root()
+    results_dir = repo / "TestResults/agent-journal-ownership-host"
+    evidence_dir = Path(args.evidence_dir) if args.evidence_dir else None
+
+    matches, counts = verify_manifest(repo)
+    trx_path = run_dotnet_ownership_tests(repo, results_dir)
+    test_count = trx_test_count(trx_path)
+    if test_count <= 0:
+        raise AssertionError("OwnershipManifestTests matched zero tests")
+
+    subprocess.run(["git", "diff", "--check"], cwd=repo, check=True)
+
+    summary = [
+        "host-compatible local agent-journal ownership verifier completed",
+        f"manifest_count={counts['manifest_count']}",
+        f"live_count={counts['live_count']}",
+        f"dormant_count={counts['dormant_count']}",
+        f"dead_count={counts['dead_count']}",
+        f"production_symbol_match_count={counts['production_symbol_match_count']}",
+        f"static_scan_candidate_count={counts['static_scan_candidate_count']}",
+        f"web_review_match_count={counts['web_review_match_count']}",
+        "dormant_interest_change_no_caller_proof=passed",
+        f"ownership_test_count={test_count}",
+        "git_diff_check=passed",
+    ]
+    write_evidence(repo, evidence_dir, summary, matches)
+    print("\n".join(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Pinder.LlmAdapters.Tests/AgentJournals/OwnershipManifestTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/AgentJournals/OwnershipManifestTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.AgentJournals
+{
+    public sealed class OwnershipManifestTests
+    {
+        private static readonly string[] RequiredIds =
+        {
+            "game.datee.performance",
+            "game.avatar.reply",
+            "game.emotional-director",
+            "game.dialogue-options",
+            "game.setup.dramatic-arc",
+            "game.prefetch.option-branch",
+            "game.speculation.option-branch",
+            "character.synthesis",
+            "admin.temporary-chat",
+            "admin.prompt-speculation",
+            "narrative.harness",
+            "session.simulation",
+            "game.delivery.success-improvement",
+            "game.delivery.horniness-question",
+            "game.delivery.steering-question",
+            "game.datee.interest-change-beat"
+        };
+
+        private static readonly string[] RequiredRowProperties =
+        {
+            "id",
+            "status",
+            "status_evidence",
+            "activation_rule",
+            "owner",
+            "owner_description",
+            "pi_agent_session",
+            "journal_destination",
+            "context_membership",
+            "player_delivery",
+            "visibility",
+            "retention_policy_key",
+            "required_owner_ids",
+            "required_correlation_ids",
+            "forbidden_owner_ids",
+            "provenance_builder_ids",
+            "implementation_matchers",
+            "verifier_group"
+        };
+
+        [Fact]
+        public void ManifestContainsClosedSixteenRowInventory()
+        {
+            using var document = LoadManifest();
+            JsonElement root = document.RootElement;
+
+            Assert.Equal("agent-journal-invocation-ownership.v1", root.GetProperty("schema_version").GetString());
+            Assert.True(root.GetProperty("closed_inventory").GetBoolean());
+            Assert.Equal(16, root.GetProperty("inventory_size").GetInt32());
+
+            string[] ids = Rows(root)
+                .Select(row => row.GetProperty("id").GetString()!)
+                .ToArray();
+
+            Assert.Equal(RequiredIds, ids);
+            Assert.Equal(RequiredIds.Length, ids.Distinct(StringComparer.Ordinal).Count());
+        }
+
+        [Fact]
+        public void RowsCarryRequiredOwnershipStatusVisibilityRetentionAndMatchers()
+        {
+            using var document = LoadManifest();
+            foreach (JsonElement row in Rows(document.RootElement))
+            {
+                string id = row.GetProperty("id").GetString()!;
+                foreach (string property in RequiredRowProperties)
+                {
+                    Assert.True(row.TryGetProperty(property, out _), $"{id} missing {property}");
+                }
+
+                Assert.NotEmpty(StringArray(row, "status_evidence"));
+                Assert.NotEmpty(row.GetProperty("activation_rule").GetString()!);
+                Assert.NotEmpty(row.GetProperty("owner").GetString()!);
+                Assert.NotEmpty(row.GetProperty("journal_destination").GetString()!);
+                Assert.NotEmpty(row.GetProperty("context_membership").GetString()!);
+                Assert.NotEmpty(row.GetProperty("player_delivery").GetString()!);
+                Assert.NotEmpty(row.GetProperty("visibility").GetString()!);
+                Assert.NotEmpty(row.GetProperty("retention_policy_key").GetString()!);
+                Assert.NotEmpty(StringArray(row, "required_owner_ids"));
+                Assert.NotEmpty(StringArray(row, "required_correlation_ids"));
+                Assert.NotEmpty(StringArray(row, "forbidden_owner_ids"));
+                Assert.NotEmpty(StringArray(row, "provenance_builder_ids"));
+
+                JsonElement[] matchers = row.GetProperty("implementation_matchers").EnumerateArray().ToArray();
+                Assert.NotEmpty(matchers);
+                foreach (JsonElement matcher in matchers)
+                {
+                    Assert.True(matcher.TryGetProperty("kind", out JsonElement kindElement), $"{id} matcher missing kind");
+                    string kind = kindElement.GetString()!;
+                    Assert.Contains(kind, new[] { "symbol", "production_call", "web_review_anchor", "no_production_caller" });
+                    if (kind == "symbol" || kind == "production_call")
+                    {
+                        string pattern = matcher.GetProperty("pattern").GetString()!;
+                        Assert.NotEqual(".*", pattern);
+                        Assert.NotEmpty(matcher.GetProperty("file").GetString()!);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ManifestHasAmendedStatusCountsAndNoDeadRows()
+        {
+            using var document = LoadManifest();
+            var rows = Rows(document.RootElement).ToArray();
+
+            Assert.Equal(15, rows.Count(row => row.GetProperty("status").GetString() == "live_production"));
+            Assert.Single(rows.Where(row => row.GetProperty("status").GetString() == "provider_capable_dormant"));
+            Assert.Empty(rows.Where(row => row.GetProperty("status").GetString() == "dead_with_proof"));
+        }
+
+        [Theory]
+        [InlineData("game.delivery.success-improvement", "DeliveryStage.cs", "GetSuccessImprovementAsync")]
+        [InlineData("game.delivery.horniness-question", "DeliveryStage.cs", "GetHorninessQuestionAsync")]
+        [InlineData("game.delivery.steering-question", "SteeringEngine.cs", "GetSteeringQuestionAsync")]
+        public void ThreeAmendedLiveDeliveryRowsBindToConfirmedProductionPaths(
+            string id,
+            string expectedFile,
+            string expectedPattern)
+        {
+            JsonElement row = Row(id);
+
+            Assert.Equal("live_production", row.GetProperty("status").GetString());
+            Assert.Contains(row.GetProperty("implementation_matchers").EnumerateArray(), matcher =>
+                matcher.TryGetProperty("file", out JsonElement file)
+                && file.GetString()!.EndsWith(expectedFile, StringComparison.Ordinal)
+                && matcher.TryGetProperty("pattern", out JsonElement pattern)
+                && pattern.GetString()!.Contains(expectedPattern, StringComparison.Ordinal));
+            Assert.DoesNotContain("agent_session_id", StringArray(row, "required_owner_ids"));
+        }
+
+        [Fact]
+        public void DormantInterestChangeRowHasNoCallerActivationGuard()
+        {
+            JsonElement row = Row("game.datee.interest-change-beat");
+
+            Assert.Equal("provider_capable_dormant", row.GetProperty("status").GetString());
+            string activationRule = row.GetProperty("activation_rule").GetString()!;
+            Assert.Contains("fails", activationRule, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("planning", activationRule, StringComparison.OrdinalIgnoreCase);
+
+            JsonElement noCallerMatcher = Assert.Single(
+                row.GetProperty("implementation_matchers").EnumerateArray(),
+                matcher => matcher.GetProperty("kind").GetString() == "no_production_caller");
+            Assert.Equal("GetInterestChangeBeatAsync\\(", noCallerMatcher.GetProperty("pattern").GetString());
+
+            string[] allowedFiles = noCallerMatcher.GetProperty("allowed_files")
+                .EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToArray();
+            Assert.Contains("src/Pinder.LlmAdapters/PinderLlmAdapter.cs", allowedFiles);
+            Assert.Contains("src/Pinder.Core/Interfaces/ILlmAdapter.cs", allowedFiles);
+            Assert.Contains("src/Pinder.Core/Conversation/NullLlmAdapter.cs", allowedFiles);
+        }
+
+        [Fact]
+        public void GameRunAndNonGameRunRowsCannotExchangeOwnerIds()
+        {
+            using var document = LoadManifest();
+            foreach (JsonElement row in Rows(document.RootElement))
+            {
+                string id = row.GetProperty("id").GetString()!;
+                string[] requiredOwnerIds = StringArray(row, "required_owner_ids");
+                string[] requiredCorrelationIds = StringArray(row, "required_correlation_ids");
+                string[] forbiddenOwnerIds = StringArray(row, "forbidden_owner_ids");
+
+                if (id.StartsWith("game.", StringComparison.Ordinal))
+                {
+                    Assert.Contains("game_run_id", requiredOwnerIds);
+                    Assert.Contains("game_run_id", requiredCorrelationIds);
+                    Assert.DoesNotContain("game_run_id", forbiddenOwnerIds);
+                }
+                else
+                {
+                    Assert.DoesNotContain("game_run_id", requiredOwnerIds);
+                    Assert.DoesNotContain("game_run_id", requiredCorrelationIds);
+                    Assert.Contains("game_run_id", forbiddenOwnerIds);
+                }
+            }
+        }
+
+        [Fact]
+        public void WebOwnedRowsHaveCheckedInReviewAnchors()
+        {
+            string docs = File.ReadAllText(Path.Combine(RepoRoot(), "docs", "agent-journal-invocation-ownership.md"));
+
+            foreach (string id in new[] { "admin.temporary-chat", "admin.prompt-speculation" })
+            {
+                JsonElement row = Row(id);
+                JsonElement matcher = Assert.Single(row.GetProperty("implementation_matchers").EnumerateArray());
+                Assert.Equal("web_review_anchor", matcher.GetProperty("kind").GetString());
+                string anchor = matcher.GetProperty("anchor").GetString()!;
+                Assert.Contains(anchor, docs, StringComparison.Ordinal);
+                Assert.Contains("admin_execution_id", StringArray(row, "required_owner_ids"));
+                Assert.Contains("game_run_id", StringArray(row, "forbidden_owner_ids"));
+            }
+        }
+
+        private static JsonElement Row(string id)
+        {
+            using JsonDocument document = LoadManifest();
+            JsonElement match = Rows(document.RootElement).Single(row => row.GetProperty("id").GetString() == id);
+            return match.Clone();
+        }
+
+        private static IEnumerable<JsonElement> Rows(JsonElement root) =>
+            root.GetProperty("rows").EnumerateArray();
+
+        private static string[] StringArray(JsonElement row, string property) =>
+            row.GetProperty(property).EnumerateArray().Select(value => value.GetString()!).ToArray();
+
+        private static JsonDocument LoadManifest() =>
+            JsonDocument.Parse(File.ReadAllText(Path.Combine(
+                RepoRoot(),
+                "contracts",
+                "agent-journal-invocation-ownership.v1.json")));
+
+        private static string RepoRoot()
+        {
+            string? current = AppContext.BaseDirectory;
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (File.Exists(Path.Combine(current, "Pinder.Core.sln"))
+                    && Directory.Exists(Path.Combine(current, "contracts")))
+                {
+                    return current;
+                }
+
+                current = Directory.GetParent(current)?.FullName;
+            }
+
+            throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #1373. Adds the reviewed 16-row invocation ownership taxonomy, dormant activation guard, static path matcher, tests, and host-compatible verifier. No GitHub CI.