### PR TITLE
feat: add agent journal recorder lifecycle

### DIFF
--- a/scripts/verify-issue-1371.ps1
+++ b/scripts/verify-issue-1371.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = "Stop"
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..")
+$script = Join-Path $repo "scripts/verify-issue-1371.sh"
+& bash $script
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/verify-issue-1371.sh
+++ b/scripts/verify-issue-1371.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo"
+
+results_dir="$repo/TestResults/issue-1371"
+mkdir -p "$results_dir"
+
+trx="$results_dir/agent-journal-recorder.trx"
+dotnet test "tests/Pinder.LlmAdapters.Tests/Pinder.LlmAdapters.Tests.csproj" \
+  --filter "FullyQualifiedName~AgentJournals.Recording" \
+  --results-directory "$results_dir" \
+  --logger "trx;LogFileName=agent-journal-recorder.trx"
+
+if [[ ! -f "$trx" ]]; then
+  echo "TRX was not produced: $trx" >&2
+  exit 1
+fi
+
+python3 - "$trx" <<'PYVERIFY'
+import sys
+import xml.etree.ElementTree as ET
+
+trx = sys.argv[1]
+ns = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+root = ET.parse(trx).getroot()
+unit_names = []
+result_names = []
+for unit in root.findall(".//t:UnitTest", ns):
+    method = unit.find("t:TestMethod", ns)
+    if method is not None:
+        unit_names.append(method.attrib.get("className", "") + "." + method.attrib.get("name", ""))
+for result in root.findall(".//t:UnitTestResult", ns):
+    result_names.append(result.attrib.get("testName", ""))
+
+checks = {
+    "AC1 dual projection identity": [
+        ["StartAndAcceptedCompletion_ProjectSameRecordInstancesToPiAndHost"],
+        ["RecorderProjection_AppendsJournalCustomEntriesWithoutProviderContext"],
+    ],
+    "AC2 accepted terminal": [["TerminalMatrix_EmitsExactlyOneTerminalResult", "accepted"]],
+    "AC2 validation rejected terminal": [["TerminalMatrix_EmitsExactlyOneTerminalResult", "validation_rejected"]],
+    "AC2 provider failed terminal": [["TerminalMatrix_EmitsExactlyOneTerminalResult", "provider_failed"]],
+    "AC2 cancelled terminal": [["TerminalMatrix_EmitsExactlyOneTerminalResult", "cancelled"]],
+    "AC2 disposed abandoned terminal": [["DisposeWithoutCompletion_EmitsAbandonedOnce"]],
+    "AC3 idempotency and separate attempts": [["StableRecordIds_MakeDuplicateHostDeliveryIdempotent"]],
+    "AC4 best effort sink policy": [["BestEffortSinkFailure_EmitsDiagnosticAndPreservesTerminalState"]],
+    "AC4 fail closed sink policy": [["FailClosedSinkFailure_ThrowsTypedPersistenceFailureBeforeAcceptance"]],
+    "AC4 sink-after-Pi retry matrix": [["SinkPolicyAfterPiProjectionMatrix_FailClosedRetriesHostWithoutDuplicatePiProjection"]],
+    "AC4 invocation start post-Pi retry": [["InvocationStartPostPiHostFailure_RetryIsSingleFlightAndReturnsSameAttempt"]],
+    "AC4 explicit start retry contract": [["RetryStartWithoutPendingInvocation_FailsExplicitly"]],
+    "AC5 Pi projection failure": [["PiProjectionFailure_PreventsSuccessfulJournalCommit"]],
+    "AC5 failed terminal retry": [["FailedTerminalProjection_DoesNotCacheCompletionAndCanRetry"]],
+    "AC5 validation-before-cache retry": [["InvalidTerminalPayload_DoesNotCacheCompletionBeforeValidationSucceeds"]],
+    "AC6 cancellation bound": [["CancelledTerminalCleanup_UsesBoundedIndependentToken"]],
+    "AC7 immutable input snapshot": [["InvocationSnapshot_IsolatedFromCallerDocumentAndRangeMutation"]],
+    "AC7 context isolation": [["RecorderProjection_AppendsJournalCustomEntriesWithoutProviderContext"]],
+    "AC7 null Agent Session projection": [["NullAgentSession_SkipsPiProjectionButStillAllowsHostSink"]],
+}
+
+all_names = unit_names + result_names
+for label, groups in checks.items():
+    total = 0
+    for needles in groups:
+        count = sum(1 for name in all_names if all(needle in name for needle in needles))
+        if count < 1:
+            raise SystemExit(f"{label} matched zero tests for {needles} in {trx}")
+        total += count
+    print(f"{label}: {total}")
+PYVERIFY
+
+dotnet build Pinder.Core.sln
+
+scan_files=(
+  "src/Pinder.Core/Diagnostics/AgentJournals/AgentJournalRecorder.cs"
+  "src/Pinder.Core/Diagnostics/AgentJournals/IAgentJournalSink.cs"
+)
+
+for f in "${scan_files[@]}"; do
+  [[ -f "$f" ]] || { echo "Missing recorder file: $f" >&2; exit 1; }
+done
+
+if rg -n "Anthropic|OpenAI|Gemini|Claude|ILlmTransport|LlmTransport|Pinder\\.LlmAdapters|Pi\\.Agent|Pi\\.AI|HttpClient|provider-specific" "${scan_files[@]}"; then
+  echo "Provider-specific namespace/type leaked into provider-neutral recorder." >&2
+  exit 1
+fi
+echo "provider-neutral recorder static scan passed"
+
+if rg -n "SendWithDiagnosticsAsync|SendStructuredWithDiagnosticsAsync|GetDateeResponseAsync|GenerateDialogueOptionsAsync|ApplyFailureCorruptionAsync|SnapshotRecordingLlmTransport|RecordingLlmTransport" \
+  src/Pinder.Core/Diagnostics/AgentJournals \
+  src/Pinder.LlmAdapters/AgentJournals \
+  tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording; then
+  echo "Verifier scope appears to claim or perform runtime call-site wiring." >&2
+  exit 1
+fi
+echo "runtime call-site wiring static absence check passed"
+
+if ! rg -n "CustomEntry|AppendCustomEntryAsync" src/Pinder.LlmAdapters/AgentJournals/PiAgentJournalProjectionSink.cs >/dev/null; then
+  echo "Pi projection adapter does not append custom entries." >&2
+  exit 1
+fi
+echo "Pi custom-entry projection scan passed"
+
+git diff --check
+untracked_owned_files=(
+  "scripts/verify-issue-1371.ps1"
+  "scripts/verify-issue-1371.sh"
+  "src/Pinder.Core/Diagnostics/AgentJournals/AgentJournalRecorder.cs"
+  "src/Pinder.Core/Diagnostics/AgentJournals/IAgentJournalSink.cs"
+  "src/Pinder.LlmAdapters/AgentJournals/PiAgentJournalProjectionSink.cs"
+  "tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/AgentJournalRecorderLifecycleTests.cs"
+  "tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/PiAgentJournalProjectionSinkTests.cs"
+)
+untracked_check_failed=0
+for f in "${untracked_owned_files[@]}"; do
+  if [[ -f "$f" && "$(git ls-files --others --exclude-standard -- "$f")" == "$f" ]]; then
+    output="$(git diff --check --no-index /dev/null "$f" 2>&1 || true)"
+    if [[ -n "$output" ]]; then
+      echo "$output"
+      untracked_check_failed=1
+    fi
+  fi
+done
+if [[ "$untracked_check_failed" -ne 0 ]]; then
+  exit 1
+fi
+echo "untracked owned-file whitespace check passed"
+
+echo "issue #1371 verifier completed"

--- a/src/Pinder.Core/Diagnostics/AgentJournals/AgentJournalRecorder.cs
+++ b/src/Pinder.Core/Diagnostics/AgentJournals/AgentJournalRecorder.cs
@@ -1,0 +1,770 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+
+namespace Pinder.Core.Diagnostics.AgentJournals
+{
+    public static class AgentJournalTerminalCodes
+    {
+        public const string Accepted = "accepted";
+        public const string ValidationRejected = "validation_rejected";
+        public const string ProviderFailed = "provider_failed";
+        public const string Cancelled = "cancelled";
+        public const string Abandoned = "abandoned";
+    }
+
+    public static class AgentJournalOperationalDiagnostics
+    {
+        public const string Source = "AgentJournalRecorder";
+        public const string SinkPersistenceFailedEventName = "AgentJournalSinkPersistenceFailed";
+        public const string PhaseCode = "agent_journal_persistence";
+
+        public static OperationalDiagnosticEvent SinkPersistenceFailed(
+            AgentJournalSinkRecord record,
+            AgentJournalSinkFailureMode failureMode,
+            Exception exception)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            if (exception == null) throw new ArgumentNullException(nameof(exception));
+
+            return new OperationalDiagnosticEvent(
+                Source,
+                SinkPersistenceFailedEventName,
+                OperationalDiagnosticSeverity.Warning,
+                "Agent journal host sink persistence failed.",
+                exception,
+                operationKind: "agent_journal",
+                phaseCode: PhaseCode,
+                lifecycle: OperationalDiagnosticLifecycle.Phase,
+                outcome: OperationalDiagnosticOutcome.Degraded,
+                failureClassification: OperationalDiagnostics.ClassifyException(exception),
+                correlationId: record.Correlation.InvocationId,
+                callId: record.Correlation.InvocationId,
+                correlationHints: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["record_id"] = record.RecordId,
+                    ["custom_type"] = record.CustomType,
+                    ["failure_mode"] = failureMode.ToString(),
+                    ["game_run_id"] = record.Correlation.GameRunId,
+                    ["agent_session_id"] = record.Correlation.AgentSessionId,
+                    ["invocation_id"] = record.Correlation.InvocationId,
+                    ["attempt_id"] = record.Correlation.AttemptId ?? string.Empty,
+                    ["attempt_ordinal"] = record.Correlation.AttemptOrdinal.ToString(CultureInfo.InvariantCulture),
+                },
+                branchId: record.Correlation.BranchId);
+        }
+    }
+
+    public sealed class AgentJournalRecorderContext
+    {
+        private TimeSpan _writeTimeout = TimeSpan.FromSeconds(2);
+
+        public AgentJournalRecorderContext(
+            AgentJournalCorrelationIds correlation,
+            string modelId,
+            string phase,
+            IReadOnlyList<AgentJournalInputDocument> inputDocuments)
+        {
+            Correlation = correlation ?? throw new ArgumentNullException(nameof(correlation));
+            ModelId = modelId ?? throw new ArgumentNullException(nameof(modelId));
+            Phase = phase ?? throw new ArgumentNullException(nameof(phase));
+            InputDocuments = inputDocuments ?? throw new ArgumentNullException(nameof(inputDocuments));
+        }
+
+        public AgentJournalCorrelationIds Correlation { get; }
+        public string ModelId { get; }
+        public string Phase { get; }
+        public IReadOnlyList<AgentJournalInputDocument> InputDocuments { get; }
+        public IAgentJournalProjectionSink? PiProjectionSink { get; set; }
+        public IAgentJournalSink? HostSink { get; set; }
+        public AgentJournalSinkFailureMode SinkFailureMode { get; set; } = AgentJournalSinkFailureMode.BestEffort;
+        public Action<OperationalDiagnosticEvent>? OnDiagnostic { get; set; }
+        public Func<DateTimeOffset>? Clock { get; set; }
+
+        public TimeSpan WriteTimeout
+        {
+            get => _writeTimeout;
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Agent journal write timeout must be positive.");
+                _writeTimeout = value;
+            }
+        }
+
+        internal string TimestampUtc()
+        {
+            DateTimeOffset now = Clock == null ? DateTimeOffset.UtcNow : Clock();
+            return now.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+        }
+    }
+
+    public sealed class AgentJournalRecorder
+    {
+        private readonly AgentJournalRecorderContext _context;
+        private readonly object _startGate = new object();
+        private Task<AgentJournalAttempt>? _startTask;
+        private AgentJournalAttempt? _startedAttempt;
+        private PendingStart? _pendingStart;
+
+        public AgentJournalRecorder(AgentJournalRecorderContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public Task<AgentJournalAttempt> StartAsync(CancellationToken cancellationToken = default)
+            => StartOrRetryAsync(createIfMissing: true, cancellationToken);
+
+        public Task<AgentJournalAttempt> RetryStartAsync(CancellationToken cancellationToken = default)
+            => StartOrRetryAsync(createIfMissing: false, cancellationToken);
+
+        private Task<AgentJournalAttempt> StartOrRetryAsync(
+            bool createIfMissing,
+            CancellationToken cancellationToken)
+        {
+            lock (_startGate)
+            {
+                if (_startedAttempt != null)
+                {
+                    return Task.FromResult(_startedAttempt);
+                }
+
+                if (_startTask != null)
+                {
+                    return _startTask;
+                }
+
+                if (_pendingStart == null)
+                {
+                    if (!createIfMissing)
+                    {
+                        return Task.FromException<AgentJournalAttempt>(new InvalidOperationException(
+                            "Agent journal start has no pending invocation to retry."));
+                    }
+
+                    var invocation = new LlmInvocationRecord(
+                        _context.Correlation,
+                        _context.ModelId,
+                        _context.Phase,
+                        SnapshotInputDocuments(_context.InputDocuments),
+                        _context.TimestampUtc());
+                    ThrowIfInvalid(AgentJournalValidator.Validate(invocation), AgentJournalSchemaNames.LlmInvocationV1);
+                    _pendingStart = new PendingStart(
+                        invocation,
+                        AgentJournalSinkRecord.Invocation(invocation));
+                }
+
+                var completion = new TaskCompletionSource<AgentJournalAttempt>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _startTask = completion.Task;
+                _ = RunStartAsync(_pendingStart, cancellationToken, completion);
+                return completion.Task;
+            }
+        }
+
+        private async Task RunStartAsync(
+            PendingStart pending,
+            CancellationToken cancellationToken,
+            TaskCompletionSource<AgentJournalAttempt> completion)
+        {
+            try
+            {
+                if (!pending.PiProjected)
+                {
+                    await ProjectToPiAsync(pending.Record, cancellationToken).ConfigureAwait(false);
+                    pending.PiProjected = true;
+                }
+
+                if (!pending.HostDelivered)
+                {
+                    pending.SinkFailures.AddRange(await PersistToHostAsync(
+                        pending.Record,
+                        cancellationToken).ConfigureAwait(false));
+                    pending.HostDelivered = true;
+                }
+
+                var attempt = new AgentJournalAttempt(
+                    _context,
+                    this,
+                    pending.Invocation,
+                    pending.SinkFailures.AsReadOnly());
+                lock (_startGate)
+                {
+                    _startedAttempt = attempt;
+                    _pendingStart = null;
+                    _startTask = null;
+                }
+                completion.TrySetResult(attempt);
+            }
+            catch (Exception ex)
+            {
+                lock (_startGate)
+                {
+                    _startTask = null;
+                }
+                completion.TrySetException(ex);
+            }
+        }
+
+        private sealed class PendingStart
+        {
+            public PendingStart(LlmInvocationRecord invocation, AgentJournalSinkRecord record)
+            {
+                Invocation = invocation;
+                Record = record;
+            }
+
+            public LlmInvocationRecord Invocation { get; }
+            public AgentJournalSinkRecord Record { get; }
+            public bool PiProjected { get; set; }
+            public bool HostDelivered { get; set; }
+            public List<AgentJournalSinkPersistenceException> SinkFailures { get; }
+                = new List<AgentJournalSinkPersistenceException>();
+        }
+
+        internal async Task ProjectToPiAsync(
+            AgentJournalSinkRecord record,
+            CancellationToken cancellationToken)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+
+            if (_context.PiProjectionSink != null)
+            {
+                try
+                {
+                    await WithTimeout(
+                        token => _context.PiProjectionSink.ProjectAsync(record, token),
+                        cancellationToken,
+                        _context.WriteTimeout).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+                {
+                    throw new AgentJournalPiProjectionException(record.RecordId, record.CustomType, ex);
+                }
+            }
+        }
+
+        internal async Task<IReadOnlyList<AgentJournalSinkPersistenceException>> PersistToHostAsync(
+            AgentJournalSinkRecord record,
+            CancellationToken cancellationToken)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+
+            if (_context.HostSink == null)
+            {
+                return Array.Empty<AgentJournalSinkPersistenceException>();
+            }
+
+            try
+            {
+                await WithTimeout(
+                    token => _context.HostSink.PersistAsync(record, token),
+                    cancellationToken,
+                    _context.WriteTimeout).ConfigureAwait(false);
+                return Array.Empty<AgentJournalSinkPersistenceException>();
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+            {
+                var failure = new AgentJournalSinkPersistenceException(record.RecordId, record.CustomType, ex);
+                if (_context.SinkFailureMode == AgentJournalSinkFailureMode.FailClosed)
+                {
+                    throw failure;
+                }
+
+                OperationalDiagnostics.Emit(
+                    _context.OnDiagnostic,
+                    AgentJournalOperationalDiagnostics.SinkPersistenceFailed(
+                        record,
+                        _context.SinkFailureMode,
+                        failure.InnerException ?? failure));
+                return new[] { failure };
+            }
+        }
+
+        private static IReadOnlyList<AgentJournalInputDocument> SnapshotInputDocuments(
+            IReadOnlyList<AgentJournalInputDocument> inputDocuments)
+        {
+            var documents = new AgentJournalInputDocument[inputDocuments.Count];
+            for (int documentIndex = 0; documentIndex < inputDocuments.Count; documentIndex++)
+            {
+                AgentJournalInputDocument document = inputDocuments[documentIndex]
+                    ?? throw new ArgumentException("Input documents cannot contain null entries.", nameof(inputDocuments));
+                var ranges = new AgentJournalProvenanceRange[document.Ranges.Count];
+                for (int rangeIndex = 0; rangeIndex < document.Ranges.Count; rangeIndex++)
+                {
+                    AgentJournalProvenanceRange range = document.Ranges[rangeIndex]
+                        ?? throw new ArgumentException("Input document ranges cannot contain null entries.", nameof(inputDocuments));
+                    AgentJournalSourceIdentity source = range.Source;
+                    ranges[rangeIndex] = new AgentJournalProvenanceRange(
+                        range.DocumentId,
+                        range.StartUtf16,
+                        range.EndUtf16,
+                        range.RangeKind,
+                        range.RedactionClass,
+                        new AgentJournalSourceIdentity(
+                            source.Kind,
+                            source.SourceId,
+                            source.KeyPath,
+                            source.Revision,
+                            source.ContentHash,
+                            source.EditorTargetId));
+                }
+
+                documents[documentIndex] = new AgentJournalInputDocument(
+                    document.DocumentId,
+                    document.Role,
+                    document.Text,
+                    Array.AsReadOnly(ranges));
+            }
+
+            return Array.AsReadOnly(documents);
+        }
+
+        private static async Task WithTimeout(
+            Func<CancellationToken, Task> operation,
+            CancellationToken cancellationToken,
+            TimeSpan timeout)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (var timeoutSource = new CancellationTokenSource())
+            using (var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutSource.Token))
+            {
+                Task operationTask;
+                try
+                {
+                    operationTask = operation(linked.Token);
+                }
+                catch
+                {
+                    throw;
+                }
+
+                if (operationTask == null)
+                {
+                    throw new InvalidOperationException("Agent journal sink returned a null task.");
+                }
+
+                Task delayTask = Task.Delay(timeout);
+                Task completed = await Task.WhenAny(operationTask, delayTask).ConfigureAwait(false);
+                if (!ReferenceEquals(completed, operationTask))
+                {
+                    timeoutSource.Cancel();
+                    throw new TimeoutException("Agent journal persistence did not complete within the configured timeout.");
+                }
+
+                await operationTask.ConfigureAwait(false);
+            }
+        }
+
+        private static void ThrowIfInvalid(AgentJournalValidationResult result, string customType)
+        {
+            if (result == null) throw new ArgumentNullException(nameof(result));
+            if (result.IsValid)
+            {
+                return;
+            }
+
+            throw new ArgumentException(
+                "Agent journal " + customType + " record is invalid: " + string.Join(", ", ErrorCodes(result)),
+                nameof(result));
+        }
+
+        private static IEnumerable<string> ErrorCodes(AgentJournalValidationResult result)
+        {
+            foreach (AgentJournalValidationError error in result.Errors)
+            {
+                yield return error.Code + "@" + error.Path;
+            }
+        }
+    }
+
+    public sealed class AgentJournalAttempt : IAsyncDisposable
+    {
+        private readonly AgentJournalRecorderContext _context;
+        private readonly AgentJournalRecorder _recorder;
+        private readonly IReadOnlyList<AgentJournalSinkPersistenceException> _startSinkFailures;
+        private readonly object _terminalGate = new object();
+        private Task<AgentJournalTerminalResult>? _completionTask;
+        private AgentJournalTerminalResult? _terminalResult;
+        private PendingTerminal? _pendingTerminal;
+
+        internal AgentJournalAttempt(
+            AgentJournalRecorderContext context,
+            AgentJournalRecorder recorder,
+            LlmInvocationRecord invocationRecord,
+            IReadOnlyList<AgentJournalSinkPersistenceException> startSinkFailures)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+            InvocationRecord = invocationRecord ?? throw new ArgumentNullException(nameof(invocationRecord));
+            _startSinkFailures = startSinkFailures ?? Array.Empty<AgentJournalSinkPersistenceException>();
+        }
+
+        public LlmInvocationRecord InvocationRecord { get; }
+        public IReadOnlyList<AgentJournalSinkPersistenceException> StartSinkFailures => _startSinkFailures;
+
+        public Task<AgentJournalTerminalResult> CompleteAcceptedAsync(
+            string outputText,
+            AgentJournalUsage? usage,
+            string? semanticEntryId = null)
+        {
+            return CompleteTerminalAsync(
+                AgentJournalTerminalStatus.Succeeded,
+                outputText,
+                usage,
+                validationCode: AgentJournalTerminalCodes.Accepted,
+                errorCode: null,
+                semanticEntryId: semanticEntryId);
+        }
+
+        public Task<AgentJournalTerminalResult> CompleteValidationRejectedAsync(string validationCode)
+        {
+            return CompleteTerminalAsync(
+                AgentJournalTerminalStatus.Rejected,
+                outputText: null,
+                usage: null,
+                validationCode: string.IsNullOrWhiteSpace(validationCode)
+                    ? AgentJournalTerminalCodes.ValidationRejected
+                    : validationCode,
+                errorCode: null,
+                semanticEntryId: null);
+        }
+
+        public Task<AgentJournalTerminalResult> CompleteProviderFailedAsync(string errorCode)
+        {
+            return CompleteTerminalAsync(
+                AgentJournalTerminalStatus.Failed,
+                outputText: null,
+                usage: null,
+                validationCode: null,
+                errorCode: string.IsNullOrWhiteSpace(errorCode)
+                    ? AgentJournalTerminalCodes.ProviderFailed
+                    : errorCode,
+                semanticEntryId: null);
+        }
+
+        public Task<AgentJournalTerminalResult> CompleteCancelledAsync(
+            string errorCode,
+            CancellationToken providerCancellationToken = default)
+        {
+            return CompleteTerminalAsync(
+                AgentJournalTerminalStatus.Cancelled,
+                outputText: null,
+                usage: null,
+                validationCode: null,
+                errorCode: string.IsNullOrWhiteSpace(errorCode)
+                    ? AgentJournalTerminalCodes.Cancelled
+                    : errorCode,
+                semanticEntryId: null);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return new ValueTask(CompleteTerminalAsync(
+                AgentJournalTerminalStatus.Failed,
+                outputText: null,
+                usage: null,
+                validationCode: null,
+                errorCode: AgentJournalTerminalCodes.Abandoned,
+                semanticEntryId: null));
+        }
+
+        private Task<AgentJournalTerminalResult> CompleteTerminalAsync(
+            AgentJournalTerminalStatus terminalStatus,
+            string? outputText,
+            AgentJournalUsage? usage,
+            string? validationCode,
+            string? errorCode,
+            string? semanticEntryId)
+        {
+            lock (_terminalGate)
+            {
+                if (_terminalResult != null)
+                {
+                    return Task.FromResult(_terminalResult.AsAlreadyCompleted());
+                }
+
+                if (_completionTask != null)
+                {
+                    return AlreadyCompletedAsync(_completionTask);
+                }
+
+                if (_pendingTerminal == null)
+                {
+                    _pendingTerminal = CreatePendingTerminal(
+                        terminalStatus,
+                        outputText,
+                        usage,
+                        validationCode,
+                        errorCode,
+                        semanticEntryId);
+                }
+
+                var completion = new TaskCompletionSource<AgentJournalTerminalResult>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _completionTask = completion.Task;
+                _ = RunCompletionAsync(_pendingTerminal, completion);
+                return completion.Task;
+            }
+        }
+
+        private async Task RunCompletionAsync(
+            PendingTerminal pending,
+            TaskCompletionSource<AgentJournalTerminalResult> completion)
+        {
+            try
+            {
+                AgentJournalTerminalResult result = await CompleteTerminalCoreAsync(pending).ConfigureAwait(false);
+                lock (_terminalGate)
+                {
+                    _terminalResult = result;
+                    _pendingTerminal = null;
+                    _completionTask = null;
+                }
+                completion.TrySetResult(result);
+            }
+            catch (Exception ex)
+            {
+                lock (_terminalGate)
+                {
+                    _completionTask = null;
+                }
+                completion.TrySetException(ex);
+            }
+        }
+
+        private static async Task<AgentJournalTerminalResult> AlreadyCompletedAsync(
+            Task<AgentJournalTerminalResult> terminalTask)
+        {
+            AgentJournalTerminalResult result = await terminalTask.ConfigureAwait(false);
+            return result.AsAlreadyCompleted();
+        }
+
+        private PendingTerminal CreatePendingTerminal(
+            AgentJournalTerminalStatus terminalStatus,
+            string? outputText,
+            AgentJournalUsage? usage,
+            string? validationCode,
+            string? errorCode,
+            string? semanticEntryId)
+        {
+            // Validate the complete immutable terminal payload before reserving lifecycle work.
+            var resultRecord = new LlmResultRecord(
+                InvocationRecord.Correlation,
+                terminalStatus,
+                outputText,
+                usage,
+                validationCode,
+                errorCode,
+                _context.TimestampUtc());
+            ThrowIfInvalidResult(resultRecord);
+
+            MessageLinkRecord? linkRecord = null;
+            if (terminalStatus == AgentJournalTerminalStatus.Succeeded
+                && !string.IsNullOrWhiteSpace(semanticEntryId))
+            {
+                linkRecord = new MessageLinkRecord(
+                    semanticEntryId!,
+                    InvocationRecord.Correlation.InvocationId,
+                    InvocationRecord.Correlation.AgentSessionId,
+                    InvocationRecord.Correlation.TurnId,
+                    InvocationRecord.Correlation.BranchId);
+                ThrowIfInvalidLink(linkRecord);
+            }
+
+            return new PendingTerminal(
+                resultRecord,
+                linkRecord,
+                new PendingProjection(AgentJournalSinkRecord.Result(resultRecord)),
+                linkRecord == null
+                    ? null
+                    : new PendingProjection(AgentJournalSinkRecord.MessageLink(
+                        linkRecord,
+                        InvocationRecord.Correlation)));
+        }
+
+        private async Task<AgentJournalTerminalResult> CompleteTerminalCoreAsync(PendingTerminal pending)
+        {
+            await DeliverAsync(pending.ResultProjection, pending.SinkFailures).ConfigureAwait(false);
+            if (pending.LinkProjection != null)
+            {
+                await DeliverAsync(pending.LinkProjection, pending.SinkFailures).ConfigureAwait(false);
+            }
+
+            return new AgentJournalTerminalResult(
+                recorded: true,
+                alreadyCompleted: false,
+                pending.ResultRecord,
+                pending.LinkRecord,
+                pending.SinkFailures.AsReadOnly());
+        }
+
+        private async Task DeliverAsync(
+            PendingProjection projection,
+            List<AgentJournalSinkPersistenceException> failures)
+        {
+            if (!projection.PiProjected)
+            {
+                await _recorder.ProjectToPiAsync(projection.Record, CancellationToken.None).ConfigureAwait(false);
+                projection.PiProjected = true;
+            }
+
+            if (!projection.HostDelivered)
+            {
+                failures.AddRange(await _recorder.PersistToHostAsync(
+                    projection.Record,
+                    CancellationToken.None).ConfigureAwait(false));
+                projection.HostDelivered = true;
+            }
+        }
+
+        private static void ThrowIfInvalidResult(LlmResultRecord resultRecord)
+        {
+            AgentJournalValidationResult validation = AgentJournalValidator.Validate(resultRecord);
+            if (!validation.IsValid)
+            {
+                throw new ArgumentException("Agent journal result record is invalid.");
+            }
+        }
+
+        private static void ThrowIfInvalidLink(MessageLinkRecord linkRecord)
+        {
+            AgentJournalValidationResult validation = AgentJournalValidator.Validate(linkRecord);
+            if (!validation.IsValid)
+            {
+                throw new ArgumentException("Agent journal message-link record is invalid.");
+            }
+        }
+
+        private sealed class PendingTerminal
+        {
+            public PendingTerminal(
+                LlmResultRecord resultRecord,
+                MessageLinkRecord? linkRecord,
+                PendingProjection resultProjection,
+                PendingProjection? linkProjection)
+            {
+                ResultRecord = resultRecord;
+                LinkRecord = linkRecord;
+                ResultProjection = resultProjection;
+                LinkProjection = linkProjection;
+            }
+
+            public LlmResultRecord ResultRecord { get; }
+            public MessageLinkRecord? LinkRecord { get; }
+            public PendingProjection ResultProjection { get; }
+            public PendingProjection? LinkProjection { get; }
+            public List<AgentJournalSinkPersistenceException> SinkFailures { get; }
+                = new List<AgentJournalSinkPersistenceException>();
+        }
+
+        private sealed class PendingProjection
+        {
+            public PendingProjection(AgentJournalSinkRecord record)
+            {
+                Record = record;
+            }
+
+            public AgentJournalSinkRecord Record { get; }
+            public bool PiProjected { get; set; }
+            public bool HostDelivered { get; set; }
+        }
+    }
+
+    public sealed class AgentJournalTerminalResult
+    {
+        internal AgentJournalTerminalResult(
+            bool recorded,
+            bool alreadyCompleted,
+            LlmResultRecord resultRecord,
+            MessageLinkRecord? messageLinkRecord,
+            IReadOnlyList<AgentJournalSinkPersistenceException> sinkFailures)
+        {
+            Recorded = recorded;
+            AlreadyCompleted = alreadyCompleted;
+            ResultRecord = resultRecord ?? throw new ArgumentNullException(nameof(resultRecord));
+            MessageLinkRecord = messageLinkRecord;
+            SinkFailures = sinkFailures ?? Array.Empty<AgentJournalSinkPersistenceException>();
+        }
+
+        public bool Recorded { get; }
+        public bool AlreadyCompleted { get; }
+        public LlmResultRecord ResultRecord { get; }
+        public MessageLinkRecord? MessageLinkRecord { get; }
+        public IReadOnlyList<AgentJournalSinkPersistenceException> SinkFailures { get; }
+
+        internal AgentJournalTerminalResult AsAlreadyCompleted()
+            => new AgentJournalTerminalResult(
+                recorded: false,
+                alreadyCompleted: true,
+                ResultRecord,
+                MessageLinkRecord,
+                SinkFailures);
+    }
+
+    public sealed class AgentJournalSinkRecord
+    {
+        private AgentJournalSinkRecord(
+            string recordId,
+            string customType,
+            object record,
+            AgentJournalCorrelationIds correlation)
+        {
+            RecordId = recordId ?? throw new ArgumentNullException(nameof(recordId));
+            CustomType = customType ?? throw new ArgumentNullException(nameof(customType));
+            Record = record ?? throw new ArgumentNullException(nameof(record));
+            Correlation = correlation ?? throw new ArgumentNullException(nameof(correlation));
+        }
+
+        public string RecordId { get; }
+        public string CustomType { get; }
+        public object Record { get; }
+        public AgentJournalCorrelationIds Correlation { get; }
+
+        public static AgentJournalSinkRecord Invocation(LlmInvocationRecord record)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            return new AgentJournalSinkRecord(
+                BaseRecordId(record.Correlation) + "/invocation",
+                AgentJournalSchemaNames.LlmInvocationV1,
+                record,
+                record.Correlation);
+        }
+
+        public static AgentJournalSinkRecord Result(LlmResultRecord record)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            return new AgentJournalSinkRecord(
+                BaseRecordId(record.Correlation) + "/result",
+                AgentJournalSchemaNames.LlmResultV1,
+                record,
+                record.Correlation);
+        }
+
+        public static AgentJournalSinkRecord MessageLink(
+            MessageLinkRecord record,
+            AgentJournalCorrelationIds correlation)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            if (correlation == null) throw new ArgumentNullException(nameof(correlation));
+            return new AgentJournalSinkRecord(
+                BaseRecordId(correlation) + "/message-link/" + record.SemanticEntryId,
+                AgentJournalSchemaNames.MessageLinkV1,
+                record,
+                correlation);
+        }
+
+        private static string BaseRecordId(AgentJournalCorrelationIds correlation)
+            => "agent-journal/"
+                + correlation.GameRunId
+                + "/"
+                + correlation.AgentSessionId
+                + "/"
+                + correlation.InvocationId
+                + "/"
+                + (correlation.AttemptId ?? correlation.AttemptOrdinal.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/src/Pinder.Core/Diagnostics/AgentJournals/IAgentJournalSink.cs
+++ b/src/Pinder.Core/Diagnostics/AgentJournals/IAgentJournalSink.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pinder.Core.Diagnostics.AgentJournals
+{
+    public enum AgentJournalSinkFailureMode
+    {
+        BestEffort,
+        FailClosed,
+    }
+
+    public interface IAgentJournalSink
+    {
+        Task PersistAsync(AgentJournalSinkRecord record, CancellationToken cancellationToken);
+    }
+
+    public interface IAgentJournalProjectionSink
+    {
+        Task ProjectAsync(AgentJournalSinkRecord record, CancellationToken cancellationToken);
+    }
+
+    public sealed class AgentJournalSinkPersistenceException : Exception
+    {
+        public AgentJournalSinkPersistenceException(
+            string recordId,
+            string customType,
+            Exception innerException)
+            : base(
+                "Agent journal host sink failed to persist record '" + recordId + "' (" + customType + ").",
+                innerException)
+        {
+            if (string.IsNullOrWhiteSpace(recordId))
+                throw new ArgumentException("Record id is required.", nameof(recordId));
+            if (string.IsNullOrWhiteSpace(customType))
+                throw new ArgumentException("Custom type is required.", nameof(customType));
+            RecordId = recordId;
+            CustomType = customType;
+        }
+
+        public string RecordId { get; }
+        public string CustomType { get; }
+    }
+
+    public sealed class AgentJournalPiProjectionException : Exception
+    {
+        public AgentJournalPiProjectionException(
+            string recordId,
+            string customType,
+            Exception innerException)
+            : base(
+                "Agent journal Pi projection failed for record '" + recordId + "' (" + customType + ").",
+                innerException)
+        {
+            if (string.IsNullOrWhiteSpace(recordId))
+                throw new ArgumentException("Record id is required.", nameof(recordId));
+            if (string.IsNullOrWhiteSpace(customType))
+                throw new ArgumentException("Custom type is required.", nameof(customType));
+            RecordId = recordId;
+            CustomType = customType;
+        }
+
+        public string RecordId { get; }
+        public string CustomType { get; }
+    }
+}

--- a/src/Pinder.LlmAdapters/AgentJournals/PiAgentJournalProjectionSink.cs
+++ b/src/Pinder.LlmAdapters/AgentJournals/PiAgentJournalProjectionSink.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Pi.Agent.Core;
+using Pinder.Core.Diagnostics.AgentJournals;
+
+namespace Pinder.LlmAdapters.AgentJournals
+{
+    public sealed class PiAgentJournalProjectionSink : IAgentJournalProjectionSink
+    {
+        private readonly ISession<SessionMetadata>? _session;
+        private readonly PiAgentJournalEntryCodec _codec;
+
+        public PiAgentJournalProjectionSink(ISession<SessionMetadata>? session)
+            : this(session, new PiAgentJournalEntryCodec())
+        {
+        }
+
+        public PiAgentJournalProjectionSink(
+            ISession<SessionMetadata>? session,
+            PiAgentJournalEntryCodec codec)
+        {
+            _session = session;
+            _codec = codec ?? throw new ArgumentNullException(nameof(codec));
+        }
+
+        public async Task ProjectAsync(AgentJournalSinkRecord record, CancellationToken cancellationToken)
+        {
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            if (_session == null)
+            {
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            CustomEntry entry = Encode(record);
+            cancellationToken.ThrowIfCancellationRequested();
+            await _session.AppendCustomEntryAsync(entry.CustomType, entry.Data).ConfigureAwait(false);
+        }
+
+        private CustomEntry Encode(AgentJournalSinkRecord record)
+        {
+            switch (record.CustomType)
+            {
+                case AgentJournalSchemaNames.LlmInvocationV1:
+                    var invocation = record.Record as LlmInvocationRecord;
+                    if (invocation == null)
+                    {
+                        throw InvalidRecordType(record, nameof(LlmInvocationRecord));
+                    }
+                    return _codec.Encode(invocation);
+
+                case AgentJournalSchemaNames.LlmResultV1:
+                    var result = record.Record as LlmResultRecord;
+                    if (result == null)
+                    {
+                        throw InvalidRecordType(record, nameof(LlmResultRecord));
+                    }
+                    return _codec.Encode(result);
+
+                case AgentJournalSchemaNames.MessageLinkV1:
+                    var link = record.Record as MessageLinkRecord;
+                    if (link == null)
+                    {
+                        throw InvalidRecordType(record, nameof(MessageLinkRecord));
+                    }
+                    return _codec.Encode(link);
+
+                default:
+                    throw new InvalidOperationException("Unsupported Pinder agent journal custom type '" + record.CustomType + "'.");
+            }
+        }
+
+        private static Exception InvalidRecordType(AgentJournalSinkRecord record, string expectedType)
+            => new InvalidOperationException("Record '" + record.RecordId + "' must contain " + expectedType + ".");
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/AgentJournalRecorderLifecycleTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/AgentJournalRecorderLifecycleTests.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Pinder.Core.Conversation;
+using Pinder.Core.Diagnostics.AgentJournals;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.AgentJournals.Recording
+{
+    public sealed class AgentJournalRecorderLifecycleTests
+    {
+        [Fact]
+        public async Task StartAndAcceptedCompletion_ProjectSameRecordInstancesToPiAndHost()
+        {
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(pi, host).StartAsync();
+
+            AgentJournalTerminalResult terminal = await attempt.CompleteAcceptedAsync(
+                "assistant text",
+                new AgentJournalUsage(10, 5, 15),
+                semanticEntryId: "semantic-entry-001");
+
+            Assert.Equal(3, pi.Records.Count);
+            Assert.Equal(3, host.Records.Count);
+            for (int i = 0; i < pi.Records.Count; i++)
+            {
+                Assert.Same(pi.Records[i].Record, host.Records[i].Record);
+                Assert.Equal(pi.Records[i].RecordId, host.Records[i].RecordId);
+                Assert.Equal(pi.Records[i].CustomType, host.Records[i].CustomType);
+            }
+
+            Assert.Same(attempt.InvocationRecord, pi.Records[0].Record);
+            Assert.Same(terminal.ResultRecord, pi.Records[1].Record);
+            Assert.Same(terminal.MessageLinkRecord, pi.Records[2].Record);
+            Assert.Equal("agent-journal/game-run-001/agent-session-datee/invocation-001/attempt-001/invocation", pi.Records[0].RecordId);
+            Assert.Equal("agent-journal/game-run-001/agent-session-datee/invocation-001/attempt-001/result", pi.Records[1].RecordId);
+            Assert.Equal("agent-journal/game-run-001/agent-session-datee/invocation-001/attempt-001/message-link/semantic-entry-001", pi.Records[2].RecordId);
+        }
+
+        [Theory]
+        [InlineData("accepted", AgentJournalTerminalStatus.Succeeded, "accepted", null)]
+        [InlineData("validation_rejected", AgentJournalTerminalStatus.Rejected, "validation_rejected", null)]
+        [InlineData("provider_failed", AgentJournalTerminalStatus.Failed, null, "provider_failed")]
+        [InlineData("cancelled", AgentJournalTerminalStatus.Cancelled, null, "cancelled")]
+        public async Task TerminalMatrix_EmitsExactlyOneTerminalResult(
+            string terminalKind,
+            AgentJournalTerminalStatus expectedStatus,
+            string? expectedValidationCode,
+            string? expectedErrorCode)
+        {
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(hostSink: host).StartAsync();
+
+            AgentJournalTerminalResult result = await CompleteAsync(attempt, terminalKind);
+            AgentJournalTerminalResult duplicate = await CompleteAsync(attempt, "provider_failed");
+
+            Assert.True(result.Recorded);
+            Assert.False(duplicate.Recorded);
+            Assert.True(duplicate.AlreadyCompleted);
+            Assert.Same(result.ResultRecord, duplicate.ResultRecord);
+            Assert.Equal(2, host.Records.Count);
+            Assert.Equal(AgentJournalSchemaNames.LlmResultV1, host.Records[1].CustomType);
+            Assert.Equal(expectedStatus, result.ResultRecord.TerminalStatus);
+            Assert.Equal(expectedValidationCode, result.ResultRecord.ValidationCode);
+            Assert.Equal(expectedErrorCode, result.ResultRecord.ErrorCode);
+            if (expectedStatus == AgentJournalTerminalStatus.Rejected)
+            {
+                Assert.Null(result.ResultRecord.OutputText);
+                Assert.True(AgentJournalValidator.Validate(result.ResultRecord).IsValid);
+            }
+        }
+
+        [Fact]
+        public async Task DisposeWithoutCompletion_EmitsAbandonedOnce()
+        {
+            var host = new RecordingJournalSink();
+            AgentJournalAttempt attempt = await NewRecorder(hostSink: host).StartAsync();
+
+            await attempt.DisposeAsync();
+            await attempt.DisposeAsync();
+
+            var result = Assert.IsType<LlmResultRecord>(host.Records.Last().Record);
+            Assert.Equal(2, host.Records.Count);
+            Assert.Equal(AgentJournalTerminalStatus.Failed, result.TerminalStatus);
+            Assert.Equal(AgentJournalTerminalCodes.Abandoned, result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task StableRecordIds_MakeDuplicateHostDeliveryIdempotent()
+        {
+            var host = new RecordingJournalSink { IdempotentByRecordId = true };
+            var context = NewContext(hostSink: host);
+            await (await new AgentJournalRecorder(context).StartAsync()).CompleteProviderFailedAsync("provider_failed");
+            await (await new AgentJournalRecorder(context).StartAsync()).CompleteProviderFailedAsync("provider_failed");
+
+            Assert.Equal(2, host.Records.Count);
+            Assert.Equal(2, host.DuplicateDeliveries);
+
+            var nextContext = NewContext(hostSink: host, invocationId: "invocation-002", attemptId: "attempt-002", attemptOrdinal: 2);
+            await (await new AgentJournalRecorder(nextContext).StartAsync()).CompleteProviderFailedAsync("provider_failed");
+
+            Assert.Equal(4, host.Records.Count);
+        }
+
+        [Fact]
+        public async Task BestEffortSinkFailure_EmitsDiagnosticAndPreservesTerminalState()
+        {
+            var diagnostics = new List<OperationalDiagnosticEvent>();
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(
+                piSink: pi,
+                hostSink: host,
+                failureMode: AgentJournalSinkFailureMode.BestEffort,
+                diagnostics: diagnostics.Add).StartAsync();
+            host.ThrowOnWrite = true;
+
+            AgentJournalTerminalResult result = await attempt.CompleteAcceptedAsync("assistant text", null);
+
+            Assert.True(result.Recorded);
+            Assert.Equal(AgentJournalTerminalStatus.Succeeded, result.ResultRecord.TerminalStatus);
+            Assert.NotEmpty(result.SinkFailures);
+            Assert.Equal(2, pi.Records.Count);
+            Assert.Contains(diagnostics, diagnostic =>
+                diagnostic.EventName == AgentJournalOperationalDiagnostics.SinkPersistenceFailedEventName
+                && diagnostic.CorrelationHints["record_id"].EndsWith("/result", StringComparison.Ordinal)
+                && diagnostic.CorrelationHints["failure_mode"] == "BestEffort");
+        }
+
+        [Fact]
+        public async Task FailClosedSinkFailure_ThrowsTypedPersistenceFailureBeforeAcceptance()
+        {
+            var host = new RecordingJournalSink { ThrowOnWrite = true };
+            var recorder = NewRecorder(
+                hostSink: host,
+                failureMode: AgentJournalSinkFailureMode.FailClosed);
+
+            AgentJournalSinkPersistenceException error = await Assert.ThrowsAsync<AgentJournalSinkPersistenceException>(
+                async () => await recorder.StartAsync());
+
+            Assert.EndsWith("/invocation", error.RecordId, StringComparison.Ordinal);
+            Assert.Equal(AgentJournalSchemaNames.LlmInvocationV1, error.CustomType);
+            Assert.IsType<InvalidOperationException>(error.InnerException);
+        }
+
+        [Fact]
+        public async Task InvocationStartPostPiHostFailure_RetryIsSingleFlightAndReturnsSameAttempt()
+        {
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink { FailuresRemaining = 1 };
+            var recorder = NewRecorder(
+                piSink: pi,
+                hostSink: host,
+                failureMode: AgentJournalSinkFailureMode.FailClosed);
+
+            AgentJournalSinkPersistenceException error = await Assert.ThrowsAsync<AgentJournalSinkPersistenceException>(
+                async () => await recorder.StartAsync());
+            var retryGate = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            host.NextWriteGate = retryGate;
+            Task<AgentJournalAttempt> firstRetry = recorder.RetryStartAsync();
+            Task<AgentJournalAttempt> concurrentRetry = recorder.RetryStartAsync();
+
+            Assert.Same(firstRetry, concurrentRetry);
+            Assert.False(firstRetry.IsCompleted);
+            retryGate.SetResult(null);
+            AgentJournalAttempt firstAttempt = await firstRetry;
+            AgentJournalAttempt concurrentAttempt = await concurrentRetry;
+            AgentJournalAttempt doubleRetryAttempt = await recorder.RetryStartAsync();
+
+            Assert.EndsWith("/invocation", error.RecordId, StringComparison.Ordinal);
+            Assert.Same(firstAttempt, concurrentAttempt);
+            Assert.Same(firstAttempt, doubleRetryAttempt);
+            Assert.Same(firstAttempt.InvocationRecord, pi.Records[0].Record);
+            Assert.Single(pi.Records);
+            Assert.Single(host.Records);
+            Assert.Equal(2, host.Attempts.Count);
+            Assert.Equal(error.RecordId, host.Attempts[0].RecordId);
+            Assert.Equal(error.RecordId, host.Attempts[1].RecordId);
+            Assert.Same(host.Attempts[0].Record, host.Attempts[1].Record);
+            Assert.Same(pi.Records[0].Record, host.Records[0].Record);
+        }
+
+        [Fact]
+        public async Task RetryStartWithoutPendingInvocation_FailsExplicitly()
+        {
+            var recorder = NewRecorder();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await recorder.RetryStartAsync());
+        }
+
+        [Fact]
+        public async Task SinkPolicyAfterPiProjectionMatrix_FailClosedRetriesHostWithoutDuplicatePiProjection()
+        {
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(
+                piSink: pi,
+                hostSink: host,
+                failureMode: AgentJournalSinkFailureMode.FailClosed).StartAsync();
+            host.FailuresRemaining = 1;
+
+            AgentJournalSinkPersistenceException error = await Assert.ThrowsAsync<AgentJournalSinkPersistenceException>(
+                async () => await attempt.CompleteAcceptedAsync("assistant text", null));
+            AgentJournalTerminalResult retried = await attempt.CompleteAcceptedAsync("ignored retry text", null);
+
+            Assert.EndsWith("/result", error.RecordId, StringComparison.Ordinal);
+            Assert.True(retried.Recorded);
+            Assert.Equal("assistant text", retried.ResultRecord.OutputText);
+            Assert.Equal(2, pi.Records.Count);
+            Assert.Equal(2, host.Records.Count);
+            Assert.Equal(3, host.Attempts.Count);
+            Assert.Equal(host.Attempts[1].RecordId, host.Attempts[2].RecordId);
+            Assert.Same(host.Attempts[1].Record, host.Attempts[2].Record);
+            Assert.Same(pi.Records[1].Record, host.Attempts[2].Record);
+        }
+
+        [Fact]
+        public async Task FailedTerminalProjection_DoesNotCacheCompletionAndCanRetry()
+        {
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(pi, host).StartAsync();
+            pi.ThrowOnWrite = true;
+
+            await Assert.ThrowsAsync<AgentJournalPiProjectionException>(
+                async () => await attempt.CompleteValidationRejectedAsync("policy_rejected"));
+            pi.ThrowOnWrite = false;
+            AgentJournalTerminalResult retried = await attempt.CompleteValidationRejectedAsync("ignored_retry_code");
+
+            Assert.True(retried.Recorded);
+            Assert.Equal("policy_rejected", retried.ResultRecord.ValidationCode);
+            Assert.Null(retried.ResultRecord.OutputText);
+            Assert.True(AgentJournalValidator.Validate(retried.ResultRecord).IsValid);
+            Assert.Equal(2, pi.Records.Count);
+            Assert.Equal(2, host.Records.Count);
+        }
+
+        [Fact]
+        public async Task InvalidTerminalPayload_DoesNotCacheCompletionBeforeValidationSucceeds()
+        {
+            var pi = new RecordingProjectionSink();
+            var host = new RecordingJournalSink();
+            var attempt = await NewRecorder(pi, host).StartAsync();
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => await attempt.CompleteAcceptedAsync(null!, null));
+            AgentJournalTerminalResult recovered = await attempt.CompleteProviderFailedAsync("provider_failed");
+
+            Assert.True(recovered.Recorded);
+            Assert.Equal(AgentJournalTerminalStatus.Failed, recovered.ResultRecord.TerminalStatus);
+            Assert.Equal("provider_failed", recovered.ResultRecord.ErrorCode);
+            Assert.Equal(2, pi.Records.Count);
+            Assert.Equal(2, host.Records.Count);
+        }
+
+        [Fact]
+        public async Task InvocationSnapshot_IsolatedFromCallerDocumentAndRangeMutation()
+        {
+            var ranges = new List<AgentJournalProvenanceRange> { Document("doc.user", "hello").Ranges[0] };
+            var callerDocument = new AgentJournalInputDocument("doc.user", AgentJournalInputRole.User, "hello", ranges);
+            var documents = new List<AgentJournalInputDocument> { callerDocument };
+            var attempt = await new AgentJournalRecorder(NewContext(inputDocuments: documents)).StartAsync();
+
+            ranges.Clear();
+            documents.Clear();
+            documents.Add(Document("doc.changed", "changed"));
+
+            AgentJournalInputDocument emitted = Assert.Single(attempt.InvocationRecord.InputDocuments);
+            AgentJournalProvenanceRange emittedRange = Assert.Single(emitted.Ranges);
+            Assert.Equal("doc.user", emitted.DocumentId);
+            Assert.Equal("doc.user", emittedRange.DocumentId);
+            Assert.NotSame(callerDocument, emitted);
+            Assert.NotSame(ranges, emitted.Ranges);
+        }
+
+        [Fact]
+        public async Task PiProjectionFailure_PreventsSuccessfulJournalCommit()
+        {
+            var pi = new RecordingProjectionSink { ThrowOnWrite = true };
+            var host = new RecordingJournalSink();
+            var recorder = NewRecorder(pi, host);
+
+            AgentJournalPiProjectionException error = await Assert.ThrowsAsync<AgentJournalPiProjectionException>(
+                async () => await recorder.StartAsync());
+
+            Assert.EndsWith("/invocation", error.RecordId, StringComparison.Ordinal);
+            Assert.Empty(host.Records);
+        }
+
+        [Fact]
+        public async Task CancelledTerminalCleanup_UsesBoundedIndependentToken()
+        {
+            var host = new RecordingJournalSink { IgnoreCancellationAndNeverComplete = true };
+            var attempt = await NewRecorder(
+                hostSink: host,
+                failureMode: AgentJournalSinkFailureMode.BestEffort,
+                writeTimeout: TimeSpan.FromMilliseconds(40)).StartAsync();
+
+            using (var cancelled = new CancellationTokenSource())
+            {
+                cancelled.Cancel();
+                var watch = Stopwatch.StartNew();
+                AgentJournalTerminalResult result = await attempt.CompleteCancelledAsync("cancelled", cancelled.Token);
+                watch.Stop();
+
+                Assert.True(result.Recorded);
+                Assert.Equal(AgentJournalTerminalStatus.Cancelled, result.ResultRecord.TerminalStatus);
+                Assert.True(watch.Elapsed < TimeSpan.FromSeconds(2));
+                Assert.NotEmpty(result.SinkFailures);
+            }
+        }
+
+        private static Task<AgentJournalTerminalResult> CompleteAsync(AgentJournalAttempt attempt, string terminalKind)
+        {
+            switch (terminalKind)
+            {
+                case "accepted":
+                    return attempt.CompleteAcceptedAsync("assistant text", new AgentJournalUsage(1, 2, 3));
+                case "validation_rejected":
+                    return attempt.CompleteValidationRejectedAsync("validation_rejected");
+                case "provider_failed":
+                    return attempt.CompleteProviderFailedAsync("provider_failed");
+                case "cancelled":
+                    return attempt.CompleteCancelledAsync("cancelled", new CancellationToken(true));
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(terminalKind), terminalKind, null);
+            }
+        }
+
+        private static AgentJournalRecorder NewRecorder(
+            IAgentJournalProjectionSink? piSink = null,
+            IAgentJournalSink? hostSink = null,
+            AgentJournalSinkFailureMode failureMode = AgentJournalSinkFailureMode.BestEffort,
+            Action<OperationalDiagnosticEvent>? diagnostics = null,
+            TimeSpan? writeTimeout = null)
+            => new AgentJournalRecorder(NewContext(piSink, hostSink, failureMode, diagnostics, writeTimeout));
+
+        private static AgentJournalRecorderContext NewContext(
+            IAgentJournalProjectionSink? piSink = null,
+            IAgentJournalSink? hostSink = null,
+            AgentJournalSinkFailureMode failureMode = AgentJournalSinkFailureMode.BestEffort,
+            Action<OperationalDiagnosticEvent>? diagnostics = null,
+            TimeSpan? writeTimeout = null,
+            string invocationId = "invocation-001",
+            string attemptId = "attempt-001",
+            int attemptOrdinal = 1,
+            IReadOnlyList<AgentJournalInputDocument>? inputDocuments = null)
+        {
+            return new AgentJournalRecorderContext(
+                new AgentJournalCorrelationIds(
+                    "game-run-001",
+                    "agent-session-datee",
+                    invocationId,
+                    "operation-dialogue-options",
+                    attemptOrdinal,
+                    attemptId: attemptId,
+                    requestId: "request-001",
+                    turnId: "turn-001",
+                    branchId: "branch-main"),
+                "test-model",
+                "dialogue_options",
+                inputDocuments ?? new[] { Document("doc.user", "hello") })
+            {
+                PiProjectionSink = piSink,
+                HostSink = hostSink,
+                SinkFailureMode = failureMode,
+                OnDiagnostic = diagnostics,
+                WriteTimeout = writeTimeout ?? TimeSpan.FromSeconds(1),
+                Clock = () => new DateTimeOffset(2026, 8, 15, 22, 30, 0, TimeSpan.Zero),
+            };
+        }
+
+        private static AgentJournalInputDocument Document(string id, string text)
+            => new AgentJournalInputDocument(
+                id,
+                AgentJournalInputRole.User,
+                text,
+                new[]
+                {
+                    new AgentJournalProvenanceRange(
+                        id,
+                        0,
+                        text.Length,
+                        AgentJournalRangeKind.RuntimeGenerated,
+                        AgentJournalRedactionClass.SafeMetadata,
+                        new AgentJournalSourceIdentity(
+                            AgentJournalSourceKind.RuntimeGenerated,
+                            "runtime.prompt",
+                            "dialogue.user")),
+                });
+
+        private sealed class RecordingProjectionSink : IAgentJournalProjectionSink
+        {
+            public readonly List<AgentJournalSinkRecord> Records = new List<AgentJournalSinkRecord>();
+            public bool ThrowOnWrite { get; set; }
+
+            public Task ProjectAsync(AgentJournalSinkRecord record, CancellationToken cancellationToken)
+            {
+                if (ThrowOnWrite)
+                {
+                    throw new InvalidOperationException("pi projection failed");
+                }
+
+                Records.Add(record);
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class RecordingJournalSink : IAgentJournalSink
+        {
+            private readonly HashSet<string> _seenIds = new HashSet<string>(StringComparer.Ordinal);
+            public readonly List<AgentJournalSinkRecord> Attempts = new List<AgentJournalSinkRecord>();
+            public readonly List<AgentJournalSinkRecord> Records = new List<AgentJournalSinkRecord>();
+            public bool ThrowOnWrite { get; set; }
+            public int FailuresRemaining { get; set; }
+            public bool IdempotentByRecordId { get; set; }
+            public bool IgnoreCancellationAndNeverComplete { get; set; }
+            public int DuplicateDeliveries { get; private set; }
+            public TaskCompletionSource<object?>? NextWriteGate { get; set; }
+
+            public Task PersistAsync(AgentJournalSinkRecord record, CancellationToken cancellationToken)
+            {
+                Attempts.Add(record);
+                if (IgnoreCancellationAndNeverComplete)
+                {
+                    return new TaskCompletionSource<object?>().Task;
+                }
+
+                if (ThrowOnWrite || FailuresRemaining-- > 0)
+                {
+                    throw new InvalidOperationException("host sink failed");
+                }
+
+                if (NextWriteGate != null)
+                {
+                    Task gate = NextWriteGate.Task;
+                    NextWriteGate = null;
+                    return PersistAfterGateAsync(record, gate);
+                }
+
+                return Commit(record);
+            }
+
+            private async Task PersistAfterGateAsync(AgentJournalSinkRecord record, Task gate)
+            {
+                await gate.ConfigureAwait(false);
+                await Commit(record).ConfigureAwait(false);
+            }
+
+            private Task Commit(AgentJournalSinkRecord record)
+            {
+                if (IdempotentByRecordId && !_seenIds.Add(record.RecordId))
+                {
+                    DuplicateDeliveries++;
+                    return Task.CompletedTask;
+                }
+
+                Records.Add(record);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/PiAgentJournalProjectionSinkTests.cs
+++ b/tests/Pinder.LlmAdapters.Tests/AgentJournals/Recording/PiAgentJournalProjectionSinkTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Pi.Agent.Core;
+using Pinder.Core.Conversation;
+using Pinder.Core.Diagnostics.AgentJournals;
+using Pinder.LlmAdapters.AgentJournals;
+using Xunit;
+
+namespace Pinder.LlmAdapters.Tests.AgentJournals.Recording
+{
+    public sealed class PiAgentJournalProjectionSinkTests
+    {
+        [Fact]
+        public async Task RecorderProjection_AppendsJournalCustomEntriesWithoutProviderContext()
+        {
+            await using PiConversationSession session = await PiConversationSession.RestoreOrImportAsync(
+                snapshot: null,
+                Array.Empty<ConversationMessage>(),
+                "datee");
+            var projector = new PiAgentJournalProjectionSink(session.Session);
+            var recorder = new AgentJournalRecorder(Context(projector));
+
+            AgentJournalAttempt attempt = await recorder.StartAsync();
+            await attempt.CompleteAcceptedAsync("assistant text", new AgentJournalUsage(2, 3, 5), "semantic-entry-001");
+
+            var entries = await session.Session.GetEntriesAsync();
+            var customEntries = entries.OfType<CustomEntry>().ToArray();
+            Assert.Equal(
+                new[]
+                {
+                    AgentJournalSchemaNames.LlmInvocationV1,
+                    AgentJournalSchemaNames.LlmResultV1,
+                    AgentJournalSchemaNames.MessageLinkV1,
+                },
+                customEntries.Select(entry => entry.CustomType).ToArray());
+
+            var codec = new PiAgentJournalEntryCodec();
+            Assert.Equal("invocation-001", Assert.IsType<LlmInvocationRecord>(codec.Decode(customEntries[0]).Record).Correlation.InvocationId);
+            Assert.Equal(AgentJournalTerminalStatus.Succeeded, Assert.IsType<LlmResultRecord>(codec.Decode(customEntries[1]).Record).TerminalStatus);
+            Assert.Equal("semantic-entry-001", Assert.IsType<MessageLinkRecord>(codec.Decode(customEntries[2]).Record).SemanticEntryId);
+
+            var context = await session.Session.BuildContextAsync(new SessionContextBuildOptions
+            {
+                EntryProjectors = PiAgentJournalRegistry.CreateZeroContextProjectors(),
+            });
+            Assert.Empty(context.Messages);
+        }
+
+        [Fact]
+        public async Task NullAgentSession_SkipsPiProjectionButStillAllowsHostSink()
+        {
+            var host = new RecordingHostSink();
+            var recorder = new AgentJournalRecorder(Context(new PiAgentJournalProjectionSink(null), host));
+
+            await (await recorder.StartAsync()).CompleteProviderFailedAsync("provider_failed");
+
+            Assert.Equal(2, host.Count);
+        }
+
+        private static AgentJournalRecorderContext Context(
+            IAgentJournalProjectionSink projector,
+            IAgentJournalSink? hostSink = null)
+            => new AgentJournalRecorderContext(
+                new AgentJournalCorrelationIds(
+                    "game-run-001",
+                    "agent-session-datee",
+                    "invocation-001",
+                    "operation-dialogue-options",
+                    1,
+                    attemptId: "attempt-001",
+                    requestId: "request-001",
+                    turnId: "turn-001",
+                    branchId: "branch-main"),
+                "test-model",
+                "dialogue_options",
+                new[] { Document("doc.user", "hello") })
+            {
+                PiProjectionSink = projector,
+                HostSink = hostSink,
+                Clock = () => new DateTimeOffset(2026, 8, 15, 22, 30, 0, TimeSpan.Zero),
+            };
+
+        private static AgentJournalInputDocument Document(string id, string text)
+            => new AgentJournalInputDocument(
+                id,
+                AgentJournalInputRole.User,
+                text,
+                new[]
+                {
+                    new AgentJournalProvenanceRange(
+                        id,
+                        0,
+                        text.Length,
+                        AgentJournalRangeKind.RuntimeGenerated,
+                        AgentJournalRedactionClass.SafeMetadata,
+                        new AgentJournalSourceIdentity(
+                            AgentJournalSourceKind.RuntimeGenerated,
+                            "runtime.prompt",
+                            "dialogue.user")),
+                });
+
+        private sealed class RecordingHostSink : IAgentJournalSink
+        {
+            public int Count { get; private set; }
+
+            public Task PersistAsync(AgentJournalSinkRecord record, System.Threading.CancellationToken cancellationToken)
+            {
+                Count++;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1371. Adds the provider-neutral recorder, host sink contract, Pi projection, terminal/failure/idempotency/retry semantics, cancellation bounds, and host-compatible verifier. No GitHub CI.