### PR TITLE
feat: add annotated invocation provenance

### DIFF
--- a/scripts/verify-agent-journal-provenance-mechanism.ps1
+++ b/scripts/verify-agent-journal-provenance-mechanism.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+
+$script = Join-Path $PSScriptRoot "verify-agent-journal-provenance-mechanism.sh"
+if (!(Test-Path $script)) {
+    throw "Missing verifier script: $script"
+}
+
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($null -eq $bash) {
+    throw "bash is required to run $script on this host."
+}
+
+& $bash.Source $script @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    exit $exitCode
+}
+
+exit 0

--- a/scripts/verify-agent-journal-provenance-mechanism.sh
+++ b/scripts/verify-agent-journal-provenance-mechanism.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo"
+
+results_dir="${RESULTS_DIR:-$repo/TestResults/agent-journal-provenance-mechanism}"
+trx_name="agent-journal-provenance-mechanism.trx"
+trx_path="$results_dir/$trx_name"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+section "scope/no-call-site modification check"
+allowed_paths=(
+  "src/Pinder.Core/Text/AnnotatedInvocationDocument.cs"
+  "src/Pinder.Core/Text/AnnotatedInvocationDocumentBuilder.cs"
+  "src/Pinder.LlmAdapters/AgentJournals/PromptProvenanceAdapter.cs"
+  "tests/Pinder.LlmAdapters.Tests/AgentJournals/Provenance/AnnotatedInvocationDocumentTests.cs"
+  "scripts/verify-agent-journal-provenance-mechanism.sh"
+  "scripts/verify-agent-journal-provenance-mechanism.ps1"
+)
+
+is_allowed_path() {
+  local candidate="$1"
+  local allowed
+  for allowed in "${allowed_paths[@]}"; do
+    if [[ "$candidate" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+changed_paths="$(
+  {
+    git diff --name-only --diff-filter=ACMRTUXB
+    git ls-files --others --exclude-standard
+  } | sort -u
+)"
+
+scope_errors=0
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  case "$path" in
+    *.orig|*.rej)
+      printf 'quarantine artifact ignored: %s\n' "$path"
+      continue
+      ;;
+  esac
+  if is_allowed_path "$path"; then
+    printf 'owned change: %s\n' "$path"
+  else
+    printf 'unexpected change outside CORE-1374 ownership: %s\n' "$path" >&2
+    scope_errors=1
+  fi
+done <<< "$changed_paths"
+if [[ "$scope_errors" -ne 0 ]]; then
+  exit 20
+fi
+
+section "netstandard release builds"
+dotnet build src/Pinder.Core/Pinder.Core.csproj --configuration Release --nologo
+dotnet build src/Pinder.LlmAdapters/Pinder.LlmAdapters.csproj --configuration Release --nologo
+
+section "focused provenance and #1370 regression tests"
+mkdir -p "$results_dir"
+dotnet test tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj \
+  --configuration Release \
+  --filter "FullyQualifiedName~AnnotatedInvocationDocumentTests|FullyQualifiedName~AgentJournalPiCodecRoundTripTests|FullyQualifiedName~AgentJournalPiContextIsolationTests" \
+  --logger "trx;LogFileName=$trx_name" \
+  --results-directory "$results_dir" \
+  --nologo
+
+section "AC group, #1370, and fixture/hash determinism counts"
+python3 - "$trx_path" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+trx_path = sys.argv[1]
+root = ET.parse(trx_path).getroot()
+ns = {"trx": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+results = root.findall(".//trx:UnitTestResult", ns)
+if not results:
+    raise SystemExit("TRX contained zero executed tests")
+
+def name(result):
+    return result.attrib.get("testName", "")
+
+def count_contains(fragment):
+    return sum(1 for result in results if fragment in name(result))
+
+failures = []
+for group in ("AC1_", "AC2_", "AC3_", "AC4_", "AC5_"):
+    count = count_contains(group)
+    print(f"{group}tests={count}")
+    if count == 0:
+        failures.append(f"{group} had zero tests")
+
+ac2_raw_identity = count_contains(
+    "AC2_AdjacentMergeableRangesWithWrongDocumentId_ReportRangeDocumentMismatch"
+)
+print(f"ac2_raw_range_identity_regression_tests={ac2_raw_identity}")
+if ac2_raw_identity != 1:
+    failures.append(
+        f"raw-range identity regression expected 1 test, found {ac2_raw_identity}")
+
+round_trip = (
+    count_contains("Invocation_RoundTripsThroughPiCustomEntryAndMatchesFixture")
+    + count_contains("Result_RoundTripsThroughPiCustomEntryAndMatchesFixture")
+    + count_contains("MessageLink_RoundTripsThroughPiCustomEntryAndMatchesFixture")
+)
+context_isolation = count_contains("DiagnosticEntries_ContributeZeroMessagesThroughPiSessionContextBuilder")
+fixture_hash = count_contains("AC4_CanonicalJsonAndHash_AreStableAcrossRuns")
+print(f"issue1370_round_trip_tests={round_trip}")
+print(f"issue1370_context_isolation_tests={context_isolation}")
+print(f"fixture_hash_determinism_tests={fixture_hash}")
+if round_trip == 0:
+    failures.append("#1370 round-trip/context fixture tests had zero tests")
+if context_isolation == 0:
+    failures.append("#1370 context isolation tests had zero tests")
+if fixture_hash == 0:
+    failures.append("fixture/hash determinism tests had zero tests")
+
+outcomes = {}
+for result in results:
+    outcome = result.attrib.get("outcome", "unknown")
+    outcomes[outcome] = outcomes.get(outcome, 0) + 1
+print("outcomes=" + ",".join(f"{key}:{outcomes[key]}" for key in sorted(outcomes)))
+for result in results:
+    if result.attrib.get("outcome") != "Passed":
+        failures.append(f"{name(result)} outcome={result.attrib.get('outcome')}")
+if failures:
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    raise SystemExit(21)
+PY
+
+section "git diff check"
+git diff --check
+
+section "verifier complete"
+printf 'trx=%s\n' "$trx_path"

--- a/src/Pinder.Core/Text/AnnotatedInvocationDocument.cs
+++ b/src/Pinder.Core/Text/AnnotatedInvocationDocument.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Pinder.Core.Diagnostics.AgentJournals;
+
+namespace Pinder.Core.Text
+{
+    public sealed class AnnotatedInvocationDocument
+    {
+        private AnnotatedInvocationDocument(
+            string documentId,
+            AgentJournalInputRole role,
+            string kind,
+            string text,
+            IReadOnlyList<AgentJournalProvenanceRange> ranges)
+        {
+            DocumentId = documentId ?? throw new ArgumentNullException(nameof(documentId));
+            Role = role;
+            Kind = kind ?? throw new ArgumentNullException(nameof(kind));
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+            IReadOnlyList<AgentJournalProvenanceRange> rawRanges =
+                (ranges ?? throw new ArgumentNullException(nameof(ranges))).ToArray();
+            ValidationResult = ValidateDocument(DocumentId, Role, Kind, Text, rawRanges);
+            Ranges = ValidationResult.IsValid
+                ? CanonicalizeRanges(rawRanges)
+                : rawRanges;
+            ContentHash = ComputeSha256(Text);
+        }
+
+        public string DocumentId { get; }
+        public AgentJournalInputRole Role { get; }
+        public string Kind { get; }
+        public string Text { get; }
+        public IReadOnlyList<AgentJournalProvenanceRange> Ranges { get; }
+        public string ContentHash { get; }
+        public AgentJournalValidationResult ValidationResult { get; }
+
+        public static AnnotatedInvocationDocument Create(
+            string documentId,
+            AgentJournalInputRole role,
+            string kind,
+            string text,
+            IReadOnlyList<AgentJournalProvenanceRange> ranges)
+            => new AnnotatedInvocationDocument(documentId, role, kind, text, ranges);
+
+        public AgentJournalInputDocument ToAgentJournalInputDocument()
+        {
+            if (!ValidationResult.IsValid)
+            {
+                throw new InvalidOperationException("Cannot convert invalid annotated invocation document.");
+            }
+
+            return new AgentJournalInputDocument(DocumentId, Role, Text, Ranges);
+        }
+
+        public string GetCanonicalJson()
+            => AgentJournalJson.Serialize(new CanonicalDocument(
+                DocumentId,
+                Role,
+                Kind,
+                Text,
+                ContentHash,
+                Ranges));
+
+        public string GetCanonicalHash()
+            => ComputeSha256(GetCanonicalJson());
+
+        internal static AgentJournalSourceIdentity RuntimeGeneratedSource(string keyPath)
+            => new AgentJournalSourceIdentity(
+                AgentJournalSourceKind.RuntimeGenerated,
+                "runtime",
+                string.IsNullOrWhiteSpace(keyPath) ? "generated" : keyPath);
+
+        internal static string ComputeSha256(string value)
+        {
+            using (SHA256 sha = SHA256.Create())
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+                byte[] hash = sha.ComputeHash(bytes);
+                var builder = new StringBuilder("sha256:", "sha256:".Length + hash.Length * 2);
+                for (int i = 0; i < hash.Length; i++)
+                {
+                    builder.Append(hash[i].ToString("x2"));
+                }
+
+                return builder.ToString();
+            }
+        }
+
+        private static AgentJournalValidationResult ValidateDocument(
+            string documentId,
+            AgentJournalInputRole role,
+            string kind,
+            string text,
+            IReadOnlyList<AgentJournalProvenanceRange> ranges)
+        {
+            var errors = new List<AgentJournalValidationError>();
+            AddMissing(documentId, "$.document_id", errors);
+            AddMissing(kind, "$.kind", errors);
+            if (AgentJournalSourceIdentifierPolicy.GetErrorCode(kind) != null)
+            {
+                errors.Add(new AgentJournalValidationError(
+                    AgentJournalValidator.ForbiddenSourceLink,
+                    "$.kind"));
+            }
+
+            var invocation = new LlmInvocationRecord(
+                new AgentJournalCorrelationIds(
+                    "validation-game-run",
+                    "validation-agent-session",
+                    "validation-invocation",
+                    "validation-operation",
+                    1,
+                    attemptId: "validation-attempt"),
+                "validation-model",
+                "validation_phase",
+                new[] { new AgentJournalInputDocument(documentId, role, text, ranges) });
+            errors.AddRange(AgentJournalValidator.Validate(invocation).Errors);
+
+            for (int i = 0; i < ranges.Count; i++)
+            {
+                AgentJournalProvenanceRange range = ranges[i];
+                if (range == null)
+                {
+                    continue;
+                }
+
+                string path = "$.ranges[" + i + "]";
+                ValidateClassification(range, path, errors);
+                ValidateRevision(range, path, errors);
+            }
+
+            return AgentJournalValidationResult.From(errors);
+        }
+
+        private static void ValidateClassification(
+            AgentJournalProvenanceRange range,
+            string path,
+            ICollection<AgentJournalValidationError> errors)
+        {
+            if (!Enum.IsDefined(typeof(AgentJournalRangeKind), range.RangeKind)
+                || !Enum.IsDefined(typeof(AgentJournalSourceKind), range.Source.Kind))
+            {
+                return;
+            }
+
+            if (range.RangeKind == AgentJournalRangeKind.RuntimeGenerated)
+            {
+                if (range.Source.Kind != AgentJournalSourceKind.RuntimeGenerated)
+                {
+                    errors.Add(new AgentJournalValidationError(
+                        AgentJournalValidator.InvalidSourceKind,
+                        path + ".source.kind"));
+                }
+
+                return;
+            }
+
+            if (range.RangeKind == AgentJournalRangeKind.Configured)
+            {
+                if (range.Source.Kind != AgentJournalSourceKind.Configuration
+                    && range.Source.Kind != AgentJournalSourceKind.Catalog)
+                {
+                    errors.Add(new AgentJournalValidationError(
+                        AgentJournalValidator.InvalidSourceKind,
+                        path + ".source.kind"));
+                }
+            }
+        }
+
+        private static void ValidateRevision(
+            AgentJournalProvenanceRange range,
+            string path,
+            ICollection<AgentJournalValidationError> errors)
+        {
+            if (!Enum.IsDefined(typeof(AgentJournalRangeKind), range.RangeKind)
+                || range.RangeKind != AgentJournalRangeKind.Configured)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(range.Source.Revision)
+                && string.IsNullOrWhiteSpace(range.Source.ContentHash))
+            {
+                errors.Add(new AgentJournalValidationError(
+                    AgentJournalValidator.MissingId,
+                    path + ".source.revision"));
+            }
+        }
+
+        private static void AddMissing(
+            string? value,
+            string path,
+            ICollection<AgentJournalValidationError> errors)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                errors.Add(new AgentJournalValidationError(AgentJournalValidator.MissingId, path));
+            }
+        }
+
+        private static IReadOnlyList<AgentJournalProvenanceRange> CanonicalizeRanges(
+            IReadOnlyList<AgentJournalProvenanceRange> ranges)
+        {
+            var canonical = new List<AgentJournalProvenanceRange>();
+            foreach (AgentJournalProvenanceRange range in ranges)
+            {
+                if (range == null)
+                {
+                    canonical.Add(range!);
+                    continue;
+                }
+
+                if (canonical.Count == 0)
+                {
+                    canonical.Add(range);
+                    continue;
+                }
+
+                AgentJournalProvenanceRange previous = canonical[canonical.Count - 1];
+                if (previous != null
+                    && previous.EndUtf16 == range.StartUtf16
+                    && previous.EndUtf16 > previous.StartUtf16
+                    && range.EndUtf16 > range.StartUtf16
+                    && RangeIdentityEquals(previous, range))
+                {
+                    canonical[canonical.Count - 1] = new AgentJournalProvenanceRange(
+                        previous.DocumentId,
+                        previous.StartUtf16,
+                        range.EndUtf16,
+                        previous.RangeKind,
+                        previous.RedactionClass,
+                        previous.Source);
+                }
+                else
+                {
+                    canonical.Add(range);
+                }
+            }
+
+            return canonical.ToArray();
+        }
+
+        private static bool RangeIdentityEquals(
+            AgentJournalProvenanceRange left,
+            AgentJournalProvenanceRange right)
+            => string.Equals(left.DocumentId, right.DocumentId, StringComparison.Ordinal)
+                && left.RangeKind == right.RangeKind
+                && left.RedactionClass == right.RedactionClass
+                && SourceEquals(left.Source, right.Source);
+
+        private static bool SourceEquals(
+            AgentJournalSourceIdentity left,
+            AgentJournalSourceIdentity right)
+            => left.Kind == right.Kind
+                && string.Equals(left.SourceId, right.SourceId, StringComparison.Ordinal)
+                && string.Equals(left.KeyPath, right.KeyPath, StringComparison.Ordinal)
+                && string.Equals(left.Revision, right.Revision, StringComparison.Ordinal)
+                && string.Equals(left.ContentHash, right.ContentHash, StringComparison.Ordinal)
+                && string.Equals(left.EditorTargetId, right.EditorTargetId, StringComparison.Ordinal);
+
+        private sealed class CanonicalDocument
+        {
+            public CanonicalDocument(
+                string documentId,
+                AgentJournalInputRole role,
+                string kind,
+                string text,
+                string contentHash,
+                IReadOnlyList<AgentJournalProvenanceRange> ranges)
+            {
+                DocumentId = documentId;
+                Role = role;
+                Kind = kind;
+                Text = text;
+                ContentHash = contentHash;
+                Ranges = ranges.Select(CanonicalRange.From).ToArray();
+            }
+
+            public string DocumentId { get; }
+            public AgentJournalInputRole Role { get; }
+            public string Kind { get; }
+            public string Text { get; }
+            public string ContentHash { get; }
+            public IReadOnlyList<CanonicalRange> Ranges { get; }
+        }
+
+        private sealed class CanonicalRange
+        {
+            private CanonicalRange(
+                string documentId,
+                int startUtf16,
+                int endUtf16,
+                AgentJournalRangeKind rangeKind,
+                AgentJournalRedactionClass redactionClass,
+                CanonicalSource source)
+            {
+                DocumentId = documentId;
+                StartUtf16 = startUtf16;
+                EndUtf16 = endUtf16;
+                RangeKind = rangeKind;
+                RedactionClass = redactionClass;
+                Source = source;
+            }
+
+            public string DocumentId { get; }
+            public int StartUtf16 { get; }
+            public int EndUtf16 { get; }
+            public AgentJournalRangeKind RangeKind { get; }
+            public AgentJournalRedactionClass RedactionClass { get; }
+            public CanonicalSource Source { get; }
+
+            public static CanonicalRange From(AgentJournalProvenanceRange range)
+                => new CanonicalRange(
+                    range.DocumentId,
+                    range.StartUtf16,
+                    range.EndUtf16,
+                    range.RangeKind,
+                    range.RedactionClass,
+                    CanonicalSource.From(range.Source));
+        }
+
+        private sealed class CanonicalSource
+        {
+            private CanonicalSource(
+                AgentJournalSourceKind kind,
+                string sourceId,
+                string keyPath,
+                string? revision,
+                string? contentHash,
+                string? editorTargetId)
+            {
+                Kind = kind;
+                SourceId = sourceId;
+                KeyPath = keyPath;
+                Revision = revision;
+                ContentHash = contentHash;
+                EditorTargetId = editorTargetId;
+            }
+
+            public AgentJournalSourceKind Kind { get; }
+            public string SourceId { get; }
+            public string KeyPath { get; }
+            public string? Revision { get; }
+            public string? ContentHash { get; }
+            public string? EditorTargetId { get; }
+
+            public static CanonicalSource From(AgentJournalSourceIdentity source)
+                => new CanonicalSource(
+                    source.Kind,
+                    source.SourceId,
+                    source.KeyPath,
+                    source.Revision,
+                    source.ContentHash,
+                    source.EditorTargetId);
+        }
+    }
+}

--- a/src/Pinder.Core/Text/AnnotatedInvocationDocumentBuilder.cs
+++ b/src/Pinder.Core/Text/AnnotatedInvocationDocumentBuilder.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Pinder.Core.Diagnostics.AgentJournals;
+
+namespace Pinder.Core.Text
+{
+    public sealed class AnnotatedInvocationDocumentBuilder
+    {
+        private readonly StringBuilder _text = new StringBuilder();
+        private readonly List<PendingRange> _ranges = new List<PendingRange>();
+
+        public int Length => _text.Length;
+
+        public AnnotatedInvocationDocumentBuilder Append(string? value)
+            => AppendRuntimeGenerated(value, "generated");
+
+        public AnnotatedInvocationDocumentBuilder AppendRuntimeGenerated(string? value, string keyPath = "generated")
+            => AppendRange(
+                value,
+                AgentJournalRangeKind.RuntimeGenerated,
+                AgentJournalRedactionClass.None,
+                AnnotatedInvocationDocument.RuntimeGeneratedSource(keyPath));
+
+        public AnnotatedInvocationDocumentBuilder AppendGeneratedLiteral(string? value, string keyPath = "literal")
+            => AppendRuntimeGenerated(value, keyPath);
+
+        public AnnotatedInvocationDocumentBuilder AppendConfigured(
+            string? value,
+            AgentJournalSourceIdentity source,
+            AgentJournalRedactionClass redactionClass = AgentJournalRedactionClass.SafeMetadata)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return AppendRange(value, AgentJournalRangeKind.Configured, redactionClass, source);
+        }
+
+        public AnnotatedInvocationDocumentBuilder AppendDocument(AnnotatedInvocationDocument? document)
+        {
+            if (document == null)
+            {
+                return this;
+            }
+
+            int offset = _text.Length;
+            _text.Append(document.Text);
+            for (int i = 0; i < document.Ranges.Count; i++)
+            {
+                AgentJournalProvenanceRange range = document.Ranges[i];
+                _ranges.Add(new PendingRange(
+                    offset + range.StartUtf16,
+                    offset + range.EndUtf16,
+                    range.RangeKind,
+                    range.RedactionClass,
+                    range.Source));
+            }
+
+            return this;
+        }
+
+        public AnnotatedInvocationDocumentBuilder AppendTemplate(
+            string template,
+            IReadOnlyDictionary<string, AnnotatedInvocationDocument> substitutions,
+            AgentJournalSourceIdentity templateSource)
+        {
+            if (template == null) throw new ArgumentNullException(nameof(template));
+            if (substitutions == null) throw new ArgumentNullException(nameof(substitutions));
+            if (templateSource == null) throw new ArgumentNullException(nameof(templateSource));
+
+            int literalStart = 0;
+            int cursor = 0;
+            while (cursor < template.Length)
+            {
+                int open = template.IndexOf('{', cursor);
+                if (open < 0)
+                {
+                    break;
+                }
+
+                int close = template.IndexOf('}', open + 1);
+                if (close < 0)
+                {
+                    break;
+                }
+
+                string key = template.Substring(open + 1, close - open - 1);
+                if (!substitutions.TryGetValue(key, out AnnotatedInvocationDocument? substitution))
+                {
+                    cursor = close + 1;
+                    continue;
+                }
+
+                AppendConfigured(template.Substring(literalStart, open - literalStart), templateSource);
+                AppendDocument(substitution);
+                cursor = close + 1;
+                literalStart = cursor;
+            }
+
+            AppendConfigured(template.Substring(literalStart), templateSource);
+            return this;
+        }
+
+        public AnnotatedInvocationDocumentBuilder Trim()
+        {
+            int originalLength = _text.Length;
+            if (originalLength == 0)
+            {
+                return this;
+            }
+
+            int start = 0;
+            while (start < originalLength && char.IsWhiteSpace(_text[start]))
+            {
+                start++;
+            }
+
+            int endExclusive = originalLength;
+            while (endExclusive > start && char.IsWhiteSpace(_text[endExclusive - 1]))
+            {
+                endExclusive--;
+            }
+
+            if (start == 0 && endExclusive == originalLength)
+            {
+                return this;
+            }
+
+            string trimmed = _text.ToString(start, endExclusive - start);
+            _text.Clear();
+            _text.Append(trimmed);
+
+            var adjusted = new List<PendingRange>();
+            for (int i = 0; i < _ranges.Count; i++)
+            {
+                PendingRange range = _ranges[i];
+                int clippedStart = Math.Max(range.StartUtf16, start);
+                int clippedEnd = Math.Min(range.EndUtf16, endExclusive);
+                if (clippedEnd <= clippedStart)
+                {
+                    continue;
+                }
+
+                adjusted.Add(new PendingRange(
+                    clippedStart - start,
+                    clippedEnd - start,
+                    range.RangeKind,
+                    range.RedactionClass,
+                    range.Source));
+            }
+
+            _ranges.Clear();
+            _ranges.AddRange(adjusted);
+            return this;
+        }
+
+        public AnnotatedInvocationDocument Build(
+            string documentId,
+            AgentJournalInputRole role,
+            string kind)
+        {
+            if (documentId == null) throw new ArgumentNullException(nameof(documentId));
+            if (kind == null) throw new ArgumentNullException(nameof(kind));
+            return AnnotatedInvocationDocument.Create(documentId, role, kind, _text.ToString(), ToRanges(documentId));
+        }
+
+        private AnnotatedInvocationDocumentBuilder AppendRange(
+            string? value,
+            AgentJournalRangeKind rangeKind,
+            AgentJournalRedactionClass redactionClass,
+            AgentJournalSourceIdentity source)
+        {
+            if (value == null || value.Length == 0)
+            {
+                return this;
+            }
+
+            int start = _text.Length;
+            _text.Append(value);
+            _ranges.Add(new PendingRange(start, _text.Length, rangeKind, redactionClass, source));
+            return this;
+        }
+
+        private AgentJournalProvenanceRange[] ToRanges(string documentId)
+        {
+            var ranges = new List<AgentJournalProvenanceRange>();
+            for (int i = 0; i < _ranges.Count; i++)
+            {
+                PendingRange range = _ranges[i];
+                if (range.EndUtf16 <= range.StartUtf16)
+                {
+                    continue;
+                }
+
+                if (ranges.Count > 0)
+                {
+                    AgentJournalProvenanceRange previous = ranges[ranges.Count - 1];
+                    if (previous.EndUtf16 == range.StartUtf16
+                        && previous.RangeKind == range.RangeKind
+                        && previous.RedactionClass == range.RedactionClass
+                        && SourceEquals(previous.Source, range.Source))
+                    {
+                        ranges[ranges.Count - 1] = new AgentJournalProvenanceRange(
+                            documentId,
+                            previous.StartUtf16,
+                            range.EndUtf16,
+                            previous.RangeKind,
+                            previous.RedactionClass,
+                            previous.Source);
+                        continue;
+                    }
+                }
+
+                ranges.Add(new AgentJournalProvenanceRange(
+                    documentId,
+                    range.StartUtf16,
+                    range.EndUtf16,
+                    range.RangeKind,
+                    range.RedactionClass,
+                    range.Source));
+            }
+
+            return ranges.ToArray();
+        }
+
+        private static bool SourceEquals(AgentJournalSourceIdentity left, AgentJournalSourceIdentity right)
+            => left.Kind == right.Kind
+                && string.Equals(left.SourceId, right.SourceId, StringComparison.Ordinal)
+                && string.Equals(left.KeyPath, right.KeyPath, StringComparison.Ordinal)
+                && string.Equals(left.Revision, right.Revision, StringComparison.Ordinal)
+                && string.Equals(left.ContentHash, right.ContentHash, StringComparison.Ordinal)
+                && string.Equals(left.EditorTargetId, right.EditorTargetId, StringComparison.Ordinal);
+
+        private sealed class PendingRange
+        {
+            public PendingRange(
+                int startUtf16,
+                int endUtf16,
+                AgentJournalRangeKind rangeKind,
+                AgentJournalRedactionClass redactionClass,
+                AgentJournalSourceIdentity source)
+            {
+                StartUtf16 = startUtf16;
+                EndUtf16 = endUtf16;
+                RangeKind = rangeKind;
+                RedactionClass = redactionClass;
+                Source = source;
+            }
+
+            public int StartUtf16 { get; }
+            public int EndUtf16 { get; }
+            public AgentJournalRangeKind RangeKind { get; }
+            public AgentJournalRedactionClass RedactionClass { get; }
+            public AgentJournalSourceIdentity Source { get; }
+        }
+    }
+}

--- a/src/Pinder.LlmAdapters/AgentJournals/PromptProvenanceAdapter.cs
+++ b/src/Pinder.LlmAdapters/AgentJournals/PromptProvenanceAdapter.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Pinder.Core.Diagnostics.AgentJournals;
+using Pinder.Core.Text;
+
+namespace Pinder.LlmAdapters.AgentJournals
+{
+    public static class PromptProvenanceAdapter
+    {
+        public const string LegacyMissingSourceRevision = "legacy-metadata-missing";
+
+        public static AnnotatedInvocationDocument FromPromptTraceResult(
+            PromptTraceResult trace,
+            string documentId,
+            AgentJournalInputRole role,
+            string kind,
+            IPromptTraceSourceIdentityResolver sourceIdentityResolver)
+        {
+            if (trace == null) throw new ArgumentNullException(nameof(trace));
+            if (documentId == null) throw new ArgumentNullException(nameof(documentId));
+            if (kind == null) throw new ArgumentNullException(nameof(kind));
+            if (sourceIdentityResolver == null) throw new ArgumentNullException(nameof(sourceIdentityResolver));
+
+            AgentJournalInputDocument legacyDocument = trace.ToAgentJournalInputDocument(
+                documentId,
+                role,
+                sourceIdentityResolver);
+            var ranges = new List<AgentJournalProvenanceRange>(legacyDocument.Ranges.Count);
+            for (int i = 0; i < legacyDocument.Ranges.Count; i++)
+            {
+                AgentJournalProvenanceRange range = legacyDocument.Ranges[i];
+                ranges.Add(new AgentJournalProvenanceRange(
+                    documentId,
+                    range.StartUtf16,
+                    range.EndUtf16,
+                    range.RangeKind,
+                    range.RedactionClass,
+                    AddLegacyMetadataMarker(range.Source, range.RangeKind)));
+            }
+
+            return AnnotatedInvocationDocument.Create(
+                documentId,
+                role,
+                kind,
+                legacyDocument.Text,
+                ranges);
+        }
+        private static AgentJournalSourceIdentity AddLegacyMetadataMarker(
+            AgentJournalSourceIdentity source,
+            AgentJournalRangeKind rangeKind)
+        {
+            if (rangeKind != AgentJournalRangeKind.Configured)
+            {
+                return source;
+            }
+
+            return new AgentJournalSourceIdentity(
+                source.Kind,
+                source.SourceId,
+                source.KeyPath,
+                revision: string.IsNullOrWhiteSpace(source.Revision)
+                    ? LegacyMissingSourceRevision
+                    : source.Revision,
+                contentHash: source.ContentHash,
+                editorTargetId: source.EditorTargetId);
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/AgentJournals/Provenance/AnnotatedInvocationDocumentTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/AgentJournals/Provenance/AnnotatedInvocationDocumentTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pinder.Core.Diagnostics.AgentJournals;
+using Pinder.Core.Text;
+using Pinder.LlmAdapters.AgentJournals;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.AgentJournals.Provenance
+{
+    public sealed class AnnotatedInvocationDocumentTests
+    {
+        private static readonly AgentJournalSourceIdentity TemplateSource =
+            new AgentJournalSourceIdentity(
+                AgentJournalSourceKind.Configuration,
+                "prompt.catalog",
+                "dialogue.template",
+                revision: "rev-template");
+
+        private static readonly AgentJournalSourceIdentity NameSource =
+            new AgentJournalSourceIdentity(
+                AgentJournalSourceKind.Catalog,
+                "character.catalog",
+                "datee.name",
+                contentHash: "sha256:name");
+
+        [Fact]
+        public void AC1_BuilderAppendSubstitutionAndTrim_PreserveExactTextAndUtf16Offsets()
+        {
+            AnnotatedInvocationDocument name = new AnnotatedInvocationDocumentBuilder()
+                .AppendConfigured("\U0001F600Ada", NameSource)
+                .Build("doc.name", AgentJournalInputRole.User, "fragment");
+            var substitutions = new Dictionary<string, AnnotatedInvocationDocument>(StringComparer.Ordinal)
+            {
+                ["name"] = name,
+            };
+
+            AnnotatedInvocationDocument document = new AnnotatedInvocationDocumentBuilder()
+                .AppendTemplate("Hello {name}. Again {name}.  ", substitutions, TemplateSource)
+                .Trim()
+                .Build("doc.user", AgentJournalInputRole.User, "dialogue-options");
+
+            Assert.Equal("Hello \U0001F600Ada. Again \U0001F600Ada.", document.Text);
+            Assert.True(document.ValidationResult.IsValid);
+            Assert.Equal(new[] { 0, 6, 11, 19, 24 }, document.Ranges.Select(range => range.StartUtf16).ToArray());
+            Assert.Equal(new[] { 6, 11, 19, 24, 25 }, document.Ranges.Select(range => range.EndUtf16).ToArray());
+            Assert.Equal(new[] { "dialogue.template", "datee.name", "dialogue.template", "datee.name", "dialogue.template" }, document.Ranges.Select(range => range.Source.KeyPath).ToArray());
+            Assert.Equal("sha256:177c1beffd5adbe4cc13fa8f3b6ee012aa7bf79ac1cf602cf44ee7d4504b4552", document.ContentHash);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidDocuments))]
+        public void AC2_ValidationRejectsDeterministicFalsifiers(
+            string label,
+            AnnotatedInvocationDocument document,
+            string expectedCode)
+        {
+            Assert.False(document.ValidationResult.IsValid);
+            Assert.Contains(document.ValidationResult.Errors, error => error.Code == expectedCode);
+            Assert.NotEmpty(label);
+        }
+
+        [Fact]
+        public void AC2_AdjacentMergeableRangesWithWrongDocumentId_ReportRangeDocumentMismatch()
+        {
+            var first = new AgentJournalProvenanceRange(
+                "doc.other",
+                0,
+                1,
+                AgentJournalRangeKind.Configured,
+                AgentJournalRedactionClass.SafeMetadata,
+                TemplateSource);
+            var second = new AgentJournalProvenanceRange(
+                "doc.other",
+                1,
+                3,
+                AgentJournalRangeKind.Configured,
+                AgentJournalRedactionClass.SafeMetadata,
+                TemplateSource);
+
+            AnnotatedInvocationDocument document = Create("abc", first, second);
+
+            Assert.False(document.ValidationResult.IsValid);
+            Assert.Contains(document.ValidationResult.Errors, error => error.Code == AgentJournalValidator.RangeDocumentMismatch);
+            Assert.Equal(2, document.Ranges.Count);
+            Assert.All(document.Ranges, range => Assert.Equal("doc.other", range.DocumentId));
+        }
+
+        [Fact]
+        public void AC3_PromptTraceResultAdapter_PreservesTextRangesAndMarksLegacyMetadata()
+        {
+            string text = "raw\U0001F600conf";
+            var trace = new PromptTraceResult(
+                text,
+                new[] { new AnnotatedSpan(5, 9, "data/prompts/structural.yaml", "dialogue.system") });
+
+            AnnotatedInvocationDocument document = PromptProvenanceAdapter.FromPromptTraceResult(
+                trace,
+                "doc.system",
+                AgentJournalInputRole.System,
+                "system-prompt",
+                PromptTraceResolver.Map("data/prompts/structural.yaml", "prompt.catalog"));
+
+            Assert.Equal(text, document.Text);
+            Assert.True(document.ValidationResult.IsValid);
+            Assert.Equal(new[] { 0, 5 }, document.Ranges.Select(range => range.StartUtf16).ToArray());
+            Assert.Equal(new[] { 5, 9 }, document.Ranges.Select(range => range.EndUtf16).ToArray());
+            Assert.Equal(AgentJournalRangeKind.RuntimeGenerated, document.Ranges[0].RangeKind);
+            Assert.Equal(AgentJournalRangeKind.Configured, document.Ranges[1].RangeKind);
+            Assert.Equal(PromptProvenanceAdapter.LegacyMissingSourceRevision, document.Ranges[1].Source.Revision);
+        }
+
+        [Fact]
+        public void AC4_CanonicalJsonAndHash_AreStableAcrossRuns()
+        {
+            AnnotatedInvocationDocument first = StableDocument();
+            AnnotatedInvocationDocument second = StableDocument();
+
+            Assert.Equal(first.GetCanonicalJson(), second.GetCanonicalJson());
+            Assert.Equal(first.GetCanonicalHash(), second.GetCanonicalHash());
+            Assert.Equal(
+                "{\"document_id\":\"doc.system\",\"role\":\"system\",\"kind\":\"system-prompt\",\"text\":\"alpha\",\"content_hash\":\"sha256:8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8\",\"ranges\":[{\"document_id\":\"doc.system\",\"start_utf16\":0,\"end_utf16\":5,\"range_kind\":\"configured\",\"redaction_class\":\"safe_metadata\",\"source\":{\"kind\":\"configuration\",\"source_id\":\"prompt.catalog\",\"key_path\":\"dialogue.template\",\"revision\":\"rev-template\"}}]}",
+                first.GetCanonicalJson());
+            Assert.Equal("sha256:e9314a0ea17c9b6c9b4c1aea246298875e6bafda69f796bbe46bcfb48a84f3e5", first.GetCanonicalHash());
+        }
+
+        [Fact]
+        public void AC5_ConversionToIssue1370InputDocument_PreservesContractValidity()
+        {
+            AnnotatedInvocationDocument document = StableDocument();
+
+            AgentJournalInputDocument input = document.ToAgentJournalInputDocument();
+            var invocation = new LlmInvocationRecord(
+                new AgentJournalCorrelationIds("game-run-001", "agent-session-datee", "invocation-001", "operation-001", 1, attemptId: "attempt-001"),
+                "test-model",
+                "dialogue_options",
+                new[] { input });
+
+            Assert.True(AgentJournalValidator.Validate(invocation).IsValid);
+            Assert.Equal(document.Text, input.Text);
+            Assert.Equal(document.Ranges.Select(range => range.StartUtf16), input.Ranges.Select(range => range.StartUtf16));
+        }
+
+        public static IEnumerable<object[]> InvalidDocuments()
+        {
+            yield return new object[]
+            {
+                "gap",
+                Create("abc", Range(0, 1), Range(2, 3)),
+                AgentJournalValidator.MissingRange,
+            };
+            yield return new object[]
+            {
+                "out-of-bounds",
+                Create("abc", Range(0, 4)),
+                AgentJournalValidator.OutOfBoundsRange,
+            };
+            yield return new object[]
+            {
+                "zero-length",
+                Create("abc", Range(0, 0), Range(0, 3)),
+                AgentJournalValidator.ZeroLengthRange,
+            };
+            yield return new object[]
+            {
+                "overlap",
+                Create("abc", Range(0, 2), Range(1, 3)),
+                AgentJournalValidator.OverlappingRange,
+            };
+            yield return new object[]
+            {
+                "missing-revision",
+                Create("abc", Range(0, 3, new AgentJournalSourceIdentity(AgentJournalSourceKind.Configuration, "prompt.catalog", "dialogue.template"))),
+                AgentJournalValidator.MissingId,
+            };
+            yield return new object[]
+            {
+                "invalid-classification",
+                Create("abc", Range(0, 3, TemplateSource, AgentJournalRangeKind.RuntimeGenerated)),
+                AgentJournalValidator.InvalidSourceKind,
+            };
+        }
+
+        private static AnnotatedInvocationDocument StableDocument()
+            => new AnnotatedInvocationDocumentBuilder()
+                .AppendConfigured("alpha", TemplateSource)
+                .Build("doc.system", AgentJournalInputRole.System, "system-prompt");
+
+        private static AnnotatedInvocationDocument Create(
+            string text,
+            params AgentJournalProvenanceRange[] ranges)
+            => AnnotatedInvocationDocument.Create(
+                "doc.test",
+                AgentJournalInputRole.System,
+                "test-kind",
+                text,
+                ranges);
+
+        private static AgentJournalProvenanceRange Range(
+            int start,
+            int end,
+            AgentJournalSourceIdentity? source = null,
+            AgentJournalRangeKind rangeKind = AgentJournalRangeKind.Configured)
+            => new AgentJournalProvenanceRange(
+                "doc.test",
+                start,
+                end,
+                rangeKind,
+                rangeKind == AgentJournalRangeKind.Configured
+                    ? AgentJournalRedactionClass.SafeMetadata
+                    : AgentJournalRedactionClass.None,
+                source ?? TemplateSource);
+
+        private sealed class PromptTraceResolver : IPromptTraceSourceIdentityResolver
+        {
+            private readonly string _sourceFile;
+            private readonly string _sourceId;
+
+            private PromptTraceResolver(string sourceFile, string sourceId)
+            {
+                _sourceFile = sourceFile;
+                _sourceId = sourceId;
+            }
+
+            public static PromptTraceResolver Map(string sourceFile, string sourceId)
+                => new PromptTraceResolver(sourceFile, sourceId);
+
+            public bool TryResolve(string? annotatedSourceFile, out string? sourceId)
+            {
+                if (string.Equals(annotatedSourceFile, _sourceFile, StringComparison.Ordinal))
+                {
+                    sourceId = _sourceId;
+                    return true;
+                }
+
+                sourceId = null;
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1374. Adds the immutable annotated invocation document and builder, validated UTF-16 provenance transforms, PromptTrace adapter, regression fixtures, and host-compatible verifier. No GitHub CI.